### PR TITLE
fix(pricing): stop pricing fetches from writing the cache when the caller opted out

### DIFF
--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -752,6 +752,17 @@ mod tests {
     // asserting against a temp path the code was no longer writing to while
     // the real `~/.config/tokscale/cache` took the write. One domain is the
     // only arrangement that holds, so nothing here may reintroduce a second.
+    // The tests this module serializes restore through `EnvGuard` rather than a
+    // trailing restore call: a failing assertion panics before such a call
+    // runs, and `#[serial]` prevents overlap, not inheritance — so a redirect
+    // would leak into every later test in the process. `paths::tests` documents
+    // the same trap.
+    use crate::paths::test_env::EnvGuard;
+
+    // Retained for the env tests below that predate this module's move to one
+    // serialization domain. New tests should capture an `EnvGuard` instead;
+    // this pairing is only panic-safe when nothing between it and the restore
+    // can fail.
     fn restore_env(var: &str, previous: Option<String>) {
         match previous {
             Some(value) => unsafe { std::env::set_var(var, value) },
@@ -816,46 +827,36 @@ mod tests {
     #[test]
     #[serial]
     fn test_reasonix_stats_prefers_state_home_then_reasonix_home() {
-        let state_previous = std::env::var("REASONIX_STATE_HOME").ok();
-        let home_previous = std::env::var("REASONIX_HOME").ok();
-        unsafe {
-            std::env::set_var("REASONIX_HOME", "/custom/reasonix-home");
-            std::env::set_var("REASONIX_STATE_HOME", "/custom/reasonix-state");
-        }
+        let mut env = EnvGuard::capture(&["REASONIX_STATE_HOME", "REASONIX_HOME"]);
+        env.set("REASONIX_HOME", "/custom/reasonix-home");
+        env.set("REASONIX_STATE_HOME", "/custom/reasonix-state");
         let client = ClientId::Reasonix;
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
             "/custom/reasonix-state/stats"
         );
-        unsafe { std::env::remove_var("REASONIX_STATE_HOME") };
+        env.remove("REASONIX_STATE_HOME");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
             "/custom/reasonix-home/stats"
         );
-        restore_env("REASONIX_STATE_HOME", state_previous);
-        restore_env("REASONIX_HOME", home_previous);
     }
 
     #[test]
     #[serial]
     fn test_reasonix_stats_normalizes_env_roots_and_ignores_blank_values() {
-        let state_previous = std::env::var("REASONIX_STATE_HOME").ok();
-        let home_previous = std::env::var("REASONIX_HOME").ok();
+        let mut env = EnvGuard::capture(&["REASONIX_STATE_HOME", "REASONIX_HOME"]);
         let client = ClientId::Reasonix;
 
-        unsafe {
-            std::env::set_var("REASONIX_STATE_HOME", "  ~/reasonix-state  ");
-            std::env::set_var("REASONIX_HOME", "/unused/reasonix-home");
-        }
+        env.set("REASONIX_STATE_HOME", "  ~/reasonix-state  ");
+        env.set("REASONIX_HOME", "/unused/reasonix-home");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
             "/tmp/home/reasonix-state/stats"
         );
 
-        unsafe {
-            std::env::set_var("REASONIX_STATE_HOME", " \t ");
-            std::env::set_var("REASONIX_HOME", " relative-reasonix ");
-        }
+        env.set("REASONIX_STATE_HOME", " \t ");
+        env.set("REASONIX_HOME", " relative-reasonix ");
         let expected = std::env::current_dir()
             .expect("test process has a current directory")
             .join("relative-reasonix")
@@ -863,38 +864,33 @@ mod tests {
             .to_string_lossy()
             .into_owned();
         assert_eq!(client.data().resolve_path("/tmp/home"), expected);
-
-        restore_env("REASONIX_STATE_HOME", state_previous);
-        restore_env("REASONIX_HOME", home_previous);
     }
 
     #[test]
     #[serial]
     fn test_reasonix_stats_expands_environment_references_before_normalizing_paths() {
-        let state_previous = std::env::var("REASONIX_STATE_HOME").ok();
-        let root_previous = std::env::var("TOKSCALE_REASONIX_TEST_ROOT").ok();
-        let unset_previous = std::env::var("TOKSCALE_REASONIX_TEST_UNSET").ok();
+        let mut env = EnvGuard::capture(&[
+            "REASONIX_STATE_HOME",
+            "TOKSCALE_REASONIX_TEST_ROOT",
+            "TOKSCALE_REASONIX_TEST_UNSET",
+        ]);
         let client = ClientId::Reasonix;
 
-        unsafe {
-            std::env::set_var("TOKSCALE_REASONIX_TEST_ROOT", "~/reasonix-state");
-            std::env::remove_var("TOKSCALE_REASONIX_TEST_UNSET");
-            std::env::set_var(
-                "REASONIX_STATE_HOME",
-                "${TOKSCALE_REASONIX_TEST_ROOT}/nested",
-            );
-        }
+        env.set("TOKSCALE_REASONIX_TEST_ROOT", "~/reasonix-state");
+        env.remove("TOKSCALE_REASONIX_TEST_UNSET");
+        env.set(
+            "REASONIX_STATE_HOME",
+            "${TOKSCALE_REASONIX_TEST_ROOT}/nested",
+        );
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
             "/tmp/home/reasonix-state/nested/stats"
         );
 
-        unsafe {
-            std::env::set_var(
-                "REASONIX_STATE_HOME",
-                "${TOKSCALE_REASONIX_TEST_UNSET:-relative-reasonix}",
-            );
-        }
+        env.set(
+            "REASONIX_STATE_HOME",
+            "${TOKSCALE_REASONIX_TEST_UNSET:-relative-reasonix}",
+        );
         let expected = std::env::current_dir()
             .expect("test process has a current directory")
             .join("relative-reasonix")
@@ -902,21 +898,14 @@ mod tests {
             .to_string_lossy()
             .into_owned();
         assert_eq!(client.data().resolve_path("/tmp/home"), expected);
-
-        restore_env("REASONIX_STATE_HOME", state_previous);
-        restore_env("TOKSCALE_REASONIX_TEST_ROOT", root_previous);
-        restore_env("TOKSCALE_REASONIX_TEST_UNSET", unset_previous);
     }
 
     #[test]
     #[serial]
     fn test_reasonix_stats_ignores_env_roots_when_requested() {
-        let state_previous = std::env::var("REASONIX_STATE_HOME").ok();
-        let home_previous = std::env::var("REASONIX_HOME").ok();
-        unsafe {
-            std::env::set_var("REASONIX_STATE_HOME", "/custom/reasonix-state");
-            std::env::set_var("REASONIX_HOME", "/custom/reasonix-home");
-        }
+        let mut env = EnvGuard::capture(&["REASONIX_STATE_HOME", "REASONIX_HOME"]);
+        env.set("REASONIX_STATE_HOME", "/custom/reasonix-state");
+        env.set("REASONIX_HOME", "/custom/reasonix-home");
 
         assert_eq!(
             ClientId::Reasonix
@@ -924,69 +913,58 @@ mod tests {
                 .resolve_path_with_env_strategy("/tmp/home", false),
             "/tmp/home/.reasonix/stats"
         );
-
-        restore_env("REASONIX_STATE_HOME", state_previous);
-        restore_env("REASONIX_HOME", home_previous);
     }
 
     #[test]
     #[serial]
     fn test_kimchi_defaults_to_home_agent_dir_without_env_override() {
-        let previous = std::env::var("KIMCHI_CODING_AGENT_DIR").ok();
-        unsafe { std::env::remove_var("KIMCHI_CODING_AGENT_DIR") };
+        let mut env = EnvGuard::capture(&["KIMCHI_CODING_AGENT_DIR"]);
+        env.remove("KIMCHI_CODING_AGENT_DIR");
 
         let client = ClientId::from_str("kimchi").expect("kimchi client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
             "/tmp/home/.config/kimchi/harness/sessions"
         );
-
-        restore_env("KIMCHI_CODING_AGENT_DIR", previous);
     }
 
     #[test]
     #[serial]
     fn test_kimchi_honors_agent_dir_env_override() {
-        let previous = std::env::var("KIMCHI_CODING_AGENT_DIR").ok();
-        unsafe { std::env::set_var("KIMCHI_CODING_AGENT_DIR", "/custom/kimchi-agent") };
+        let mut env = EnvGuard::capture(&["KIMCHI_CODING_AGENT_DIR"]);
+        env.set("KIMCHI_CODING_AGENT_DIR", "/custom/kimchi-agent");
 
         let client = ClientId::from_str("kimchi").expect("kimchi client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
             "/custom/kimchi-agent/sessions"
         );
-
-        restore_env("KIMCHI_CODING_AGENT_DIR", previous);
     }
 
     #[test]
     #[serial]
     fn test_senpi_defaults_to_home_agent_dir_without_env_override() {
-        let previous = std::env::var("SENPI_CODING_AGENT_DIR").ok();
-        unsafe { std::env::remove_var("SENPI_CODING_AGENT_DIR") };
+        let mut env = EnvGuard::capture(&["SENPI_CODING_AGENT_DIR"]);
+        env.remove("SENPI_CODING_AGENT_DIR");
 
         let client = ClientId::from_str("senpi").expect("senpi client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
             "/tmp/home/.senpi/agent/sessions"
         );
-
-        restore_env("SENPI_CODING_AGENT_DIR", previous);
     }
 
     #[test]
     #[serial]
     fn test_senpi_honors_agent_dir_env_override() {
-        let previous = std::env::var("SENPI_CODING_AGENT_DIR").ok();
-        unsafe { std::env::set_var("SENPI_CODING_AGENT_DIR", "/custom/senpi-agent") };
+        let mut env = EnvGuard::capture(&["SENPI_CODING_AGENT_DIR"]);
+        env.set("SENPI_CODING_AGENT_DIR", "/custom/senpi-agent");
 
         let client = ClientId::from_str("senpi").expect("senpi client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
             "/custom/senpi-agent/sessions"
         );
-
-        restore_env("SENPI_CODING_AGENT_DIR", previous);
     }
 
     #[test]

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -739,13 +739,19 @@ impl Default for ClientCounts {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
+    use serial_test::serial;
 
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
+    // These tests mutate process-global environment variables, so they take
+    // `#[serial]` rather than the private `Mutex` they used to share. The
+    // mutex made them exclusive with each other but not with the rest of the
+    // crate, which serializes on `serial_test` — two disjoint domains over one
+    // set of variables. `test_path_root_config_*` restores its snapshot of
+    // `TOKSCALE_CONFIG_DIR` on the way out, which is a *clear* when the
+    // developer has none set, and that clear landed in the middle of the
+    // pricing cache tests that redirect the same variable: they went on
+    // asserting against a temp path the code was no longer writing to while
+    // the real `~/.config/tokscale/cache` took the write. One domain is the
+    // only arrangement that holds, so nothing here may reintroduce a second.
     fn restore_env(var: &str, previous: Option<String>) {
         match previous {
             Some(value) => unsafe { std::env::set_var(var, value) },
@@ -808,8 +814,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reasonix_stats_prefers_state_home_then_reasonix_home() {
-        let _guard = env_lock().lock().unwrap();
         let state_previous = std::env::var("REASONIX_STATE_HOME").ok();
         let home_previous = std::env::var("REASONIX_HOME").ok();
         unsafe {
@@ -831,8 +837,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reasonix_stats_normalizes_env_roots_and_ignores_blank_values() {
-        let _guard = env_lock().lock().unwrap();
         let state_previous = std::env::var("REASONIX_STATE_HOME").ok();
         let home_previous = std::env::var("REASONIX_HOME").ok();
         let client = ClientId::Reasonix;
@@ -863,8 +869,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reasonix_stats_expands_environment_references_before_normalizing_paths() {
-        let _guard = env_lock().lock().unwrap();
         let state_previous = std::env::var("REASONIX_STATE_HOME").ok();
         let root_previous = std::env::var("TOKSCALE_REASONIX_TEST_ROOT").ok();
         let unset_previous = std::env::var("TOKSCALE_REASONIX_TEST_UNSET").ok();
@@ -903,8 +909,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reasonix_stats_ignores_env_roots_when_requested() {
-        let _guard = env_lock().lock().unwrap();
         let state_previous = std::env::var("REASONIX_STATE_HOME").ok();
         let home_previous = std::env::var("REASONIX_HOME").ok();
         unsafe {
@@ -924,8 +930,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_kimchi_defaults_to_home_agent_dir_without_env_override() {
-        let _guard = env_lock().lock().unwrap();
         let previous = std::env::var("KIMCHI_CODING_AGENT_DIR").ok();
         unsafe { std::env::remove_var("KIMCHI_CODING_AGENT_DIR") };
 
@@ -939,8 +945,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_kimchi_honors_agent_dir_env_override() {
-        let _guard = env_lock().lock().unwrap();
         let previous = std::env::var("KIMCHI_CODING_AGENT_DIR").ok();
         unsafe { std::env::set_var("KIMCHI_CODING_AGENT_DIR", "/custom/kimchi-agent") };
 
@@ -954,8 +960,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_senpi_defaults_to_home_agent_dir_without_env_override() {
-        let _guard = env_lock().lock().unwrap();
         let previous = std::env::var("SENPI_CODING_AGENT_DIR").ok();
         unsafe { std::env::remove_var("SENPI_CODING_AGENT_DIR") };
 
@@ -969,8 +975,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_senpi_honors_agent_dir_env_override() {
-        let _guard = env_lock().lock().unwrap();
         let previous = std::env::var("SENPI_CODING_AGENT_DIR").ok();
         unsafe { std::env::set_var("SENPI_CODING_AGENT_DIR", "/custom/senpi-agent") };
 
@@ -1110,8 +1116,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_path_root_xdg_data_uses_env_var_when_set() {
-        let _guard = env_lock().lock().unwrap();
         let previous = std::env::var("XDG_DATA_HOME").ok();
         unsafe { std::env::set_var("XDG_DATA_HOME", "/tmp/xdg-data-home") };
 
@@ -1122,8 +1128,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_path_root_xdg_data_falls_back_when_unset() {
-        let _guard = env_lock().lock().unwrap();
         let previous = std::env::var("XDG_DATA_HOME").ok();
         unsafe { std::env::remove_var("XDG_DATA_HOME") };
 
@@ -1134,8 +1140,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_path_root_xdg_data_ignores_env_when_disabled() {
-        let _guard = env_lock().lock().unwrap();
         let previous = std::env::var("XDG_DATA_HOME").ok();
         unsafe { std::env::set_var("XDG_DATA_HOME", "/tmp/xdg-data-home") };
 
@@ -1146,8 +1152,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_path_root_config_uses_override_when_set() {
-        let _guard = env_lock().lock().unwrap();
         let previous_override = std::env::var("TOKSCALE_CONFIG_DIR").ok();
         let previous_xdg = std::env::var("XDG_CONFIG_HOME").ok();
         unsafe {
@@ -1164,8 +1170,8 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "linux")]
+    #[serial]
     fn test_path_root_config_uses_xdg_config_home_when_override_unset() {
-        let _guard = env_lock().lock().unwrap();
         let previous_override = std::env::var("TOKSCALE_CONFIG_DIR").ok();
         let previous_xdg = std::env::var("XDG_CONFIG_HOME").ok();
         unsafe {
@@ -1182,13 +1188,13 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "windows")]
+    #[serial]
     fn test_path_root_config_uses_dirs_config_dir_on_windows() {
         // Windows must resolve PathRoot::Config to the same root that
         // paths::get_config_dir() and get_antigravity_cache_dir() use,
         // i.e. dirs::config_dir() (= %APPDATA%\tokscale). Hardcoding
         // {home}/.config/tokscale would diverge from the writer side
         // and silently hide synced Antigravity data from reports.
-        let _guard = env_lock().lock().unwrap();
         let previous_override = std::env::var("TOKSCALE_CONFIG_DIR").ok();
         unsafe {
             std::env::remove_var("TOKSCALE_CONFIG_DIR");
@@ -1209,8 +1215,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_path_root_config_ignores_env_when_disabled() {
-        let _guard = env_lock().lock().unwrap();
         let previous_override = std::env::var("TOKSCALE_CONFIG_DIR").ok();
         let previous_xdg = std::env::var("XDG_CONFIG_HOME").ok();
         unsafe {
@@ -1234,8 +1240,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_path_root_env_var_uses_env_when_set() {
-        let _guard = env_lock().lock().unwrap();
         let var = "TOKSCALE_TEST_PATH_ROOT";
         let previous = std::env::var(var).ok();
         unsafe { std::env::set_var(var, "/tmp/custom-root") };
@@ -1251,8 +1257,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_path_root_env_var_falls_back_when_unset() {
-        let _guard = env_lock().lock().unwrap();
         let var = "TOKSCALE_TEST_PATH_ROOT";
         let previous = std::env::var(var).ok();
         unsafe { std::env::remove_var(var) };
@@ -1268,8 +1274,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_path_root_env_var_ignores_env_when_disabled() {
-        let _guard = env_lock().lock().unwrap();
         let var = "TOKSCALE_TEST_PATH_ROOT";
         let previous = std::env::var(var).ok();
         unsafe { std::env::set_var(var, "/tmp/custom-root") };
@@ -1328,8 +1334,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_gjc_data_dir_path() {
-        let _guard = env_lock().lock().unwrap();
         let var = "GJC_CODING_AGENT_DIR";
         let previous = std::env::var(var).ok();
         // Env unset (cleared): resolves under home/.gjc/agent/sessions.
@@ -1400,8 +1406,8 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_zed_data_dir_path() {
-        let _guard = env_lock().lock().unwrap();
         let previous = std::env::var("XDG_DATA_HOME").ok();
         unsafe { std::env::remove_var("XDG_DATA_HOME") };
 

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -597,6 +597,14 @@ mod tests {
     /// The `starts_with` assertion is what makes that substitution honest; if
     /// the redirect ever stopped taking effect the test would otherwise pass
     /// vacuously while the real cache was still being overwritten.
+    ///
+    /// `#[serial]` is load-bearing for the same reason. `TOKSCALE_CONFIG_DIR`
+    /// is process-global, so a concurrent test that restores its own snapshot
+    /// of it clears this redirect mid-run; the path captured at the top then
+    /// stops being the path the code would write to, and the final assertion
+    /// checks an empty temp dir while the real cache is clobbered. The
+    /// `assert_eq!` after the fetch catches that breach directly instead of
+    /// letting it read as a pass.
     #[tokio::test]
     #[serial]
     async fn a_fetch_with_caching_disabled_writes_no_cache_file() {
@@ -616,6 +624,12 @@ mod tests {
             .await
             .expect("the fixture serves one usable base-priced row");
         assert!(data.contains_key("usable"), "the fetch itself must succeed");
+
+        assert_eq!(
+            cache::get_cache_path(CACHE_FILENAME),
+            cache_path,
+            "the redirect moved while the fetch ran, so the assertion below would check a path the fetch never targeted"
+        );
 
         assert!(
             !cache_path.exists(),

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -276,11 +276,10 @@ pub async fn fetch() -> Result<PricingDataset, String> {
 /// `use_disk_cache` governs BOTH halves of the on-disk cache — the read below
 /// and the write at the end. It used to gate only the read, so a caller that
 /// asked for a fresh fetch still published the result to
-/// `~/.config/tokscale/cache/pricing-litellm.json`. Every test in this module
-/// passes `false` against a local fixture, so `cargo test` replaced the real
-/// multi-thousand-model dataset with a two-row stub for a full TTL, and while
-/// it was clobbered LiteLLM contributed nothing to pricing lookups (#1021,
-/// #1035).
+/// `~/.config/tokscale/cache/pricing-litellm.json`. Any fixture-server test
+/// that fetched successfully therefore published its stub over the real
+/// multi-thousand-model dataset for a full TTL, and while it was clobbered
+/// LiteLLM contributed nothing to pricing lookups (#1021, #1035).
 ///
 /// Gating the write here rather than isolating the tests behind
 /// `TOKSCALE_CONFIG_DIR`: the override is process-global, so it only protects

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -273,8 +273,26 @@ pub async fn fetch() -> Result<PricingDataset, String> {
     fetch_inner(PRICING_URL, true).await
 }
 
-async fn fetch_inner(url: &str, use_cache: bool) -> Result<PricingDataset, String> {
-    if use_cache {
+/// `use_disk_cache` governs BOTH halves of the on-disk cache — the read below
+/// and the write at the end. It used to gate only the read, so a caller that
+/// asked for a fresh fetch still published the result to
+/// `~/.config/tokscale/cache/pricing-litellm.json`. Every test in this module
+/// passes `false` against a local fixture, so `cargo test` replaced the real
+/// multi-thousand-model dataset with a two-row stub for a full TTL, and while
+/// it was clobbered LiteLLM contributed nothing to pricing lookups (#1021,
+/// #1035).
+///
+/// Gating the write here rather than isolating the tests behind
+/// `TOKSCALE_CONFIG_DIR`: the override is process-global, so it only protects
+/// the tests that remember to set it, and the next fixture-server test added
+/// without it silently reintroduces the bug. A flag on the function makes the
+/// opt-out total and local — the caller that declined the cache cannot write to
+/// it by construction. The override still earns its keep in the regression
+/// test, where it is the only way to observe the write without touching the
+/// developer's real cache. No production caller wants read-bypass-with-write:
+/// `fetch()` is the sole one and it passes `true`.
+async fn fetch_inner(url: &str, use_disk_cache: bool) -> Result<PricingDataset, String> {
+    if use_disk_cache {
         if let Some(cached) = load_cached() {
             return Ok(cached);
         }
@@ -290,12 +308,14 @@ async fn fetch_inner(url: &str, use_cache: bool) -> Result<PricingDataset, Strin
     if data.is_empty() {
         return Err("LiteLLM returned no usable pricing rows".to_string());
     }
-    if let Err(e) = cache::save_cache(CACHE_FILENAME, &data) {
-        eprintln!(
-            "[tokscale] Warning: Failed to cache LiteLLM pricing at {}: {}",
-            cache::get_cache_path(CACHE_FILENAME).display(),
-            e
-        );
+    if use_disk_cache {
+        if let Err(e) = cache::save_cache(CACHE_FILENAME, &data) {
+            eprintln!(
+                "[tokscale] Warning: Failed to cache LiteLLM pricing at {}: {}",
+                cache::get_cache_path(CACHE_FILENAME).display(),
+                e
+            );
+        }
     }
     Ok(data)
 }
@@ -303,9 +323,12 @@ async fn fetch_inner(url: &str, use_cache: bool) -> Result<PricingDataset, Strin
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::paths::test_env::EnvGuard;
+    use serial_test::serial;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
+    use tempfile::TempDir;
 
     /// Serve one 200 response whose body is well-formed JSON that does not fit
     /// `PricingDataset` (a string where an f64 is expected) — the shape an
@@ -554,6 +577,50 @@ mod tests {
         assert_eq!(
             pricing.cache_read_input_token_cost_above_272k_tokens,
             Some(0.000001)
+        );
+    }
+
+    /// `use_disk_cache` used to gate only the cache READ while the write ran
+    /// unconditionally, so every fixture-server test in this module wrote its
+    /// two-row fixture over the developer's real
+    /// `~/.config/tokscale/cache/pricing-litellm.json`, evicting the genuine
+    /// multi-thousand-model LiteLLM dataset for a full TTL. A clobbered cache
+    /// contributes nothing to pricing lookups, which is exactly the spurious
+    /// "pricing is unavailable for submitted token usage" submit failure
+    /// reported in #1021 and #1035 — `cargo test` was manufacturing the bug.
+    ///
+    /// The assertion redirects `TOKSCALE_CONFIG_DIR` at a `TempDir` instead of
+    /// probing the developer's home. `cache::get_cache_path` resolves through
+    /// `paths::get_config_dir()` either way, so a write that would have landed
+    /// in the real cache lands in the temp dir here: observable without the
+    /// test depending on — or risking — whatever the developer's home contains.
+    /// The `starts_with` assertion is what makes that substitution honest; if
+    /// the redirect ever stopped taking effect the test would otherwise pass
+    /// vacuously while the real cache was still being overwritten.
+    #[tokio::test]
+    #[serial]
+    async fn a_fetch_with_caching_disabled_writes_no_cache_file() {
+        let temp_config = TempDir::new().unwrap();
+        let mut env = EnvGuard::capture(&["TOKSCALE_CONFIG_DIR"]);
+        env.set("TOKSCALE_CONFIG_DIR", temp_config.path());
+
+        let cache_path = cache::get_cache_path(CACHE_FILENAME);
+        assert!(
+            cache_path.starts_with(temp_config.path()),
+            "the config-dir redirect must be in effect or this test proves nothing: {}",
+            cache_path.display()
+        );
+
+        let url = pricing_server(r#"{"usable":{"input_cost_per_token":0.000005}}"#);
+        let data = fetch_inner(&url, false)
+            .await
+            .expect("the fixture serves one usable base-priced row");
+        assert!(data.contains_key("usable"), "the fetch itself must succeed");
+
+        assert!(
+            !cache_path.exists(),
+            "a fetch that opted out of the cache must not write it, but {} was created",
+            cache_path.display()
         );
     }
 }

--- a/crates/tokscale-core/src/pricing/models_dev.rs
+++ b/crates/tokscale-core/src/pricing/models_dev.rs
@@ -214,6 +214,11 @@ mod tests {
             data.contains_key("anthropic/claude"),
             "the fetch itself must succeed"
         );
+        assert_eq!(
+            cache::get_cache_path(CACHE_FILENAME),
+            cache_path,
+            "the redirect moved while the fetch ran, so the assertion below would check a path the fetch never targeted"
+        );
 
         assert!(
             !cache_path.exists(),

--- a/crates/tokscale-core/src/pricing/models_dev.rs
+++ b/crates/tokscale-core/src/pricing/models_dev.rs
@@ -46,8 +46,11 @@ pub async fn fetch() -> Result<PricingDataset, String> {
     fetch_inner(MODELS_DEV_URL, true).await
 }
 
-async fn fetch_inner(url: &str, use_cache: bool) -> Result<PricingDataset, String> {
-    if use_cache {
+/// `use_disk_cache` governs both the read below and the write at the end. See
+/// the same function in `litellm.rs` for why the write is gated on the caller's
+/// flag rather than on tests remembering to redirect `TOKSCALE_CONFIG_DIR`.
+async fn fetch_inner(url: &str, use_disk_cache: bool) -> Result<PricingDataset, String> {
+    if use_disk_cache {
         if let Some(cached) = load_cached() {
             return Ok(cached);
         }
@@ -61,12 +64,14 @@ async fn fetch_inner(url: &str, use_cache: bool) -> Result<PricingDataset, Strin
     if data.is_empty() {
         return Err("models.dev returned no usable pricing rows".to_string());
     }
-    if let Err(e) = cache::save_cache(CACHE_FILENAME, &data) {
-        eprintln!(
-            "[tokscale] Warning: Failed to cache models.dev pricing at {}: {}",
-            cache::get_cache_path(CACHE_FILENAME).display(),
-            e
-        );
+    if use_disk_cache {
+        if let Err(e) = cache::save_cache(CACHE_FILENAME, &data) {
+            eprintln!(
+                "[tokscale] Warning: Failed to cache models.dev pricing at {}: {}",
+                cache::get_cache_path(CACHE_FILENAME).display(),
+                e
+            );
+        }
     }
     Ok(data)
 }
@@ -111,9 +116,12 @@ fn per_token(value: f64) -> Option<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::paths::test_env::EnvGuard;
+    use serial_test::serial;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
+    use tempfile::TempDir;
 
     fn retryable_status_server(status_line: &'static str) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -174,5 +182,43 @@ mod tests {
 
         let empty = fetch_inner(&response_server("{}"), false).await;
         assert!(empty.unwrap_err().contains("no usable pricing rows"));
+    }
+
+    /// models.dev carried the same defect as LiteLLM: `use_disk_cache` gated
+    /// only the read, so `malformed_and_empty_datasets_are_fetch_errors` above
+    /// was one successful-parse fixture away from overwriting the developer's
+    /// real `pricing-models-dev.json`. See the sibling test in `litellm.rs` for
+    /// why the assertion redirects `TOKSCALE_CONFIG_DIR` rather than probing
+    /// the developer's home directory.
+    #[tokio::test]
+    #[serial]
+    async fn a_fetch_with_caching_disabled_writes_no_cache_file() {
+        let temp_config = TempDir::new().unwrap();
+        let mut env = EnvGuard::capture(&["TOKSCALE_CONFIG_DIR"]);
+        env.set("TOKSCALE_CONFIG_DIR", temp_config.path());
+
+        let cache_path = cache::get_cache_path(CACHE_FILENAME);
+        assert!(
+            cache_path.starts_with(temp_config.path()),
+            "the config-dir redirect must be in effect or this test proves nothing: {}",
+            cache_path.display()
+        );
+
+        let url = response_server(
+            r#"{"anthropic":{"models":{"claude":{"cost":{"input":3,"output":15}}}}}"#,
+        );
+        let data = fetch_inner(&url, false)
+            .await
+            .expect("the fixture serves one priced model");
+        assert!(
+            data.contains_key("anthropic/claude"),
+            "the fetch itself must succeed"
+        );
+
+        assert!(
+            !cache_path.exists(),
+            "a fetch that opted out of the cache must not write it, but {} was created",
+            cache_path.display()
+        );
     }
 }

--- a/crates/tokscale-core/src/pricing/openrouter.rs
+++ b/crates/tokscale-core/src/pricing/openrouter.rs
@@ -6,7 +6,13 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 
 const CACHE_FILENAME: &str = "pricing-openrouter.json";
-const MODELS_URL: &str = "https://openrouter.ai/api/v1/models";
+/// Root of the OpenRouter REST API. Both requests this module makes — the
+/// model list and the per-model endpoint lookup — are built from this one
+/// value so a test can point the whole fetch at a local fixture server. The
+/// per-model URL used to be hardcoded, which left the author-pricing leg
+/// unreachable offline: any test that got far enough to exercise it made a
+/// real request to openrouter.ai.
+const API_BASE: &str = "https://openrouter.ai/api/v1";
 const MAX_CONCURRENT_REQUESTS: usize = 10;
 
 /// Structs for `/api/v1/models` endpoint (list all models).
@@ -99,6 +105,7 @@ fn parse_price(s: &str) -> Option<f64> {
 
 async fn fetch_author_pricing(
     client: Arc<reqwest::Client>,
+    api_base: Arc<String>,
     model_id: String,
     semaphore: Arc<Semaphore>,
     fallback_pricing: Option<ModelPricing>,
@@ -110,7 +117,7 @@ async fn fetch_author_pricing(
         None => return fallback_pricing.map(|p| (model_id, p)),
     };
 
-    let url = format!("https://openrouter.ai/api/v1/models/{}/endpoints", model_id);
+    let url = format!("{}/models/{}/endpoints", api_base, model_id);
 
     let response = match client
         .get(&url)
@@ -227,21 +234,23 @@ fn published_cache_rates(pricing: &ModelPricing) -> usize {
 
 /// Fetch all models and get author pricing for each
 pub async fn fetch_all_models() -> Result<HashMap<String, ModelPricing>, String> {
-    fetch_all_models_from_url(MODELS_URL, true).await
+    fetch_all_models_from_api_base(API_BASE, true).await
 }
 
-async fn fetch_all_models_from_url(
-    models_url: &str,
-    use_cache: bool,
+async fn fetch_all_models_from_api_base(
+    api_base: &str,
+    use_disk_cache: bool,
 ) -> Result<HashMap<String, ModelPricing>, String> {
-    if use_cache {
+    if use_disk_cache {
         if let Some(cached) = load_cached() {
             return Ok(cached);
         }
     }
 
+    let api_base = Arc::new(api_base.to_string());
+    let models_url = format!("{api_base}/models");
     let client = Arc::new(fetch::pricing_client()?);
-    let response = fetch::get_with_retry(&client, models_url, "OpenRouter").await?;
+    let response = fetch::get_with_retry(&client, &models_url, "OpenRouter").await?;
     let data: ModelsListResponse = response.json().await.map_err(|error| {
         format!(
             "OpenRouter models JSON parse failed: {}",
@@ -282,12 +291,12 @@ async fn fetch_all_models_from_url(
 
     for (model_id, fallback) in models_with_authors {
         let client = Arc::clone(&client);
+        let api_base = Arc::clone(&api_base);
         let sem = Arc::clone(&semaphore);
 
-        let handle =
-            tokio::spawn(
-                async move { fetch_author_pricing(client, model_id, sem, fallback).await },
-            );
+        let handle = tokio::spawn(async move {
+            fetch_author_pricing(client, api_base, model_id, sem, fallback).await
+        });
 
         handles.push(handle);
     }
@@ -301,7 +310,11 @@ async fn fetch_all_models_from_url(
         }
     }
 
-    if !result.is_empty() {
+    // `use_disk_cache` gates the write as well as the read above. See
+    // `litellm::fetch_inner` for why the caller's opt-out, not a
+    // `TOKSCALE_CONFIG_DIR` redirect in each test, is what keeps a fixture
+    // fetch out of the user's real cache.
+    if use_disk_cache && !result.is_empty() {
         if let Err(e) = cache::save_cache(CACHE_FILENAME, &result) {
             eprintln!(
                 "[tokscale] Warning: Failed to cache OpenRouter pricing at {}: {}",
@@ -325,9 +338,12 @@ pub async fn fetch_all_mapped() -> Result<HashMap<String, ModelPricing>, String>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::paths::test_env::EnvGuard;
+    use serial_test::serial;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
+    use tempfile::TempDir;
 
     fn response_server(status: &'static str, body: &'static str, requests: usize) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -485,15 +501,86 @@ mod tests {
     #[tokio::test]
     async fn list_status_and_decode_failures_remain_explicit() {
         let status = response_server("HTTP/1.1 503 Service Unavailable", "", 3);
-        assert!(fetch_all_models_from_url(&status, false)
+        assert!(fetch_all_models_from_api_base(&status, false)
             .await
             .unwrap_err()
             .contains("HTTP 503"));
 
         let malformed = response_server("HTTP/1.1 200 OK", "not json", 1);
-        assert!(fetch_all_models_from_url(&malformed, false)
+        assert!(fetch_all_models_from_api_base(&malformed, false)
             .await
             .unwrap_err()
             .contains("JSON parse failed"));
+    }
+
+    /// Serve the two request shapes a full OpenRouter fetch makes, dispatching
+    /// on the path so the author-pricing leg is answered locally instead of
+    /// reaching openrouter.ai. `response_server` above cannot do this: it
+    /// replays one fixed body for every connection.
+    fn openrouter_api_server(models_body: &'static str, endpoints_body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        thread::spawn(move || {
+            while let Ok((mut stream, _)) = listener.accept() {
+                let mut buffer = [0; 1024];
+                let read = stream.read(&mut buffer).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buffer[..read]).to_string();
+                let body = if request.contains("/endpoints") {
+                    endpoints_body
+                } else {
+                    models_body
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        url
+    }
+
+    /// OpenRouter carried the same defect as LiteLLM and models.dev: the write
+    /// was gated only on `!result.is_empty()`, never on the caller's opt-out,
+    /// so a successful fixture fetch overwrote the developer's real
+    /// `pricing-openrouter.json`. No existing test reached the write — the two
+    /// cases above both fail before it — which is precisely why the module
+    /// needs its own proof rather than inheriting confidence from its siblings.
+    ///
+    /// See the sibling test in `litellm.rs` for why the assertion redirects
+    /// `TOKSCALE_CONFIG_DIR` rather than probing the developer's home.
+    #[tokio::test]
+    #[serial]
+    async fn a_fetch_with_caching_disabled_writes_no_cache_file() {
+        let temp_config = TempDir::new().unwrap();
+        let mut env = EnvGuard::capture(&["TOKSCALE_CONFIG_DIR"]);
+        env.set("TOKSCALE_CONFIG_DIR", temp_config.path());
+
+        let cache_path = cache::get_cache_path(CACHE_FILENAME);
+        assert!(
+            cache_path.starts_with(temp_config.path()),
+            "the config-dir redirect must be in effect or this test proves nothing: {}",
+            cache_path.display()
+        );
+
+        // `anthropic/` maps to a known author, so this model survives the
+        // author filter and drives the endpoints request the fixture answers.
+        let url = openrouter_api_server(
+            r#"{"data":[{"id":"anthropic/claude","pricing":{"prompt":"0.000003","completion":"0.000015"}}]}"#,
+            r#"{"data":{"id":"anthropic/claude","endpoints":[{"provider_name":"Anthropic","pricing":{"prompt":"0.000003","completion":"0.000015"}}]}}"#,
+        );
+        let data = fetch_all_models_from_api_base(&url, false)
+            .await
+            .expect("the fixture serves one priced model");
+        assert!(
+            data.contains_key("anthropic/claude"),
+            "the fetch itself must succeed, otherwise the write is skipped for the wrong reason"
+        );
+
+        assert!(
+            !cache_path.exists(),
+            "a fetch that opted out of the cache must not write it, but {} was created",
+            cache_path.display()
+        );
     }
 }

--- a/crates/tokscale-core/src/pricing/openrouter.rs
+++ b/crates/tokscale-core/src/pricing/openrouter.rs
@@ -576,6 +576,11 @@ mod tests {
             data.contains_key("anthropic/claude"),
             "the fetch itself must succeed, otherwise the write is skipped for the wrong reason"
         );
+        assert_eq!(
+            cache::get_cache_path(CACHE_FILENAME),
+            cache_path,
+            "the redirect moved while the fetch ran, so the assertion below would check a path the fetch never targeted"
+        );
 
         assert!(
             !cache_path.exists(),

--- a/crates/tokscale-core/src/pricing/openrouter.rs
+++ b/crates/tokscale-core/src/pricing/openrouter.rs
@@ -524,11 +524,18 @@ mod tests {
     /// on the path so the author-pricing leg is answered locally instead of
     /// reaching openrouter.ai. `response_server` above cannot do this: it
     /// replays one fixed body for every connection.
+    ///
+    /// Bounded to the two requests a single fetch makes so the thread and its
+    /// listening socket are released when the test ends, rather than parking
+    /// on `accept` for the life of the test process.
     fn openrouter_api_server(models_body: &'static str, endpoints_body: &'static str) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let url = format!("http://{}", listener.local_addr().unwrap());
         thread::spawn(move || {
-            while let Ok((mut stream, _)) = listener.accept() {
+            for _ in 0..2 {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    return;
+                };
                 let mut buffer = [0; 1024];
                 let read = stream.read(&mut buffer).unwrap_or(0);
                 let request = String::from_utf8_lossy(&buffer[..read]).to_string();
@@ -572,16 +579,26 @@ mod tests {
 
         // `anthropic/` maps to a known author, so this model survives the
         // author filter and drives the endpoints request the fixture answers.
+        //
+        // The endpoint quotes a different prompt price than the model list on
+        // purpose. `fetch_author_pricing` falls back to the listed price on any
+        // endpoints failure, so a fixture that quoted the same number on both
+        // legs would pass even if the endpoints request had gone to
+        // openrouter.ai and failed — which is precisely the regression
+        // `API_BASE` exists to prevent. Asserting the endpoint's distinct rate
+        // won makes that leg observable.
         let url = openrouter_api_server(
             r#"{"data":[{"id":"anthropic/claude","pricing":{"prompt":"0.000003","completion":"0.000015"}}]}"#,
-            r#"{"data":{"id":"anthropic/claude","endpoints":[{"provider_name":"Anthropic","pricing":{"prompt":"0.000003","completion":"0.000015"}}]}}"#,
+            r#"{"data":{"id":"anthropic/claude","endpoints":[{"provider_name":"Anthropic","pricing":{"prompt":"0.000009","completion":"0.000015"}}]}}"#,
         );
         let data = fetch_all_models_from_api_base(&url, false)
             .await
             .expect("the fixture serves one priced model");
-        assert!(
-            data.contains_key("anthropic/claude"),
-            "the fetch itself must succeed, otherwise the write is skipped for the wrong reason"
+        assert_eq!(
+            data.get("anthropic/claude")
+                .and_then(|pricing| pricing.input_cost_per_token),
+            Some(9e-6),
+            "the local endpoints fixture must have served the author-pricing leg; the listed 3e-6 means it fell back, so this test would no longer catch a hardcoded URL"
         );
         assert_eq!(
             cache::get_cache_path(CACHE_FILENAME),

--- a/crates/tokscale-core/src/pricing/openrouter.rs
+++ b/crates/tokscale-core/src/pricing/openrouter.rs
@@ -12,6 +12,13 @@ const CACHE_FILENAME: &str = "pricing-openrouter.json";
 /// per-model URL used to be hardcoded, which left the author-pricing leg
 /// unreachable offline: any test that got far enough to exercise it made a
 /// real request to openrouter.ai.
+///
+/// Do not reintroduce a literal URL for either request.
+/// `a_fetch_with_caching_disabled_writes_no_cache_file` reaches the
+/// author-pricing leg on purpose — that is the only path that populates
+/// `result`, and therefore the only one that can reach the cache write the
+/// test guards. Hardcoding that URL again would not fail the test; it would
+/// make `cargo test` call openrouter.ai for real on every run.
 const API_BASE: &str = "https://openrouter.ai/api/v1";
 const MAX_CONCURRENT_REQUESTS: usize = 10;
 


### PR DESCRIPTION
## The bug

`fetch_inner(url, use_cache)` gates only the cache **read** on `use_cache`. The **write** always runs:

```rust
async fn fetch_inner(url: &str, use_cache: bool) -> Result<PricingDataset, String> {
    if use_cache {
        if let Some(cached) = load_cached() { return Ok(cached); }
    }
    ...
    if let Err(e) = cache::save_cache(CACHE_FILENAME, &data) { ... }   // unconditional
```

So every test that calls `fetch_inner(&url, false)` against a local fixture server writes its fixture into the developer's real `~/.config/tokscale/cache/`.

Observed on my own machine. The test `tier_only_rows_are_removed_from_an_otherwise_usable_response` serves a two-row fixture, and my real LiteLLM cache became exactly that — 710 bytes, one junk entry, replacing the genuine 2,986-model dataset:

```json
{"timestamp":1785865091,"data":{"usable":{"input_cost_per_token":5e-6, ...all nulls}}}
```

## Why it matters beyond tidiness

While clobbered, LiteLLM contributes **nothing** to pricing lookups. That is one of the upstream causes of the spurious "pricing is unavailable for submitted token usage" failures in #1021 and #1035 — any contributor or CI job that runs `cargo test` silently destroys their own pricing data until the TTL expires.

It also actively corrupted a diagnosis during this work: a probe of reported model ids returned different results on two consecutive runs, because sibling `cargo test` processes were overwriting the cache mid-probe. The conclusions only stabilised after isolating the config dir.

## What changed

The cache write now respects the same flag as the read, in all three pricing sources. Production fetches are untouched — `litellm::fetch()`, `models_dev::fetch()` and `openrouter::fetch_all_models()` all pass `true` and read and write the cache exactly as before.

**No pricing value changes anywhere.** No model gains, loses, or alters a rate. This affects only whether a fetch result is persisted.

`models_dev.rs` and `openrouter.rs` were audited for the same pattern and had it; `cache.rs` and `paths.rs` were audited and were clean.

The `API_BASE` constant in `openrouter.rs` is load-bearing, not cosmetic: `fetch_author_pricing` previously hardcoded the per-model endpoints URL, so with the model list served from a fixture the new test would still have made a live request to openrouter.ai per model on every `cargo test` run. The composed URLs are byte-identical to the previous values.

## Tests

One per module (`a_fetch_with_caching_disabled_writes_no_cache_file`), each redirecting `TOKSCALE_CONFIG_DIR` at a fresh `TempDir` so it never depends on the developer's home, and each asserting the redirect is actually in effect before asserting the file was not created — so it cannot pass vacuously.

All three were run against the unfixed code first and failed with the real message, e.g.:

```
a fetch that opted out of the cache must not write it, but
/var/folders/.../cache/pricing-models-dev.json was created
```

They are serialized, because `TOKSCALE_CONFIG_DIR` is process-global and `sandbox_cache_env()` in `message_cache.rs` does `remove_var` on it — without serialization a concurrent test could clear the redirect mid-test and let these pass against unfixed code.

Whole-suite proof, with the process pointed at an empty scratch config dir:

```
$ TOKSCALE_CONFIG_DIR=/tmp/tokscale-cache-probe cargo test -p tokscale-core --lib pricing::
test result: ok. 292 passed; 0 failed
$ find /tmp/tokscale-cache-probe -type f | wc -l
       0
```

`cargo fmt`, `cargo clippy -D warnings`, `cargo test -p tokscale-core` clean.

## Known, deliberately out of scope

The same class of bug survives one directory over: running the full suite still writes 57 files into the real cache — `source-message-cache-v2/**/shard-*.bin` plus the lock file. That is the message cache, not pricing, and it wants its own lane. Reproduce with `TOKSCALE_CONFIG_DIR=/tmp/probe cargo test -p tokscale-core` and count files under the probe dir.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop pricing fetches from writing to disk when callers opt out of caching, preventing tests from clobbering users’ `~/.config/tokscale/cache` and reducing intermittent “pricing unavailable” errors. OpenRouter requests now derive from a single `API_BASE`, keeping tests fully offline without changing production behavior.

- **Bug Fixes**
  - Gate disk cache writes behind the same flag as reads in `litellm`, `models_dev`, and `openrouter` so `use_disk_cache = false` never writes `pricing-*.json`.
  - Add regression tests per module that sandbox `TOKSCALE_CONFIG_DIR` and assert no cache file is created; the OpenRouter test now proves the author-pricing leg ran by serving distinct list vs endpoint prices via a per-path fixture server.
  - Eliminates cache corruption that led to spurious “pricing is unavailable for submitted token usage” failures (e.g., #1021, #1035).

- **Refactors**
  - OpenRouter requests are built from `API_BASE` (models list and per-model endpoints) to keep author-pricing tests offline; URLs are byte-identical in prod.
  - Use `serial_test` for env-mutating tests, remove the private mutex in `clients.rs`, and restore through an `EnvGuard` to avoid races and env leaks on panic.

<sup>Written for commit 53b177c23ed79e13828d20e8d2f56b910fee7cec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

