### PR TITLE
fix(pricing): price free models whose rows omit cache rates

### DIFF
--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -26,10 +26,69 @@ pub struct ModelPricing {
 }
 
 impl ModelPricing {
+    /// Whether this row prices a genuinely free model, so the buckets it never
+    /// quotes can be read as free too.
+    ///
+    /// Free models and free router routes reach us as rows that quote `0.0`
+    /// for the buckets upstream bothered to list and omit the rest:
+    /// `kenari/nemotron-3-ultra-550b-a55b` publishes input and output at zero
+    /// and no cache rates at all, while `zai/glm-4.5-flash` publishes the
+    /// redundant cache zeros too. Whether a genuinely free model blocks a
+    /// submission should not hinge on that editorial difference (#1021, #1035).
+    ///
+    /// Two conditions, and both matter:
+    ///
+    /// The row must quote base rates for *both* input and output. Those are
+    /// the two buckets every completion populates and every provider prices,
+    /// so quoting zero for both is a statement that the deal is free. One
+    /// zero rate is not: a row quoting free input while omitting output has
+    /// said nothing about generation, which is where the money is, and
+    /// extrapolating from it would report a paid model at $0.00.
+    ///
+    /// Every rate the row quotes must then be zero, tiers included. A zero
+    /// base rate beside a paid above-128k tier is a promotional tier rather
+    /// than a free model, and keeps the strict coverage check below.
+    fn prices_everything_at_zero(&self) -> bool {
+        let quoted_rate =
+            |rate: Option<f64>| rate.is_some_and(|rate| rate.is_finite() && rate >= 0.0);
+        quoted_rate(self.input_cost_per_token)
+            && quoted_rate(self.output_cost_per_token)
+            && [
+                self.input_cost_per_token,
+                self.input_cost_per_token_above_128k_tokens,
+                self.input_cost_per_token_above_200k_tokens,
+                self.input_cost_per_token_above_256k_tokens,
+                self.input_cost_per_token_above_272k_tokens,
+                self.output_cost_per_token,
+                self.output_cost_per_token_above_128k_tokens,
+                self.output_cost_per_token_above_200k_tokens,
+                self.output_cost_per_token_above_256k_tokens,
+                self.output_cost_per_token_above_272k_tokens,
+                self.cache_creation_input_token_cost,
+                self.cache_creation_input_token_cost_above_200k_tokens,
+                self.cache_read_input_token_cost,
+                self.cache_read_input_token_cost_above_200k_tokens,
+                self.cache_read_input_token_cost_above_272k_tokens,
+            ]
+            .into_iter()
+            .flatten()
+            // Rejects NaN as well as any real price, so a row carrying an
+            // unusable rate is never mistaken for a free one.
+            .all(|rate| rate == 0.0)
+    }
+
     /// Whether this row can price every populated token bucket under
     /// `compute_cost`'s current base-rate fallback semantics. Explicit zeroes
     /// are valid prices; a missing base rate is not covered by a later tier.
     pub(crate) fn covers_usage(&self, usage: &crate::TokenBreakdown) -> bool {
+        // A model that charges nothing for the rates it does quote charges
+        // nothing for the ones it omits, so a free row covers any usage shape.
+        // `compute_cost` already reads an absent rate as 0.0, so this only
+        // stops a $0.00 submission being rejected — it changes no total.
+        if self.prices_everything_at_zero() {
+            return true;
+        }
+
         let valid_rate =
             |rate: Option<f64>| rate.is_some_and(|rate| rate.is_finite() && rate >= 0.0);
         (usage.input <= 0 || valid_rate(self.input_cost_per_token))
@@ -240,6 +299,122 @@ mod pricing_row_tests {
             filled.cache_read_input_token_cost_above_200k_tokens,
             Some(9.9e-7)
         );
+    }
+
+    fn free_model_usage() -> TokenBreakdown {
+        TokenBreakdown {
+            input: 1_000,
+            output: 500,
+            cache_read: 2_000,
+            cache_write: 300,
+            reasoning: 200,
+        }
+    }
+
+    // #1021, #1035: a free model whose row omits the redundant cache zeros was
+    // judged unpriced the moment a message carried one cached token, and the
+    // whole submission aborted.
+    #[test]
+    fn a_row_priced_entirely_at_zero_covers_cache_usage_it_never_quotes() {
+        let free = ModelPricing {
+            input_cost_per_token: Some(0.0),
+            output_cost_per_token: Some(0.0),
+            ..Default::default()
+        };
+
+        assert!(free.covers_usage(&free_model_usage()));
+    }
+
+    // Absence of data is not a price of zero.
+    #[test]
+    fn a_row_with_no_rates_at_all_covers_nothing() {
+        let empty = ModelPricing::default();
+
+        assert!(!empty.covers_usage(&free_model_usage()));
+        assert!(!empty.covers_usage(&cache_read_usage()));
+    }
+
+    // The zero shortcut must never borrow a real rate for a bucket the row
+    // leaves unquoted: that would bill cached tokens at the input price.
+    #[test]
+    fn a_row_charging_for_input_still_does_not_cover_unquoted_cache_reads() {
+        let paid = ModelPricing {
+            input_cost_per_token: Some(1e-6),
+            output_cost_per_token: Some(1e-5),
+            ..Default::default()
+        };
+
+        assert!(!paid.covers_usage(&cache_read_usage()));
+    }
+
+    // A zero base rate with a paid long-context tier is not a free model, so
+    // the strict rule still applies to the buckets it never quotes.
+    #[test]
+    fn a_zero_base_rate_with_a_paid_tier_does_not_cover_unquoted_cache_reads() {
+        let promotional = ModelPricing {
+            input_cost_per_token: Some(0.0),
+            input_cost_per_token_above_128k_tokens: Some(1e-6),
+            output_cost_per_token: Some(0.0),
+            ..Default::default()
+        };
+
+        assert!(!promotional.covers_usage(&cache_read_usage()));
+    }
+
+    // One zero rate is not a free deal. A row quoting free input while saying
+    // nothing about output has said nothing about generation, so the buckets
+    // it omits stay unpriced.
+    #[test]
+    fn a_row_quoting_only_a_zero_input_rate_does_not_cover_output() {
+        let input_only = ModelPricing {
+            input_cost_per_token: Some(0.0),
+            ..Default::default()
+        };
+
+        assert!(!input_only.covers_usage(&free_model_usage()));
+        assert!(input_only.covers_usage(&TokenBreakdown {
+            input: 1_000,
+            output: 0,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        }));
+    }
+
+    // A tier-only row has no base rate to prove the deal is free, so its zeros
+    // must not make it cover usage the pricing path would bill at zero anyway.
+    #[test]
+    fn a_tier_only_zero_row_covers_nothing() {
+        let tier_only = ModelPricing {
+            input_cost_per_token_above_128k_tokens: Some(0.0),
+            ..Default::default()
+        };
+
+        assert!(!tier_only.covers_usage(&free_model_usage()));
+    }
+
+    // Covering the usage is only useful if the price that follows is a real
+    // 0.0: an unquoted bucket must not leak a NaN into the leaderboard totals.
+    #[test]
+    fn a_free_row_prices_cache_usage_at_exactly_zero() {
+        let free = ModelPricing {
+            input_cost_per_token: Some(0.0),
+            output_cost_per_token: Some(0.0),
+            ..Default::default()
+        };
+        let usage = free_model_usage();
+
+        let cost = crate::pricing::lookup::compute_cost(
+            &free,
+            usage.input,
+            usage.output,
+            usage.cache_read,
+            usage.cache_write,
+            usage.reasoning,
+        );
+
+        assert_eq!(cost, 0.0);
+        assert!(cost.is_finite());
     }
 
     // A bucket the usage does not touch is never filled.

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -26,29 +26,41 @@ pub struct ModelPricing {
 }
 
 impl ModelPricing {
-    /// Whether this row prices a genuinely free model, so the buckets it never
-    /// quotes can be read as free too.
+    /// Whether every rate this row publishes is exactly `0.0`, so the buckets
+    /// it never quotes can be read as zero as well.
     ///
-    /// Free models and free router routes reach us as rows that quote `0.0`
-    /// for the buckets upstream bothered to list and omit the rest:
-    /// `kenari/nemotron-3-ultra-550b-a55b` publishes input and output at zero
-    /// and no cache rates at all, while `zai/glm-4.5-flash` publishes the
-    /// redundant cache zeros too. Whether a genuinely free model blocks a
-    /// submission should not hinge on that editorial difference (#1021, #1035).
+    /// This is a statement about the row, not about the deal. Rows that quote
+    /// `0.0` for the buckets upstream bothered to list and omit the rest reach
+    /// us from two different worlds and are indistinguishable in the data:
+    /// `kenari/nemotron-3-ultra-550b-a55b` is a genuinely free model, and
+    /// `kenari/claude-opus-4-7` is a premium model whose zeros mean "included
+    /// in your subscription" — both arrive as
+    /// `{input_cost_per_token: 0.0, output_cost_per_token: 0.0}` with null
+    /// cache fields, byte for byte. Nothing in the dataset separates them, so
+    /// tokscale reports both at $0.00 and cannot do better from this input
+    /// alone. If upstream ever publishes a plan/subscription marker, that is
+    /// the signal to split these two cases apart.
+    ///
+    /// That limitation predates this predicate rather than arriving with it:
+    /// `0.0` has always satisfied `valid_rate`, so a plan-priced row already
+    /// covered — and already reported at $0.00 — any usage without cache
+    /// tokens. What this widens is the usage shapes it covers, extending the
+    /// same $0.00 answer to cache-bearing usage instead of aborting the
+    /// submission that carries it (#1021, #1035).
     ///
     /// Two conditions, and both matter:
     ///
     /// The row must quote base rates for *both* input and output. Those are
     /// the two buckets every completion populates and every provider prices,
-    /// so quoting zero for both is a statement that the deal is free. One
+    /// so quoting zero for both is the strongest signal the data offers. One
     /// zero rate is not: a row quoting free input while omitting output has
     /// said nothing about generation, which is where the money is, and
     /// extrapolating from it would report a paid model at $0.00.
     ///
     /// Every rate the row quotes must then be zero, tiers included. A zero
     /// base rate beside a paid above-128k tier is a promotional tier rather
-    /// than a free model, and keeps the strict coverage check below.
-    fn prices_everything_at_zero(&self) -> bool {
+    /// than an all-zero row, and keeps the strict coverage check below.
+    fn quotes_zero_for_every_published_rate(&self) -> bool {
         let quoted_rate =
             |rate: Option<f64>| rate.is_some_and(|rate| rate.is_finite() && rate >= 0.0);
         quoted_rate(self.input_cost_per_token)
@@ -73,7 +85,7 @@ impl ModelPricing {
             .into_iter()
             .flatten()
             // Rejects NaN as well as any real price, so a row carrying an
-            // unusable rate is never mistaken for a free one.
+            // unusable rate is never mistaken for a published zero.
             .all(|rate| rate == 0.0)
     }
 
@@ -81,11 +93,17 @@ impl ModelPricing {
     /// `compute_cost`'s current base-rate fallback semantics. Explicit zeroes
     /// are valid prices; a missing base rate is not covered by a later tier.
     pub(crate) fn covers_usage(&self, usage: &crate::TokenBreakdown) -> bool {
-        // A model that charges nothing for the rates it does quote charges
-        // nothing for the ones it omits, so a free row covers any usage shape.
-        // `compute_cost` already reads an absent rate as 0.0, so this only
-        // stops a $0.00 submission being rejected — it changes no total.
-        if self.prices_everything_at_zero() {
+        // A row that quotes zero for every rate it publishes prices the ones
+        // it omits at zero too, so it covers any usage shape. `compute_cost`
+        // already reads an absent rate as 0.0, so this only stops a $0.00
+        // submission being rejected — it changes no total.
+        //
+        // Answering true here deliberately pre-empts `resolve_for_usage`'s
+        // canonical-borrow path (#1013), which exists to fill omitted cache
+        // rates from the unhinted row. Nothing is lost: an all-zero row can
+        // only borrow from a canonical row quoting the same base rates, so
+        // every rate it could take is zero and the total is unchanged.
+        if self.quotes_zero_for_every_published_rate() {
             return true;
         }
 
@@ -301,7 +319,7 @@ mod pricing_row_tests {
         );
     }
 
-    fn free_model_usage() -> TokenBreakdown {
+    fn every_bucket_usage() -> TokenBreakdown {
         TokenBreakdown {
             input: 1_000,
             output: 500,
@@ -322,7 +340,7 @@ mod pricing_row_tests {
             ..Default::default()
         };
 
-        assert!(free.covers_usage(&free_model_usage()));
+        assert!(free.covers_usage(&every_bucket_usage()));
     }
 
     // Absence of data is not a price of zero.
@@ -330,7 +348,7 @@ mod pricing_row_tests {
     fn a_row_with_no_rates_at_all_covers_nothing() {
         let empty = ModelPricing::default();
 
-        assert!(!empty.covers_usage(&free_model_usage()));
+        assert!(!empty.covers_usage(&every_bucket_usage()));
         assert!(!empty.covers_usage(&cache_read_usage()));
     }
 
@@ -347,8 +365,8 @@ mod pricing_row_tests {
         assert!(!paid.covers_usage(&cache_read_usage()));
     }
 
-    // A zero base rate with a paid long-context tier is not a free model, so
-    // the strict rule still applies to the buckets it never quotes.
+    // A zero base rate beside a paid long-context tier is not an all-zero row,
+    // so the strict rule still applies to the buckets it never quotes.
     #[test]
     fn a_zero_base_rate_with_a_paid_tier_does_not_cover_unquoted_cache_reads() {
         let promotional = ModelPricing {
@@ -361,7 +379,7 @@ mod pricing_row_tests {
         assert!(!promotional.covers_usage(&cache_read_usage()));
     }
 
-    // One zero rate is not a free deal. A row quoting free input while saying
+    // One zero rate is not enough. A row quoting zero input while saying
     // nothing about output has said nothing about generation, so the buckets
     // it omits stay unpriced.
     #[test]
@@ -371,7 +389,7 @@ mod pricing_row_tests {
             ..Default::default()
         };
 
-        assert!(!input_only.covers_usage(&free_model_usage()));
+        assert!(!input_only.covers_usage(&every_bucket_usage()));
         assert!(input_only.covers_usage(&TokenBreakdown {
             input: 1_000,
             output: 0,
@@ -381,7 +399,7 @@ mod pricing_row_tests {
         }));
     }
 
-    // A tier-only row has no base rate to prove the deal is free, so its zeros
+    // A tier-only row has no base rate to anchor its zeros, so they
     // must not make it cover usage the pricing path would bill at zero anyway.
     #[test]
     fn a_tier_only_zero_row_covers_nothing() {
@@ -390,19 +408,19 @@ mod pricing_row_tests {
             ..Default::default()
         };
 
-        assert!(!tier_only.covers_usage(&free_model_usage()));
+        assert!(!tier_only.covers_usage(&every_bucket_usage()));
     }
 
     // Covering the usage is only useful if the price that follows is a real
     // 0.0: an unquoted bucket must not leak a NaN into the leaderboard totals.
     #[test]
-    fn a_free_row_prices_cache_usage_at_exactly_zero() {
+    fn an_all_zero_row_prices_cache_usage_at_exactly_zero() {
         let free = ModelPricing {
             input_cost_per_token: Some(0.0),
             output_cost_per_token: Some(0.0),
             ..Default::default()
         };
-        let usage = free_model_usage();
+        let usage = every_bucket_usage();
 
         let cost = crate::pricing::lookup::compute_cost(
             &free,

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -26,6 +26,53 @@ pub struct ModelPricing {
 }
 
 impl ModelPricing {
+    /// Every rate this row can carry, base rates and long-context tiers alike,
+    /// as one list.
+    ///
+    /// The destructure below deliberately carries no `..` rest pattern: adding
+    /// a field to `ModelPricing` breaks this function at compile time and
+    /// forces the new rate into every predicate that reasons over *all* rates.
+    /// Leaving that to a comment is not safe enough for
+    /// `quotes_zero_for_every_published_rate`, where an overlooked rate is
+    /// treated as zero and a new paid tier would read as free.
+    pub(crate) fn all_rates(&self) -> [Option<f64>; 15] {
+        let Self {
+            input_cost_per_token,
+            input_cost_per_token_above_128k_tokens,
+            input_cost_per_token_above_200k_tokens,
+            input_cost_per_token_above_256k_tokens,
+            input_cost_per_token_above_272k_tokens,
+            output_cost_per_token,
+            output_cost_per_token_above_128k_tokens,
+            output_cost_per_token_above_200k_tokens,
+            output_cost_per_token_above_256k_tokens,
+            output_cost_per_token_above_272k_tokens,
+            cache_creation_input_token_cost,
+            cache_creation_input_token_cost_above_200k_tokens,
+            cache_read_input_token_cost,
+            cache_read_input_token_cost_above_200k_tokens,
+            cache_read_input_token_cost_above_272k_tokens,
+        } = *self;
+
+        [
+            input_cost_per_token,
+            input_cost_per_token_above_128k_tokens,
+            input_cost_per_token_above_200k_tokens,
+            input_cost_per_token_above_256k_tokens,
+            input_cost_per_token_above_272k_tokens,
+            output_cost_per_token,
+            output_cost_per_token_above_128k_tokens,
+            output_cost_per_token_above_200k_tokens,
+            output_cost_per_token_above_256k_tokens,
+            output_cost_per_token_above_272k_tokens,
+            cache_creation_input_token_cost,
+            cache_creation_input_token_cost_above_200k_tokens,
+            cache_read_input_token_cost,
+            cache_read_input_token_cost_above_200k_tokens,
+            cache_read_input_token_cost_above_272k_tokens,
+        ]
+    }
+
     /// Whether every rate this row publishes is exactly `0.0`, so the buckets
     /// it never quotes can be read as zero as well.
     ///
@@ -65,28 +112,13 @@ impl ModelPricing {
             |rate: Option<f64>| rate.is_some_and(|rate| rate.is_finite() && rate >= 0.0);
         quoted_rate(self.input_cost_per_token)
             && quoted_rate(self.output_cost_per_token)
-            && [
-                self.input_cost_per_token,
-                self.input_cost_per_token_above_128k_tokens,
-                self.input_cost_per_token_above_200k_tokens,
-                self.input_cost_per_token_above_256k_tokens,
-                self.input_cost_per_token_above_272k_tokens,
-                self.output_cost_per_token,
-                self.output_cost_per_token_above_128k_tokens,
-                self.output_cost_per_token_above_200k_tokens,
-                self.output_cost_per_token_above_256k_tokens,
-                self.output_cost_per_token_above_272k_tokens,
-                self.cache_creation_input_token_cost,
-                self.cache_creation_input_token_cost_above_200k_tokens,
-                self.cache_read_input_token_cost,
-                self.cache_read_input_token_cost_above_200k_tokens,
-                self.cache_read_input_token_cost_above_272k_tokens,
-            ]
-            .into_iter()
-            .flatten()
-            // Rejects NaN as well as any real price, so a row carrying an
-            // unusable rate is never mistaken for a published zero.
-            .all(|rate| rate == 0.0)
+            && self
+                .all_rates()
+                .into_iter()
+                .flatten()
+                // Rejects NaN as well as any real price, so a row carrying an
+                // unusable rate is never mistaken for a published zero.
+                .all(|rate| rate == 0.0)
     }
 
     /// Whether this row can price every populated token bucket under

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -1541,9 +1541,12 @@ pub fn compute_cost(
     // because upstream LiteLLM does not currently declare 128k or 256k
     // cache-read pricing for any model. If upstream begins emitting
     // those keys, also add matching fields to `ModelPricing`,
-    // `has_any_usable_pricing`, `has_any_valid_above_tier_value`, and
-    // `has_meaningful_tier_support`; otherwise tier walks will silently
-    // undercost long-context cache reads on those models.
+    // `has_any_valid_above_tier_value`, and `has_meaningful_tier_support`;
+    // otherwise tier walks will silently undercost long-context cache reads
+    // on those models. `has_any_usable_pricing` and
+    // `quotes_zero_for_every_published_rate` need no entry here: they read
+    // `ModelPricing::all_rates`, whose exhaustive destructure fails to
+    // compile until the new field is added there.
     let cache_read_cost = tiered_cost(
         cache_read_clamped,
         pricing.cache_read_input_token_cost,
@@ -1929,25 +1932,10 @@ fn is_valid_price_value(value: f64) -> bool {
 /// subscription-based providers like Perplexity) are useless for
 /// pay-per-token cost estimation and should be deprioritized.
 fn has_any_usable_pricing(pricing: &ModelPricing) -> bool {
-    [
-        pricing.input_cost_per_token,
-        pricing.output_cost_per_token,
-        pricing.cache_read_input_token_cost,
-        pricing.cache_creation_input_token_cost,
-        pricing.input_cost_per_token_above_128k_tokens,
-        pricing.input_cost_per_token_above_200k_tokens,
-        pricing.input_cost_per_token_above_256k_tokens,
-        pricing.input_cost_per_token_above_272k_tokens,
-        pricing.output_cost_per_token_above_128k_tokens,
-        pricing.output_cost_per_token_above_200k_tokens,
-        pricing.output_cost_per_token_above_256k_tokens,
-        pricing.output_cost_per_token_above_272k_tokens,
-        pricing.cache_read_input_token_cost_above_200k_tokens,
-        pricing.cache_read_input_token_cost_above_272k_tokens,
-        pricing.cache_creation_input_token_cost_above_200k_tokens,
-    ]
-    .into_iter()
-    .any(|opt| opt.is_some_and(is_valid_price_value))
+    pricing
+        .all_rates()
+        .into_iter()
+        .any(|opt| opt.is_some_and(is_valid_price_value))
 }
 
 fn lookup_result_if_usable(

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -498,6 +498,37 @@ mod tests {
         assert!((cost - 1.925).abs() < 1e-9, "unexpected cost: {cost}");
     }
 
+    // Regression: #1021, #1035. The unit tests around `covers_usage` pin the
+    // row-level rule; this pins the behaviour the issues actually reported,
+    // which is a submission aborting. It has to run through `PricingService`
+    // because the shortcut is only reached via `resolve_for_usage`, whose
+    // `normalize_provider_hint(..).is_none() || covers_usage(..)` condition
+    // decides whether a hinted row is consulted at all — reordering that
+    // condition would reintroduce the aborted submission while every
+    // row-level test kept passing.
+    #[test]
+    fn a_hinted_all_zero_row_covers_cache_usage_through_the_service() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "kenari/nemotron-free-fixture".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0),
+                output_cost_per_token: Some(0.0),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(litellm, HashMap::new());
+        let usage = cache_read_usage();
+
+        assert!(
+            service.covers_usage_with_provider("nemotron-free-fixture", Some("kenari"), &usage),
+            "cache-bearing usage on an all-zero row must not abort the submission"
+        );
+        let cost =
+            service.calculate_cost_with_provider("nemotron-free-fixture", Some("kenari"), &usage);
+        assert_eq!(cost, 0.0, "an all-zero row must price at exactly zero");
+    }
+
     #[test]
     fn reasonix_uses_the_inferred_upstream_provider_for_pricing() {
         let mut litellm = HashMap::new();


### PR DESCRIPTION
Part of #1021 and #1035.

## The bug

`tokscale submit` aborts the whole batch when any token-bearing row is unpriced. One reason a row is judged unpriced is `ModelPricing::covers_usage`, which demands a published rate for **every** populated token bucket:

```rust
(usage.input <= 0 || valid_rate(self.input_cost_per_token))
    && (usage.output <= 0 && usage.reasoning <= 0 || valid_rate(self.output_cost_per_token))
    && (usage.cache_read <= 0 || valid_rate(self.cache_read_input_token_cost))
    && (usage.cache_write <= 0 || valid_rate(self.cache_creation_input_token_cost))
```

Several models resolve to a row that quotes input and output at exactly `0.0` — genuinely free models and free router routes — but quotes no cache rate at all. The moment such a message carries one cache-read token the model is judged unpriced and the entire submission is rejected, even though the cost is unambiguously $0.00.

Probed against the live pricing service (`cache` = usage with cache_read=500, `nocache` = without):

```
freerouter/nvidia/nemotron-3-ultra-550b-a55b  cache=false nocache=true
    match=kenari/nemotron-3-ultra-550b-a55b  in=Some(0.0) out=Some(0.0) cread=None cwrite=None
nvidia/minimaxai/minimax-m2.7                 cache=false nocache=true
    match=nvidia/minimaxai/minimax-m2.7      in=Some(0.0) out=Some(0.0) cread=None cwrite=None
zai/glm-4.5-flash                             cache=true  nocache=true
    match=zai/glm-4.5-flash  in=Some(0.0) out=Some(0.0) cread=Some(0.0) cwrite=Some(0.0)
```

So whether a free model blocks your submission comes down to whether the upstream dataset bothered to publish the redundant zero.

## What changed

When a row quotes zero for every rate it publishes, the buckets it omits are read as zero too, so a free row covers any usage shape.

Two conditions, both load-bearing:

- **Input and output must both be quoted.** One zero is not enough — a row quoting free input while omitting output has said nothing about generation, which is where the money is, and extrapolating would report a paid model at $0.00.
- **Every quoted rate must be zero, tiers included.** A zero base rate beside a paid above-128k tier is a promotional tier, not a free model, and keeps the strict check.

A row with no rates at all still covers nothing — absence of data is not a price of zero. A row with any non-zero rate keeps today's strict behavior; the input rate is never borrowed for cache reads, which would over-bill real money.

## A limitation stated in the code, not hidden

This predicate **cannot distinguish a genuinely free model from a plan-priced one** whose `0.0` means "included in your subscription". `kenari/claude-opus-4-7` is `{input: 0.0, output: 0.0, cache: null}` — byte-for-byte the same shape as the nemotron row this exists to cover. Across live models.dev the change flips 327 rows to covered, roughly 55 of them premium models.

This widens existing behavior rather than introducing it: those rows already resolved at $0.00 for usage without cache tokens, because `0.0` has always been a valid rate. But the doc comment now says so explicitly and cites `kenari/claude-opus-4-7`, instead of claiming the check identifies free models.

## Tests

- an all-zero row with omitted cache rates covers cache-read and cache-write usage
- a row with no rates covers nothing
- a row with a non-zero input rate and omitted cache-read rate still does **not** cover cache-read usage
- the free-model cost computes to exactly 0.0, not NaN
- end-to-end through `PricingService`, not just `ModelPricing` — this guards a real reordering risk, since the shortcut is only reached via `resolve_for_usage`'s `normalize_provider_hint(...).is_none() || hinted.pricing.covers_usage(usage)` condition

The rate-field set is exhaustive by construction rather than a hand-listed array, so a future upstream tier field cannot silently default to being treated as zero.

`cargo fmt`, `cargo clippy -D warnings`, `cargo test -p tokscale-core` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pricing for free models that publish 0.0 input/output but omit cache rates, so `tokscale submit` no longer aborts when cache tokens appear. Totals stay the same; this broadens coverage only. Addresses #1021 and #1035.

- **Bug Fixes**
  - Update `ModelPricing::covers_usage` to treat rows with 0.0 base `input` and `output`, and all quoted rates at zero (tiers included), as covering any usage; omitted cache rates are read as zero.
  - Keep strict behavior for any non-zero rate, missing base `output`/`input`, tier-only rows, or promotional tiers; rows with no rates still cover nothing.
  - Add end-to-end test through `PricingService` to ensure cache-bearing submissions are priced at $0.00 and do not abort.

- **Refactors**
  - Add `ModelPricing::all_rates` (exhaustive destructure) and use it in `has_any_usable_pricing` and the new zero-check for compile-time safety when new fields are added.
  - Rename and document the predicate as `quotes_zero_for_every_published_rate`, noting we cannot distinguish free models from subscription-included zeros without upstream signals.

<sup>Written for commit b417d7e68a91ca7c51a421f0533ae3b4a975e3f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

