### PR TITLE
fix(claude): drop tool results that inherit the `<synthetic>` placeholder

### DIFF
--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -1018,10 +1018,18 @@ fn extract_claude_tool_result_message(
         // model-less result after a local synthetic notice rather than emit
         // another unpriceable `provider/unknown` estimate.
         None if context.suppress_unattributed => return None,
-        None => context
-            .last_model
-            .map(str::to_string)
-            .unwrap_or_else(|| "unknown".to_string()),
+        // A tool result inherits the preceding assistant model. That carrier can
+        // still be Claude Code's local `<synthetic>` notice when the placeholder
+        // arrived in a different transcript (a subagent sidechain resets the
+        // per-file suppression flag), so re-check the inherited value instead of
+        // trusting `suppress_unattributed` alone. Without this, the placeholder
+        // becomes a `model_id` carrying a char-based estimate and submission
+        // fails with "pricing is unavailable for submitted token usage".
+        None => match context.last_model {
+            Some(model) if is_claude_synthetic_placeholder_model(model) => return None,
+            Some(model) => model.to_string(),
+            None => "unknown".to_string(),
+        },
     };
     let provider_hint = provider_hint
         .or_else(|| context.last_provider_hint.map(str::to_string))
@@ -2347,6 +2355,41 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].model_id, "claude-sonnet-4-6");
         assert_eq!(messages[0].tokens.input, 4);
+    }
+
+    #[test]
+    fn test_inherited_synthetic_model_does_not_price_a_tool_result() {
+        // A `<synthetic>` notice that is not immediately followed by the tool
+        // result in the same transcript still leaves the placeholder as the
+        // inherited carrier model. The estimate must be dropped rather than
+        // emitted as `unknown/<synthetic>`, which submission rejects as
+        // unpriceable usage.
+        let context = ClaudeToolResultContext {
+            entry: &ClaudeEntry {
+                entry_type: "user".to_string(),
+                timestamp: Some("2026-05-30T01:00:00.000Z".to_string()),
+                message: None,
+                request_id: None,
+                is_sidechain: false,
+                agent_id: None,
+                session_id: None,
+                provider_id: None,
+            },
+            last_model: Some("<synthetic>"),
+            last_provider_hint: None,
+            client_id: "claude",
+            default_provider_hint: None,
+            session_id: "session",
+            fallback_timestamp: 1_782_259_200_000,
+            workspace_key: None,
+            workspace_label: None,
+            sidechain_agent: None,
+            suppress_unattributed: false,
+            allow_char_estimate: true,
+        };
+        let raw = r#"{"type":"user","timestamp":"2026-05-30T01:00:00.000Z","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"XXXXXXXXXXXXXXXX"}]}}"#;
+
+        assert!(extract_claude_tool_result_message(raw, context).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`tokscale submit` fails for a full-history submit with:

```
Error: pricing is unavailable for submitted token usage: unknown/<synthetic>, unknown/<synthetic>
```

Claude Code writes local notices — API errors, expired-SSO warnings, and `"No response requested."` replies to slash commands — as assistant messages with `model: "<synthetic>"` and all-zero usage. These are not API usage.

A tool result carries no model of its own, so it inherits `last_model`. In `extract_claude_tool_result_message`, the *explicit* model is guarded against the placeholder and `suppress_unattributed` is honored, but the `None` fallback took `context.last_model` **unchecked**:

```rust
None => context
    .last_model
    .map(str::to_string)
    .unwrap_or_else(|| "unknown".to_string()),
```

When the placeholder reaches that fallback without the per-file suppression flag set, the tool result is emitted with `model_id = "<synthetic>"` plus a char-based token estimate (`extract_tool_result_input_tokens`). `validate_priced_messages` then correctly rejects it as unpriceable, and the whole submission is blocked.

Notably the affected rows are **fabricated during parsing** — every `<synthetic>` record in the source transcripts has zero tokens. On my machine, all 158 of them do.

## Why it is easy to miss

The bad row only surfaces on an unfiltered submit. Every date-scoped submit succeeded while plain `tokscale submit` failed, which makes it look like a backend/pricing problem rather than a parser one:

```
--today / --yesterday / --week / --month  ->  OK
--year 2026                               ->  Error
(bisected to two single days, one row each)
```

The three existing `test_synthetic_notice_*` tests all place the notice and the tool result in the same transcript, where `suppress_unattributed_tool_results` catches it — so this fallback path was uncovered.

## Fix

Re-check the inherited model against `is_claude_synthetic_placeholder_model`, matching the four other call sites that already guard it (lines ~604, ~1015, ~1411, ~1639). The placeholder never represents billable usage, so dropping the estimate — rather than pricing it or renaming it — is the consistent behavior. This mirrors the existing cache-side repair `remove_synthetic_placeholder_messages`, which already strips these rows from warm cache entries; the cold-parse path simply lacked the equivalent guard.

## Testing

- Added `test_inherited_synthetic_model_does_not_price_a_tool_result`, which drives the exact fallback (`last_model = Some("<synthetic>")`, `suppress_unattributed = false`). **Verified it fails without the fix and passes with it.**
- `cargo test -p tokscale-core --lib` — 1475 passed, 0 failed.
- `cargo clippy --locked -p tokscale-core --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- End-to-end against a real history that previously could not submit at all:

```
Before:  Error: pricing is unavailable for submitted token usage: unknown/<synthetic>, unknown/<synthetic>
After:   Date range: 2026-05-18 to 2026-08-04
         Active days: 72
         Total tokens: 15,581,607,258
         Clients: claude, opencode
         Models: 9 models
         Dry run - not submitting data.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `tokscale submit` failures on full-history runs by dropping Claude tool results that inherit the `<synthetic>` placeholder. Stops emitting unpriceable `unknown/<synthetic>` rows.

- **Bug Fixes**
  - In `extract_claude_tool_result_message`, re-check inherited `last_model`; if `<synthetic>`, skip the message. Matches other guards and cache-side `remove_synthetic_placeholder_messages`.
  - Added a unit test for the inherited placeholder path; suite passes and full-history submit now succeeds.

<sup>Written for commit 6f51421cc541ca5790c0417b9e17fb0534230427. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

