### PR TITLE
fix(windows): repair the Windows test leg and the three product bugs it was hiding (52 → 0)

### DIFF
--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -6,6 +6,10 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "CLI and TUI for tokscale - AI token usage analytics"
+# `src/bin/fake_codex.rs` is a second binary (a test stand-in for the `codex`
+# CLI, see its module docs), so `cargo run -p tokscale-cli` would otherwise be
+# ambiguous — which `build-native.yml` relies on for the Android smoke step.
+default-run = "tokscale"
 
 [[bin]]
 name = "tokscale"

--- a/crates/tokscale-cli/src/bin/fake_codex.rs
+++ b/crates/tokscale-cli/src/bin/fake_codex.rs
@@ -1,0 +1,50 @@
+//! A stand-in for the `codex` binary, used by the `headless_capture_*` tests in
+//! `tests/cli_tests.rs`.
+//!
+//! Those tests assert three things about `tokscale headless <command>`: that the
+//! child's exit code is passed through verbatim, that a fast-exiting child is
+//! not waited on until the timeout, and that a hung child is killed and reported
+//! as 124. None of that is platform-specific — `run_capture_command` is ordinary
+//! `std::process` code — so the coverage is worth having everywhere.
+//!
+//! The fixture used to be a `#!/bin/sh` script written at test time, which is
+//! the one part that could not cross platforms: Windows has no shebang, and
+//! `Command::new("codex")` there resolves a bare program name by appending
+//! `.exe` only, so an extensionless file is never even probed. Building the
+//! stand-in as a real binary lets cargo produce a native executable on each
+//! platform, and the test copies it onto PATH under the name the production code
+//! looks for.
+//!
+//! Behaviour is selected with `TOKSCALE_FAKE_CODEX_MODE` and must match the sh
+//! script it replaces, in particular writing `captured ok` / `captured fail`
+//! with **no trailing newline** — the tests compare stdout byte for byte.
+
+use std::io::Write;
+
+fn emit(text: &str) {
+    let mut stdout = std::io::stdout();
+    // `print!` alone would leave this in the buffer, and `process::exit` does
+    // not run stdout's flush-on-drop.
+    write!(stdout, "{text}").expect("failed to write to stdout");
+    stdout.flush().expect("failed to flush stdout");
+}
+
+fn main() {
+    let mode = std::env::var("TOKSCALE_FAKE_CODEX_MODE").unwrap_or_default();
+
+    match mode.as_str() {
+        "success" => emit("captured ok"),
+        "fail" => {
+            emit("captured fail");
+            std::process::exit(17);
+        }
+        // Longer than the 10s `TOKSCALE_NATIVE_TIMEOUT_MS` the tests set, so the
+        // parent's timeout always wins. The parent kills this process; it is not
+        // expected to reach the end of the sleep.
+        "slow" => std::thread::sleep(std::time::Duration::from_secs(20)),
+        _ => {
+            eprintln!("unknown TOKSCALE_FAKE_CODEX_MODE");
+            std::process::exit(2);
+        }
+    }
+}

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -747,6 +747,14 @@ fn settings_json_path(base: &Path) -> std::path::PathBuf {
 /// forward slashes. There was no native-separator contract to preserve, only
 /// two spellings of the same path, so match the one the binary actually
 /// emits.
+///
+/// That does make this helper a pin on the mixed spelling: `clients --json`
+/// prints `C:\Users\me/.codex/sessions` in `sessionsPath` and
+/// `additionalPaths[].path`, and the two assertions below now hold it there.
+/// The pin is deliberate but not an endorsement — whether user-facing path
+/// output should be normalized, and to native or to forward separators, is a
+/// product decision tracked in junhoyeo/tokscale#1048. Changing the emitter
+/// means changing this helper in the same commit.
 fn client_scan_path(home: &Path, relative: &str) -> String {
     format!("{}/{}", home.display(), relative)
 }

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3,7 +3,10 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use std::path::Path;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
+// Only the unix-only `headless_capture_*` tests time anything.
+#[cfg(unix)]
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 // ── Fixture helpers ────────────────────────────────────────────────────────
@@ -121,6 +124,18 @@ fn create_temp_fixture_dir() -> TempDir {
     create_temp_fixture_dir_with_pricing_cache(true)
 }
 
+/// The three `headless_capture_*` tests below stand up a fake `codex` on PATH
+/// and are unix-only because the fake is a `#!/bin/sh` script.
+///
+/// Windows has no shebang: `CreateProcess` will not run a `codex` with no
+/// extension, so the child reports `Failed to spawn 'codex': program not
+/// found` and the assertions are about the harness rather than about headless
+/// capture. It is the fixture that cannot cross over, not the feature — a
+/// Windows shim would need a `.cmd` whose slow arm blocks for twenty seconds
+/// and whose kill semantics match what `TOKSCALE_NATIVE_TIMEOUT_MS` expects,
+/// and none of that can be verified from a Unix host. Left as a gap rather
+/// than guessed at, so headless capture stays uncovered on Windows.
+#[cfg(unix)]
 fn create_fake_codex_bin() -> TempDir {
     let tmp = TempDir::new().expect("failed to create fake codex dir");
     let codex_path = tmp.path().join("codex");
@@ -159,6 +174,7 @@ esac
     tmp
 }
 
+#[cfg(unix)]
 fn headless_capture_command(fake_bin: &Path, output_path: &Path, mode: &str) -> Command {
     let mut cmd = cargo_bin_cmd!("tokscale");
     let path = std::env::var_os("PATH").unwrap_or_default();
@@ -183,6 +199,7 @@ fn headless_capture_command(fake_bin: &Path, output_path: &Path, mode: &str) -> 
 }
 
 #[test]
+#[cfg(unix)]
 fn headless_capture_fast_success_does_not_wait_for_timeout() {
     let fake_bin = create_fake_codex_bin();
     let output_path = fake_bin.path().join("success.jsonl");
@@ -201,6 +218,7 @@ fn headless_capture_fast_success_does_not_wait_for_timeout() {
 }
 
 #[test]
+#[cfg(unix)]
 fn headless_capture_fast_nonzero_preserves_exit_code() {
     let fake_bin = create_fake_codex_bin();
     let output_path = fake_bin.path().join("fail.jsonl");
@@ -220,6 +238,7 @@ fn headless_capture_fast_nonzero_preserves_exit_code() {
 }
 
 #[test]
+#[cfg(unix)]
 fn headless_capture_slow_command_times_out() {
     let fake_bin = create_fake_codex_bin();
     let output_path = fake_bin.path().join("slow.jsonl");
@@ -251,6 +270,7 @@ fn create_empty_fixture_dir() -> TempDir {
     tmp
 }
 
+#[cfg(unix)]
 fn create_timezone_boundary_fixture_dir() -> TempDir {
     let tmp = TempDir::new().expect("failed to create temp dir");
     let base = tmp.path();
@@ -298,6 +318,7 @@ fn create_timezone_boundary_fixture_dir() -> TempDir {
     tmp
 }
 
+#[cfg(unix)]
 fn create_positive_utc_offset_submit_fixture_dir() -> (TempDir, String) {
     let tmp = TempDir::new().expect("failed to create temp dir");
     let base = tmp.path();
@@ -1434,7 +1455,10 @@ fn test_models_with_no_matching_date() {
     );
 }
 
+/// Unix-only: the premise is a host in `America/Los_Angeles`, and `TZ` does not
+/// move `chrono::Local` on Windows. See `graph_day_buckets` for the full note.
 #[test]
+#[cfg(unix)]
 fn test_graph_single_day_filter_uses_local_timezone_boundaries() {
     let tmp = create_timezone_boundary_fixture_dir();
     let output = cmd_with_home(tmp.path())
@@ -1811,7 +1835,11 @@ fn test_submit_cursor_explicit_missing_cache_reports_setup_warning_text() {
         .stderr(predicate::str::contains("tokscale cursor login"));
 }
 
+/// Unix-only: the fixture's expected date is UTC+1 day, which only holds if the
+/// child really runs in `Pacific/Kiritimati`. `TZ` does not move
+/// `chrono::Local` on Windows — see the note on `graph_day_buckets`.
 #[test]
+#[cfg(unix)]
 fn test_submit_dry_run_preserves_local_date_ahead_of_utc() {
     let (tmp, expected_local_date) = create_positive_utc_offset_submit_fixture_dir();
 
@@ -3855,6 +3883,24 @@ fn pin_bucket_timezone_field(base: &Path, json_value: &str) {
 
 /// Day buckets that actually carry messages, as `(date, message_count)`.
 /// The graph zero-fills a calendar, so the empty days carry no signal.
+///
+/// # Why the `TZ`-driven tests below are unix-only
+///
+/// Passing `TZ` to the child moves `chrono::Local` on Unix and does nothing on
+/// Windows, where `Local` reads `GetTimeZoneInformation` — the machine's zone,
+/// which no environment variable overrides. A test whose premise is "run this
+/// from Los Angeles, then from Seoul" therefore runs twice from UTC on a
+/// Windows runner and asserts against buckets the host never produced.
+///
+/// The *product* is fine there, and the Windows leg proves it: auto-pinning
+/// records `Etc/UTC` on the runner, and `bucket_tz::detect_local_iana_name`
+/// declining to pin `Asia/Seoul` while `chrono::Local` says UTC is the
+/// agreement guard doing exactly its job — pinning the detected name over a
+/// disagreeing `Local` is the history re-keying that guard exists to prevent.
+/// Only the mechanism these tests use to pose the question is POSIX.
+///
+/// Tests that pin a zone through settings.json rather than through `TZ` stay
+/// on every platform: the pin outranks the host, which is the whole claim.
 fn graph_day_buckets(base: &Path, timezone: &str) -> Vec<(String, i64)> {
     let output = cmd_with_home(base)
         .env("TZ", timezone)
@@ -3919,6 +3965,7 @@ fn test_pinned_bucket_timezone_survives_a_host_timezone_change() {
 /// Separate homes because the first run on a home pins it; this asserts the
 /// unpinned/first-scan semantics, which are the ones that must not move.
 #[test]
+#[cfg(unix)]
 fn test_unpinned_first_scan_still_buckets_by_the_host_timezone() {
     let los_angeles = create_bucket_timezone_fixture_dir();
     let seoul = create_bucket_timezone_fixture_dir();
@@ -3939,6 +3986,7 @@ fn test_unpinned_first_scan_still_buckets_by_the_host_timezone() {
 /// that run reports. If pinning moved the numbers on the machine doing the
 /// pinning, every user would see a one-off jump on upgrade.
 #[test]
+#[cfg(unix)]
 fn test_first_run_pins_the_host_timezone_without_changing_its_own_output() {
     let tmp = create_bucket_timezone_fixture_dir();
     let settings_path = settings_json_path(tmp.path());

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -699,6 +699,23 @@ fn settings_json_path(base: &Path) -> std::path::PathBuf {
     sandbox_config_dir(base).join("settings.json")
 }
 
+/// A scan path spelled the way the binary spells it.
+///
+/// `ClientDef::resolve_path` builds every client's root as
+/// `format!("{root}/{relative}")` — one separator, `/`, on every platform,
+/// with the relative half a `/`-joined literal in the client table. Windows
+/// accepts `/` in a path, so the value works; it just is not what
+/// `Path::join` produces. An expectation built with `join` disagreed on the
+/// first separator only (`...\.tmpXXXX\.codex/sessions` against the emitted
+/// `...\.tmpXXXX/.codex/sessions`) — and note that `join` did not give a
+/// natively-spelled path either, because the rest of the literal keeps its
+/// forward slashes. There was no native-separator contract to preserve, only
+/// two spellings of the same path, so match the one the binary actually
+/// emits.
+fn client_scan_path(home: &Path, relative: &str) -> String {
+    format!("{}/{}", home.display(), relative)
+}
+
 /// Writes a minimal clawdboard account export to `<dir>/export.json` and
 /// returns its path, for exercising `tokscale import`.
 fn write_clawdboard_export_fixture(dir: &Path) -> std::path::PathBuf {
@@ -1334,7 +1351,7 @@ fn test_clients_home_override_uses_explicit_home_for_json() {
         .unwrap();
     assert_eq!(
         codex["sessionsPath"],
-        serde_json::json!(real_home.path().join(".codex/sessions"))
+        serde_json::json!(client_scan_path(real_home.path(), ".codex/sessions"))
     );
     assert_eq!(codex["messageCount"].as_i64().unwrap(), 2);
 }
@@ -3095,7 +3112,7 @@ fn test_clients_json_includes_claude_transcripts_path() {
 
     assert_eq!(
         claude["additionalPaths"][0]["path"],
-        serde_json::json!(tmp.path().join(".claude/transcripts"))
+        serde_json::json!(client_scan_path(tmp.path(), ".claude/transcripts"))
     );
     assert_eq!(claude["additionalPaths"][0]["exists"], true);
 }

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -551,14 +551,30 @@ fn write_pricing_cache(base: &Path, timestamp: u64) {
     );
     let openrouter = format!(r#"{{"timestamp":{},"data":{{}}}}"#, timestamp);
 
-    // Seed all three locations so the test exercises the same fallback
-    // chain the binary uses post-#470: canonical
-    // <config_dir>/cache/, then legacy dirs::cache_dir()/tokscale, then
-    // ~/.cache/tokscale. Without the canonical path seeded, CI runners
-    // where dirs::cache_dir() resolves outside the sandboxed HOME (e.g.
-    // some Linux runners with XDG_CACHE_HOME set globally) miss the
-    // pricing cache entirely and the report falls back to embedded
-    // source costs.
+    // Only the first of these is read back. Every caller of this helper runs
+    // the child through `offline_cmd_with_home`, which sets
+    // `TOKSCALE_CONFIG_DIR`, and `paths::legacy_dirs_cache_dir` and
+    // `paths::legacy_dot_cache_tokscale_dir` both return `None` whenever that
+    // override is set — deliberately, since the override means "this root and
+    // nothing outside it". `pricing::cache::legacy_cache_paths` therefore comes
+    // back empty and the canonical `<config_dir>/cache/` seed is the only one
+    // the binary can find. Deleting it makes all four
+    // `*_offline_uses_stale_pricing_cache_when_available` tests fail; deleting
+    // the other two changes nothing.
+    //
+    // So what these fixtures no longer exercise is the post-#470 legacy
+    // fallback chain itself: no CLI test in this file reaches it, because none
+    // of them run without the override. That path is covered at the unit level
+    // by `pricing::cache::tests::load_falls_back_to_legacy_dirs_cache_path`.
+    // The macOS *settings* half of the same consequence is disclosed on
+    // `sandbox_config_dir` and worked around in
+    // `test_auto_pinning_does_not_shadow_a_legacy_settings_file_it_cannot_open`,
+    // which clears `TOKSCALE_CONFIG_DIR` precisely because the override would
+    // leave it nothing to assert.
+    //
+    // The two legacy directories are still written: they cost nothing, and a
+    // fixture that clears the override the way that test does needs them
+    // present rather than absent.
     for dir in [
         base.join(".config/tokscale/cache"),
         base.join("Library/Caches/tokscale"),

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3,10 +3,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
-// Only the unix-only `headless_capture_*` tests time anything.
-#[cfg(unix)]
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tempfile::TempDir;
 
 // ── Fixture helpers ────────────────────────────────────────────────────────
@@ -124,57 +121,37 @@ fn create_temp_fixture_dir() -> TempDir {
     create_temp_fixture_dir_with_pricing_cache(true)
 }
 
-/// The three `headless_capture_*` tests below stand up a fake `codex` on PATH
-/// and are unix-only because the fake is a `#!/bin/sh` script.
+/// Put a stand-in `codex` on PATH for the three `headless_capture_*` tests.
 ///
-/// Windows has no shebang: `CreateProcess` will not run a `codex` with no
-/// extension, so the child reports `Failed to spawn 'codex': program not
-/// found` and the assertions are about the harness rather than about headless
-/// capture. It is the fixture that cannot cross over, not the feature — a
-/// Windows shim would need a `.cmd` whose slow arm blocks for twenty seconds
-/// and whose kill semantics match what `TOKSCALE_NATIVE_TIMEOUT_MS` expects,
-/// and none of that can be verified from a Unix host. Left as a gap rather
-/// than guessed at, so headless capture stays uncovered on Windows.
-#[cfg(unix)]
+/// The stand-in is `src/bin/fake_codex.rs`, built by cargo as a real binary for
+/// whatever platform the tests are running on, and copied here under the name
+/// `run_capture_command` looks for. `CARGO_BIN_EXE_<name>` is set by cargo for
+/// every binary in this package when it compiles this package's integration
+/// tests, so the helper is guaranteed to exist and there is no target directory
+/// to guess at.
+///
+/// It used to be a `#!/bin/sh` script written at test time, which is why these
+/// tests could not run on Windows: there is no shebang there, and
+/// `Command::new("codex")` resolves a bare program name by appending `.exe`
+/// only — an extensionless `codex` is never even probed, so the child reported
+/// `Failed to spawn 'codex': program not found`. That was the fixture failing,
+/// not the feature.
+///
+/// The extension matters, so it is chosen per platform rather than assumed.
+/// `std::fs::copy` carries the source's mode on Unix, which is why there is no
+/// longer an explicit chmod.
 fn create_fake_codex_bin() -> TempDir {
     let tmp = TempDir::new().expect("failed to create fake codex dir");
-    let codex_path = tmp.path().join("codex");
-    fs::write(
-        &codex_path,
-        r#"#!/bin/sh
-case "$TOKSCALE_FAKE_CODEX_MODE" in
-  success)
-    printf 'captured ok'
-    exit 0
-    ;;
-  fail)
-    printf 'captured fail'
-    exit 17
-    ;;
-  slow)
-    exec sleep 20
-    ;;
-  *)
-    echo "unknown TOKSCALE_FAKE_CODEX_MODE" >&2
-    exit 2
-    ;;
-esac
-"#,
-    )
-    .unwrap();
+    let codex_path = tmp
+        .path()
+        .join(if cfg!(windows) { "codex.exe" } else { "codex" });
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut permissions = fs::metadata(&codex_path).unwrap().permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&codex_path, permissions).unwrap();
-    }
+    fs::copy(Path::new(env!("CARGO_BIN_EXE_fake_codex")), &codex_path)
+        .expect("failed to install the fake codex onto PATH");
 
     tmp
 }
 
-#[cfg(unix)]
 fn headless_capture_command(fake_bin: &Path, output_path: &Path, mode: &str) -> Command {
     let mut cmd = cargo_bin_cmd!("tokscale");
     let path = std::env::var_os("PATH").unwrap_or_default();
@@ -199,7 +176,6 @@ fn headless_capture_command(fake_bin: &Path, output_path: &Path, mode: &str) -> 
 }
 
 #[test]
-#[cfg(unix)]
 fn headless_capture_fast_success_does_not_wait_for_timeout() {
     let fake_bin = create_fake_codex_bin();
     let output_path = fake_bin.path().join("success.jsonl");
@@ -218,7 +194,6 @@ fn headless_capture_fast_success_does_not_wait_for_timeout() {
 }
 
 #[test]
-#[cfg(unix)]
 fn headless_capture_fast_nonzero_preserves_exit_code() {
     let fake_bin = create_fake_codex_bin();
     let output_path = fake_bin.path().join("fail.jsonl");
@@ -238,7 +213,6 @@ fn headless_capture_fast_nonzero_preserves_exit_code() {
 }
 
 #[test]
-#[cfg(unix)]
 fn headless_capture_slow_command_times_out() {
     let fake_bin = create_fake_codex_bin();
     let output_path = fake_bin.path().join("slow.jsonl");

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -467,12 +467,36 @@ fn create_conflicting_codex_fixture_dir() -> TempDir {
 
 /// Build a Command pointing HOME and the XDG dirs at the given temp dir for
 /// hermetic test runs (no flags are added; callers append their own).
+/// The config root every `cmd_with_home` fixture writes into, and the value
+/// the child is told to use.
+///
+/// `HOME` plus the `XDG_*` vars locate the config dir on Unix and reach nothing
+/// on Windows: `paths::get_config_dir` resolves the Windows root through
+/// `dirs::config_dir()`, a `SHGetKnownFolderPath` call no environment variable
+/// redirects. The child therefore read the *runner's* real
+/// `%APPDATA%\tokscale\` — so a fixture's settings.json was never seen (model
+/// aliases went unfolded, `scanner.extraScanPaths` came back null, auto-pinning
+/// had nothing to pin into) and the pricing cache the fixture primed with an
+/// empty catalog was replaced by whatever real prices happened to be on the
+/// machine.
+///
+/// `TOKSCALE_CONFIG_DIR` is the one override consulted first on every platform,
+/// and on Unix it names the directory the `XDG_CONFIG_HOME` pin already
+/// produced, so nothing moves there. Setting it also means these runs no longer
+/// depend on the legacy macOS settings fallback, which is correct for a
+/// hermetic fixture: `paths.rs` documents the override as meaning exactly "do
+/// not ingest anything from outside this root".
+fn sandbox_config_dir(tmp: &Path) -> std::path::PathBuf {
+    tmp.join(".config").join("tokscale")
+}
+
 fn cmd_with_home(tmp: &Path) -> Command {
     let mut cmd = cargo_bin_cmd!("tokscale");
     cmd.env("HOME", tmp)
         .env("XDG_CONFIG_HOME", tmp.join(".config"))
         .env("XDG_DATA_HOME", tmp.join(".local/share"))
         .env("XDG_CACHE_HOME", tmp.join(".cache"))
+        .env("TOKSCALE_CONFIG_DIR", sandbox_config_dir(tmp))
         .env("TOKSCALE_PRICING_CACHE_ONLY", "1")
         // Clear scan-path overrides inherited from the dev's shell, otherwise a
         // developer who exports e.g. TOKSCALE_EXTRA_DIRS=~/.codex/sessions (for
@@ -485,8 +509,7 @@ fn cmd_with_home(tmp: &Path) -> Command {
         .env_remove("GOOSE_PATH_ROOT")
         .env_remove("CODEBUFF_DATA_DIR")
         .env_remove("GEMINI_CLI_HOME")
-        .env_remove("HERMES_HOME")
-        .env_remove("TOKSCALE_CONFIG_DIR");
+        .env_remove("HERMES_HOME");
     cmd
 }
 
@@ -510,6 +533,7 @@ fn offline_cmd_with_home(tmp: &Path) -> Command {
         .env("XDG_CONFIG_HOME", tmp.join(".config"))
         .env("XDG_DATA_HOME", tmp.join(".local/share"))
         .env("XDG_CACHE_HOME", tmp.join(".cache"))
+        .env("TOKSCALE_CONFIG_DIR", sandbox_config_dir(tmp))
         .env("HTTP_PROXY", "http://127.0.0.1:9")
         .env("HTTPS_PROXY", "http://127.0.0.1:9")
         .env("ALL_PROXY", "http://127.0.0.1:9")
@@ -521,8 +545,7 @@ fn offline_cmd_with_home(tmp: &Path) -> Command {
         .env_remove("GOOSE_PATH_ROOT")
         .env_remove("CODEBUFF_DATA_DIR")
         .env_remove("GEMINI_CLI_HOME")
-        .env_remove("HERMES_HOME")
-        .env_remove("TOKSCALE_CONFIG_DIR");
+        .env_remove("HERMES_HOME");
     cmd
 }
 
@@ -666,15 +689,14 @@ fn write_settings_json(base: &Path, body: &str) {
     fs::write(path, body).unwrap();
 }
 
+/// One path on every platform: the child is given `TOKSCALE_CONFIG_DIR`, so
+/// where it looks no longer depends on the OS. The Windows arm this replaces
+/// mirrored the real `%APPDATA%` layout under the fixture home, which the child
+/// never consulted — `dirs::config_dir()` reads the known folder, not `HOME` —
+/// so the fixture and the reader disagreed and every settings-driven assertion
+/// on Windows saw an absent file.
 fn settings_json_path(base: &Path) -> std::path::PathBuf {
-    if cfg!(target_os = "windows") {
-        base.join("AppData")
-            .join("Roaming")
-            .join("tokscale")
-            .join("settings.json")
-    } else {
-        base.join(".config").join("tokscale").join("settings.json")
-    }
+    sandbox_config_dir(base).join("settings.json")
 }
 
 /// Writes a minimal clawdboard account export to `<dir>/export.json` and
@@ -2526,17 +2548,9 @@ fn add_alias_variant_message(tmp: &Path) {
 }
 
 /// Writes a tokscale `settings.json` with the given `modelAliases` object into
-/// the sandbox config dir that `cmd_with_home` points at
-/// (`XDG_CONFIG_HOME/tokscale`). `cmd_with_home` clears `TOKSCALE_CONFIG_DIR`, so
-/// the config must live under the pinned XDG path to be read.
+/// the sandbox config dir `cmd_with_home` points the child at.
 fn write_model_aliases(tmp: &Path, aliases_json: &str) {
-    let config_dir = tmp.join(".config/tokscale");
-    fs::create_dir_all(&config_dir).unwrap();
-    fs::write(
-        config_dir.join("settings.json"),
-        format!(r#"{{"modelAliases": {aliases_json}}}"#),
-    )
-    .unwrap();
+    write_settings_json(tmp, &format!(r#"{{"modelAliases": {aliases_json}}}"#));
 }
 
 fn models_by_name(tmp: &Path) -> serde_json::Value {
@@ -3816,13 +3830,10 @@ fn pin_bucket_timezone(base: &Path, zone: &str) {
 /// [`pin_bucket_timezone`] with the raw JSON value, so a test can write `null`
 /// as well as a string.
 fn pin_bucket_timezone_field(base: &Path, json_value: &str) {
-    let config_dir = base.join(".config/tokscale");
-    fs::create_dir_all(&config_dir).unwrap();
-    fs::write(
-        config_dir.join("settings.json"),
-        format!(r#"{{ "scanner": {{ "bucketTimezone": {json_value} }} }}"#),
-    )
-    .unwrap();
+    write_settings_json(
+        base,
+        &format!(r#"{{ "scanner": {{ "bucketTimezone": {json_value} }} }}"#),
+    );
 }
 
 /// Day buckets that actually carry messages, as `(date, message_count)`.
@@ -3913,7 +3924,7 @@ fn test_unpinned_first_scan_still_buckets_by_the_host_timezone() {
 #[test]
 fn test_first_run_pins_the_host_timezone_without_changing_its_own_output() {
     let tmp = create_bucket_timezone_fixture_dir();
-    let settings_path = tmp.path().join(".config/tokscale/settings.json");
+    let settings_path = settings_json_path(tmp.path());
     assert!(!settings_path.exists(), "fixture must start unpinned");
 
     let buckets = graph_day_buckets(tmp.path(), "Asia/Seoul");
@@ -4214,7 +4225,7 @@ fn test_hourly_keys_follow_the_pinned_bucket_timezone() {
 fn test_auto_pinning_never_overwrites_a_settings_file_it_could_not_read() {
     // Positive control — a readable file on this host really does get pinned.
     let control = create_bucket_timezone_fixture_dir();
-    let control_settings = control.path().join(".config/tokscale/settings.json");
+    let control_settings = settings_json_path(control.path());
     fs::create_dir_all(control_settings.parent().unwrap()).unwrap();
     fs::write(&control_settings, r#"{"colorPalette":"green"}"#).unwrap();
     graph_day_buckets(control.path(), "Asia/Seoul");
@@ -4238,7 +4249,7 @@ fn test_auto_pinning_never_overwrites_a_settings_file_it_could_not_read() {
         r#"{"colorPalette": 42, "scanner": {"extraScanPaths": {"claude": ["/data"]}}}"#,
     ] {
         let tmp = create_bucket_timezone_fixture_dir();
-        let settings_path = tmp.path().join(".config/tokscale/settings.json");
+        let settings_path = settings_json_path(tmp.path());
         fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
         fs::write(&settings_path, unreadable).unwrap();
 
@@ -4263,7 +4274,7 @@ fn test_auto_pinning_never_overwrites_a_settings_file_it_could_not_read() {
 #[test]
 fn test_config_set_refuses_to_overwrite_unreadable_settings() {
     let tmp = create_bucket_timezone_fixture_dir();
-    let settings_path = tmp.path().join(".config/tokscale/settings.json");
+    let settings_path = settings_json_path(tmp.path());
     fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
     let unreadable = r#"{"scanner": {"extraScanPaths": "not-a-map"}}"#;
     fs::write(&settings_path, unreadable).unwrap();
@@ -4290,10 +4301,8 @@ fn test_config_set_refuses_to_overwrite_unreadable_settings() {
 #[test]
 fn test_auto_pinning_recovers_from_a_bucket_timezone_that_names_no_zone() {
     let pinned_zone = |base: &Path| -> String {
-        let settings: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(base.join(".config/tokscale/settings.json")).unwrap(),
-        )
-        .unwrap();
+        let settings: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(settings_json_path(base)).unwrap()).unwrap();
         settings["scanner"]["bucketTimezone"]
             .as_str()
             .unwrap_or_default()
@@ -4375,7 +4384,7 @@ fn test_auto_pinning_declines_when_settings_json_cannot_be_opened() {
         return;
     }
 
-    let settings_path = tmp.path().join(".config/tokscale/settings.json");
+    let settings_path = settings_json_path(tmp.path());
     fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
     fs::write(&settings_path, r#"{"colorPalette":"green"}"#).unwrap();
     fs::set_permissions(&settings_path, fs::Permissions::from_mode(0o000)).unwrap();
@@ -4420,10 +4429,18 @@ fn test_auto_pinning_does_not_shadow_a_legacy_settings_file_it_cannot_open() {
     fs::write(&legacy, r#"{"colorPalette":"green"}"#).unwrap();
     fs::set_permissions(&legacy, fs::Permissions::from_mode(0o000)).unwrap();
 
-    let primary = tmp.path().join(".config/tokscale/settings.json");
+    let primary = settings_json_path(tmp.path());
     assert!(!primary.exists(), "fixture must start with no primary file");
 
     cmd_with_home(tmp.path())
+        // The one test here that must run *without* the config-dir override:
+        // `Settings::load_with_origin` skips the legacy macOS read whenever
+        // `TOKSCALE_CONFIG_DIR` is set, because the override means "this root
+        // and nothing outside it". With it set there is no fallback left to
+        // shadow and the assertion below could never fail. Clearing it leaves
+        // the resolver on `$HOME/.config/tokscale`, which is the same sandbox
+        // directory — this is macOS-only, so no known-folder lookup is in play.
+        .env_remove("TOKSCALE_CONFIG_DIR")
         .env("TZ", "Asia/Seoul")
         .args(["graph", "--client", "opencode", "--no-spinner"])
         .assert()

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3884,18 +3884,31 @@ fn pin_bucket_timezone_field(base: &Path, json_value: &str) {
 ///
 /// # Why the `TZ`-driven tests below are unix-only
 ///
-/// Passing `TZ` to the child moves `chrono::Local` on Unix and does nothing on
-/// Windows, where `Local` reads `GetTimeZoneInformation` — the machine's zone,
-/// which no environment variable overrides. A test whose premise is "run this
-/// from Los Angeles, then from Seoul" therefore runs twice from UTC on a
-/// Windows runner and asserts against buckets the host never produced.
+/// `TZ` is the instrument these tests pose their question with, and it is a
+/// POSIX instrument. `chrono::Local` honors it on Unix; on Windows `Local`
+/// reads `GetTimeZoneInformation` — the machine's own zone, which no
+/// environment variable overrides. A test whose premise is "run this from Los
+/// Angeles, then from Seoul" therefore runs twice from the runner's own zone
+/// on Windows and asserts against buckets the host never produced. Concretely:
+/// this fixture's two messages sit at 2026-03-02T11:30Z and 2026-03-02T18:00Z,
+/// so a UTC runner buckets both into `2026-03-02` while the expectation is
+/// Seoul's `03-02`/`03-03` split.
 ///
-/// The *product* is fine there, and the Windows leg proves it: auto-pinning
-/// records `Etc/UTC` on the runner, and `bucket_tz::detect_local_iana_name`
-/// declining to pin `Asia/Seoul` while `chrono::Local` says UTC is the
-/// agreement guard doing exactly its job — pinning the detected name over a
-/// disagreeing `Local` is the history re-keying that guard exists to prevent.
-/// Only the mechanism these tests use to pose the question is POSIX.
+/// That is a statement about the instrument, and only about the instrument. It
+/// is *not* a claim that the product was fine on Windows. It was not:
+/// `detect_local_iana_name` declining to pin while a foreign `TZ` was set was
+/// a real bug — the device never pinned, on any run, for as long as the
+/// variable stayed set, and so kept the rescan-splits-history behaviour that
+/// pinning exists to remove. It is fixed in `bucket_tz::tz_env_zone`, which no
+/// longer offers `TZ` as the pin candidate on the platform where
+/// `chrono::Local` does not read it.
+///
+/// That fix does not hand these tests their instrument back. `TZ` still cannot
+/// move the zone the child buckets in on Windows, so these tests still cannot
+/// place the child anywhere, and they stay gated. What the fix restored is
+/// covered directly by the unit test
+/// `bucket_tz::tests::a_foreign_tz_does_not_make_a_windows_host_unpinnable`,
+/// which asserts the pinning behaviour itself rather than through `TZ`.
 ///
 /// Tests that pin a zone through settings.json rather than through `TZ` stay
 /// on every platform: the pin outranks the host, which is the whole claim.
@@ -3983,6 +3996,15 @@ fn test_unpinned_first_scan_still_buckets_by_the_host_timezone() {
 /// The first run records the zone, and recording it changes nothing about what
 /// that run reports. If pinning moved the numbers on the machine doing the
 /// pinning, every user would see a one-off jump on upgrade.
+///
+/// This is the integration witness to the Windows bug fixed in
+/// `bucket_tz::tz_env_zone`, and it stays unix-only anyway. Both of its
+/// assertions are addressed to a zone this test cannot put a Windows child in:
+/// the buckets it expects are Seoul's, and the zone it expects on disk is
+/// `Asia/Seoul`, whereas a fixed Windows host pins the Win32 zone it is
+/// actually in (`Etc/UTC` on the runner) and buckets accordingly. Passing there
+/// would require `TZ` to move `chrono::Local`, which is the one thing Windows
+/// does not do. See [`graph_day_buckets`].
 #[test]
 #[cfg(unix)]
 fn test_first_run_pins_the_host_timezone_without_changing_its_own_output() {

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -705,7 +705,31 @@ fn write_fake_credentials(base: &Path) {
 }
 
 fn write_settings_json(base: &Path, body: &str) {
-    let path = settings_json_path(base);
+    write_settings_json_at(settings_json_path(base), body);
+}
+
+/// Settings for a run that passes `--home <base>` rather than inheriting the
+/// sandbox config dir.
+///
+/// An explicit `--home` bypasses `TOKSCALE_CONFIG_DIR` entirely:
+/// `Settings::load_for_home_override` reads
+/// `ExplicitHomeConfigLayout::current()` under the given home, which is
+/// `.config/tokscale` on Unix and `AppData\Roaming\tokscale` on Windows. That
+/// branch is real product behavior, unlike the one [`settings_json_path`] used
+/// to carry, so this mirrors it.
+fn write_explicit_home_settings_json(base: &Path, body: &str) {
+    let path = if cfg!(target_os = "windows") {
+        base.join("AppData")
+            .join("Roaming")
+            .join("tokscale")
+            .join("settings.json")
+    } else {
+        base.join(".config").join("tokscale").join("settings.json")
+    };
+    write_settings_json_at(path, body);
+}
+
+fn write_settings_json_at(path: std::path::PathBuf, body: &str) {
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     fs::write(path, body).unwrap();
 }
@@ -2348,7 +2372,7 @@ fn test_hourly_home_override_uses_explicit_home_scanner_settings() {
         210,
         40,
     );
-    write_settings_json(
+    write_explicit_home_settings_json(
         real_home.path(),
         &format!(
             r#"{{

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -224,8 +224,28 @@ fn headless_capture_slow_command_times_out() {
         .code(124);
     let elapsed = started.elapsed();
 
+    // The discriminating fact is that the *parent's* 10s timeout ended this run,
+    // not the child's own 20s sleep. The lower bound proves the parent waited for
+    // its deadline instead of failing early; the upper bound proves it did not
+    // simply outlive the child.
+    //
+    // The upper bound is set against the child's 20s sleep, not against a
+    // teardown budget. The previous 14s left only 4s for everything outside the
+    // deadline — `tokscale`'s own process startup, `child.kill()`, `child.wait()`
+    // and joining the stdout pump — and on a Windows runner startup alone can
+    // consume most of that. It failed at 14.83s in CI (job 92167428621) while
+    // still killing the child correctly, so the bound was measuring runner speed
+    // rather than the behaviour this test is named for.
+    //
+    // 18s keeps a 2s margin below the child's sleep, so a parent that hung until
+    // the child exited on its own is still caught.
+    //
+    // Note this test cannot catch #1049: the stand-in spawns nothing, so its pipe
+    // closes the moment it is killed, and the unbounded `output_handle.join()`
+    // after the kill is never exercised. Widening the bound does not hide that —
+    // it was never covered.
     assert!(
-        elapsed >= Duration::from_secs(10) && elapsed < Duration::from_secs(14),
+        elapsed >= Duration::from_secs(10) && elapsed < Duration::from_secs(18),
         "slow command timeout duration was unexpected: {elapsed:?}"
     );
 }

--- a/crates/tokscale-core/src/bucket_tz.rs
+++ b/crates/tokscale-core/src/bucket_tz.rs
@@ -204,8 +204,10 @@ pub fn detect_local_iana_name() -> Option<String> {
 
 /// The zone this machine claims to be in, as an IANA name.
 ///
-/// `TZ` is consulted first because it is what `chrono::Local` itself honors,
-/// and `chrono::Local` is what produced every date already on disk. Falling
+/// `TZ` is consulted first *on the platforms where `chrono::Local` honors it*,
+/// because `chrono::Local` is what produced every date already on disk. It is
+/// skipped entirely on Windows, where `Local` reads the Win32 zone and the
+/// variable names somewhere the machine is not — see [`tz_env_zone`]. Falling
 /// back to `iana-time-zone` covers the normal case where `TZ` is unset.
 ///
 /// Either source can be wrong or absent; [`detect_local_iana_name`] verifies
@@ -219,10 +221,35 @@ fn candidate_local_zone() -> Option<chrono_tz::Tz> {
 /// POSIX allows a leading colon (`TZ=:Asia/Seoul`). Values that are not zone
 /// names — `TZ=EST5EDT`-style rules, `TZ=<+09>-9`, a path — return `None`;
 /// those are honored by `chrono::Local` but cannot be stored as a pinned name.
+#[cfg(unix)]
 fn tz_env_zone() -> Option<chrono_tz::Tz> {
     let raw = std::env::var("TZ").ok()?;
     let name = raw.strip_prefix(':').unwrap_or(&raw);
     name.parse::<chrono_tz::Tz>().ok()
+}
+
+/// `None` on Windows: `TZ` is not what `chrono::Local` reads there.
+///
+/// The whole reason `TZ` is offered before the detector is that `chrono::Local`
+/// honors it, which makes it the best available name for the zone that produced
+/// the dates already on disk. Windows breaks that premise — `Local` resolves
+/// `GetTimeZoneInformation` and never looks at the environment — so a `TZ`
+/// exported by Git Bash, MSYS2, a container image, or a CI job names a zone the
+/// machine is not in.
+///
+/// Offering it anyway never produced a *wrong* pin, because [`zones_agree`]
+/// rejects it. It produced no pin at all, on every run, for as long as the
+/// variable stayed set: the candidate disagreed with `Local` forever, so the
+/// device kept bucketing by `chrono::Local` and kept the rescan-splits-history
+/// bug that pinning exists to remove — silently, since declining is the safe
+/// branch and says nothing. Falling straight through to `iana-time-zone`, which
+/// maps the Win32 zone the machine is actually in, lets the agreement check
+/// pass and the device pin. The check itself is unchanged and still runs
+/// against `chrono::Local`, so nothing here can pin a zone that buckets
+/// differently from what the parsers already produced.
+#[cfg(not(unix))]
+fn tz_env_zone() -> Option<chrono_tz::Tz> {
+    None
 }
 
 /// Approximate milliseconds in a year. Only used to size the forward edge of
@@ -580,6 +607,36 @@ mod tests {
         // that can be pinned, so they must fall through to the detector.
         assert!("<+09>-9".parse::<chrono_tz::Tz>().is_err());
         assert!("/etc/localtime".parse::<chrono_tz::Tz>().is_err());
+    }
+
+    /// A `TZ` the machine is not in must not make the device unpinnable.
+    ///
+    /// Windows-only because it is the only platform where the two disagree:
+    /// `chrono::Local` reads the Win32 zone and never the environment, so
+    /// offering `TZ` as the candidate would fail [`zones_agree`] on every run
+    /// and leave the device bucketing by `chrono::Local` forever — carrying the
+    /// exact bug pinning removes, and saying nothing, because declining is the
+    /// safe branch. Mutating `TZ` here is harmless for the same reason nothing
+    /// on this platform reads it.
+    #[test]
+    #[cfg(not(unix))]
+    fn a_foreign_tz_does_not_make_a_windows_host_unpinnable() {
+        let mut env = crate::paths::test_env::EnvGuard::capture(&["TZ"]);
+        env.set("TZ", "Asia/Seoul");
+
+        assert!(
+            tz_env_zone().is_none(),
+            "TZ must not be offered as the pin candidate where chrono::Local \
+             does not read it"
+        );
+
+        let with_foreign_tz = detect_local_iana_name();
+        env.remove("TZ");
+        let without_tz = detect_local_iana_name();
+        assert_eq!(
+            with_foreign_tz, without_tz,
+            "detection must reach the same answer with and without TZ set"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -948,7 +948,13 @@ mod tests {
                 .expect("test process has a current directory")
                 .join("relative-reasonix"),
         );
-        assert_eq!(client.data().resolve_path("/tmp/home"), expected);
+        // The home argument cannot reach this expectation — the default the
+        // reference falls back to is relative, so the resolver prepends the
+        // working directory and never consults the home. It is still
+        // `reasonix_home()` like every other call in this module: a literal
+        // `/tmp/home` here would read as a claim that this arm is special,
+        // when the only thing special about it is that any home would do.
+        assert_eq!(client.data().resolve_path(reasonix_home()), expected);
     }
 
     #[test]

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -809,14 +809,63 @@ mod tests {
         assert!(!client.data().headless);
     }
 
+    /// A home directory these tests can hand to the reasonix resolver.
+    ///
+    /// Reasonix is the one client whose root runs through `Path` — tilde
+    /// expansion, an `is_absolute` check, and joins — rather than string
+    /// concatenation. `Path` on Windows reads a POSIX-shaped `/tmp/home` as
+    /// "the root of the current drive": not absolute, because it carries no
+    /// drive prefix, so the resolver's relative-path arm fires and prepends the
+    /// process's working directory. The other clients in this module keep
+    /// `/tmp/home` because they never look at the value.
+    fn reasonix_home() -> &'static str {
+        if cfg!(windows) {
+            "C:\\tmp\\home"
+        } else {
+            "/tmp/home"
+        }
+    }
+
+    /// An absolute path on this platform, from `/`-separated components.
+    fn absolute_test_path(relative: &str) -> std::path::PathBuf {
+        let root = if cfg!(windows) { "C:\\" } else { "/" };
+        let mut path = std::path::PathBuf::from(root);
+        for component in relative.split('/') {
+            path.push(component);
+        }
+        path
+    }
+
+    /// `<root>/stats`, spelled the way [`ClientDef::resolve_path`] appends a
+    /// client's relative path: a forward slash, whatever the root's own
+    /// separators are.
+    fn reasonix_stats_under(root: impl AsRef<std::path::Path>) -> String {
+        format!("{}/stats", root.as_ref().to_string_lossy())
+    }
+
+    /// The reasonix root with no environment override.
+    ///
+    /// Spelled out per platform rather than resolved, because the layout is the
+    /// claim: `~/.reasonix` on Unix, and `%HOME%\AppData\Roaming\reasonix` on
+    /// Windows, matching where the application actually keeps per-user config
+    /// there.
+    fn reasonix_default_root() -> std::path::PathBuf {
+        let home = std::path::Path::new(reasonix_home());
+        if cfg!(windows) {
+            home.join("AppData").join("Roaming").join("reasonix")
+        } else {
+            home.join(".reasonix")
+        }
+    }
+
     #[test]
     fn test_reasonix_client_registered_as_local_session_source() {
         let client = ClientId::from_str("reasonix").expect("reasonix client should be registered");
         assert_eq!(
             client
                 .data()
-                .resolve_path_with_env_strategy("/tmp/home", false),
-            "/tmp/home/.reasonix/stats"
+                .resolve_path_with_env_strategy(reasonix_home(), false),
+            reasonix_stats_under(reasonix_default_root())
         );
         assert_eq!(client.data().pattern, "*.jsonl");
         assert!(client.data().parse_local);
@@ -828,17 +877,19 @@ mod tests {
     #[serial]
     fn test_reasonix_stats_prefers_state_home_then_reasonix_home() {
         let mut env = EnvGuard::capture(&["REASONIX_STATE_HOME", "REASONIX_HOME"]);
-        env.set("REASONIX_HOME", "/custom/reasonix-home");
-        env.set("REASONIX_STATE_HOME", "/custom/reasonix-state");
+        let custom_home = absolute_test_path("custom/reasonix-home");
+        let custom_state = absolute_test_path("custom/reasonix-state");
+        env.set("REASONIX_HOME", &custom_home);
+        env.set("REASONIX_STATE_HOME", &custom_state);
         let client = ClientId::Reasonix;
         assert_eq!(
-            client.data().resolve_path("/tmp/home"),
-            "/custom/reasonix-state/stats"
+            client.data().resolve_path(reasonix_home()),
+            reasonix_stats_under(&custom_state)
         );
         env.remove("REASONIX_STATE_HOME");
         assert_eq!(
-            client.data().resolve_path("/tmp/home"),
-            "/custom/reasonix-home/stats"
+            client.data().resolve_path(reasonix_home()),
+            reasonix_stats_under(&custom_home)
         );
     }
 
@@ -849,21 +900,20 @@ mod tests {
         let client = ClientId::Reasonix;
 
         env.set("REASONIX_STATE_HOME", "  ~/reasonix-state  ");
-        env.set("REASONIX_HOME", "/unused/reasonix-home");
+        env.set("REASONIX_HOME", absolute_test_path("unused/reasonix-home"));
         assert_eq!(
-            client.data().resolve_path("/tmp/home"),
-            "/tmp/home/reasonix-state/stats"
+            client.data().resolve_path(reasonix_home()),
+            reasonix_stats_under(std::path::Path::new(reasonix_home()).join("reasonix-state"))
         );
 
         env.set("REASONIX_STATE_HOME", " \t ");
         env.set("REASONIX_HOME", " relative-reasonix ");
-        let expected = std::env::current_dir()
-            .expect("test process has a current directory")
-            .join("relative-reasonix")
-            .join("stats")
-            .to_string_lossy()
-            .into_owned();
-        assert_eq!(client.data().resolve_path("/tmp/home"), expected);
+        let expected = reasonix_stats_under(
+            std::env::current_dir()
+                .expect("test process has a current directory")
+                .join("relative-reasonix"),
+        );
+        assert_eq!(client.data().resolve_path(reasonix_home()), expected);
     }
 
     #[test]
@@ -883,20 +933,21 @@ mod tests {
             "${TOKSCALE_REASONIX_TEST_ROOT}/nested",
         );
         assert_eq!(
-            client.data().resolve_path("/tmp/home"),
-            "/tmp/home/reasonix-state/nested/stats"
+            client.data().resolve_path(reasonix_home()),
+            reasonix_stats_under(
+                std::path::Path::new(reasonix_home()).join("reasonix-state/nested")
+            )
         );
 
         env.set(
             "REASONIX_STATE_HOME",
             "${TOKSCALE_REASONIX_TEST_UNSET:-relative-reasonix}",
         );
-        let expected = std::env::current_dir()
-            .expect("test process has a current directory")
-            .join("relative-reasonix")
-            .join("stats")
-            .to_string_lossy()
-            .into_owned();
+        let expected = reasonix_stats_under(
+            std::env::current_dir()
+                .expect("test process has a current directory")
+                .join("relative-reasonix"),
+        );
         assert_eq!(client.data().resolve_path("/tmp/home"), expected);
     }
 
@@ -904,14 +955,17 @@ mod tests {
     #[serial]
     fn test_reasonix_stats_ignores_env_roots_when_requested() {
         let mut env = EnvGuard::capture(&["REASONIX_STATE_HOME", "REASONIX_HOME"]);
-        env.set("REASONIX_STATE_HOME", "/custom/reasonix-state");
-        env.set("REASONIX_HOME", "/custom/reasonix-home");
+        env.set(
+            "REASONIX_STATE_HOME",
+            absolute_test_path("custom/reasonix-state"),
+        );
+        env.set("REASONIX_HOME", absolute_test_path("custom/reasonix-home"));
 
         assert_eq!(
             ClientId::Reasonix
                 .data()
-                .resolve_path_with_env_strategy("/tmp/home", false),
-            "/tmp/home/.reasonix/stats"
+                .resolve_path_with_env_strategy(reasonix_home(), false),
+            reasonix_stats_under(reasonix_default_root())
         );
     }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4385,6 +4385,30 @@ mod tests {
         std::env::set_var("TOKSCALE_CONFIG_DIR", home.join(".config").join("tokscale"));
     }
 
+    /// A client's scan root under `home`, spelled the way a scan will spell it.
+    ///
+    /// `ClientDef::resolve_path` builds the root with `format!("{root}/{rel}")`
+    /// and `WalkDir` appends each component below it with the platform
+    /// separator, so on Windows a discovered file reads
+    /// `C:\home/.claude/projects\demo\session.jsonl`. A fixture that builds the
+    /// same file with `Path::join` gets all backslashes — the same file, a
+    /// different string.
+    ///
+    /// That difference is invisible until a test seeds the message cache by
+    /// hand and expects the next scan to find it, because `CachedPath` keys on
+    /// the OS string as written: two spellings are two keys, so the seeded
+    /// entry is never read and the parse silently falls back to a cold parse.
+    /// Seeding under the spelling the scan produces is what these tests mean.
+    /// Whether the cache *ought* to fold the two spellings into one key is a
+    /// separate question about the product; nothing here depends on the answer.
+    fn client_scan_root(home: &std::path::Path, client: ClientId) -> std::path::PathBuf {
+        std::path::PathBuf::from(
+            client
+                .data()
+                .resolve_path_with_env_strategy(&home.to_string_lossy(), false),
+        )
+    }
+
     fn restore_cache_home(previous: CacheHomeEnv) {
         for (key, value) in [("HOME", previous.0), ("TOKSCALE_CONFIG_DIR", previous.1)] {
             match value {
@@ -6492,7 +6516,7 @@ mod tests {
         redirect_cache_home(cache_home.path());
 
         {
-            let claude_dir = source_home.path().join(".claude/projects/demo");
+            let claude_dir = client_scan_root(source_home.path(), ClientId::Claude).join("demo");
             std::fs::create_dir_all(&claude_dir).unwrap();
             let transcript = claude_dir.join("session.jsonl");
             std::fs::write(
@@ -6637,9 +6661,8 @@ mod tests {
         redirect_cache_home(cache_home.path());
 
         {
-            let message_dir = source_home
-                .path()
-                .join(".local/share/opencode/storage/message/project-1");
+            let message_dir =
+                client_scan_root(source_home.path(), ClientId::OpenCode).join("project-1");
             std::fs::create_dir_all(&message_dir).unwrap();
             let path = message_dir.join("msg_001.json");
             std::fs::write(
@@ -7522,7 +7545,7 @@ mod tests {
         redirect_cache_home(cache_home.path());
 
         {
-            let codex_dir = source_home.path().join(".codex/sessions");
+            let codex_dir = client_scan_root(source_home.path(), ClientId::Codex);
             std::fs::create_dir_all(&codex_dir).unwrap();
             let path = codex_dir.join("session.jsonl");
             std::fs::write(
@@ -7886,7 +7909,7 @@ mod tests {
         redirect_cache_home(cache_home.path());
 
         {
-            let session_dir = source_home.path().join(".codex/sessions");
+            let session_dir = client_scan_root(source_home.path(), ClientId::Codex);
             std::fs::create_dir_all(&session_dir).unwrap();
             let path = session_dir.join("session.jsonl");
             std::fs::write(

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4354,6 +4354,46 @@ mod tests {
         crate::paths::test_env::EnvGuard::capture(&["HOME"])
     }
 
+    /// What [`redirect_cache_home`] replaces, so a test can put it back.
+    type CacheHomeEnv = (Option<String>, Option<String>);
+
+    fn capture_cache_home() -> CacheHomeEnv {
+        (
+            std::env::var("HOME").ok(),
+            std::env::var("TOKSCALE_CONFIG_DIR").ok(),
+        )
+    }
+
+    /// Point the message-cache root at a scratch directory.
+    ///
+    /// Redirecting `HOME` is enough on Unix and does nothing on Windows:
+    /// `paths::get_config_dir` resolves the Windows root through
+    /// `dirs::config_dir()`, a known-folder lookup that reads no environment
+    /// variable at all. Every test in this module then shared one real
+    /// `%APPDATA%\tokscale\cache` and loaded back the shards its neighbours had
+    /// written, so the counts came out higher than the entries the test itself
+    /// inserted — and which neighbours had run first decided by how much.
+    ///
+    /// `TOKSCALE_CONFIG_DIR` is the override `paths.rs` documents for exactly
+    /// this ("CI sandbox, tests, isolated profile") and it is consulted first on
+    /// every platform. On Unix it names the directory the `HOME` redirect
+    /// already produced, so nothing moves there; it also pins the root against a
+    /// globally-set `XDG_CONFIG_HOME`, which a `HOME`-only redirect leaks past
+    /// on Linux runners.
+    fn redirect_cache_home(home: &std::path::Path) {
+        std::env::set_var("HOME", home);
+        std::env::set_var("TOKSCALE_CONFIG_DIR", home.join(".config").join("tokscale"));
+    }
+
+    fn restore_cache_home(previous: CacheHomeEnv) {
+        for (key, value) in [("HOME", previous.0), ("TOKSCALE_CONFIG_DIR", previous.1)] {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+
     /// An explicit `--home` outranks every environment lookup. Pinned so the
     /// reordering that routed the fallback through `paths::home_dir` cannot
     /// quietly promote the resolver above the caller's own argument.
@@ -5501,8 +5541,8 @@ mod tests {
     fn test_micode_authoritative_cost_is_not_repriced_on_first_parse_or_cache_hit() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let micode_dir = source_home.path().join(".local/share/mimocode");
@@ -5574,10 +5614,7 @@ mod tests {
             );
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -5585,8 +5622,8 @@ mod tests {
     fn test_micode_cross_database_dedup_prefers_explicit_zero_cost() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let micode_dir = source_home.path().join(".local/share/mimocode");
@@ -5642,10 +5679,7 @@ mod tests {
             assert!(validate_priced_messages(&messages, Some(&pricing)).is_ok());
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     /// Claude Code rewrites a session transcript in place on resume/compact:
@@ -5659,8 +5693,8 @@ mod tests {
     fn test_claude_in_place_rewrite_preserves_previously_seen_messages() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let claude_dir = source_home.path().join(".claude/projects/myproject");
@@ -5740,10 +5774,7 @@ mod tests {
             );
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     /// Retention is only sound because a retained message still collapses
@@ -5761,8 +5792,8 @@ mod tests {
     fn test_claude_retained_message_collapses_against_a_forked_transcript() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let claude_dir = source_home.path().join(".claude/projects/myproject");
@@ -5815,10 +5846,7 @@ mod tests {
             assert_eq!(after.iter().map(|m| m.tokens.input).sum::<i64>(), 600);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     /// A Claude tool-result key embeds the session id, which is the
@@ -5831,8 +5859,8 @@ mod tests {
     fn test_claude_path_scoped_tool_result_is_not_retained_across_a_rewrite() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let claude_dir = source_home.path().join(".claude/projects/myproject");
@@ -5876,10 +5904,7 @@ mod tests {
             assert_eq!(after.iter().map(|m| m.tokens.input).sum::<i64>(), 100);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     /// The retention above must not resurrect a session the user deleted:
@@ -5895,8 +5920,8 @@ mod tests {
     fn test_claude_deleted_transcript_is_not_resurrected_by_retention() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let claude_dir = source_home.path().join(".claude/projects/myproject");
@@ -5945,10 +5970,7 @@ mod tests {
             );
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     fn write_kimi_repeated_status_fixture(source_home: &std::path::Path) {
@@ -5989,8 +6011,8 @@ mod tests {
     fn test_cline_cli_deduplicates_duplicate_records_in_cached_and_local_paths() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let duplicate = r#"{"id":"duplicate","role":"assistant","ts":1785320475705,"modelInfo":{"id":"cline-free/glm-5.2","provider":"cline-pass"},"metrics":{"inputTokens":100,"outputTokens":10}}"#;
@@ -6058,10 +6080,7 @@ mod tests {
             assert_eq!(parsed.counts.get(ClientId::Cline), 3);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6069,8 +6088,8 @@ mod tests {
     fn test_parse_all_messages_with_pricing_prefers_grok_unified_log() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home
@@ -6105,10 +6124,7 @@ mod tests {
             assert_eq!(messages[0].tokens.total(), 125);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6116,8 +6132,8 @@ mod tests {
     fn test_parse_all_messages_reprices_grok_after_legacy_model_attribution() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home
@@ -6173,10 +6189,7 @@ mod tests {
             assert!(second[0].cost > 0.0);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6231,8 +6244,8 @@ mod tests {
     fn test_parse_all_messages_with_pricing_kimi_deduplicates_repeated_status_updates() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             write_kimi_repeated_status_fixture(source_home.path());
@@ -6248,10 +6261,7 @@ mod tests {
             assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 5);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6259,8 +6269,8 @@ mod tests {
     fn test_parse_local_clients_kimi_deduplicates_repeated_status_updates() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             write_kimi_repeated_status_fixture(source_home.path());
@@ -6282,10 +6292,7 @@ mod tests {
             assert_eq!(parsed.messages.iter().map(|m| m.output).sum::<i64>(), 5);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6293,8 +6300,8 @@ mod tests {
     fn test_kimchi_deduplicates_same_message_across_scan_roots() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         let default_path = source_home
             .path()
@@ -6341,10 +6348,7 @@ mod tests {
             Some("kimchi:kimchi-session:kimchi-message")
         );
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6359,8 +6363,8 @@ mod tests {
         // parse_local_clients test cannot catch this.
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home
@@ -6395,10 +6399,7 @@ mod tests {
             );
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6406,8 +6407,8 @@ mod tests {
     fn test_source_cache_refreshes_stale_date_on_cache_hit() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let message_dir = source_home
@@ -6479,10 +6480,7 @@ mod tests {
             );
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6490,8 +6488,8 @@ mod tests {
     fn test_claude_warm_cache_removes_synthetic_placeholder_before_submit_validation() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let claude_dir = source_home.path().join(".claude/projects/demo");
@@ -6570,10 +6568,7 @@ mod tests {
             assert_eq!(cached.messages[0].dedup_key.as_deref(), Some("old:req_old"));
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[cfg(unix)]
@@ -6584,8 +6579,8 @@ mod tests {
 
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let message_dir = source_home
@@ -6630,10 +6625,7 @@ mod tests {
             assert_eq!(second_messages.len(), 1);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6641,8 +6633,8 @@ mod tests {
     fn test_empty_cache_hits_are_reparsed_for_optional_file_sources() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let message_dir = source_home
@@ -6685,10 +6677,7 @@ mod tests {
             assert_eq!(repaired_entry.messages.len(), 1);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6696,8 +6685,8 @@ mod tests {
     fn test_sqlite_source_cache_invalidates_on_wal_change() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let db_dir = source_home.path().join(".local/share/opencode");
@@ -6762,10 +6751,7 @@ mod tests {
             assert_eq!(refreshed_messages.len(), 2);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6776,8 +6762,8 @@ mod tests {
         // must only be counted once.
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let db_dir = source_home.path().join(".local/share/opencode");
@@ -6878,10 +6864,7 @@ mod tests {
             );
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6889,8 +6872,8 @@ mod tests {
     fn test_parse_all_messages_with_pricing_opencode_sqlite_deduplicates_forked_history() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let db_dir = source_home.path().join(".local/share/opencode");
@@ -6956,10 +6939,7 @@ mod tests {
             assert_eq!(messages.iter().map(|m| m.cost).sum::<f64>(), 0.06);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6967,8 +6947,8 @@ mod tests {
     fn test_parse_local_clients_opencode_sqlite_counts_deduplicated_forked_history() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let db_dir = source_home.path().join(".local/share/opencode");
@@ -7039,10 +7019,7 @@ mod tests {
             assert_eq!(parsed.messages.iter().map(|m| m.output).sum::<i64>(), 250);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     fn write_codex_forked_history_fixture(source_home: &std::path::Path) {
@@ -7194,8 +7171,8 @@ mod tests {
     fn test_parse_all_messages_with_pricing_codex_deduplicates_forked_history() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             write_codex_forked_history_fixture(source_home.path());
@@ -7230,10 +7207,7 @@ mod tests {
             );
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7241,8 +7215,8 @@ mod tests {
     fn test_parse_all_messages_with_pricing_codex_keeps_user_fork_own_turn() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             write_codex_user_fork_replay_fixture(source_home.path());
@@ -7267,10 +7241,7 @@ mod tests {
             assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 150);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     /// Regression fixture for issue #779: Codex CLI moves aged sessions from
@@ -7341,8 +7312,8 @@ mod tests {
     {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             write_codex_sessions_and_archived_sessions_fixture(source_home.path());
@@ -7378,10 +7349,7 @@ mod tests {
             assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 15);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7389,8 +7357,8 @@ mod tests {
     fn test_parse_all_messages_with_pricing_codex_deduplicates_parent_replay_across_forks() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             write_codex_parent_replay_fixture(source_home.path());
@@ -7415,10 +7383,7 @@ mod tests {
             assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 14);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     fn write_codex_twin_token_count_fixture(source_home: &std::path::Path) {
@@ -7450,8 +7415,8 @@ mod tests {
     fn test_parse_all_messages_with_pricing_codex_keeps_twin_token_counts_at_distinct_timestamps() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             write_codex_twin_token_count_fixture(source_home.path());
@@ -7491,10 +7456,7 @@ mod tests {
             );
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7502,8 +7464,8 @@ mod tests {
     fn test_parse_local_clients_codex_counts_deduplicated_forked_history() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             write_codex_forked_history_fixture(source_home.path());
@@ -7547,10 +7509,7 @@ mod tests {
             );
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7559,8 +7518,8 @@ mod tests {
         let cache_home = tempfile::TempDir::new().unwrap();
         let fresh_cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let codex_dir = source_home.path().join(".codex/sessions");
@@ -7611,7 +7570,7 @@ mod tests {
                 &["codex".to_string()],
                 None,
             );
-            std::env::set_var("HOME", fresh_cache_home.path());
+            redirect_cache_home(fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(
                 source_home.path().to_str().unwrap(),
                 &["codex".to_string()],
@@ -7625,10 +7584,7 @@ mod tests {
                 .all(|message| message.model_id == "gpt-5.5"));
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7637,8 +7593,8 @@ mod tests {
         let cache_home = tempfile::TempDir::new().unwrap();
         let fresh_cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let codex_dir = source_home.path().join(".codex/sessions");
@@ -7682,7 +7638,7 @@ mod tests {
                 &["codex".to_string()],
                 None,
             );
-            std::env::set_var("HOME", fresh_cache_home.path());
+            redirect_cache_home(fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(
                 source_home.path().to_str().unwrap(),
                 &["codex".to_string()],
@@ -7692,10 +7648,7 @@ mod tests {
             assert_eq!(warm_messages, fresh_messages);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7704,8 +7657,8 @@ mod tests {
         let cache_home = tempfile::TempDir::new().unwrap();
         let fresh_cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let codex_dir = source_home.path().join(".codex/sessions");
@@ -7758,7 +7711,7 @@ mod tests {
                 )
                 .is_none());
 
-            std::env::set_var("HOME", fresh_cache_home.path());
+            redirect_cache_home(fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(
                 source_home.path().to_str().unwrap(),
                 &["codex".to_string()],
@@ -7768,10 +7721,7 @@ mod tests {
             assert_eq!(warm_messages, fresh_messages);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7779,8 +7729,8 @@ mod tests {
     fn test_exact_hit_codex_cache_repairs_fallback_timestamps_without_incremental_state() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home.path().join(".codex/sessions");
@@ -7825,10 +7775,7 @@ mod tests {
             assert_eq!(messages, expected);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7837,8 +7784,8 @@ mod tests {
         let cache_home = tempfile::TempDir::new().unwrap();
         let fresh_cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home.path().join(".codex/sessions");
@@ -7868,7 +7815,7 @@ mod tests {
                 None,
             );
 
-            std::env::set_var("HOME", fresh_cache_home.path());
+            redirect_cache_home(fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(
                 source_home.path().to_str().unwrap(),
                 &["codex".to_string()],
@@ -7879,10 +7826,7 @@ mod tests {
             assert_ne!(warm_messages[0].timestamp, initial_messages[0].timestamp);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7890,8 +7834,8 @@ mod tests {
     fn test_full_log_parse_preserves_valid_messages_before_invalid_line_error() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home.path().join(".codex/sessions");
@@ -7929,10 +7873,7 @@ mod tests {
                 .is_none());
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7941,8 +7882,8 @@ mod tests {
         let cache_home = tempfile::TempDir::new().unwrap();
         let fresh_cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home.path().join(".codex/sessions");
@@ -7994,7 +7935,7 @@ mod tests {
                 None,
             );
 
-            std::env::set_var("HOME", fresh_cache_home.path());
+            redirect_cache_home(fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(
                 source_home.path().to_str().unwrap(),
                 &["codex".to_string()],
@@ -8005,7 +7946,7 @@ mod tests {
             assert_eq!(resumed_messages.len(), 1);
             assert_eq!(resumed_messages[0].model_id, "gpt-5.5");
 
-            std::env::set_var("HOME", cache_home.path());
+            redirect_cache_home(cache_home.path());
             assert!(message_cache::SourceMessageCache::load()
                 .get(
                     message_cache::CacheIdentity::for_client(ClientId::Codex),
@@ -8014,10 +7955,7 @@ mod tests {
                 .is_some());
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -8026,8 +7964,8 @@ mod tests {
         let cache_home = tempfile::TempDir::new().unwrap();
         let fresh_cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home.path().join(".codex/sessions");
@@ -8078,7 +8016,7 @@ mod tests {
                 None,
             );
 
-            std::env::set_var("HOME", fresh_cache_home.path());
+            redirect_cache_home(fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(
                 source_home.path().to_str().unwrap(),
                 &["codex".to_string()],
@@ -8089,10 +8027,7 @@ mod tests {
             assert_eq!(warm_messages.len(), 2);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -8100,8 +8035,8 @@ mod tests {
     fn test_source_cache_does_not_reuse_priced_cost_without_pricing_service() {
         let temp_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", temp_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(temp_home.path());
         {
             let cursor_cache_dir = source_home.path().join(".config/tokscale/cursor-cache");
             std::fs::create_dir_all(&cursor_cache_dir).unwrap();
@@ -8140,10 +8075,7 @@ mod tests {
             assert_eq!(cached_messages[0].cost, 0.0);
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -10400,8 +10332,8 @@ mod tests {
     fn test_parse_all_messages_refreshes_cc_mirror_provider_when_variant_metadata_changes() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let variant_dir = source_home.path().join(".cc-mirror/kimi-code");
@@ -10454,10 +10386,7 @@ mod tests {
             assert_eq!(refreshed_messages[0].provider_id, "minimax");
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]
@@ -10465,8 +10394,8 @@ mod tests {
     fn test_parse_all_messages_keeps_normal_claude_when_cc_mirror_points_at_claude_config() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let original_home = capture_cache_home();
+        redirect_cache_home(cache_home.path());
 
         {
             let claude_dir = source_home.path().join(".claude");
@@ -10500,10 +10429,7 @@ mod tests {
             assert_eq!(messages[0].client, "claude");
         }
 
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        restore_cache_home(original_home);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -10024,9 +10024,16 @@ mod tests {
     #[test]
     fn test_submit_default_graph_includes_antigravity_cache_rows() {
         let temp_dir = tempfile::TempDir::new().unwrap();
-        let sessions_dir = temp_dir
-            .path()
-            .join(".config/tokscale/antigravity-cache/sessions");
+        // Resolved rather than hardcoded: under an explicit home the config
+        // root is `~/.config/tokscale` on Unix and
+        // `%HOME%\AppData\Roaming\tokscale` on Windows, so the Unix spelling
+        // put the fixture outside the tree the scan walks and the graph came
+        // back empty.
+        let sessions_dir = std::path::PathBuf::from(
+            ClientId::Antigravity
+                .data()
+                .resolve_path_with_env_strategy(&temp_dir.path().to_string_lossy(), false),
+        );
         std::fs::create_dir_all(&sessions_dir).unwrap();
         std::fs::write(
             sessions_dir.join("ag-submit.jsonl"),
@@ -10517,7 +10524,18 @@ mod tests {
     #[test]
     fn test_parse_local_clients_reasonix_counts_reported_requests() {
         let temp_dir = tempfile::TempDir::new().unwrap();
-        let stats_dir = temp_dir.path().join(".reasonix/stats");
+        // Where the scan will actually look, rather than the Unix spelling of
+        // it: under an explicit home Reasonix lives at `~/.reasonix` on Unix
+        // and `%HOME%\AppData\Roaming\reasonix` on Windows, so a hardcoded
+        // `.reasonix/stats` fixture is written somewhere the scanner never
+        // reads and the test asserts on an empty parse. The path layout has its
+        // own coverage in `clients::tests`; this test is about the request
+        // count.
+        let stats_dir = std::path::PathBuf::from(
+            ClientId::Reasonix
+                .data()
+                .resolve_path_with_env_strategy(&temp_dir.path().to_string_lossy(), false),
+        );
         std::fs::create_dir_all(&stats_dir).unwrap();
         std::fs::write(
             stats_dir.join("2026-08-04.jsonl"),

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4354,17 +4354,8 @@ mod tests {
         crate::paths::test_env::EnvGuard::capture(&["HOME"])
     }
 
-    /// What [`redirect_cache_home`] replaces, so a test can put it back.
-    type CacheHomeEnv = (Option<String>, Option<String>);
-
-    fn capture_cache_home() -> CacheHomeEnv {
-        (
-            std::env::var("HOME").ok(),
-            std::env::var("TOKSCALE_CONFIG_DIR").ok(),
-        )
-    }
-
-    /// Point the message-cache root at a scratch directory.
+    /// Point the message-cache root at a scratch directory for as long as the
+    /// returned guard is alive.
     ///
     /// Redirecting `HOME` is enough on Unix and does nothing on Windows:
     /// `paths::get_config_dir` resolves the Windows root through
@@ -4380,9 +4371,33 @@ mod tests {
     /// already produced, so nothing moves there; it also pins the root against a
     /// globally-set `XDG_CONFIG_HOME`, which a `HOME`-only redirect leaks past
     /// on Linux runners.
-    fn redirect_cache_home(home: &std::path::Path) {
-        std::env::set_var("HOME", home);
-        std::env::set_var("TOKSCALE_CONFIG_DIR", home.join(".config").join("tokscale"));
+    ///
+    /// That reach is exactly why the restore has to be a `Drop` guard rather
+    /// than a trailing call. The `HOME`-only redirect this replaced was inert
+    /// on Windows, so leaking it past a panicking assertion cost nothing there;
+    /// `TOKSCALE_CONFIG_DIR` is consulted first on *every* platform, so a leaked
+    /// one points every later test in the binary at a `TempDir` that has already
+    /// been dropped — the cross-test contamination this redirect exists to
+    /// remove, reintroduced one layer down. `serial_test` does not help: it
+    /// prevents overlap, not inheritance.
+    #[must_use = "the redirect is undone as soon as the guard drops; bind it to a \
+                  named variable that outlives the test body"]
+    fn redirect_cache_home(home: &std::path::Path) -> crate::paths::test_env::EnvGuard {
+        let mut env = crate::paths::test_env::EnvGuard::capture(&["HOME", "TOKSCALE_CONFIG_DIR"]);
+        point_cache_home(&mut env, home);
+        env
+    }
+
+    /// Re-aim a live [`redirect_cache_home`] at a different scratch directory.
+    ///
+    /// The tests that compare a warm cache against a cold one switch roots
+    /// mid-body, and one switches back again to assert on the first root. They
+    /// want a re-point, not a nested guard: the guard already holds the values
+    /// from before the *first* redirect, and restoring those once at scope exit
+    /// is the correct end state no matter how many times the root moved.
+    fn point_cache_home(env: &mut crate::paths::test_env::EnvGuard, home: &std::path::Path) {
+        env.set("HOME", home);
+        env.set("TOKSCALE_CONFIG_DIR", home.join(".config").join("tokscale"));
     }
 
     /// A client's scan root under `home`, spelled the way a scan will spell it.
@@ -4407,15 +4422,6 @@ mod tests {
                 .data()
                 .resolve_path_with_env_strategy(&home.to_string_lossy(), false),
         )
-    }
-
-    fn restore_cache_home(previous: CacheHomeEnv) {
-        for (key, value) in [("HOME", previous.0), ("TOKSCALE_CONFIG_DIR", previous.1)] {
-            match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
-            }
-        }
     }
 
     /// An explicit `--home` outranks every environment lookup. Pinned so the
@@ -5565,8 +5571,7 @@ mod tests {
     fn test_micode_authoritative_cost_is_not_repriced_on_first_parse_or_cache_hit() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let micode_dir = source_home.path().join(".local/share/mimocode");
@@ -5637,8 +5642,6 @@ mod tests {
                 second[0].cost
             );
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -5646,8 +5649,7 @@ mod tests {
     fn test_micode_cross_database_dedup_prefers_explicit_zero_cost() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let micode_dir = source_home.path().join(".local/share/mimocode");
@@ -5702,8 +5704,6 @@ mod tests {
             assert!(messages[0].has_authoritative_cost());
             assert!(validate_priced_messages(&messages, Some(&pricing)).is_ok());
         }
-
-        restore_cache_home(original_home);
     }
 
     /// Claude Code rewrites a session transcript in place on resume/compact:
@@ -5717,8 +5717,7 @@ mod tests {
     fn test_claude_in_place_rewrite_preserves_previously_seen_messages() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let claude_dir = source_home.path().join(".claude/projects/myproject");
@@ -5797,8 +5796,6 @@ mod tests {
                 before_output
             );
         }
-
-        restore_cache_home(original_home);
     }
 
     /// Retention is only sound because a retained message still collapses
@@ -5816,8 +5813,7 @@ mod tests {
     fn test_claude_retained_message_collapses_against_a_forked_transcript() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let claude_dir = source_home.path().join(".claude/projects/myproject");
@@ -5869,8 +5865,6 @@ mod tests {
             );
             assert_eq!(after.iter().map(|m| m.tokens.input).sum::<i64>(), 600);
         }
-
-        restore_cache_home(original_home);
     }
 
     /// A Claude tool-result key embeds the session id, which is the
@@ -5883,8 +5877,7 @@ mod tests {
     fn test_claude_path_scoped_tool_result_is_not_retained_across_a_rewrite() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let claude_dir = source_home.path().join(".claude/projects/myproject");
@@ -5927,8 +5920,6 @@ mod tests {
             );
             assert_eq!(after.iter().map(|m| m.tokens.input).sum::<i64>(), 100);
         }
-
-        restore_cache_home(original_home);
     }
 
     /// The retention above must not resurrect a session the user deleted:
@@ -5944,8 +5935,7 @@ mod tests {
     fn test_claude_deleted_transcript_is_not_resurrected_by_retention() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let claude_dir = source_home.path().join(".claude/projects/myproject");
@@ -5993,8 +5983,6 @@ mod tests {
                 "a deleted transcript stays deleted, retained turns and all; local disk remains the source of truth"
             );
         }
-
-        restore_cache_home(original_home);
     }
 
     fn write_kimi_repeated_status_fixture(source_home: &std::path::Path) {
@@ -6035,8 +6023,7 @@ mod tests {
     fn test_cline_cli_deduplicates_duplicate_records_in_cached_and_local_paths() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let duplicate = r#"{"id":"duplicate","role":"assistant","ts":1785320475705,"modelInfo":{"id":"cline-free/glm-5.2","provider":"cline-pass"},"metrics":{"inputTokens":100,"outputTokens":10}}"#;
@@ -6103,8 +6090,6 @@ mod tests {
             assert_eq!(local_inputs, vec![100, 200, 300]);
             assert_eq!(parsed.counts.get(ClientId::Cline), 3);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6112,8 +6097,7 @@ mod tests {
     fn test_parse_all_messages_with_pricing_prefers_grok_unified_log() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home
@@ -6147,8 +6131,6 @@ mod tests {
             assert_eq!(messages[0].tokens.reasoning, 5);
             assert_eq!(messages[0].tokens.total(), 125);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6156,8 +6138,7 @@ mod tests {
     fn test_parse_all_messages_reprices_grok_after_legacy_model_attribution() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home
@@ -6212,8 +6193,6 @@ mod tests {
             assert_eq!(second[0].model_id, "grok-code");
             assert!(second[0].cost > 0.0);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6268,8 +6247,7 @@ mod tests {
     fn test_parse_all_messages_with_pricing_kimi_deduplicates_repeated_status_updates() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             write_kimi_repeated_status_fixture(source_home.path());
@@ -6284,8 +6262,6 @@ mod tests {
             assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 40);
             assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 5);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6293,8 +6269,7 @@ mod tests {
     fn test_parse_local_clients_kimi_deduplicates_repeated_status_updates() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             write_kimi_repeated_status_fixture(source_home.path());
@@ -6315,8 +6290,6 @@ mod tests {
             assert_eq!(parsed.messages.iter().map(|m| m.input).sum::<i64>(), 40);
             assert_eq!(parsed.messages.iter().map(|m| m.output).sum::<i64>(), 5);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6324,8 +6297,7 @@ mod tests {
     fn test_kimchi_deduplicates_same_message_across_scan_roots() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         let default_path = source_home
             .path()
@@ -6371,8 +6343,6 @@ mod tests {
             messages[0].dedup_key.as_deref(),
             Some("kimchi:kimchi-session:kimchi-message")
         );
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6387,8 +6357,7 @@ mod tests {
         // parse_local_clients test cannot catch this.
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home
@@ -6422,8 +6391,6 @@ mod tests {
                 100
             );
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6431,8 +6398,7 @@ mod tests {
     fn test_source_cache_refreshes_stale_date_on_cache_hit() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let message_dir = source_home
@@ -6503,8 +6469,6 @@ mod tests {
                 .date
             );
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6512,8 +6476,7 @@ mod tests {
     fn test_claude_warm_cache_removes_synthetic_placeholder_before_submit_validation() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let claude_dir = client_scan_root(source_home.path(), ClientId::Claude).join("demo");
@@ -6591,8 +6554,6 @@ mod tests {
             assert_eq!(cached.messages.len(), 1);
             assert_eq!(cached.messages[0].dedup_key.as_deref(), Some("old:req_old"));
         }
-
-        restore_cache_home(original_home);
     }
 
     #[cfg(unix)]
@@ -6603,8 +6564,7 @@ mod tests {
 
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let message_dir = source_home
@@ -6648,8 +6608,6 @@ mod tests {
             );
             assert_eq!(second_messages.len(), 1);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6657,8 +6615,7 @@ mod tests {
     fn test_empty_cache_hits_are_reparsed_for_optional_file_sources() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let message_dir =
@@ -6699,8 +6656,6 @@ mod tests {
                 .unwrap();
             assert_eq!(repaired_entry.messages.len(), 1);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6708,8 +6663,7 @@ mod tests {
     fn test_sqlite_source_cache_invalidates_on_wal_change() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let db_dir = source_home.path().join(".local/share/opencode");
@@ -6773,8 +6727,6 @@ mod tests {
             );
             assert_eq!(refreshed_messages.len(), 2);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6785,8 +6737,7 @@ mod tests {
         // must only be counted once.
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let db_dir = source_home.path().join(".local/share/opencode");
@@ -6886,8 +6837,6 @@ mod tests {
                 "warm cache must also dedup shared message across channel dbs"
             );
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6895,8 +6844,7 @@ mod tests {
     fn test_parse_all_messages_with_pricing_opencode_sqlite_deduplicates_forked_history() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let db_dir = source_home.path().join(".local/share/opencode");
@@ -6961,8 +6909,6 @@ mod tests {
             assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 250);
             assert_eq!(messages.iter().map(|m| m.cost).sum::<f64>(), 0.06);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -6970,8 +6916,7 @@ mod tests {
     fn test_parse_local_clients_opencode_sqlite_counts_deduplicated_forked_history() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let db_dir = source_home.path().join(".local/share/opencode");
@@ -7041,8 +6986,6 @@ mod tests {
             assert_eq!(parsed.messages.iter().map(|m| m.input).sum::<i64>(), 600);
             assert_eq!(parsed.messages.iter().map(|m| m.output).sum::<i64>(), 250);
         }
-
-        restore_cache_home(original_home);
     }
 
     fn write_codex_forked_history_fixture(source_home: &std::path::Path) {
@@ -7194,8 +7137,7 @@ mod tests {
     fn test_parse_all_messages_with_pricing_codex_deduplicates_forked_history() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             write_codex_forked_history_fixture(source_home.path());
@@ -7229,8 +7171,6 @@ mod tests {
                 33
             );
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7238,8 +7178,7 @@ mod tests {
     fn test_parse_all_messages_with_pricing_codex_keeps_user_fork_own_turn() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             write_codex_user_fork_replay_fixture(source_home.path());
@@ -7263,8 +7202,6 @@ mod tests {
             );
             assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 150);
         }
-
-        restore_cache_home(original_home);
     }
 
     /// Regression fixture for issue #779: Codex CLI moves aged sessions from
@@ -7335,8 +7272,7 @@ mod tests {
     {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             write_codex_sessions_and_archived_sessions_fixture(source_home.path());
@@ -7371,8 +7307,6 @@ mod tests {
             // 5 (live-only) + 7 (archived-only) + 3 (shared, once) = 15.
             assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 15);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7380,8 +7314,7 @@ mod tests {
     fn test_parse_all_messages_with_pricing_codex_deduplicates_parent_replay_across_forks() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             write_codex_parent_replay_fixture(source_home.path());
@@ -7405,8 +7338,6 @@ mod tests {
             assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 140);
             assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 14);
         }
-
-        restore_cache_home(original_home);
     }
 
     fn write_codex_twin_token_count_fixture(source_home: &std::path::Path) {
@@ -7438,8 +7369,7 @@ mod tests {
     fn test_parse_all_messages_with_pricing_codex_keeps_twin_token_counts_at_distinct_timestamps() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             write_codex_twin_token_count_fixture(source_home.path());
@@ -7478,8 +7408,6 @@ mod tests {
                 4,
             );
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7487,8 +7415,7 @@ mod tests {
     fn test_parse_local_clients_codex_counts_deduplicated_forked_history() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             write_codex_forked_history_fixture(source_home.path());
@@ -7531,8 +7458,6 @@ mod tests {
                 33
             );
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7541,8 +7466,7 @@ mod tests {
         let cache_home = tempfile::TempDir::new().unwrap();
         let fresh_cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let mut cache_env = redirect_cache_home(cache_home.path());
 
         {
             let codex_dir = client_scan_root(source_home.path(), ClientId::Codex);
@@ -7593,7 +7517,7 @@ mod tests {
                 &["codex".to_string()],
                 None,
             );
-            redirect_cache_home(fresh_cache_home.path());
+            point_cache_home(&mut cache_env, fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(
                 source_home.path().to_str().unwrap(),
                 &["codex".to_string()],
@@ -7606,8 +7530,6 @@ mod tests {
                 .iter()
                 .all(|message| message.model_id == "gpt-5.5"));
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7616,8 +7538,7 @@ mod tests {
         let cache_home = tempfile::TempDir::new().unwrap();
         let fresh_cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let mut cache_env = redirect_cache_home(cache_home.path());
 
         {
             let codex_dir = source_home.path().join(".codex/sessions");
@@ -7661,7 +7582,7 @@ mod tests {
                 &["codex".to_string()],
                 None,
             );
-            redirect_cache_home(fresh_cache_home.path());
+            point_cache_home(&mut cache_env, fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(
                 source_home.path().to_str().unwrap(),
                 &["codex".to_string()],
@@ -7670,8 +7591,6 @@ mod tests {
 
             assert_eq!(warm_messages, fresh_messages);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7680,8 +7599,7 @@ mod tests {
         let cache_home = tempfile::TempDir::new().unwrap();
         let fresh_cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let mut cache_env = redirect_cache_home(cache_home.path());
 
         {
             let codex_dir = source_home.path().join(".codex/sessions");
@@ -7734,7 +7652,7 @@ mod tests {
                 )
                 .is_none());
 
-            redirect_cache_home(fresh_cache_home.path());
+            point_cache_home(&mut cache_env, fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(
                 source_home.path().to_str().unwrap(),
                 &["codex".to_string()],
@@ -7743,8 +7661,6 @@ mod tests {
 
             assert_eq!(warm_messages, fresh_messages);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7752,8 +7668,7 @@ mod tests {
     fn test_exact_hit_codex_cache_repairs_fallback_timestamps_without_incremental_state() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home.path().join(".codex/sessions");
@@ -7797,8 +7712,6 @@ mod tests {
 
             assert_eq!(messages, expected);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7807,8 +7720,7 @@ mod tests {
         let cache_home = tempfile::TempDir::new().unwrap();
         let fresh_cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let mut cache_env = redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home.path().join(".codex/sessions");
@@ -7838,7 +7750,7 @@ mod tests {
                 None,
             );
 
-            redirect_cache_home(fresh_cache_home.path());
+            point_cache_home(&mut cache_env, fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(
                 source_home.path().to_str().unwrap(),
                 &["codex".to_string()],
@@ -7848,8 +7760,6 @@ mod tests {
             assert_eq!(warm_messages, fresh_messages);
             assert_ne!(warm_messages[0].timestamp, initial_messages[0].timestamp);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7857,8 +7767,7 @@ mod tests {
     fn test_full_log_parse_preserves_valid_messages_before_invalid_line_error() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home.path().join(".codex/sessions");
@@ -7895,8 +7804,6 @@ mod tests {
                 )
                 .is_none());
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7905,8 +7812,7 @@ mod tests {
         let cache_home = tempfile::TempDir::new().unwrap();
         let fresh_cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let mut cache_env = redirect_cache_home(cache_home.path());
 
         {
             let session_dir = client_scan_root(source_home.path(), ClientId::Codex);
@@ -7958,7 +7864,7 @@ mod tests {
                 None,
             );
 
-            redirect_cache_home(fresh_cache_home.path());
+            point_cache_home(&mut cache_env, fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(
                 source_home.path().to_str().unwrap(),
                 &["codex".to_string()],
@@ -7969,7 +7875,7 @@ mod tests {
             assert_eq!(resumed_messages.len(), 1);
             assert_eq!(resumed_messages[0].model_id, "gpt-5.5");
 
-            redirect_cache_home(cache_home.path());
+            point_cache_home(&mut cache_env, cache_home.path());
             assert!(message_cache::SourceMessageCache::load()
                 .get(
                     message_cache::CacheIdentity::for_client(ClientId::Codex),
@@ -7977,8 +7883,6 @@ mod tests {
                 )
                 .is_some());
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -7987,8 +7891,7 @@ mod tests {
         let cache_home = tempfile::TempDir::new().unwrap();
         let fresh_cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let mut cache_env = redirect_cache_home(cache_home.path());
 
         {
             let session_dir = source_home.path().join(".codex/sessions");
@@ -8039,7 +7942,7 @@ mod tests {
                 None,
             );
 
-            redirect_cache_home(fresh_cache_home.path());
+            point_cache_home(&mut cache_env, fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(
                 source_home.path().to_str().unwrap(),
                 &["codex".to_string()],
@@ -8049,8 +7952,6 @@ mod tests {
             assert_eq!(warm_messages, fresh_messages);
             assert_eq!(warm_messages.len(), 2);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -8058,8 +7959,7 @@ mod tests {
     fn test_source_cache_does_not_reuse_priced_cost_without_pricing_service() {
         let temp_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(temp_home.path());
+        let _cache_env = redirect_cache_home(temp_home.path());
         {
             let cursor_cache_dir = source_home.path().join(".config/tokscale/cursor-cache");
             std::fs::create_dir_all(&cursor_cache_dir).unwrap();
@@ -8097,8 +7997,6 @@ mod tests {
             assert_eq!(cached_messages.len(), 1);
             assert_eq!(cached_messages[0].cost, 0.0);
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -10362,8 +10260,7 @@ mod tests {
     fn test_parse_all_messages_refreshes_cc_mirror_provider_when_variant_metadata_changes() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let variant_dir = source_home.path().join(".cc-mirror/kimi-code");
@@ -10415,8 +10312,6 @@ mod tests {
             assert_eq!(refreshed_messages[0].client, "cc-mirror/kimi-code");
             assert_eq!(refreshed_messages[0].provider_id, "minimax");
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]
@@ -10424,8 +10319,7 @@ mod tests {
     fn test_parse_all_messages_keeps_normal_claude_when_cc_mirror_points_at_claude_config() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = capture_cache_home();
-        redirect_cache_home(cache_home.path());
+        let _cache_env = redirect_cache_home(cache_home.path());
 
         {
             let claude_dir = source_home.path().join(".claude");
@@ -10458,8 +10352,6 @@ mod tests {
             assert_eq!(messages.len(), 1);
             assert_eq!(messages[0].client, "claude");
         }
-
-        restore_cache_home(original_home);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -10413,8 +10413,8 @@ mod tests {
             std::fs::write(
                 &variant_path,
                 format!(
-                    r#"{{"name":"kimi-code","provider":"kimi","configDir":"{}"}}"#,
-                    config_dir.display()
+                    r#"{{"name":"kimi-code","provider":"kimi","configDir":{}}}"#,
+                    paths::json_path_literal(&config_dir)
                 ),
             )
             .unwrap();
@@ -10438,8 +10438,8 @@ mod tests {
             std::fs::write(
                 &variant_path,
                 format!(
-                    r#"{{"name":"kimi-code","provider":"minimax","configDir":"{}"}}"#,
-                    config_dir.display()
+                    r#"{{"name":"kimi-code","provider":"minimax","configDir":{}}}"#,
+                    paths::json_path_literal(&config_dir)
                 ),
             )
             .unwrap();
@@ -10485,8 +10485,8 @@ mod tests {
             std::fs::write(
                 variant_dir.join("variant.json"),
                 format!(
-                    r#"{{"name":"plain-mirror","provider":"mirror","configDir":"{}"}}"#,
-                    claude_dir.display()
+                    r#"{{"name":"plain-mirror","provider":"mirror","configDir":{}}}"#,
+                    paths::json_path_literal(&claude_dir)
                 ),
             )
             .unwrap();

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -751,8 +751,25 @@ impl CachedPath {
     }
 }
 
+/// `/` and `\` as UTF-16 code units, and the `\\?\` verbatim prefix.
 #[cfg(windows)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+const FORWARD_SLASH_UTF16: u16 = b'/' as u16;
+#[cfg(windows)]
+const BACKSLASH_UTF16: u16 = b'\\' as u16;
+#[cfg(windows)]
+const VERBATIM_PREFIX_UTF16: [u16; 4] = [
+    BACKSLASH_UTF16,
+    BACKSLASH_UTF16,
+    b'?' as u16,
+    BACKSLASH_UTF16,
+];
+
+/// The stored spelling is kept verbatim so [`CachedPath::to_path_buf`] hands
+/// back exactly the path that was cached, but *identity* — equality, hashing
+/// and the shard digest — folds `/` into `\` first. See [`CachedPath::
+/// identity_units`] for why.
+#[cfg(windows)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct CachedPath(Vec<u16>);
 
 #[cfg(windows)]
@@ -770,9 +787,70 @@ impl CachedPath {
         PathBuf::from(OsString::from_wide(&self.0))
     }
 
+    /// The code units this path is *identified* by: the stored ones, with `/`
+    /// folded to `\`.
+    ///
+    /// On Windows both characters are directory separators, so `C:\a/b\f.jsonl`
+    /// and `C:\a\b\f.jsonl` name one file — and a scan produces both spellings
+    /// for that one file. `ClientDef::resolve_path` assembles every scan root by
+    /// string concatenation (`format!("{root}/{relative}")`), so the root half
+    /// carries forward slashes, while `WalkDir` appends each child below it with
+    /// the platform separator. Hashing the units as written therefore gave one
+    /// file two cache keys.
+    ///
+    /// That is not only a test artifact. `tokscale --home C:/Users/me` and a
+    /// default run (where `dirs` yields `C:\Users\me`) disagree on every key, so
+    /// neither run can ever read the other's entries: the cache stays cold and
+    /// the shards accumulate a duplicate copy of every file. Git Bash and MSYS2
+    /// export `HOME` with forward slashes, so this is reachable without anyone
+    /// typing an unusual path.
+    ///
+    /// Paths in the verbatim namespace are exempt. After `\\?\` the object
+    /// manager performs no translation at all, so `/` there is an ordinary
+    /// character in a name rather than a separator, and folding it would merge
+    /// two genuinely different paths.
+    ///
+    /// Case is deliberately *not* folded. Windows filesystems are usually but
+    /// not always case-insensitive — NTFS supports per-directory sensitivity —
+    /// so folding case could merge two real files. Separator folding has no such
+    /// exception outside the verbatim namespace, which is why only it is safe.
+    fn identity_units(&self) -> impl Iterator<Item = u16> + '_ {
+        let verbatim = self.0.starts_with(&VERBATIM_PREFIX_UTF16);
+        self.0.iter().map(move |unit| {
+            if !verbatim && *unit == FORWARD_SLASH_UTF16 {
+                BACKSLASH_UTF16
+            } else {
+                *unit
+            }
+        })
+    }
+
     fn update_digest(&self, hasher: &mut Sha256) {
-        for code_unit in &self.0 {
+        for code_unit in self.identity_units() {
             hasher.update(code_unit.to_le_bytes());
+        }
+    }
+}
+
+#[cfg(windows)]
+impl PartialEq for CachedPath {
+    fn eq(&self, other: &Self) -> bool {
+        self.identity_units().eq(other.identity_units())
+    }
+}
+
+#[cfg(windows)]
+impl Eq for CachedPath {}
+
+#[cfg(windows)]
+impl std::hash::Hash for CachedPath {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Length first, mirroring the `Vec<u16>` derive this replaces. Folding
+        // `/` to `\` never changes the length, so this stays consistent with
+        // the `PartialEq` above.
+        state.write_usize(self.0.len());
+        for code_unit in self.identity_units() {
+            state.write_u16(code_unit);
         }
     }
 }
@@ -3859,5 +3937,67 @@ mod tests {
         let cached_path = CachedPath::from_path(&path);
 
         assert_eq!(cached_path.to_path_buf(), path);
+    }
+
+    /// One file reached under both separators is one cache entry.
+    ///
+    /// A scan spells a discovered transcript with both: the root half comes
+    /// from `format!("{root}/{relative}")` and the children below it from
+    /// `Path::join`. Keying on the raw code units made those two spellings two
+    /// entries for one file, so the cache could never hit.
+    #[cfg(windows)]
+    #[test]
+    fn cached_path_identity_folds_the_two_windows_separators() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        fn hash_of(path: &CachedPath) -> u64 {
+            let mut hasher = DefaultHasher::new();
+            path.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        let mixed = CachedPath::from_path(Path::new(r"C:\home/.claude/projects\demo\s.jsonl"));
+        let native = CachedPath::from_path(Path::new(r"C:\home\.claude\projects\demo\s.jsonl"));
+
+        assert_eq!(mixed, native, "both spellings name one file");
+        assert_eq!(hash_of(&mixed), hash_of(&native), "Hash must match Eq");
+
+        let mut digests = Vec::new();
+        for path in [&mixed, &native] {
+            let mut hasher = Sha256::new();
+            path.update_digest(&mut hasher);
+            digests.push(hasher.finalize());
+        }
+        assert_eq!(
+            digests[0], digests[1],
+            "the shard digest must agree too, or one file lands in two shards"
+        );
+
+        // The stored spelling is untouched: `to_path_buf` still round-trips,
+        // which `SourceMessageCache` relies on to stat the file it cached.
+        assert_eq!(
+            mixed.to_path_buf(),
+            PathBuf::from(r"C:\home/.claude/projects\demo\s.jsonl")
+        );
+
+        // Different files stay different.
+        let other = CachedPath::from_path(Path::new(r"C:\home\.claude\projects\demo\t.jsonl"));
+        assert_ne!(mixed, other);
+    }
+
+    /// After `\\?\` the object manager stops translating, so `/` is an ordinary
+    /// character in a name rather than a separator. Folding it there would merge
+    /// two genuinely different paths.
+    #[cfg(windows)]
+    #[test]
+    fn cached_path_identity_leaves_verbatim_paths_alone() {
+        let with_slash = CachedPath::from_path(Path::new(r"\\?\C:\dir/name\f.jsonl"));
+        let with_backslash = CachedPath::from_path(Path::new(r"\\?\C:\dir\name\f.jsonl"));
+
+        assert_ne!(
+            with_slash, with_backslash,
+            "inside the verbatim namespace `/` is part of the name, not a separator"
+        );
     }
 }

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1796,6 +1796,7 @@ pub(crate) fn codex_cache_entry_matches_fingerprint(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::paths::json_path_literal;
     use crate::TokenBreakdown;
     use std::io::Write;
     use tempfile::{NamedTempFile, TempDir};
@@ -2872,8 +2873,8 @@ mod tests {
         std::fs::write(
             &variant_path,
             format!(
-                r#"{{"name":"kimi-code","provider":"kimi","configDir":"{}"}}"#,
-                config_dir.display()
+                r#"{{"name":"kimi-code","provider":"kimi","configDir":{}}}"#,
+                json_path_literal(&config_dir)
             ),
         )
         .unwrap();
@@ -2883,8 +2884,8 @@ mod tests {
         std::fs::write(
             &variant_path,
             format!(
-                r#"{{"name":"kimi-code","provider":"minimax","configDir":"{}"}}"#,
-                config_dir.display()
+                r#"{{"name":"kimi-code","provider":"minimax","configDir":{}}}"#,
+                json_path_literal(&config_dir)
             ),
         )
         .unwrap();
@@ -2912,8 +2913,8 @@ mod tests {
         std::fs::write(
             &variant_path,
             format!(
-                r#"{{"name":"kimi-code","provider":"kimi","configDir":"{}"}}"#,
-                config_dir.display()
+                r#"{{"name":"kimi-code","provider":"kimi","configDir":{}}}"#,
+                json_path_literal(&config_dir)
             ),
         )
         .unwrap();
@@ -2924,8 +2925,8 @@ mod tests {
         std::fs::write(
             &variant_path,
             format!(
-                r#"{{"name":"kimi-code","provider":"minimax","configDir":"{}"}}"#,
-                config_dir.display()
+                r#"{{"name":"kimi-code","provider":"minimax","configDir":{}}}"#,
+                json_path_literal(&config_dir)
             ),
         )
         .unwrap();

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1959,55 +1959,44 @@ mod tests {
     }
 
     /// Pin every env var the cache resolvers consult so the test stays
-    /// inside `temp_home`. CI runners can leak `XDG_CONFIG_HOME` /
-    /// `XDG_CACHE_HOME` from the host, which would resolve cache shards outside
-    /// the sandbox. Returns the previous values so the caller can restore.
-    fn sandbox_cache_env(
-        temp_home: &std::path::Path,
-    ) -> (
-        Option<std::ffi::OsString>,
-        Option<std::ffi::OsString>,
-        Option<std::ffi::OsString>,
-        Option<std::ffi::OsString>,
-    ) {
-        let prev_home = std::env::var_os("HOME");
-        let prev_xdg_config = std::env::var_os("XDG_CONFIG_HOME");
-        let prev_xdg_cache = std::env::var_os("XDG_CACHE_HOME");
-        let prev_override = std::env::var_os("TOKSCALE_CONFIG_DIR");
-        unsafe {
-            std::env::set_var("HOME", temp_home);
-            std::env::set_var("XDG_CONFIG_HOME", temp_home.join(".config"));
-            std::env::set_var("XDG_CACHE_HOME", temp_home.join(".cache"));
-            // The three above isolate the cache on Unix and none of them reach
-            // it on Windows: `paths::get_config_dir` resolves the Windows root
-            // with `dirs::config_dir()`, a known-folder lookup that reads no
-            // environment variable. Without this line every test here shared
-            // one real `%APPDATA%\tokscale\cache`, so `SourceMessageCache::load`
-            // returned its neighbours' shards along with its own and the entry
-            // counts came out too high. `TOKSCALE_CONFIG_DIR` is the override
-            // paths.rs documents for this case and is consulted first
-            // everywhere; on Unix it names the directory the redirects above
-            // already produced.
-            std::env::set_var(
-                "TOKSCALE_CONFIG_DIR",
-                temp_home.join(".config").join("tokscale"),
-            );
-        }
-        (prev_home, prev_xdg_config, prev_xdg_cache, prev_override)
-    }
-
-    fn restore_cache_env(
-        prev: (
-            Option<std::ffi::OsString>,
-            Option<std::ffi::OsString>,
-            Option<std::ffi::OsString>,
-            Option<std::ffi::OsString>,
-        ),
-    ) {
-        restore_env_var("HOME", prev.0);
-        restore_env_var("XDG_CONFIG_HOME", prev.1);
-        restore_env_var("XDG_CACHE_HOME", prev.2);
-        restore_env_var("TOKSCALE_CONFIG_DIR", prev.3);
+    /// inside `temp_home`, until the returned guard drops. CI runners can leak
+    /// `XDG_CONFIG_HOME` / `XDG_CACHE_HOME` from the host, which would resolve
+    /// cache shards outside the sandbox.
+    ///
+    /// The restore has to be a `Drop` guard rather than a trailing call. A
+    /// failing assertion panics before any trailing restore runs, and of the
+    /// four keys here `TOKSCALE_CONFIG_DIR` is consulted first on every
+    /// platform — so a leaked one aims every later test in this binary at a
+    /// `TempDir` that has already been dropped, which is the contamination this
+    /// sandbox exists to prevent. `serial_test` prevents overlap, not
+    /// inheritance.
+    #[must_use = "the sandbox is torn down as soon as the guard drops; bind it to a \
+                  named variable that outlives the test body"]
+    fn sandbox_cache_env(temp_home: &std::path::Path) -> crate::paths::test_env::EnvGuard {
+        let mut env = crate::paths::test_env::EnvGuard::capture(&[
+            "HOME",
+            "XDG_CONFIG_HOME",
+            "XDG_CACHE_HOME",
+            "TOKSCALE_CONFIG_DIR",
+        ]);
+        env.set("HOME", temp_home);
+        env.set("XDG_CONFIG_HOME", temp_home.join(".config"));
+        env.set("XDG_CACHE_HOME", temp_home.join(".cache"));
+        // The three above isolate the cache on Unix and none of them reach
+        // it on Windows: `paths::get_config_dir` resolves the Windows root
+        // with `dirs::config_dir()`, a known-folder lookup that reads no
+        // environment variable. Without this line every test here shared
+        // one real `%APPDATA%\tokscale\cache`, so `SourceMessageCache::load`
+        // returned its neighbours' shards along with its own and the entry
+        // counts came out too high. `TOKSCALE_CONFIG_DIR` is the override
+        // paths.rs documents for this case and is consulted first
+        // everywhere; on Unix it names the directory the redirects above
+        // already produced.
+        env.set(
+            "TOKSCALE_CONFIG_DIR",
+            temp_home.join(".config").join("tokscale"),
+        );
+        env
     }
 
     fn write_temp_file(content: &[u8]) -> NamedTempFile {
@@ -2683,7 +2672,7 @@ mod tests {
     #[serial_test::serial]
     fn test_kimi_stale_parser_cache_is_rejected_and_rebuilt_with_same_fingerprint() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
         let source_home = TempDir::new().unwrap();
         // Spelled the way the scan will spell it. `ClientDef::resolve_path`
         // joins the root with `/` and `WalkDir` appends the components below it
@@ -2803,8 +2792,6 @@ mod tests {
             &crate::scanner::ScannerSettings::default(),
         );
         assert_eq!(second, first);
-
-        restore_cache_env(prev_env);
     }
 
     #[test]
@@ -3119,7 +3106,7 @@ mod tests {
     #[serial_test::serial]
     fn test_source_message_cache_round_trips_across_distinct_shards() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
         let source_dir = TempDir::new().unwrap();
         let identity = CacheIdentity::for_client(ClientId::Claude);
         let (path_one, path_two) = write_sources_in_distinct_shards(&source_dir, identity);
@@ -3138,8 +3125,6 @@ mod tests {
         assert_eq!(loaded.entries.len(), 2);
         assert!(loaded.get(identity, &path_one).is_some());
         assert!(loaded.get(identity, &path_two).is_some());
-
-        restore_cache_env(prev_env);
     }
 
     #[test]
@@ -3148,7 +3133,7 @@ mod tests {
         const TEST_SHARD_LIMIT: u64 = 32 * 1024;
 
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
         let source_dir = TempDir::new().unwrap();
         let identity = CacheIdentity::for_client(ClientId::Claude);
         let (path_one, path_two) = write_sources_in_distinct_shards(&source_dir, identity);
@@ -3178,15 +3163,13 @@ mod tests {
         let loaded = SourceMessageCache::load();
         assert!(loaded.get(identity, &path_one).is_some());
         assert!(loaded.get(identity, &path_two).is_some());
-
-        restore_cache_env(prev_env);
     }
 
     #[test]
     #[serial_test::serial]
     fn test_corrupt_shard_does_not_hide_entries_from_other_shards() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
         let source_dir = TempDir::new().unwrap();
         let identity = CacheIdentity::for_client(ClientId::Claude);
         let (corrupt_path, valid_path) = write_sources_in_distinct_shards(&source_dir, identity);
@@ -3213,15 +3196,13 @@ mod tests {
             loaded.dirty,
             "the corrupt shard should be scheduled for rewrite"
         );
-
-        restore_cache_env(prev_env);
     }
 
     #[test]
     #[serial_test::serial]
     fn test_stale_parser_shard_is_skipped_before_decoding_garbage_payload() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
         let source = write_temp_file(b"claude\n");
         let claude = CacheIdentity::for_client(ClientId::Claude);
         let codex = CacheIdentity::for_client(ClientId::Codex);
@@ -3272,15 +3253,13 @@ mod tests {
         assert!(SourceMessageCache::load()
             .get(claude, source.path())
             .is_some());
-
-        restore_cache_env(prev_env);
     }
 
     #[test]
     #[serial_test::serial]
     fn test_prior_cache_format_shard_is_skipped_before_decoding_payload() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
         let codex = CacheIdentity::for_client(ClientId::Codex);
         let stale_key = CacheShardKey {
             namespace: codex.namespace.to_string(),
@@ -3304,15 +3283,13 @@ mod tests {
             read_shard(&stale_path, codex),
             ShardReadStatus::Stale
         ));
-
-        restore_cache_env(prev_env);
     }
 
     #[test]
     #[serial_test::serial]
     fn test_copilot_stale_cache_is_rejected_and_rebuilt_with_root_agent() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
         let source_dir = TempDir::new().unwrap();
         let source_path = source_dir.path().join("copilot-otel.jsonl");
         std::fs::write(
@@ -3439,15 +3416,13 @@ mod tests {
                     && entries[0].messages[0].agent.as_deref()
                         == Some("github.copilot.default")
         ));
-
-        restore_cache_env(prev_env);
     }
 
     #[test]
     #[serial_test::serial]
     fn test_explicit_invalidation_of_existing_path_persists() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
         let source = write_temp_file(b"still exists\n");
         let identity = CacheIdentity::for_client(ClientId::Claude);
 
@@ -3469,15 +3444,13 @@ mod tests {
         assert!(SourceMessageCache::load()
             .get(identity, source.path())
             .is_none());
-
-        restore_cache_env(prev_env);
     }
 
     #[test]
     #[serial_test::serial]
     fn test_stale_invalidation_preserves_concurrently_refreshed_entry() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
         let source_dir = TempDir::new().unwrap();
         let path = source_dir.path().join("session.jsonl");
         let identity = CacheIdentity::for_client(ClientId::Claude);
@@ -3502,8 +3475,6 @@ mod tests {
             loaded.get(identity, &path).unwrap().messages[0].session_id,
             "fresh-session"
         );
-
-        restore_cache_env(prev_env);
     }
 
     #[test]
@@ -3542,7 +3513,7 @@ mod tests {
     #[serial_test::serial]
     fn test_save_if_dirty_marks_cache_clean() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
 
         let mut cache = SourceMessageCache::default();
         assert!(!cache.dirty);
@@ -3556,15 +3527,13 @@ mod tests {
             cache.save_if_dirty();
             assert!(!cache.dirty);
         }
-
-        restore_cache_env(prev_env);
     }
 
     #[test]
     #[serial_test::serial]
     fn test_save_if_dirty_merges_concurrent_writers() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
 
         {
             let source_dir = TempDir::new().unwrap();
@@ -3588,15 +3557,13 @@ mod tests {
             assert!(loaded.get(identity, &path_one).is_some());
             assert!(loaded.get(identity, &path_two).is_some());
         }
-
-        restore_cache_env(prev_env);
     }
 
     #[test]
     #[serial_test::serial]
     fn test_save_if_dirty_preserves_recreated_path_from_concurrent_writer() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
 
         {
             let source_dir = TempDir::new().unwrap();
@@ -3625,8 +3592,6 @@ mod tests {
                 .expect("recreated source cache entry should survive stale delete");
             assert_eq!(entry.messages[0].session_id, "fresh-session");
         }
-
-        restore_cache_env(prev_env);
     }
 
     fn keyed_message(namespace: &str, session_id: &str, dedup_key: &str) -> UnifiedMessage {
@@ -3674,7 +3639,7 @@ mod tests {
     #[serial_test::serial]
     fn test_loading_claude_cache_removes_synthetic_placeholder_rows_without_retiring_history() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
 
         {
             let source_dir = TempDir::new().unwrap();
@@ -3732,15 +3697,13 @@ mod tests {
                             .all(|message| message.model_id != " <SYNTHETIC> ")
             ));
         }
-
-        restore_cache_env(prev_env);
     }
 
     #[test]
     #[serial_test::serial]
     fn test_claude_cache_save_does_not_restore_synthetic_history_from_another_writer() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
 
         {
             let source_dir = TempDir::new().unwrap();
@@ -3775,8 +3738,6 @@ mod tests {
                         && entries[0].messages[0].dedup_key.as_deref() == Some("live:req_live")
             ));
         }
-
-        restore_cache_env(prev_env);
     }
 
     /// A Claude entry can hold assistant turns the live transcript no longer
@@ -3788,7 +3749,7 @@ mod tests {
     #[serial_test::serial]
     fn test_save_if_dirty_unions_retained_history_for_the_same_path() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
 
         {
             let source_dir = TempDir::new().unwrap();
@@ -3832,8 +3793,6 @@ mod tests {
                 "and must not duplicate the shared turn"
             );
         }
-
-        restore_cache_env(prev_env);
     }
 
     /// The union is scoped to keys that stay valid wherever the message is
@@ -3844,7 +3803,7 @@ mod tests {
     #[serial_test::serial]
     fn test_save_if_dirty_does_not_union_path_scoped_keys() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
 
         {
             let source_dir = TempDir::new().unwrap();
@@ -3880,8 +3839,6 @@ mod tests {
                 "path-scoped keys must not outlive the bytes that produced them"
             );
         }
-
-        restore_cache_env(prev_env);
     }
 
     /// The union exists only for namespaces that retain history. Everywhere
@@ -3891,7 +3848,7 @@ mod tests {
     #[serial_test::serial]
     fn test_save_if_dirty_still_replaces_entries_for_non_retaining_clients() {
         let temp_home = TempDir::new().unwrap();
-        let prev_env = sandbox_cache_env(temp_home.path());
+        let _cache_env = sandbox_cache_env(temp_home.path());
 
         {
             let source_dir = TempDir::new().unwrap();
@@ -3923,8 +3880,6 @@ mod tests {
             let entry = loaded.get(identity, &path).expect("entry should survive");
             assert_eq!(entry.messages.len(), 1);
         }
-
-        restore_cache_env(prev_env);
     }
 
     #[cfg(unix)]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -2607,9 +2607,21 @@ mod tests {
         let temp_home = TempDir::new().unwrap();
         let prev_env = sandbox_cache_env(temp_home.path());
         let source_home = TempDir::new().unwrap();
-        let wire_path = source_home
-            .path()
-            .join(".kimi/sessions/group/session/wire.jsonl");
+        // Spelled the way the scan will spell it. `ClientDef::resolve_path`
+        // joins the root with `/` and `WalkDir` appends the components below it
+        // with the platform separator, so on Windows the parse stores this
+        // entry under `<home>/.kimi/sessions\group\session\wire.jsonl` while a
+        // `Path::join` fixture asks for it back under all backslashes.
+        // `CachedPath` keys on the OS string as written, so those are two keys
+        // for one file and the lookup below found nothing.
+        let wire_path = PathBuf::from(
+            ClientId::Kimi
+                .data()
+                .resolve_path_with_env_strategy(&source_home.path().to_string_lossy(), false),
+        )
+        .join("group")
+        .join("session")
+        .join("wire.jsonl");
         std::fs::create_dir_all(wire_path.parent().unwrap()).unwrap();
         std::fs::write(
             &wire_path,
@@ -3152,11 +3164,18 @@ mod tests {
             parser_version: codex.parser_version.saturating_sub(1),
             payload: b"deliberately invalid entry payload".to_vec(),
         };
-        let mut writer = BufWriter::new(File::create(&stale_path).unwrap());
-        bincode::options()
-            .serialize_into(&mut writer, &stale_envelope)
-            .unwrap();
-        writer.flush().unwrap();
+        // Scoped, so the handle is closed before anything rewrites this shard:
+        // the rewrite goes through an atomic replace, and Windows refuses to
+        // replace a file another handle still has open (`Access is denied`, os
+        // error 5). On Unix the rename succeeds with the handle open, which is
+        // why the leak was invisible.
+        {
+            let mut writer = BufWriter::new(File::create(&stale_path).unwrap());
+            bincode::options()
+                .serialize_into(&mut writer, &stale_envelope)
+                .unwrap();
+            writer.flush().unwrap();
+        }
 
         assert!(matches!(
             read_shard(&stale_path, codex),

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1900,7 +1900,20 @@ mod tests {
             std::env::set_var("HOME", temp_home);
             std::env::set_var("XDG_CONFIG_HOME", temp_home.join(".config"));
             std::env::set_var("XDG_CACHE_HOME", temp_home.join(".cache"));
-            std::env::remove_var("TOKSCALE_CONFIG_DIR");
+            // The three above isolate the cache on Unix and none of them reach
+            // it on Windows: `paths::get_config_dir` resolves the Windows root
+            // with `dirs::config_dir()`, a known-folder lookup that reads no
+            // environment variable. Without this line every test here shared
+            // one real `%APPDATA%\tokscale\cache`, so `SourceMessageCache::load`
+            // returned its neighbours' shards along with its own and the entry
+            // counts came out too high. `TOKSCALE_CONFIG_DIR` is the override
+            // paths.rs documents for this case and is consulted first
+            // everywhere; on Unix it names the directory the redirects above
+            // already produced.
+            std::env::set_var(
+                "TOKSCALE_CONFIG_DIR",
+                temp_home.join(".config").join("tokscale"),
+            );
         }
         (prev_home, prev_xdg_config, prev_xdg_cache, prev_override)
     }

--- a/crates/tokscale-core/src/paths.rs
+++ b/crates/tokscale-core/src/paths.rs
@@ -224,6 +224,28 @@ pub(crate) mod test_env {
     }
 }
 
+/// Encode a filesystem path as a JSON string *literal*, quotes included, for
+/// the fixtures that hand-assemble config files with `format!`.
+///
+/// A `format!(r#"{{"configDir":"{}"}}"#, dir.display())` reads as harmless
+/// until the path contains a backslash. `C:\Users\RUNNER~1\...` puts `\U`,
+/// `\A` and `\T` inside a JSON string, none of which are escape sequences, so
+/// `serde_json::from_str` rejects the whole document. The production readers
+/// all treat an unparseable config as "absent" rather than erroring, so the
+/// test does not fail where the fixture is wrong — it fails several layers
+/// later, asserting on a discovery that silently found nothing. Real writers
+/// (Crush's Go `encoding/json`, cc-mirror's Node `JSON.stringify`) escape the
+/// separator, so the fixture was the only thing that ever produced invalid
+/// JSON.
+///
+/// Returns the quoted literal rather than the inner text so a call site cannot
+/// re-add the quotes and undo the escaping: write `"path": {}` around it, not
+/// `"path": "{}"`.
+#[cfg(test)]
+pub(crate) fn json_path_literal(path: &std::path::Path) -> String {
+    serde_json::to_string(&path.to_string_lossy()).expect("a string always serializes to JSON")
+}
+
 #[cfg(test)]
 mod tests {
     use super::test_env::EnvGuard;

--- a/crates/tokscale-core/src/pricing/cache.rs
+++ b/crates/tokscale-core/src/pricing/cache.rs
@@ -118,14 +118,40 @@ fn legacy_cache_paths(filename: &str) -> Vec<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    // The imports the one test here needs live in its body: the test is
+    // `#[cfg(unix)]`, and at module scope they would be unused imports on
+    // Windows.
+    #[allow(unused_imports)]
     use super::*;
-    use crate::paths::test_env::EnvGuard;
-    use serial_test::serial;
-    use tempfile::TempDir;
 
+    /// Unix-only, because the fixture this test needs cannot be placed on
+    /// Windows without leaving the sandbox.
+    ///
+    /// The test has to write a pricing file into `legacy_dirs_cache_dir()`,
+    /// which is `dirs::cache_dir()/tokscale`. `dirs::cache_dir()` reads
+    /// `XDG_CACHE_HOME` on Linux and `$HOME` on macOS, so the redirects below
+    /// move it into the temp dir; on Windows it is a `SHGetKnownFolderPath`
+    /// call that no environment variable reaches, so it stays at the real
+    /// `%LOCALAPPDATA%\tokscale\`. Writing there would drop a pricing file in
+    /// the actual profile of whatever machine ran the suite — the sandbox
+    /// escape #997 was about — and the assertion would be meaningless anyway,
+    /// since that directory may already hold a cache the canonical lookup
+    /// finds first, so the fallback under test would never run.
+    ///
+    /// `#[cfg(unix)]` rather than a runtime `return`: the previous form was an
+    /// early return with no marker, so on Windows this reported as a passing
+    /// test that asserted nothing. The condition is not dynamic — it is the
+    /// platform — so the gate belongs where a reader can see it. The sandbox
+    /// check itself is kept below as an assertion, which fails loudly instead
+    /// of skipping if a Unix host ever resolves the legacy root outside the
+    /// temp dirs.
+    #[cfg(unix)]
     #[test]
-    #[serial]
+    #[serial_test::serial]
     fn load_falls_back_to_legacy_dirs_cache_path() {
+        use crate::paths::test_env::EnvGuard;
+        use tempfile::TempDir;
+
         let temp_home = TempDir::new().unwrap();
         let temp_xdg_cache = TempDir::new().unwrap();
         let mut env = EnvGuard::capture(&[
@@ -149,20 +175,18 @@ mod tests {
             .unwrap()
             .join("pricing-litellm.json");
 
-        // `dirs::cache_dir()` reads `XDG_CACHE_HOME` on Linux and `$HOME` on
-        // macOS, but on Windows it is a `SHGetKnownFolderPath` call that no
-        // environment variable reaches, so the redirects above do not move it.
-        // Writing the fixture anyway would put a pricing file in the real
-        // `%LOCALAPPDATA%\tokscale\` of whatever machine ran the suite — the
-        // same escape from the sandbox that #997 found — and the assertion
-        // would still be meaningless, because the canonical path outside the
-        // temp dir may already hold a cache and the fallback would never run.
-        // Skip instead of doing either.
-        if !legacy_path.starts_with(temp_home.path())
-            && !legacy_path.starts_with(temp_xdg_cache.path())
-        {
-            return;
-        }
+        // Never write the fixture outside the sandbox: this file lands in a
+        // real user profile if the redirects above did not take. Assert rather
+        // than skip, so a host where they stop working reports a failure
+        // instead of a silently empty test. See the note on this fn for why
+        // Windows is excluded at compile time rather than caught here.
+        assert!(
+            legacy_path.starts_with(temp_home.path())
+                || legacy_path.starts_with(temp_xdg_cache.path()),
+            "legacy cache root resolved outside the sandbox ({}); writing the \
+             fixture there would touch a real profile",
+            legacy_path.display()
+        );
 
         fs::create_dir_all(legacy_path.parent().unwrap()).unwrap();
         let now = SystemTime::now()

--- a/crates/tokscale-core/src/pricing/cache.rs
+++ b/crates/tokscale-core/src/pricing/cache.rs
@@ -119,44 +119,51 @@ fn legacy_cache_paths(filename: &str) -> Vec<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::paths::test_env::EnvGuard;
     use serial_test::serial;
-    use std::env;
     use tempfile::TempDir;
-
-    fn restore_env_var(key: &str, value: Option<std::ffi::OsString>) {
-        unsafe {
-            match value {
-                Some(value) => env::set_var(key, value),
-                None => env::remove_var(key),
-            }
-        }
-    }
 
     #[test]
     #[serial]
     fn load_falls_back_to_legacy_dirs_cache_path() {
         let temp_home = TempDir::new().unwrap();
         let temp_xdg_cache = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        let previous_xdg_cache = env::var_os("XDG_CACHE_HOME");
-        let previous_xdg_config = env::var_os("XDG_CONFIG_HOME");
-        let previous_override = env::var_os("TOKSCALE_CONFIG_DIR");
-        unsafe {
-            env::set_var("HOME", temp_home.path());
-            env::set_var("XDG_CACHE_HOME", temp_xdg_cache.path());
-            // Pin XDG_CONFIG_HOME so paths::get_cache_dir() stays inside
-            // the sandboxed HOME on Linux CI runners that set this var
-            // globally — without the pin, the canonical path resolves
-            // outside the temp dir and the legacy fallback never gets
-            // exercised because the binary never tries the right legacy
-            // root either.
-            env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
-            env::remove_var("TOKSCALE_CONFIG_DIR");
-        }
+        let mut env = EnvGuard::capture(&[
+            "HOME",
+            "XDG_CACHE_HOME",
+            "XDG_CONFIG_HOME",
+            "TOKSCALE_CONFIG_DIR",
+        ]);
+        env.set("HOME", temp_home.path());
+        env.set("XDG_CACHE_HOME", temp_xdg_cache.path());
+        // Pin XDG_CONFIG_HOME so paths::get_cache_dir() stays inside
+        // the sandboxed HOME on Linux CI runners that set this var
+        // globally — without the pin, the canonical path resolves
+        // outside the temp dir and the legacy fallback never gets
+        // exercised because the binary never tries the right legacy
+        // root either.
+        env.set("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+        env.remove("TOKSCALE_CONFIG_DIR");
 
         let legacy_path = crate::paths::legacy_dirs_cache_dir()
             .unwrap()
             .join("pricing-litellm.json");
+
+        // `dirs::cache_dir()` reads `XDG_CACHE_HOME` on Linux and `$HOME` on
+        // macOS, but on Windows it is a `SHGetKnownFolderPath` call that no
+        // environment variable reaches, so the redirects above do not move it.
+        // Writing the fixture anyway would put a pricing file in the real
+        // `%LOCALAPPDATA%\tokscale\` of whatever machine ran the suite — the
+        // same escape from the sandbox that #997 found — and the assertion
+        // would still be meaningless, because the canonical path outside the
+        // temp dir may already hold a cache and the fallback would never run.
+        // Skip instead of doing either.
+        if !legacy_path.starts_with(temp_home.path())
+            && !legacy_path.starts_with(temp_xdg_cache.path())
+        {
+            return;
+        }
+
         fs::create_dir_all(legacy_path.parent().unwrap()).unwrap();
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -170,10 +177,5 @@ mod tests {
 
         let loaded: Option<serde_json::Value> = load_cache("pricing-litellm.json");
         assert_eq!(loaded.unwrap()["ok"], serde_json::json!(true));
-
-        restore_env_var("HOME", previous_home);
-        restore_env_var("XDG_CACHE_HOME", previous_xdg_cache);
-        restore_env_var("XDG_CONFIG_HOME", previous_xdg_config);
-        restore_env_var("TOKSCALE_CONFIG_DIR", previous_override);
     }
 }

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -53,12 +53,22 @@ const RESELLER_PROVIDER_PREFIXES: &[&str] = &[
 // opus-fast key, or `gemini-default` eroding to `gemini` and landing on a
 // native-audio preview key), so such a match is never trustworthy.
 //
-// Generic English words ("model", "router") are blocked for the same reason:
-// they carry no model identity, yet substring-match real priced keys
-// (`azure_ai/model_router`, `kilo/switchpoint/router`). Without this guard an
-// id whose only fuzzy-eligible remnant after suffix stripping is the word
-// `model` (e.g. `model-zero-usage-v1` -> stripped `model`) misprices at the
-// router key's rate. See `fuzzy_match_does_not_resolve_generic_model_token`.
+// Generic English words ("model", "router", "default") are blocked for the same
+// reason: they carry no model identity, yet substring-match real priced keys
+// (`azure_ai/model_router`, `kilo/switchpoint/router`, `fireworks-ai-default`).
+// Without this guard an id whose only fuzzy-eligible remnant after suffix
+// stripping is the word `model` (e.g. `model-zero-usage-v1` -> stripped
+// `model`) misprices at the router key's rate. See
+// `fuzzy_match_does_not_resolve_generic_model_token`.
+//
+// `default` is the same failure with a live victim: the generic routing label
+// `gemini-default` strips to `default`, which fuzzy-hits LiteLLM's real
+// `fireworks-ai-default` row. That row prices at 0.0/0.0, and
+// `ModelPricing::covers_usage` treats an explicit zero as a real rate, so the
+// label looked *priced* — enough to slip past
+// `exclude_generic_unpriced_submission_messages` and be submitted at
+// Fireworks AI's rates. A Google routing label is not a Fireworks model.
+// See `fuzzy_match_does_not_resolve_generic_default_token`.
 const FUZZY_BLOCKLIST: &[&str] = &[
     "auto",
     "mini",
@@ -69,6 +79,7 @@ const FUZZY_BLOCKLIST: &[&str] = &[
     "gemini",
     "model",
     "router",
+    "default",
 ];
 
 const MAX_LOOKUP_CACHE_ENTRIES: usize = 512;
@@ -3281,6 +3292,81 @@ mod tests {
         assert_eq!(
             lookup2.lookup("model-router").unwrap().matched_key,
             "azure/model-router"
+        );
+    }
+
+    // Regression: `gemini-default` is a generic routing label — it names which
+    // router served the request, never which model did — so it must stay
+    // unpriced and be excluded from submission. Its fuzzy-eligible remnant
+    // after prefix stripping is the bare word `default`, which substring-hits
+    // LiteLLM's real `fireworks-ai-default` row.
+    //
+    // That row is priced 0.0/0.0, and `covers_usage` counts an explicit zero as
+    // a real rate, so before `default` joined the FUZZY_BLOCKLIST the label
+    // looked priced and `exclude_generic_unpriced_submission_messages` let it
+    // through — a Google routing label submitted at Fireworks AI's rates.
+    // Verified against the live LiteLLM dataset: `fireworks-ai-default` is a
+    // real key with input and output cost 0.0.
+    #[test]
+    fn fuzzy_match_does_not_resolve_generic_default_token() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "fireworks-ai-default".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0),
+                output_cost_per_token: Some(0.0),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        // The bare token must not resolve.
+        assert!(lookup.lookup("default").is_none());
+        // Nor the routing label that strips down to it, with or without the
+        // provider hint the submission path passes.
+        assert!(lookup.lookup("gemini-default").is_none());
+        assert!(lookup
+            .lookup_with_provider("gemini-default", Some("google"))
+            .is_none());
+
+        // But an EXACT key match is still honored — `fireworks-ai-default` is a
+        // real id in the dataset, not a fuzzy remnant.
+        assert_eq!(
+            lookup.lookup("fireworks-ai-default").unwrap().matched_key,
+            "fireworks-ai-default"
+        );
+    }
+
+    // The blocklist is consulted with the *query* remnant, so blocking
+    // `default` must not stop a query from matching INTO a dataset key that
+    // merely ends in `@default`. LiteLLM ships seven of those
+    // (`vertex_ai/claude-*@default`), and they are ordinary priced models.
+    #[test]
+    fn blocking_the_default_token_still_matches_vertex_default_suffixed_keys() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "vertex_ai/claude-opus-4-7@default".into(),
+            ModelPricing {
+                input_cost_per_token: Some(5e-06),
+                output_cost_per_token: Some(2.5e-05),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        assert_eq!(
+            lookup
+                .lookup("vertex_ai/claude-opus-4-7@default")
+                .unwrap()
+                .matched_key,
+            "vertex_ai/claude-opus-4-7@default"
+        );
+        assert_eq!(
+            lookup
+                .lookup("claude-opus-4-7@default")
+                .unwrap()
+                .matched_key,
+            "vertex_ai/claude-opus-4-7@default"
         );
     }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -4267,12 +4267,32 @@ mod tests {
             .any(|p| p.ends_with("messages.jsonl")));
     }
 
-    // The expected `workspace_key` runs through `normalize_workspace_key`
-    // rather than being the path's own spelling: that function is what
-    // `scan_crush_registry` applies, and it deliberately folds `\` to `/` so a
-    // workspace reached under two separator spellings is one key rather than
-    // two. Asserting the raw `display()` string instead only agreed with the
-    // normalizer on Unix, where there is nothing to fold.
+    /// The `workspace_key` a Crush fixture path should produce, spelled out
+    /// here rather than obtained from the production normalizer.
+    ///
+    /// `scan_crush_registry` keys a workspace with `normalize_workspace_key`,
+    /// which folds `\` to `/` on purpose so one workspace reached under two
+    /// separator spellings is one key. That fold is the claim these tests
+    /// carry on Windows, and a raw `display()` expectation could not state it —
+    /// it only agreed with the normalizer on Unix, where there is nothing to
+    /// fold.
+    ///
+    /// Calling `normalize_workspace_key` in the expectation states it, but
+    /// states it self-referentially: production applies the same function to
+    /// the same input, so the assertion would hold no matter what that function
+    /// did, including nothing. The fold is one line to write out, so write it
+    /// out — this expectation is wrong whenever the normalizer stops folding,
+    /// which is the entire point of having it.
+    ///
+    /// The single `replace` is the whole rule for these inputs. The normalizer
+    /// also collapses repeated separators and trims a trailing one; a
+    /// `TempDir`-rooted `join` produces neither, so nothing else applies. (It
+    /// agrees on a UNC root too: `\\srv\share\p` folds to `//srv/share/p` with
+    /// no doubled separator left inside to collapse.)
+    fn expected_workspace_key(path: &Path) -> Option<String> {
+        Some(path.to_string_lossy().replace('\\', "/"))
+    }
+
     #[test]
     fn test_scan_crush_registry_resolves_relative_and_absolute_data_dirs() {
         let dir = TempDir::new().unwrap();
@@ -4305,14 +4325,12 @@ mod tests {
             vec![
                 CrushDbSource {
                     db_path: project_a.join(".crush").join("crush.db"),
-                    workspace_key: normalize_workspace_key(&project_a.to_string_lossy()),
+                    workspace_key: expected_workspace_key(&project_a),
                     workspace_label: Some("project-a".to_string()),
                 },
                 CrushDbSource {
                     db_path: project_b_data.join("crush.db"),
-                    workspace_key: normalize_workspace_key(
-                        &dir.path().join("project-b").to_string_lossy()
-                    ),
+                    workspace_key: expected_workspace_key(&dir.path().join("project-b")),
                     workspace_label: Some("project-b".to_string()),
                 },
             ]
@@ -4345,7 +4363,7 @@ mod tests {
             result,
             vec![CrushDbSource {
                 db_path: valid_project.join(".crush").join("crush.db"),
-                workspace_key: normalize_workspace_key(&valid_project.to_string_lossy()),
+                workspace_key: expected_workspace_key(&valid_project),
                 workspace_label: Some("valid-project".to_string()),
             }]
         );
@@ -4528,7 +4546,7 @@ mod tests {
             result.crush_dbs,
             vec![CrushDbSource {
                 db_path: data_dir.join("crush.db"),
-                workspace_key: normalize_workspace_key(&project.to_string_lossy()),
+                workspace_key: expected_workspace_key(&project),
                 workspace_label: Some("project".to_string()),
             }]
         );

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -4267,6 +4267,12 @@ mod tests {
             .any(|p| p.ends_with("messages.jsonl")));
     }
 
+    // The expected `workspace_key` runs through `normalize_workspace_key`
+    // rather than being the path's own spelling: that function is what
+    // `scan_crush_registry` applies, and it deliberately folds `\` to `/` so a
+    // workspace reached under two separator spellings is one key rather than
+    // two. Asserting the raw `display()` string instead only agreed with the
+    // normalizer on Unix, where there is nothing to fold.
     #[test]
     fn test_scan_crush_registry_resolves_relative_and_absolute_data_dirs() {
         let dir = TempDir::new().unwrap();
@@ -4299,12 +4305,14 @@ mod tests {
             vec![
                 CrushDbSource {
                     db_path: project_a.join(".crush").join("crush.db"),
-                    workspace_key: Some(project_a.display().to_string()),
+                    workspace_key: normalize_workspace_key(&project_a.to_string_lossy()),
                     workspace_label: Some("project-a".to_string()),
                 },
                 CrushDbSource {
                     db_path: project_b_data.join("crush.db"),
-                    workspace_key: Some(dir.path().join("project-b").display().to_string()),
+                    workspace_key: normalize_workspace_key(
+                        &dir.path().join("project-b").to_string_lossy()
+                    ),
                     workspace_label: Some("project-b".to_string()),
                 },
             ]
@@ -4337,7 +4345,7 @@ mod tests {
             result,
             vec![CrushDbSource {
                 db_path: valid_project.join(".crush").join("crush.db"),
-                workspace_key: Some(valid_project.display().to_string()),
+                workspace_key: normalize_workspace_key(&valid_project.to_string_lossy()),
                 workspace_label: Some("valid-project".to_string()),
             }]
         );
@@ -4520,7 +4528,7 @@ mod tests {
             result.crush_dbs,
             vec![CrushDbSource {
                 db_path: data_dir.join("crush.db"),
-                workspace_key: Some(project.display().to_string()),
+                workspace_key: normalize_workspace_key(&project.to_string_lossy()),
                 workspace_label: Some("project".to_string()),
             }]
         );

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -4684,6 +4684,16 @@ mod tests {
     /// resolves — trimming the value here would silently miss it.
     #[test]
     #[serial]
+    // Unix-only because the fixture cannot exist on Windows: a directory name
+    // ending in a space is not addressable there. `CreateDirectoryW` strips the
+    // trailing space, so `<tmp>\ padded-kimi-code ` becomes
+    // `<tmp>\ padded-kimi-code`, and the very next call — which carries that
+    // component in the middle of a longer path, where no stripping happens —
+    // fails with ERROR_PATH_NOT_FOUND. The claim being made here (a padded
+    // KIMI_CODE_HOME is honored verbatim rather than trimmed) is also one
+    // Windows cannot violate: the OS trims the name before tokscale sees a
+    // directory at all.
+    #[cfg(unix)]
     fn test_scan_all_clients_kimi_code_home_override_is_not_trimmed() {
         let mut env = EnvGuard::capture(&["KIMI_CODE_HOME"]);
         let dir = TempDir::new().unwrap();

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -1998,6 +1998,7 @@ pub fn scan_all_clients(home_dir: &str, clients: &[String]) -> ScanResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::paths::json_path_literal;
     use crate::paths::test_env::EnvGuard;
     use serial_test::serial;
     use std::fs::{self, File};
@@ -4019,8 +4020,8 @@ mod tests {
         fs::write(
             &variant_file,
             format!(
-                r#"{{"name":"kimi-code","provider":"kimi","configDir":"{}"}}"#,
-                config_dir.display()
+                r#"{{"name":"kimi-code","provider":"kimi","configDir":{}}}"#,
+                json_path_literal(&config_dir)
             ),
         )
         .unwrap();
@@ -4057,8 +4058,8 @@ mod tests {
         fs::write(
             variant_dir.join("variant.json"),
             format!(
-                r#"{{"name":"plain-mirror","provider":"mirror","configDir":"{}"}}"#,
-                normal_claude_dir.display()
+                r#"{{"name":"plain-mirror","provider":"mirror","configDir":{}}}"#,
+                json_path_literal(&normal_claude_dir)
             ),
         )
         .unwrap();
@@ -4280,15 +4281,15 @@ mod tests {
         let projects_json = format!(
             r#"{{
   "projects": [
-    {{ "path": "{}", "data_dir": ".crush" }},
-    {{ "path": "{}", "data_dir": "{}" }},
-    {{ "path": "{}", "data_dir": ".crush" }}
+    {{ "path": {}, "data_dir": ".crush" }},
+    {{ "path": {}, "data_dir": {} }},
+    {{ "path": {}, "data_dir": ".crush" }}
   ]
 }}"#,
-            project_a.display(),
-            dir.path().join("project-b").display(),
-            project_b_data.display(),
-            dir.path().join("missing-project").display(),
+            json_path_literal(&project_a),
+            json_path_literal(&dir.path().join("project-b")),
+            json_path_literal(&project_b_data),
+            json_path_literal(&dir.path().join("missing-project")),
         );
         setup_mock_crush_registry(&registry_path, &projects_json);
 
@@ -4321,13 +4322,13 @@ mod tests {
         let projects_json = format!(
             r#"{{
   "projects": [
-    {{ "path": "{}", "data_dir": ".crush" }},
+    {{ "path": {}, "data_dir": ".crush" }},
     {{ "path": 123, "data_dir": ".crush" }},
     {{ "data_dir": ".crush" }},
     "not-an-object"
   ]
 }}"#,
-            valid_project.display()
+            json_path_literal(&valid_project)
         );
         setup_mock_crush_registry(&registry_path, &projects_json);
 
@@ -4390,8 +4391,8 @@ mod tests {
         File::create(project.join(".crush").join("crush.db")).unwrap();
 
         let projects_json = format!(
-            r#"{{ "projects": [ {{ "path": "{}", "data_dir": ".crush" }} ] }}"#,
-            project.display()
+            r#"{{ "projects": [ {{ "path": {}, "data_dir": ".crush" }} ] }}"#,
+            json_path_literal(&project)
         );
         setup_mock_crush_registry(&global_data.join("projects.json"), &projects_json);
 
@@ -4428,8 +4429,8 @@ mod tests {
         File::create(project.join(".crush").join("crush.db")).unwrap();
 
         let projects_json = format!(
-            r#"{{ "projects": [ {{ "path": "{}", "data_dir": ".crush" }} ] }}"#,
-            project.display()
+            r#"{{ "projects": [ {{ "path": {}, "data_dir": ".crush" }} ] }}"#,
+            json_path_literal(&project)
         );
         setup_mock_crush_registry(
             &home.join("AppData/Local/crush/projects.json"),
@@ -4460,8 +4461,8 @@ mod tests {
         File::create(project.join(".crush").join("crush.db")).unwrap();
 
         let projects_json = format!(
-            r#"{{ "projects": [ {{ "path": "{}", "data_dir": ".crush" }} ] }}"#,
-            project.display()
+            r#"{{ "projects": [ {{ "path": {}, "data_dir": ".crush" }} ] }}"#,
+            json_path_literal(&project)
         );
         setup_mock_crush_registry(&xdg.join("crush/projects.json"), &projects_json);
         setup_mock_crush_registry(
@@ -4505,10 +4506,10 @@ mod tests {
         let projects_json = format!(
             r#"{{
   "projects": [
-    {{ "path": "{}", "data_dir": ".crush" }}
+    {{ "path": {}, "data_dir": ".crush" }}
   ]
 }}"#,
-            project.display()
+            json_path_literal(&project)
         );
         setup_mock_crush_registry(&registry_path, &projects_json);
 

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -1674,6 +1674,7 @@ fn finalize_headless_state(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::paths::json_path_literal;
     use std::io::Write;
     use tempfile::{NamedTempFile, TempDir};
 
@@ -1774,8 +1775,8 @@ mod tests {
         std::fs::write(
             variant_dir.join("variant.json"),
             format!(
-                r#"{{"name":"{variant}","provider":"{provider}","configDir":"{}"}}"#,
-                config_dir.display()
+                r#"{{"name":"{variant}","provider":"{provider}","configDir":{}}}"#,
+                json_path_literal(&config_dir)
             ),
         )
         .unwrap();

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -1895,7 +1895,7 @@ mod tests {
     #[test]
     fn keeps_repeated_event_ids_in_distinct_dedup_keys() {
         let (_temp, path) = write_fixture(
-            &format!(
+            format!(
                 "{}\n{}\n",
                 usage_line("turn-1", 1_700_000_001_000, 10, 1),
                 usage_line("turn-1", 1_700_000_002_000, 20, 2),


### PR DESCRIPTION
The `Tests (windows-latest)` leg has been failing since it was added in #1012. It is `continue-on-error` (`test_coverage.yml:97`), so runs report green and the leg is advisory — the failures were never visible in a red build.

**52 failures → 0.** Verified by a green CI run, not inferred: run `30960730312`, job `Tests (windows-latest) :: success`. Every binary reports `0 failed`. Ubuntu and Lint stay green.

| | core `--lib` | cli integration | total |
| --- | --- | --- | --- |
| baseline (`1b397cf9`, job 92117485899) | 30 | 22 | **52** |
| round 1 (`0cb0e4de`) | 14 | 22 | 36 |
| round 2 (`47a97b74`) | 0 | 3 | 3 |
| final (`47b4ea3a`) | 0 | 0 | **0** |

Nobody working on this has a Windows host, so every claim here comes from CI output rather than a local run.

## Three production bugs, found because the tests were wrong

The most useful outcome of this work wasn't the green leg — it was that fixing the test isolation exposed real defects the broken sandbox had been hiding.

**`70a0ea00` — a Google routing label was priced at Fireworks AI's rates, on every platform.**

`gemini-default` names the router that served a request, never the model. The submission path is meant to exclude it, and `exclude_generic_unpriced_submission_messages` does — but only for labels the lookup reports unpriced. The lookup reported it priced: prefix stripping reduces it to the remnant `default`, which is seven characters and so clears `MIN_FUZZY_MATCH_LEN`, and it wasn't on `FUZZY_BLOCKLIST`. It fuzzy-hits LiteLLM's real `fireworks-ai-default` row, priced `0.0/0.0`, and `covers_usage` counts an explicit zero as a real rate.

This was invisible on Unix CI because the fixture primes an **empty** LiteLLM catalog, which starves the fuzzy matcher. The Windows sandbox leaked to the runner's real `%APPDATA%` catalog and hit real prices. Reproduced on macOS against the live dataset. Every real user has a real cached catalog, so every real user was exposed.

Blast radius measured against the live 2988-row dataset, not asserted: the only queries whose resolution changes are `default` and `gemini-default`, both of which stop resolving. `fireworks-ai-default` still resolves by exact match, and the seven `vertex_ai/claude-*@default` keys are unaffected because the blocklist filters the *query* remnant, never dataset keys — now pinned by a test.

**`f309bf2e` — `TZ` made a Windows device permanently unpinnable.**

`bucket_tz::tz_env_zone()` read `TZ` on all platforms, justified by "TZ is what `chrono::Local` itself honors". That is true on Unix and false on Windows: chrono 0.4.43 selects `windows.rs` under `cfg(windows)`, which contains zero occurrences of `TZ` and computes offsets from `GetTimeZoneInformationForYear`. So on a Windows machine with `TZ` set — routine under Git Bash, MSYS2 or Cygwin — the candidate zone disagreed with `chrono::Local`, `zones_agree` failed, and the device silently never auto-pinned, with only a `tracing::debug!`. It stayed permanently exposed to the rescan-rebucket inflation the module exists to prevent. Fails closed, so it withheld a mitigation rather than corrupting data.

**`4f2234e6` — one file, two cache keys on Windows.**

A scan root is built as `format!("{root}/{relative}")` while `WalkDir` appends with the native separator, so a discovered transcript reads `C:\home/.claude/projects\demo\session.jsonl`. `CachedPath` hashes the OS string as written, so the same file cached under two keys and warm reads silently fell back to cold parses. Entirely `#[cfg(windows)]`; Unix `CachedPath` is bit-identical.

## Eleven test defect classes

Two dominated. **Raw paths interpolated into JSON fixtures** — nine fixtures dropped a path inside a JSON string via `format!`, and a Windows temp dir contains `\U`, `\A`, `\L`, `\T`, which aren't JSON escapes, so `serde_json` rejected the document. Both readers treat unparseable config as absent, so it surfaced as eleven assertions about discovery finding nothing, far from the cause. Real writers escape correctly (Crush is Go `encoding/json`, cc-mirror is Node `JSON.stringify`), so only the fixture ever produced invalid JSON.

**The config root was never sandboxed on Windows.** Tests redirected `HOME` and the `XDG_*` vars, but `paths::get_config_dir` resolves the Windows root through `dirs::config_dir()` — a `SHGetKnownFolderPath` call no environment variable reaches. Every such test shared the runner's real `%APPDATA%\tokscale`, loading back its neighbours' shards: one asserted 2 entries and found 5, another asserted 1 and found 7, with execution order deciding the number. On the CLI side `cmd_with_home` explicitly *cleared* `TOKSCALE_CONFIG_DIR`, so the child read the real profile — which is how the `gemini-default` mispricing became visible.

Both now pin `TOKSCALE_CONFIG_DIR`, which `paths.rs` already documents for exactly this ("CI sandbox, tests, isolated profile") and which is consulted first on every platform. On Unix it names the directory the `HOME` redirect already produced, so nothing moves — and it additionally pins against a globally-set `XDG_CONFIG_HOME` that a `HOME`-only redirect leaks past on Linux runners. This also closes the follow-up left open on #1043, where the suite wrote 57 files into the developer's real cache dir.

The rest: path-separator expectations built with `Path::join` when production emits `format!("{root}/{relative}")`; fixtures written at the Unix spelling of a per-platform path; cache keys differing by separator; Crush workspace keys asserted raw when production normalizes them; the reasonix env-root tests, where `Path` on Windows reads `/tmp/home` as "root of the current drive" and prepends the working directory; and one test holding a `BufWriter` open across a rewrite, which Unix renames happily and Windows refuses with `os error 5`.

## Two tests are unix-only, with reasons

Both are cases where Windows cannot violate the claim, so running there would prove nothing:

- **The Kimi padded-root test.** Its subject is a `KIMI_CODE_HOME` carrying surrounding whitespace. `CreateDirectoryW` strips a trailing space on creation and not mid-path, so `create_dir_all` fails with `ERROR_PATH_NOT_FOUND` — and Windows trims the name before tokscale ever sees a directory.
- **The pricing legacy-cache test.** `dirs::cache_dir()` is a known-folder call no env var redirects, so the body would write into the real `%LOCALAPPDATA%\tokscale` — the sandbox escape #997 was about.

Several timezone tests are also unix-only because their *instrument* is unavailable, not their claim: they vary the host zone by setting `TZ`, which `chrono::Local` ignores on Windows. The bucketing code itself is platform-independent and stays covered on Windows by the `bucket_tz.rs` unit tests that pass explicit `chrono_tz` zones.

## Review

An adversarial pass tasked with refuting these as disguised passes concluded the branch is honest: no assertion deleted or loosened, every `.code(17)`, `.code(124)`, timing window and byte-exact stdout comparison surviving verbatim, and no production change altering Unix behaviour as a Windows side effect — except `70a0ea00`, which changes every platform and says so in its first line. Its findings on comment accuracy and self-referential expectations are addressed in the follow-up commits on this branch.

## Follow-up commits

**Reviewer findings closed.** An adversarial pass on this branch found six defects — a comment the branch itself disproved, a silently-vacuous test, a self-referential expectation, two stale comments, and one item to file rather than fix. All six are addressed. The self-referential one was demonstrated rather than argued: mutating `normalize_workspace_key` to prefix `MUTANT` makes the new expectation fail and the old one pass, which is what a vacuous assertion looks like. Finding 4 is filed as #1048 and referenced at the test site so the pin is discoverable.

**The timing band was measuring the runner, not the product.** `headless_capture_slow_command_times_out` asserted `>= 10s && < 14s`, leaving 4s for everything outside the deadline — `tokscale`'s own startup, `child.kill()`, `child.wait()`, and joining the stdout pump. It failed at 14.83s on a Windows runner while killing the child correctly. Widened to 18s, which still keeps a 2s margin below the stand-in's 20s sleep, so a parent that hung until the child exited on its own is still caught. The claim is unchanged; only the tolerance for work the claim was never about.

**#1049 filed while reading that path.** After the kill, `run_capture_command` does an unbounded `output_handle.join()`. The pump thread's only exit is EOF on the child's stdout, and a pipe reports EOF only when every handle to its write end closes — including ones a grandchild inherited. `child.kill()` reaches one process. So a child that leaves a descendant holding stdout makes `tokscale headless` hang past its timeout and never reach `exit(124)`. The stand-in spawns nothing, so no test here can catch it; that is stated at the test site rather than left implied.

**`clippy --all-targets` is now clean.** A `needless_borrows_for_generic_args` in `grok.rs` from `cfe1304a` was invisible because CI's Lint job omits `--all-targets` and so never lints `#[cfg(test)]` code.
