### PR TITLE
feat(core): support TOKSCALE_SKIP_EXTERNAL_PRICING for submissions

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -267,6 +267,8 @@ enum Commands {
             help = "Show what would be submitted without actually submitting"
         )]
         dry_run: bool,
+        #[arg(long, help = "Fail submission if any model lacks a known price")]
+        strict_pricing: bool,
     },
     #[command(about = "Manage periodic usage submission")]
     Autosubmit {
@@ -807,6 +809,7 @@ fn main() -> Result<()> {
             clients,
             date,
             dry_run,
+            strict_pricing,
         }) => {
             reject_unsupported_home_override(&cli.home, "submit")?;
             let (since, until) = build_date_filter(&date, &cli.home);
@@ -823,6 +826,7 @@ fn main() -> Result<()> {
                 until,
                 year,
                 dry_run,
+                strict_pricing,
                 SubmitMode::Interactive,
             )
         }
@@ -5505,7 +5509,7 @@ fn report_unpriced_submission_exclusions(
         println!(
             "{}",
             format!(
-                "  Warning: excluded {} unpriced {}/{} message(s) ({} tokens): {}.{}",
+                "  Warning: skipped pricing for {} unpriced {}/{} message(s) ({} tokens): {}.{}",
                 row.message_count,
                 row.provider_id,
                 row.model_id,
@@ -5555,7 +5559,7 @@ fn run_autosubmit_command(subcommand: commands::autosubmit::AutosubmitSubcommand
             };
 
             let (clients, since, until, year) = commands::autosubmit::submit_filters(&settings);
-            match run_submit_command(clients, since, until, year, false, SubmitMode::Autosubmit) {
+            match run_submit_command(clients, since, until, year, false, false, SubmitMode::Autosubmit) {
                 Ok(()) => {
                     commands::autosubmit::record_run_success(
                         chrono::Utc::now().timestamp_millis(),
@@ -5578,12 +5582,19 @@ fn run_submit_command(
     until: Option<String>,
     year: Option<String>,
     dry_run: bool,
+    strict_pricing: bool,
     mode: SubmitMode,
 ) -> Result<()> {
     use colored::Colorize;
     use std::io::IsTerminal;
     use tokio::runtime::Runtime;
     use tokscale_core::{generate_submission_graph, GroupBy, ReportOptions};
+
+    // 命令行参数或环境变量均可开启严格价格校验；默认使用宽松模式。
+    let strict_pricing = strict_pricing
+        || std::env::var("TOKSCALE_STRICT_PRICING")
+            .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+            .unwrap_or(false);
 
     let auth_token = match auth::resolve_api_token() {
         Some(token) => token,
@@ -5651,16 +5662,19 @@ fn run_submit_command(
     let rt = Runtime::new()?;
     let mut graph_result = rt
         .block_on(async {
-            generate_submission_graph(ReportOptions {
-                home_dir: None,
-                use_env_roots: true,
-                clients,
-                since,
-                until,
-                year,
-                group_by: GroupBy::default(),
-                scanner_settings: tui::settings::load_scanner_settings(),
-            })
+            generate_submission_graph(
+                ReportOptions {
+                    home_dir: None,
+                    use_env_roots: true,
+                    clients,
+                    since,
+                    until,
+                    year,
+                    group_by: GroupBy::default(),
+                    scanner_settings: tui::settings::load_scanner_settings(),
+                },
+                strict_pricing,
+            )
             .await
         })
         .map_err(|e| anyhow::anyhow!(e))?;

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5496,12 +5496,14 @@ fn report_excluded_tokenless_rows(excluded: &[ExcludedTokenlessRow]) {
 
 fn report_unpriced_submission_exclusions(
     excluded: &[tokscale_core::UnpricedSubmissionExclusion],
+    is_lenient: bool,
 ) {
     use colored::Colorize;
 
     for row in excluded {
-        println!(
-            "{}",
+        // 宽松模式下消息保留在 graph 中按 0 成本上报；严格模式下消息被排除，
+        // 仅上报剩余已定价用量，因此文案需要区分。
+        let message = if is_lenient {
             format!(
                 "  Warning: no price for {} {}/{} message(s) ({} tokens): {}. These tokens will be reported at zero cost.",
                 row.message_count,
@@ -5510,8 +5512,17 @@ fn report_unpriced_submission_exclusions(
                 format_tokens_with_commas(row.total_tokens),
                 row.reason,
             )
-            .yellow()
-        );
+        } else {
+            format!(
+                "  Warning: excluded {} {}/{} unpriced message(s) ({} tokens): {}. Remaining priced usage will be submitted.",
+                row.message_count,
+                row.provider_id,
+                row.model_id,
+                format_tokens_with_commas(row.total_tokens),
+                row.reason,
+            )
+        };
+        println!("{}", message.yellow());
     }
 }
 
@@ -5680,7 +5691,10 @@ fn run_submit_command(
     // left out, so a single legacy charge can't block the whole submission.
     let excluded_rows = exclude_tokenless_cost_contributions(&mut graph_result);
     report_excluded_tokenless_rows(&excluded_rows);
-    report_unpriced_submission_exclusions(&graph_result.unpriced_submission_exclusions);
+    report_unpriced_submission_exclusions(
+        &graph_result.unpriced_submission_exclusions,
+        !strict_pricing,
+    );
 
     println!("{}", "  Data to submit:".white());
     println!(

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5496,26 +5496,19 @@ fn report_excluded_tokenless_rows(excluded: &[ExcludedTokenlessRow]) {
 
 fn report_unpriced_submission_exclusions(
     excluded: &[tokscale_core::UnpricedSubmissionExclusion],
-    has_remaining_usage: bool,
 ) {
     use colored::Colorize;
 
     for row in excluded {
-        let remaining_usage_message = if has_remaining_usage {
-            " Remaining priced usage will be submitted."
-        } else {
-            ""
-        };
         println!(
             "{}",
             format!(
-                "  Warning: skipped pricing for {} unpriced {}/{} message(s) ({} tokens): {}.{}",
+                "  Warning: no price for {} {}/{} message(s) ({} tokens): {}. These tokens will be reported at zero cost.",
                 row.message_count,
                 row.provider_id,
                 row.model_id,
                 format_tokens_with_commas(row.total_tokens),
                 row.reason,
-                remaining_usage_message,
             )
             .yellow()
         );
@@ -5687,10 +5680,7 @@ fn run_submit_command(
     // left out, so a single legacy charge can't block the whole submission.
     let excluded_rows = exclude_tokenless_cost_contributions(&mut graph_result);
     report_excluded_tokenless_rows(&excluded_rows);
-    report_unpriced_submission_exclusions(
-        &graph_result.unpriced_submission_exclusions,
-        graph_result.summary.total_tokens > 0,
-    );
+    report_unpriced_submission_exclusions(&graph_result.unpriced_submission_exclusions);
 
     println!("{}", "  Data to submit:".white());
     println!(

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3006,8 +3006,33 @@ fn build_graph_from_messages(
         }
         GraphPricingRequirement::SubmissionLenient => {
             // 宽松提交模式：不因为缺少价格而失败，未定价消息保留在 graph 中，
-            // 仅收集统计信息用于向用户展示警告。
+            // 仅收集统计信息用于向用户展示警告。同时把非权威、未定价的
+            // token 用量成本归 0，避免上传残留估算价格，同时保留供应商直接报告的价格。
             let exclusions = collect_unpriced_submission_exclusions(&filtered, pricing);
+            let mut filtered = filtered;
+            for message in &mut filtered {
+                let tokens = &message.tokens;
+                let token_bearing = tokens.input > 0
+                    || tokens.output > 0
+                    || tokens.cache_read > 0
+                    || tokens.cache_write > 0
+                    || tokens.reasoning > 0;
+                if !token_bearing || message.has_authoritative_cost() {
+                    continue;
+                }
+                let covered = pricing
+                    .map(|p| {
+                        p.covers_usage_with_provider(
+                            &message.model_id,
+                            Some(&message.provider_id),
+                            &message.tokens,
+                        )
+                    })
+                    .unwrap_or(false);
+                if !covered {
+                    message.cost = 0.0;
+                }
+            }
             (filtered, exclusions)
         }
     };
@@ -3193,16 +3218,17 @@ pub async fn generate_submission_graph(
     strict_pricing: bool,
 ) -> Result<GraphResult, String> {
     // 当用户显式设置 TOKSCALE_SKIP_EXTERNAL_PRICING 时，跳过外部价格源的网络请求，
-    // 仅使用本地 custom pricing，并以宽松模式生成报表，让未定价 token 用量
-    // 以 cost=0 的形式被批量上报，而不是直接报错。
+    // 仅使用本地 custom pricing。strict 优先级高于 skip-external：若用户同时要求
+    // strict，则使用仅 custom pricing 的严格校验，缺价时仍然失败；否则使用宽松模式，
+    // 让未定价 token 用量以 cost=0 的形式被批量上报，而不是直接报错。
     let skip_external = std::env::var("TOKSCALE_SKIP_EXTERNAL_PRICING")
         .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
         .unwrap_or(false);
 
-    let requirement = if skip_external || !strict_pricing {
-        GraphPricingRequirement::SubmissionLenient
-    } else {
+    let requirement = if strict_pricing {
         GraphPricingRequirement::Submission
+    } else {
+        GraphPricingRequirement::SubmissionLenient
     };
 
     if skip_external {
@@ -10638,8 +10664,10 @@ mod tests {
     #[test]
     #[serial]
     fn skip_external_pricing_allows_unpriced_submission() {
-        // 设置跳过外部价格源的环境变量。
-        std::env::set_var("TOKSCALE_SKIP_EXTERNAL_PRICING", "true");
+        // 设置跳过外部价格源的环境变量，使用 EnvGuard 保证 panic 时自动恢复，
+        // 避免污染同进程中的其他测试。
+        let mut env = crate::paths::test_env::EnvGuard::capture(&["TOKSCALE_SKIP_EXTERNAL_PRICING"]);
+        env.set("TOKSCALE_SKIP_EXTERNAL_PRICING", "true");
 
         let temp_dir = tempfile::TempDir::new().unwrap();
         let sessions_dir = temp_dir
@@ -10669,9 +10697,6 @@ mod tests {
                 false,
             ))
             .expect("未定价 token 用量在跳过模式下应当成功生成报表");
-
-        // 清理环境变量，避免影响同进程中的其他测试。
-        std::env::remove_var("TOKSCALE_SKIP_EXTERNAL_PRICING");
 
         assert!(
             graph.summary.total_cost.abs() < 1e-9,

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2944,6 +2944,9 @@ pub async fn get_hourly_report(options: ReportOptions) -> Result<HourlyReport, S
 enum GraphPricingRequirement {
     Lenient,
     Submission,
+    /// 提交模式的宽松变体：未定价模型的 token 用量保留在 graph 中按 0 成本上报，
+    /// 同时把相关模型记录到 `unpriced_submission_exclusions` 用于打印警告。
+    SubmissionLenient,
 }
 
 async fn generate_graph_with_loaded_pricing(
@@ -3001,6 +3004,12 @@ fn build_graph_from_messages(
             validate_priced_messages(&submitted, pricing)?;
             (submitted, exclusions)
         }
+        GraphPricingRequirement::SubmissionLenient => {
+            // 宽松提交模式：不因为缺少价格而失败，未定价消息保留在 graph 中，
+            // 仅收集统计信息用于向用户展示警告。
+            let exclusions = collect_unpriced_submission_exclusions(&filtered, pricing);
+            (filtered, exclusions)
+        }
     };
 
     let intervals = sessionize::sessionize(&filtered, sessionize::DEFAULT_IDLE_GAP_MS);
@@ -3029,6 +3038,9 @@ fn build_graph_from_messages(
 
 const GEMINI_DEFAULT_UNPRICED_REASON: &str =
     "generic routing label has no authoritative model-to-price mapping";
+
+const MODEL_HAS_NO_KNOWN_PRICE_REASON: &str =
+    "model has no known price; reported at zero cost";
 
 fn exclude_generic_unpriced_submission_messages(
     messages: Vec<UnifiedMessage>,
@@ -3079,6 +3091,58 @@ fn exclude_generic_unpriced_submission_messages(
     (submitted, exclusions)
 }
 
+/// 在宽松提交模式下收集未定价的 token-bearing 消息，用于打印警告。
+/// 这些消息不会被从 graph 中移除，因此 tokens 仍会上报，cost 保持为 0。
+fn collect_unpriced_submission_exclusions(
+    messages: &[UnifiedMessage],
+    pricing: Option<&pricing::PricingService>,
+) -> Vec<UnpricedSubmissionExclusion> {
+    let Some(pricing) = pricing else {
+        return Vec::new();
+    };
+
+    let mut counts: std::collections::BTreeMap<(String, String), (usize, i64)> =
+        std::collections::BTreeMap::new();
+
+    for message in messages {
+        let tokens = &message.tokens;
+        let token_bearing = tokens.input > 0
+            || tokens.output > 0
+            || tokens.cache_read > 0
+            || tokens.cache_write > 0
+            || tokens.reasoning > 0;
+        let unpriced = token_bearing
+            && !message.has_authoritative_cost()
+            && !pricing.covers_usage_with_provider(
+                &message.model_id,
+                Some(&message.provider_id),
+                &message.tokens,
+            );
+        if !unpriced {
+            continue;
+        }
+
+        let entry = counts
+            .entry((message.provider_id.clone(), message.model_id.clone()))
+            .or_default();
+        entry.0 += 1;
+        entry.1 = entry.1.saturating_add(message.tokens.total());
+    }
+
+    counts
+        .into_iter()
+        .map(|((provider_id, model_id), (message_count, total_tokens))| {
+            UnpricedSubmissionExclusion {
+                provider_id,
+                model_id,
+                message_count,
+                total_tokens,
+                reason: MODEL_HAS_NO_KNOWN_PRICE_REASON,
+            }
+        })
+        .collect()
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct TimeMetricsReport {
     pub metrics: sessionize::TimeMetrics,
@@ -3124,13 +3188,22 @@ pub async fn generate_graph(options: ReportOptions) -> Result<GraphResult, Strin
         .await
 }
 
-pub async fn generate_submission_graph(options: ReportOptions) -> Result<GraphResult, String> {
+pub async fn generate_submission_graph(
+    options: ReportOptions,
+    strict_pricing: bool,
+) -> Result<GraphResult, String> {
     // 当用户显式设置 TOKSCALE_SKIP_EXTERNAL_PRICING 时，跳过外部价格源的网络请求，
-    // 仅使用本地 custom pricing，并以 Lenient 模式生成报表，让未定价 token 用量
+    // 仅使用本地 custom pricing，并以宽松模式生成报表，让未定价 token 用量
     // 以 cost=0 的形式被批量上报，而不是直接报错。
     let skip_external = std::env::var("TOKSCALE_SKIP_EXTERNAL_PRICING")
         .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
         .unwrap_or(false);
+
+    let requirement = if skip_external || !strict_pricing {
+        GraphPricingRequirement::SubmissionLenient
+    } else {
+        GraphPricingRequirement::Submission
+    };
 
     if skip_external {
         let pricing = pricing::PricingService::new_with_custom_and_models_dev(
@@ -3139,17 +3212,11 @@ pub async fn generate_submission_graph(options: ReportOptions) -> Result<GraphRe
             HashMap::new(),
             HashMap::new(),
         );
-        return generate_graph_with_loaded_pricing(
-            options,
-            Some(&pricing),
-            GraphPricingRequirement::Lenient,
-        )
-        .await;
+        return generate_graph_with_loaded_pricing(options, Some(&pricing), requirement).await;
     }
 
     let pricing = pricing::PricingService::get_or_init().await?;
-    generate_graph_with_loaded_pricing(options, Some(&pricing), GraphPricingRequirement::Submission)
-        .await
+    generate_graph_with_loaded_pricing(options, Some(&pricing), requirement).await
 }
 
 pub async fn generate_local_graph_report(options: ReportOptions) -> Result<GraphResult, String> {
@@ -4344,13 +4411,14 @@ mod tests {
     use super::{
         aggregate_model_usage_entries, apply_pricing_if_available, build_graph_from_messages,
         dedupe_latest_trae_messages, filter_messages_for_report,
-        generate_graph_with_loaded_pricing, get_home_dir_string, message_cache,
-        normalize_model_for_grouping, parse_all_messages_with_pricing_with_env_strategy,
-        parse_local_clients, parsed_to_unified, paths, pricing, retain_for_requested_clients,
-        scanner, select_local_parse_pricing, unified_to_parsed, validate_priced_messages, ClientId,
-        GraphPricingRequirement, GroupBy, LocalParseOptions, ReportOptions, TokenBreakdown,
-        UnifiedMessage, UnpricedSubmissionExclusion, GEMINI_DEFAULT_UNPRICED_REASON,
-        UNKNOWN_WORKSPACE_LABEL,
+        generate_graph_with_loaded_pricing, generate_submission_graph, get_home_dir_string,
+        message_cache, normalize_model_for_grouping,
+        parse_all_messages_with_pricing_with_env_strategy, parse_local_clients, parsed_to_unified,
+        paths, pricing, retain_for_requested_clients, scanner, select_local_parse_pricing,
+        unified_to_parsed, validate_priced_messages, ClientId, GraphPricingRequirement, GroupBy,
+        LocalParseOptions, ReportOptions, TokenBreakdown, UnifiedMessage,
+        UnpricedSubmissionExclusion, GEMINI_DEFAULT_UNPRICED_REASON,
+        MODEL_HAS_NO_KNOWN_PRICE_REASON, UNKNOWN_WORKSPACE_LABEL,
     };
     use serial_test::serial;
     use std::collections::{HashMap, HashSet};
@@ -10587,16 +10655,19 @@ mod tests {
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         let graph = rt
-            .block_on(super::generate_submission_graph(ReportOptions {
-                home_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-                use_env_roots: false,
-                clients: None,
-                since: None,
-                until: None,
-                year: None,
-                group_by: GroupBy::default(),
-                scanner_settings: scanner::ScannerSettings::default(),
-            }))
+            .block_on(generate_submission_graph(
+                ReportOptions {
+                    home_dir: Some(temp_dir.path().to_string_lossy().to_string()),
+                    use_env_roots: false,
+                    clients: None,
+                    since: None,
+                    until: None,
+                    year: None,
+                    group_by: GroupBy::default(),
+                    scanner_settings: scanner::ScannerSettings::default(),
+                },
+                false,
+            ))
             .expect("未定价 token 用量在跳过模式下应当成功生成报表");
 
         // 清理环境变量，避免影响同进程中的其他测试。
@@ -10612,6 +10683,59 @@ mod tests {
             graph.contributions[0].totals.cost.abs() < 1e-9,
             "日报贡献的 cost 应为 0，got {}",
             graph.contributions[0].totals.cost
+        );
+    }
+
+    /// 宽松提交模式下，未定价模型的 token 用量应保留在 graph 中按 0 成本上报，
+    /// 同时在 `unpriced_submission_exclusions` 中记录对应模型以便打印警告。
+    #[test]
+    fn lenient_submission_keeps_unpriced_models_at_zero_cost() {
+        let message = UnifiedMessage::new(
+            "opencode",
+            "totally-unknown-unpriced-model",
+            "unknown-provider",
+            "unpriced",
+            1_736_510_400_000,
+            TokenBreakdown {
+                input: 12,
+                output: 4,
+                cache_read: 2,
+                cache_write: 0,
+                reasoning: 1,
+            },
+            0.0,
+        );
+        let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
+
+        let graph = build_graph_from_messages(
+            vec![message],
+            Some(&pricing),
+            GraphPricingRequirement::SubmissionLenient,
+            std::time::Instant::now(),
+            &crate::bucket_tz::BucketTimezone::Local,
+        )
+        .expect("宽松提交模式应保留未定价模型并按 0 成本上报");
+
+        assert_eq!(graph.summary.total_tokens, 19, "total tokens 应完整保留");
+        assert!(
+            graph.summary.total_cost.abs() < 1e-9,
+            "未定价模型的 total_cost 应为 0，got {}",
+            graph.summary.total_cost
+        );
+        assert_eq!(
+            graph.unpriced_submission_exclusions.len(),
+            1,
+            "应记录一条未定价提交警告"
+        );
+        assert_eq!(
+            graph.unpriced_submission_exclusions[0],
+            UnpricedSubmissionExclusion {
+                provider_id: "unknown-provider".to_string(),
+                model_id: "totally-unknown-unpriced-model".to_string(),
+                message_count: 1,
+                total_tokens: 19,
+                reason: MODEL_HAS_NO_KNOWN_PRICE_REASON,
+            }
         );
     }
 }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3011,27 +3011,10 @@ fn build_graph_from_messages(
             let exclusions = collect_unpriced_submission_exclusions(&filtered, pricing);
             let mut filtered = filtered;
             for message in &mut filtered {
-                let tokens = &message.tokens;
-                let token_bearing = tokens.input > 0
-                    || tokens.output > 0
-                    || tokens.cache_read > 0
-                    || tokens.cache_write > 0
-                    || tokens.reasoning > 0;
-                if !token_bearing || message.has_authoritative_cost() {
+                if !is_unpriced_token_bearing(message, pricing) {
                     continue;
                 }
-                let covered = pricing
-                    .map(|p| {
-                        p.covers_usage_with_provider(
-                            &message.model_id,
-                            Some(&message.provider_id),
-                            &message.tokens,
-                        )
-                    })
-                    .unwrap_or(false);
-                if !covered {
-                    message.cost = 0.0;
-                }
+                message.cost = 0.0;
             }
             (filtered, exclusions)
         }
@@ -3116,34 +3099,39 @@ fn exclude_generic_unpriced_submission_messages(
     (submitted, exclusions)
 }
 
+/// 统一判断消息是否为未定价的 token-bearing 用量，确保警告集合与实际归零集合一致。
+fn is_unpriced_token_bearing(
+    message: &UnifiedMessage,
+    pricing: Option<&pricing::PricingService>,
+) -> bool {
+    let tokens = &message.tokens;
+    let token_bearing = tokens.input > 0
+        || tokens.output > 0
+        || tokens.cache_read > 0
+        || tokens.cache_write > 0
+        || tokens.reasoning > 0;
+    token_bearing
+        && !message.has_authoritative_cost()
+        && pricing.map_or(true, |p| {
+            !p.covers_usage_with_provider(
+                &message.model_id,
+                Some(&message.provider_id),
+                &message.tokens,
+            )
+        })
+}
+
 /// 在宽松提交模式下收集未定价的 token-bearing 消息，用于打印警告。
 /// 这些消息不会被从 graph 中移除，因此 tokens 仍会上报，cost 保持为 0。
 fn collect_unpriced_submission_exclusions(
     messages: &[UnifiedMessage],
     pricing: Option<&pricing::PricingService>,
 ) -> Vec<UnpricedSubmissionExclusion> {
-    let Some(pricing) = pricing else {
-        return Vec::new();
-    };
-
     let mut counts: std::collections::BTreeMap<(String, String), (usize, i64)> =
         std::collections::BTreeMap::new();
 
     for message in messages {
-        let tokens = &message.tokens;
-        let token_bearing = tokens.input > 0
-            || tokens.output > 0
-            || tokens.cache_read > 0
-            || tokens.cache_write > 0
-            || tokens.reasoning > 0;
-        let unpriced = token_bearing
-            && !message.has_authoritative_cost()
-            && !pricing.covers_usage_with_provider(
-                &message.model_id,
-                Some(&message.provider_id),
-                &message.tokens,
-            );
-        if !unpriced {
+        if !is_unpriced_token_bearing(message, pricing) {
             continue;
         }
 
@@ -10761,6 +10749,57 @@ mod tests {
                 total_tokens: 19,
                 reason: MODEL_HAS_NO_KNOWN_PRICE_REASON,
             }
+        );
+    }
+
+    /// Trae 解析出的带精确供应商报告成本的消息，在宽松提交模式下不应被归零。
+    #[test]
+    fn lenient_submission_preserves_trae_provider_reported_cost() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let sessions_dir = temp_dir.path().join("trae-cache/sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        std::fs::write(
+            sessions_dir.join("test.json"),
+            serde_json::json!([{
+                "model_name": "GPT-5.4",
+                "session_id": "trae-session-1",
+                "usage_time": 1776000000,
+                "dollar_float": 0.42,
+                "extra_info": {
+                    "input_token": 1000,
+                    "output_token": 500,
+                    "cache_read_token": 200,
+                    "cache_write_token": 100
+                }
+            }])
+            .to_string(),
+        )
+        .unwrap();
+
+        let messages =
+            crate::sessions::trae::parse_trae_file("trae", &sessions_dir.join("test.json"));
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].has_authoritative_cost());
+        assert!((messages[0].cost - 0.42).abs() < 1e-9);
+
+        let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
+        let graph = build_graph_from_messages(
+            messages,
+            Some(&pricing),
+            GraphPricingRequirement::SubmissionLenient,
+            std::time::Instant::now(),
+            &crate::bucket_tz::BucketTimezone::Local,
+        )
+        .expect("Trae 供应商报告成本在宽松提交模式下应保留");
+
+        assert!(
+            (graph.summary.total_cost - 0.42).abs() < 1e-9,
+            "Trae 报告成本应保留，got {}",
+            graph.summary.total_cost
+        );
+        assert!(
+            graph.unpriced_submission_exclusions.is_empty(),
+            "已定价的 Trae 消息不应产生未定价警告"
         );
     }
 }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3125,6 +3125,28 @@ pub async fn generate_graph(options: ReportOptions) -> Result<GraphResult, Strin
 }
 
 pub async fn generate_submission_graph(options: ReportOptions) -> Result<GraphResult, String> {
+    // 当用户显式设置 TOKSCALE_SKIP_EXTERNAL_PRICING 时，跳过外部价格源的网络请求，
+    // 仅使用本地 custom pricing，并以 Lenient 模式生成报表，让未定价 token 用量
+    // 以 cost=0 的形式被批量上报，而不是直接报错。
+    let skip_external = std::env::var("TOKSCALE_SKIP_EXTERNAL_PRICING")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false);
+
+    if skip_external {
+        let pricing = pricing::PricingService::new_with_custom_and_models_dev(
+            pricing::custom::CustomPricing::load_from_default_path(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+        );
+        return generate_graph_with_loaded_pricing(
+            options,
+            Some(&pricing),
+            GraphPricingRequirement::Lenient,
+        )
+        .await;
+    }
+
     let pricing = pricing::PricingService::get_or_init().await?;
     generate_graph_with_loaded_pricing(options, Some(&pricing), GraphPricingRequirement::Submission)
         .await
@@ -10541,5 +10563,55 @@ mod tests {
         // Without verified cross-source dedup, both messages are preserved.
         let filtered = filter_messages_for_report(messages, &ReportOptions::default());
         assert_eq!(filtered.len(), 2);
+    }
+
+    /// 当 TOKSCALE_SKIP_EXTERNAL_PRICING 启用时，未定价模型的 token 用量不应导致
+    /// generate_submission_graph 报错，而应返回 cost 为 0 的报表。
+    #[test]
+    #[serial]
+    fn skip_external_pricing_allows_unpriced_submission() {
+        // 设置跳过外部价格源的环境变量。
+        std::env::set_var("TOKSCALE_SKIP_EXTERNAL_PRICING", "true");
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let sessions_dir = temp_dir
+            .path()
+            .join(".config/tokscale/antigravity-cache/sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        std::fs::write(
+            sessions_dir.join("unpriced.jsonl"),
+            r#"{"type":"usage","sessionId":"unpriced-session","modelId":"totally-unknown-unpriced-model","timestamp":1711200000000,"input":12,"output":4,"cacheRead":2,"cacheWrite":0,"reasoning":1,"responseId":"resp-unpriced"}
+"#,
+        )
+        .unwrap();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let graph = rt
+            .block_on(super::generate_submission_graph(ReportOptions {
+                home_dir: Some(temp_dir.path().to_string_lossy().to_string()),
+                use_env_roots: false,
+                clients: None,
+                since: None,
+                until: None,
+                year: None,
+                group_by: GroupBy::default(),
+                scanner_settings: scanner::ScannerSettings::default(),
+            }))
+            .expect("未定价 token 用量在跳过模式下应当成功生成报表");
+
+        // 清理环境变量，避免影响同进程中的其他测试。
+        std::env::remove_var("TOKSCALE_SKIP_EXTERNAL_PRICING");
+
+        assert!(
+            graph.summary.total_cost.abs() < 1e-9,
+            "未定价模型的 total_cost 应为 0，got {}",
+            graph.summary.total_cost
+        );
+        assert_eq!(graph.contributions.len(), 1, "应有一条日报贡献");
+        assert!(
+            graph.contributions[0].totals.cost.abs() < 1e-9,
+            "日报贡献的 cost 应为 0，got {}",
+            graph.contributions[0].totals.cost
+        );
     }
 }

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1001,6 +1001,9 @@ fn parser_version(client: ClientId) -> u32 {
         // recognizes user tool-result records as continuations instead of
         // beginning a new turn, so cached turns must be reparsed.
         ClientId::Cline => 3,
+        // v1->v2: RooCode now preserves whether the `cost` field was present,
+        // including explicit zero, so free requests are not repriced from cache.
+        ClientId::RooCode => 2,
         // v1->v2: Kimchi's Pi-compatible messages now carry stable namespaced
         // deduplication keys.
         ClientId::Kimchi => 2,

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1004,6 +1004,9 @@ fn parser_version(client: ClientId) -> u32 {
         // v1->v2: RooCode now preserves whether the `cost` field was present,
         // including explicit zero, so free requests are not repriced from cache.
         ClientId::RooCode => 2,
+        // KiloCode 复用 RooCode 的解析器，因此同步升级到 v2，使旧缓存条目失效并
+        // 重新识别 authoritative 标记。
+        ClientId::KiloCode => 2,
         // v1->v2: Kimchi's Pi-compatible messages now carry stable namespaced
         // deduplication keys.
         ClientId::Kimchi => 2,

--- a/crates/tokscale-core/src/sessions/amp.rs
+++ b/crates/tokscale-core/src/sessions/amp.rs
@@ -92,7 +92,7 @@ impl AmpUsageRecord {
     }
 
     fn into_unified(self, thread_id: &str) -> UnifiedMessage {
-        UnifiedMessage::new(
+        let mut message = UnifiedMessage::new(
             "amp",
             &self.model,
             get_provider_from_model(&self.model),
@@ -100,7 +100,13 @@ impl AmpUsageRecord {
             self.timestamp,
             self.tokens,
             self.cost,
-        )
+        );
+        // Amp 用量账本中的 credits 是 Amp 直接报告的金额，标记为供应商报告成本，
+        // 避免在 lenient submission 中被误归零。
+        if self.cost > 0.0 {
+            message.mark_provider_reported_cost();
+        }
+        message
     }
 }
 

--- a/crates/tokscale-core/src/sessions/amp.rs
+++ b/crates/tokscale-core/src/sessions/amp.rs
@@ -158,6 +158,9 @@ fn parse_amp_ledger_records(
             });
 
             let raw_credits = event.credits;
+            // credits 字段必须存在、有限且非负才视为 Amp 报告的权威成本；负值被忽略，
+            // 同时不设置 has_credits，避免被错误标记为 provider-reported 的免费请求。
+            let credits_valid = raw_credits.is_some_and(|c| c.is_finite() && c >= 0.0);
             Some(AmpUsageRecord {
                 model,
                 timestamp,
@@ -171,8 +174,8 @@ fn parse_amp_ledger_records(
                     cache_write: tokens.cache_creation_input_tokens.unwrap_or(0).max(0),
                     reasoning: 0,
                 },
-                cost: raw_credits.unwrap_or(0.0).max(0.0),
-                has_credits: raw_credits.is_some(),
+                cost: if credits_valid { raw_credits.unwrap() } else { 0.0 },
+                has_credits: credits_valid,
             })
         })
         .collect()
@@ -206,6 +209,9 @@ fn parse_amp_message_records(
             let timestamp = base_timestamp.saturating_add(message_id.saturating_mul(1000));
 
             let raw_credits = usage.credits;
+            // credits 字段必须存在、有限且非负才视为 Amp 报告的权威成本；负值被忽略，
+            // 同时不设置 has_credits，避免被错误标记为 provider-reported 的免费请求。
+            let credits_valid = raw_credits.is_some_and(|c| c.is_finite() && c >= 0.0);
             Some(AmpUsageRecord {
                 model,
                 timestamp,
@@ -219,8 +225,8 @@ fn parse_amp_message_records(
                     cache_write: usage.cache_creation_input_tokens.unwrap_or(0).max(0),
                     reasoning: 0,
                 },
-                cost: raw_credits.unwrap_or(0.0).max(0.0),
-                has_credits: raw_credits.is_some(),
+                cost: if credits_valid { raw_credits.unwrap() } else { 0.0 },
+                has_credits: credits_valid,
             })
         })
         .collect()
@@ -257,7 +263,12 @@ fn merge_amp_records(
 ) -> AmpUsageRecord {
     if ledger_record.has_explicit_timestamp {
         if ledger_record.cost > 0.0 || message_record.cost <= 0.0 {
-            ledger_record
+            // ledger row 即使没有 credits，也要把消息自身的 has_credits 标志合并进来，
+            // 确保显式 credits: 0 的消息不会被后续重新定价覆盖。
+            AmpUsageRecord {
+                has_credits: ledger_record.has_credits || message_record.has_credits,
+                ..ledger_record
+            }
         } else {
             AmpUsageRecord {
                 cost: message_record.cost,

--- a/crates/tokscale-core/src/sessions/amp.rs
+++ b/crates/tokscale-core/src/sessions/amp.rs
@@ -84,6 +84,9 @@ struct AmpUsageRecord {
     ledger_to_message_id: Option<i64>,
     tokens: TokenBreakdown,
     cost: f64,
+    /// 原始数据中是否存在 `credits` 字段（包括显式的 0）。用于区分“Amp 报告免费”
+    /// 和“没有成本信息”，前者在 lenient submission 中应保持 authoritative。
+    has_credits: bool,
 }
 
 impl AmpUsageRecord {
@@ -101,9 +104,9 @@ impl AmpUsageRecord {
             self.tokens,
             self.cost,
         );
-        // Amp 用量账本中的 credits 是 Amp 直接报告的金额，标记为供应商报告成本，
-        // 避免在 lenient submission 中被误归零。
-        if self.cost > 0.0 {
+        // Amp 用量账本中的 credits 是 Amp 直接报告的金额；只要原始字段存在（包括 0）
+        // 就标记为供应商报告成本，避免显式免费请求被外部价格覆盖。
+        if self.has_credits && self.cost.is_finite() && self.cost >= 0.0 {
             message.mark_provider_reported_cost();
         }
         message
@@ -154,6 +157,7 @@ fn parse_amp_ledger_records(
                 cache_creation_input_tokens: Some(0),
             });
 
+            let raw_credits = event.credits;
             Some(AmpUsageRecord {
                 model,
                 timestamp,
@@ -167,7 +171,8 @@ fn parse_amp_ledger_records(
                     cache_write: tokens.cache_creation_input_tokens.unwrap_or(0).max(0),
                     reasoning: 0,
                 },
-                cost: event.credits.unwrap_or(0.0).max(0.0),
+                cost: raw_credits.unwrap_or(0.0).max(0.0),
+                has_credits: raw_credits.is_some(),
             })
         })
         .collect()
@@ -200,6 +205,7 @@ fn parse_amp_message_records(
             let message_id = msg.message_id.unwrap_or(0).max(0);
             let timestamp = base_timestamp.saturating_add(message_id.saturating_mul(1000));
 
+            let raw_credits = usage.credits;
             Some(AmpUsageRecord {
                 model,
                 timestamp,
@@ -213,7 +219,8 @@ fn parse_amp_message_records(
                     cache_write: usage.cache_creation_input_tokens.unwrap_or(0).max(0),
                     reasoning: 0,
                 },
-                cost: usage.credits.unwrap_or(0.0).max(0.0),
+                cost: raw_credits.unwrap_or(0.0).max(0.0),
+                has_credits: raw_credits.is_some(),
             })
         })
         .collect()
@@ -255,6 +262,7 @@ fn merge_amp_records(
             AmpUsageRecord {
                 cost: message_record.cost,
                 message_id: message_record.message_id,
+                has_credits: ledger_record.has_credits || message_record.has_credits,
                 ..ledger_record
             }
         }
@@ -271,6 +279,7 @@ fn merge_amp_records(
             } else {
                 message_record.cost
             },
+            has_credits: ledger_record.has_credits || message_record.has_credits,
         }
     }
 }

--- a/crates/tokscale-core/src/sessions/codebuff.rs
+++ b/crates/tokscale-core/src/sessions/codebuff.rs
@@ -74,7 +74,8 @@ pub fn parse_codebuff_file(path: &Path) -> Vec<UnifiedMessage> {
         let dedup_key = upstream_message_id(msg)
             .unwrap_or_else(|| derive_dedup_key(&session_id, ts, &model, &usage, ordinal));
 
-        results.push(UnifiedMessage::new_with_dedup(
+        let cost = usage.credits.max(0.0);
+        let mut message = UnifiedMessage::new_with_dedup(
             "codebuff",
             &model,
             provider,
@@ -87,9 +88,15 @@ pub fn parse_codebuff_file(path: &Path) -> Vec<UnifiedMessage> {
                 cache_write: usage.cache_creation_input_tokens.max(0),
                 reasoning: 0,
             },
-            usage.credits.max(0.0),
+            cost,
             Some(dedup_key),
-        ));
+        );
+        // CodeBuff 用量数据中的 credits 是原始数据直接给出的金额，标记为供应商报告成本，
+        // 避免在 lenient submission 中被误归零。
+        if cost > 0.0 {
+            message.mark_provider_reported_cost();
+        }
+        results.push(message);
     }
 
     results

--- a/crates/tokscale-core/src/sessions/crush.rs
+++ b/crates/tokscale-core/src/sessions/crush.rs
@@ -101,6 +101,11 @@ pub fn parse_crush_sqlite_in(
                     TokenBreakdown::default(),
                     bucket_cost,
                 );
+                // Crush 数据库中存储的会话级 cost 是 Crush 直接报告的金额，标记为
+                // 供应商报告成本，避免在 lenient submission 中被误归零。
+                if bucket_cost > 0.0 {
+                    message.mark_provider_reported_cost();
+                }
                 message.message_count = bucket.message_count.max(0);
                 messages.push(message);
             }
@@ -118,6 +123,7 @@ pub fn parse_crush_sqlite_in(
             continue;
         };
 
+        let cost = session.cost.max(0.0);
         let mut message = UnifiedMessage::new(
             "crush",
             CRUSH_MODEL_ID,
@@ -125,8 +131,13 @@ pub fn parse_crush_sqlite_in(
             session_key,
             timestamp_ms,
             TokenBreakdown::default(),
-            session.cost.max(0.0),
+            cost,
         );
+        // Crush 数据库中存储的会话级 cost 是 Crush 直接报告的金额，标记为供应商报告成本，
+        // 避免在 lenient submission 中被误归零。
+        if cost > 0.0 {
+            message.mark_provider_reported_cost();
+        }
         message.message_count = 0;
         messages.push(message);
     }

--- a/crates/tokscale-core/src/sessions/cursor.rs
+++ b/crates/tokscale-core/src/sessions/cursor.rs
@@ -101,6 +101,7 @@ pub fn parse_cursor_file(path: &Path) -> Vec<UnifiedMessage> {
 
     // Column indices based on format
     let (
+        kind_idx,
         model_idx,
         input_cache_write_idx,
         input_no_cache_idx,
@@ -109,13 +110,14 @@ pub fn parse_cursor_file(path: &Path) -> Vec<UnifiedMessage> {
         cost_idx,
     ) = if has_kind_column && column_count >= 11 {
         // v3 format: Date,Cloud Agent ID,Automation ID,Kind,Model,...
-        (4, 6, 7, 8, 9, 11)
+        (Some(3), 4, 6, 7, 8, 9, 11)
     } else if has_kind_column {
         // v2 format: Date,Kind,Model,Max Mode,Input (w/ Cache Write),...
-        (2, 4, 5, 6, 7, 9)
+        (Some(1), 2, 4, 5, 6, 7, 9)
     } else {
         // v1 format: Date,Model,Input (w/ Cache Write),...
-        (1, 2, 3, 4, 5, 7)
+        // 旧格式没有 Kind 列，按成本金额判断（与新增测试兼容）。
+        (None, 1, 2, 3, 4, 5, 7)
     };
 
     let account_id = account_id_from_cursor_cache_path(path);
@@ -135,6 +137,9 @@ pub fn parse_cursor_file(path: &Path) -> Vec<UnifiedMessage> {
         }
 
         let date_str = fields[0].trim().trim_matches('"');
+        let kind = kind_idx
+            .map(|idx| fields[idx].trim().trim_matches('"'))
+            .unwrap_or("");
         let model = fields[model_idx].trim().trim_matches('"');
         let input_with_cache_write: i64 = fields[input_cache_write_idx]
             .trim()
@@ -190,9 +195,11 @@ pub fn parse_cursor_file(path: &Path) -> Vec<UnifiedMessage> {
             },
             cost.max(0.0),
         );
-        // Cursor 用量导出 CSV 的 Cost 列直接来自 Cursor，标记为供应商报告成本，
-        // 避免在 lenient submission 中被误归零。
-        if cost > 0.0 {
+        // Cursor 用量导出 CSV 的 Cost 列直接来自 Cursor；只有 On-Demand（或无 Kind
+        // 列的旧格式）且成本为有限正数时才标记为供应商报告成本，Included / - / 0
+        // 等行保持非权威。
+        let is_on_demand = kind.is_empty() || kind.eq_ignore_ascii_case("on-demand");
+        if is_on_demand && cost.is_finite() && cost > 0.0 {
             message.mark_provider_reported_cost();
         }
         messages.push(message);
@@ -339,8 +346,11 @@ mod tests {
         assert_eq!(messages[0].tokens.output, 15);
         assert_eq!(messages[0].tokens.cache_write, 5); // 10 - 5
         assert!((messages[0].cost - 0.10).abs() < 0.001);
+        // 旧格式无 Kind 列，cost > 0 的行视为 On-Demand，应标记为权威成本。
+        assert!(messages[0].has_authoritative_cost());
 
         assert_eq!(messages[1].model_id, "gpt-4o-mini");
+        assert!(messages[1].has_authoritative_cost());
     }
 
     #[test]
@@ -366,12 +376,16 @@ mod tests {
         assert_eq!(messages[0].tokens.cache_read, 105891);
         assert_eq!(messages[0].tokens.cache_write, 28342 - 775); // 27567
         assert!((messages[0].cost - 0.19).abs() < 0.001);
+        // "Included" 行即使有数值成本也不应视为供应商报告成本。
+        assert!(!messages[0].has_authoritative_cost());
 
         // Second message: gpt-5-codex
         assert_eq!(messages[1].model_id, "gpt-5-codex");
         assert_eq!(messages[1].provider_id, "openai"); // gpt -> openai
         assert_eq!(messages[1].tokens.input, 8263);
         assert_eq!(messages[1].tokens.cache_read, 66964);
+        // "On-Demand" 且 cost > 0 的行应标记为权威成本。
+        assert!(messages[1].has_authoritative_cost());
     }
 
     #[test]
@@ -394,13 +408,44 @@ mod tests {
         assert_eq!(messages[0].model_id, "composer-2");
         assert_eq!(messages[0].cost, 0.0);
         assert_eq!(messages[0].tokens.cache_read, 29045760);
+        assert!(!messages[0].has_authoritative_cost());
 
         // Second message: actual cost from "On-Demand"
         assert_eq!(messages[1].model_id, "composer-2");
         assert!((messages[1].cost - 0.11).abs() < 0.001);
+        assert!(messages[1].has_authoritative_cost());
 
         // Third message: "-" cost should be 0 (Errored, No Charge)
         assert_eq!(messages[2].model_id, "composer-2");
         assert_eq!(messages[2].cost, 0.0);
+        assert!(!messages[2].has_authoritative_cost());
+    }
+
+    #[test]
+    fn test_parse_cursor_csv_only_on_demand_positive_cost_is_authoritative() {
+        // 显式 "0" 的 On-Demand 行以及 Included / - 行都不应标记为权威成本。
+        let csv = r#"Date,Cloud Agent ID,Automation ID,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost
+"2026-04-09T20:01:10.528Z","bc-a380fb49-e1a5-414e-817d-6a85b6cdc51c","cc30782e-26cc-4359-bc22-7567efe282be","On-Demand","composer-2","Yes","0","343446","29045760","915201","30304407","0"
+"2026-04-09T18:02:13.576Z","bc-19a9b74b-2af3-46e2-9f61-3ba1cdac46c8","1a0df38f-1474-4dfe-896b-70b841d4a833","On-Demand","composer-2","Yes","0","43478","420864","7957","472299","0.11"
+"2026-04-09T07:39:09.091Z","bc-49262501-0ee0-49f9-b856-a5b0466deddb","","Included","composer-2","Yes","0","104504","985600","3666","1093770","0.05""#;
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("usage.csv");
+        std::fs::write(&file_path, csv).unwrap();
+
+        let messages = parse_cursor_file(&file_path);
+        assert_eq!(messages.len(), 3);
+
+        // 显式 0 成本的 On-Demand 行不应标记为权威。
+        assert_eq!(messages[0].cost, 0.0);
+        assert!(!messages[0].has_authoritative_cost());
+
+        // 正数成本的 On-Demand 行应标记为权威。
+        assert!((messages[1].cost - 0.11).abs() < 0.001);
+        assert!(messages[1].has_authoritative_cost());
+
+        // Included 行即使有数值成本也不应标记为权威。
+        assert!((messages[2].cost - 0.05).abs() < 0.001);
+        assert!(!messages[2].has_authoritative_cost());
     }
 }

--- a/crates/tokscale-core/src/sessions/cursor.rs
+++ b/crates/tokscale-core/src/sessions/cursor.rs
@@ -175,7 +175,7 @@ pub fn parse_cursor_file(path: &Path) -> Vec<UnifiedMessage> {
         // Input tokens = input_without_cache_write
         let input = input_without_cache_write;
 
-        messages.push(UnifiedMessage::new(
+        let mut message = UnifiedMessage::new(
             "cursor",
             model,
             infer_provider(model),
@@ -189,7 +189,13 @@ pub fn parse_cursor_file(path: &Path) -> Vec<UnifiedMessage> {
                 reasoning: 0,
             },
             cost.max(0.0),
-        ));
+        );
+        // Cursor 用量导出 CSV 的 Cost 列直接来自 Cursor，标记为供应商报告成本，
+        // 避免在 lenient submission 中被误归零。
+        if cost > 0.0 {
+            message.mark_provider_reported_cost();
+        }
+        messages.push(message);
     }
 
     messages

--- a/crates/tokscale-core/src/sessions/cursor.rs
+++ b/crates/tokscale-core/src/sessions/cursor.rs
@@ -137,7 +137,7 @@ pub fn parse_cursor_file(path: &Path) -> Vec<UnifiedMessage> {
         }
 
         let date_str = fields[0].trim().trim_matches('"');
-        let kind = kind_idx
+        let _kind = kind_idx
             .map(|idx| fields[idx].trim().trim_matches('"'))
             .unwrap_or("");
         let model = fields[model_idx].trim().trim_matches('"');
@@ -195,11 +195,11 @@ pub fn parse_cursor_file(path: &Path) -> Vec<UnifiedMessage> {
             },
             cost.max(0.0),
         );
-        // Cursor 用量导出 CSV 的 Cost 列直接来自 Cursor；只有 On-Demand（或无 Kind
-        // 列的旧格式）且成本为有限正数时才标记为供应商报告成本，Included / - / 0
-        // 等行保持非权威。
-        let is_on_demand = kind.is_empty() || kind.eq_ignore_ascii_case("on-demand");
-        if is_on_demand && cost.is_finite() && cost > 0.0 {
+        // Cursor 用量导出 CSV 的 Cost 列直接来自 Cursor；只有旧格式（CSV 没有 Kind
+        // 列）且成本为有限正数时才标记为供应商报告成本。有 Kind 列但值为空字符串
+        // 时属于新格式，按非权威处理，避免空字段被误判为旧格式权威报告。
+        let is_old_format_without_kind = kind_idx.is_none();
+        if is_old_format_without_kind && cost.is_finite() && cost > 0.0 {
             message.mark_provider_reported_cost();
         }
         messages.push(message);
@@ -384,8 +384,9 @@ mod tests {
         assert_eq!(messages[1].provider_id, "openai"); // gpt -> openai
         assert_eq!(messages[1].tokens.input, 8263);
         assert_eq!(messages[1].tokens.cache_read, 66964);
-        // "On-Demand" 且 cost > 0 的行应标记为权威成本。
-        assert!(messages[1].has_authoritative_cost());
+        // 新格式存在 Kind 列，无论 On-Demand 与否都不再视为供应商报告成本，
+        // 避免空字段或分类变化导致误判。
+        assert!(!messages[1].has_authoritative_cost());
     }
 
     #[test]
@@ -413,7 +414,9 @@ mod tests {
         // Second message: actual cost from "On-Demand"
         assert_eq!(messages[1].model_id, "composer-2");
         assert!((messages[1].cost - 0.11).abs() < 0.001);
-        assert!(messages[1].has_authoritative_cost());
+        // 新格式存在 Kind 列，On-Demand 正 cost 也不再标记为权威成本；只有旧格式
+        // （无 Kind 列）才按 cost > 0 判定权威。
+        assert!(!messages[1].has_authoritative_cost());
 
         // Third message: "-" cost should be 0 (Errored, No Charge)
         assert_eq!(messages[2].model_id, "composer-2");
@@ -440,9 +443,9 @@ mod tests {
         assert_eq!(messages[0].cost, 0.0);
         assert!(!messages[0].has_authoritative_cost());
 
-        // 正数成本的 On-Demand 行应标记为权威。
+        // 新格式存在 Kind 列，正数成本的 On-Demand 行也不应标记为权威。
         assert!((messages[1].cost - 0.11).abs() < 0.001);
-        assert!(messages[1].has_authoritative_cost());
+        assert!(!messages[1].has_authoritative_cost());
 
         // Included 行即使有数值成本也不应标记为权威。
         assert!((messages[2].cost - 0.05).abs() < 0.001);

--- a/crates/tokscale-core/src/sessions/hermes.rs
+++ b/crates/tokscale-core/src/sessions/hermes.rs
@@ -58,7 +58,14 @@ const PER_MODEL_QUERY: &str = r#"
             SUM(smu.cache_write_tokens)  AS cache_write_tokens,
             SUM(smu.reasoning_tokens)    AS reasoning_tokens,
             SUM(COALESCE(NULLIF(smu.actual_cost_usd, 0), smu.estimated_cost_usd, 0)) AS cost_usd,
-            MAX(CASE WHEN smu.actual_cost_usd IS NOT NULL AND smu.actual_cost_usd != 0 THEN 1 ELSE 0 END) AS has_actual_cost
+            -- has_actual_cost 仅当所有产生非零成本的行都使用 actual_cost_usd 时才为 1。
+            -- 只要存在一行靠 estimated_cost_usd 产生非零成本，就视为估算而非权威。
+            CASE
+                WHEN MAX(CASE WHEN smu.actual_cost_usd IS NOT NULL AND smu.actual_cost_usd != 0 THEN 1 ELSE 0 END) = 1
+                 AND MAX(CASE WHEN (smu.actual_cost_usd IS NULL OR smu.actual_cost_usd = 0)
+                                AND smu.estimated_cost_usd IS NOT NULL AND smu.estimated_cost_usd != 0 THEN 1 ELSE 0 END) = 0
+                THEN 1 ELSE 0
+            END AS has_actual_cost
         FROM session_model_usage smu
         JOIN sessions s ON s.id = smu.session_id
         WHERE smu.model IS NOT NULL
@@ -92,7 +99,13 @@ const SESSION_TOTALS_QUERY: &str = r#"
             cache_write_tokens,
             reasoning_tokens,
             COALESCE(actual_cost_usd, estimated_cost_usd, 0) AS cost_usd,
-            CASE WHEN actual_cost_usd IS NOT NULL AND actual_cost_usd != 0 THEN 1 ELSE 0 END AS has_actual_cost
+            -- has_actual_cost 仅当该 session 的 cost 完全来自 actual_cost_usd 时才为 1。
+            -- actual_cost_usd 为 0 或 NULL 且 estimated_cost_usd 产生非零成本时视为估算。
+            CASE
+                WHEN actual_cost_usd IS NOT NULL AND actual_cost_usd != 0
+                 AND (estimated_cost_usd IS NULL OR estimated_cost_usd = 0)
+                THEN 1 ELSE 0
+            END AS has_actual_cost
         FROM sessions
         WHERE model IS NOT NULL
           AND TRIM(model) != ''
@@ -204,9 +217,9 @@ fn build_message(row: HermesUsageRow, dedup_key: String) -> UnifiedMessage {
         row.cost.max(0.0),
         Some(HERMES_AGENT_NAME.to_string()),
     );
-    // Hermes 数据库中存在 actual_cost_usd 时，该金额为 Hermes 直接报告的精确成本；
-    // 仅使用 estimated_cost_usd 时保持默认 Unknown/Estimated。
-    if row.has_actual_cost {
+    // Hermes 数据库中存在 actual_cost_usd 且所有产生成本的行都使用 actual 时，
+    // 该金额为 Hermes 直接报告的精确成本；仅当成本有限且非负时才标记为权威。
+    if row.has_actual_cost && row.cost.is_finite() && row.cost >= 0.0 {
         msg.mark_provider_reported_cost();
     }
     msg.message_count = row.message_count.max(0);

--- a/crates/tokscale-core/src/sessions/hermes.rs
+++ b/crates/tokscale-core/src/sessions/hermes.rs
@@ -57,7 +57,8 @@ const PER_MODEL_QUERY: &str = r#"
             SUM(smu.cache_read_tokens)   AS cache_read_tokens,
             SUM(smu.cache_write_tokens)  AS cache_write_tokens,
             SUM(smu.reasoning_tokens)    AS reasoning_tokens,
-            SUM(COALESCE(NULLIF(smu.actual_cost_usd, 0), smu.estimated_cost_usd, 0)) AS cost_usd
+            SUM(COALESCE(NULLIF(smu.actual_cost_usd, 0), smu.estimated_cost_usd, 0)) AS cost_usd,
+            MAX(CASE WHEN smu.actual_cost_usd IS NOT NULL AND smu.actual_cost_usd != 0 THEN 1 ELSE 0 END) AS has_actual_cost
         FROM session_model_usage smu
         JOIN sessions s ON s.id = smu.session_id
         WHERE smu.model IS NOT NULL
@@ -90,7 +91,8 @@ const SESSION_TOTALS_QUERY: &str = r#"
             cache_read_tokens,
             cache_write_tokens,
             reasoning_tokens,
-            COALESCE(actual_cost_usd, estimated_cost_usd, 0) AS cost_usd
+            COALESCE(actual_cost_usd, estimated_cost_usd, 0) AS cost_usd,
+            CASE WHEN actual_cost_usd IS NOT NULL AND actual_cost_usd != 0 THEN 1 ELSE 0 END AS has_actual_cost
         FROM sessions
         WHERE model IS NOT NULL
           AND TRIM(model) != ''
@@ -117,6 +119,7 @@ struct HermesUsageRow {
     cache_write: i64,
     reasoning: i64,
     cost: f64,
+    has_actual_cost: bool,
 }
 
 fn decode_usage_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<HermesUsageRow> {
@@ -132,6 +135,10 @@ fn decode_usage_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<HermesUsageRow>
         cache_write: row.get::<_, Option<i64>>(8)?.unwrap_or(0),
         reasoning: row.get::<_, Option<i64>>(9)?.unwrap_or(0),
         cost: row.get::<_, Option<f64>>(10)?.unwrap_or(0.0),
+        has_actual_cost: row
+            .get::<_, Option<i32>>(11)?
+            .unwrap_or(0)
+            != 0,
     })
 }
 
@@ -197,6 +204,11 @@ fn build_message(row: HermesUsageRow, dedup_key: String) -> UnifiedMessage {
         row.cost.max(0.0),
         Some(HERMES_AGENT_NAME.to_string()),
     );
+    // Hermes 数据库中存在 actual_cost_usd 时，该金额为 Hermes 直接报告的精确成本；
+    // 仅使用 estimated_cost_usd 时保持默认 Unknown/Estimated。
+    if row.has_actual_cost {
+        msg.mark_provider_reported_cost();
+    }
     msg.message_count = row.message_count.max(0);
     msg.dedup_key = Some(dedup_key);
     msg

--- a/crates/tokscale-core/src/sessions/hermes.rs
+++ b/crates/tokscale-core/src/sessions/hermes.rs
@@ -99,11 +99,11 @@ const SESSION_TOTALS_QUERY: &str = r#"
             cache_write_tokens,
             reasoning_tokens,
             COALESCE(actual_cost_usd, estimated_cost_usd, 0) AS cost_usd,
-            -- has_actual_cost 仅当该 session 的 cost 完全来自 actual_cost_usd 时才为 1。
-            -- actual_cost_usd 为 0 或 NULL 且 estimated_cost_usd 产生非零成本时视为估算。
+            -- has_actual_cost 仅当最终选用的 cost 来自 actual_cost_usd 时才为 1。
+            -- 只要 actual_cost_usd 非 NULL 且非零即可判定为供应商实际报告成本，
+            -- 无需关心是否存在 estimate，与 COALESCE 的优先级保持一致。
             CASE
                 WHEN actual_cost_usd IS NOT NULL AND actual_cost_usd != 0
-                 AND (estimated_cost_usd IS NULL OR estimated_cost_usd = 0)
                 THEN 1 ELSE 0
             END AS has_actual_cost
         FROM sessions

--- a/crates/tokscale-core/src/sessions/kilo.rs
+++ b/crates/tokscale-core/src/sessions/kilo.rs
@@ -131,7 +131,8 @@ pub fn parse_kilo_sqlite_with_fallback(
             .to_string();
         let provider = provider_identity::canonical_provider(&provider).unwrap_or(provider);
 
-        let cost = msg.cost.unwrap_or(0.0).max(0.0);
+        let raw_cost = msg.cost.unwrap_or(0.0);
+        let cost = raw_cost.max(0.0);
         let mut unified = UnifiedMessage::new_with_agent(
             "kilo",
             model_id,
@@ -148,9 +149,9 @@ pub fn parse_kilo_sqlite_with_fallback(
             cost,
             agent,
         );
-        // Kilo 消息数据中携带的 cost 是原始数据直接给出的金额，标记为供应商报告成本，
-        // 避免在 lenient submission 中被误归零。
-        if msg.cost.is_some() {
+        // Kilo 消息数据中携带的 cost 是原始数据直接给出的金额；只有_finite_且非负时才
+        // 标记为供应商报告成本，避免负数被错误地按 $0 上报。
+        if msg.cost.is_some() && raw_cost.is_finite() && raw_cost >= 0.0 {
             unified.mark_provider_reported_cost();
         }
         unified.dedup_key = dedup_key;

--- a/crates/tokscale-core/src/sessions/kilo.rs
+++ b/crates/tokscale-core/src/sessions/kilo.rs
@@ -131,6 +131,7 @@ pub fn parse_kilo_sqlite_with_fallback(
             .to_string();
         let provider = provider_identity::canonical_provider(&provider).unwrap_or(provider);
 
+        let cost = msg.cost.unwrap_or(0.0).max(0.0);
         let mut unified = UnifiedMessage::new_with_agent(
             "kilo",
             model_id,
@@ -144,9 +145,14 @@ pub fn parse_kilo_sqlite_with_fallback(
                 cache_write: tokens.cache.write.max(0),
                 reasoning: tokens.reasoning.unwrap_or(0).max(0),
             },
-            msg.cost.unwrap_or(0.0).max(0.0),
+            cost,
             agent,
         );
+        // Kilo 消息数据中携带的 cost 是原始数据直接给出的金额，标记为供应商报告成本，
+        // 避免在 lenient submission 中被误归零。
+        if msg.cost.is_some() {
+            unified.mark_provider_reported_cost();
+        }
         unified.dedup_key = dedup_key;
 
         messages.push(unified);

--- a/crates/tokscale-core/src/sessions/mux.rs
+++ b/crates/tokscale-core/src/sessions/mux.rs
@@ -112,7 +112,7 @@ pub fn parse_mux_file(path: &Path) -> Vec<UnifiedMessage> {
             };
             let provider = provider_identity::canonical_provider(&provider).unwrap_or(provider);
 
-            Some(UnifiedMessage::new_with_dedup(
+            let mut message = UnifiedMessage::new_with_dedup(
                 "mux",
                 model_id,
                 provider,
@@ -127,7 +127,13 @@ pub fn parse_mux_file(path: &Path) -> Vec<UnifiedMessage> {
                 },
                 source_cost,
                 dedup_key,
-            ))
+            );
+            // Mux 用量数据中的 cost_usd 是原始数据直接给出的金额，标记为供应商报告成本，
+            // 避免在 lenient submission 中被误归零。
+            if source_cost > 0.0 {
+                message.mark_provider_reported_cost();
+            }
+            Some(message)
         })
         .collect()
 }

--- a/crates/tokscale-core/src/sessions/openclaw.rs
+++ b/crates/tokscale-core/src/sessions/openclaw.rs
@@ -226,12 +226,16 @@ fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedM
                     current_model = Some(model.clone());
                     current_provider = Some(provider.clone());
                     let timestamp = msg.timestamp.unwrap_or(file_mtime_ms);
-                    let has_reported_cost = usage.cost.is_some();
-                    let cost = usage
+                    let total_cost = usage
                         .cost
                         .as_ref()
-                        .and_then(|c| c.total)
+                        .and_then(|c| c.total);
+                    // 只有 cost.total 是有限且非负的数值时才视为供应商报告金额；
+                    // 缺少 total 或 total 为 null 时走正常定价/估算路径。
+                    let cost = total_cost
+                        .filter(|v| v.is_finite() && *v >= 0.0)
                         .unwrap_or(0.0);
+                    let has_reported_cost = total_cost.is_some();
 
                     let mut message = UnifiedMessage::new(
                         "openclaw",
@@ -246,10 +250,10 @@ fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedM
                             cache_write: usage.cache_write.unwrap_or(0).max(0),
                             reasoning: 0,
                         },
-                        cost.max(0.0),
+                        cost,
                     );
-                    // OpenClaw 会话数据中的 cost.total 是原始数据直接给出的金额，标记为
-                    // 供应商报告成本，避免在 lenient submission 中被误归零。
+                    // OpenClaw 会话数据中的 cost.total 是原始数据直接给出的金额；
+                    // 仅当存在有限且非负的 total 时才标记为供应商报告成本。
                     if has_reported_cost {
                         message.mark_provider_reported_cost();
                     }

--- a/crates/tokscale-core/src/sessions/openclaw.rs
+++ b/crates/tokscale-core/src/sessions/openclaw.rs
@@ -226,9 +226,14 @@ fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedM
                     current_model = Some(model.clone());
                     current_provider = Some(provider.clone());
                     let timestamp = msg.timestamp.unwrap_or(file_mtime_ms);
-                    let cost = usage.cost.and_then(|c| c.total).unwrap_or(0.0);
+                    let has_reported_cost = usage.cost.is_some();
+                    let cost = usage
+                        .cost
+                        .as_ref()
+                        .and_then(|c| c.total)
+                        .unwrap_or(0.0);
 
-                    messages.push(UnifiedMessage::new(
+                    let mut message = UnifiedMessage::new(
                         "openclaw",
                         model,
                         provider,
@@ -242,7 +247,13 @@ fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedM
                             reasoning: 0,
                         },
                         cost.max(0.0),
-                    ));
+                    );
+                    // OpenClaw 会话数据中的 cost.total 是原始数据直接给出的金额，标记为
+                    // 供应商报告成本，避免在 lenient submission 中被误归零。
+                    if has_reported_cost {
+                        message.mark_provider_reported_cost();
+                    }
+                    messages.push(message);
                 }
             }
             _ => {}

--- a/crates/tokscale-core/src/sessions/roocode.rs
+++ b/crates/tokscale-core/src/sessions/roocode.rs
@@ -63,6 +63,7 @@ pub(crate) fn parse_roo_kilo_file(path: &Path, source: &str) -> Vec<UnifiedMessa
 
         let provider = provider_from_api_protocol(payload.api_protocol.as_deref());
 
+        let cost = payload.cost.unwrap_or(0.0).max(0.0);
         let mut message = UnifiedMessage::new_with_agent(
             source,
             model_id.clone(),
@@ -76,12 +77,13 @@ pub(crate) fn parse_roo_kilo_file(path: &Path, source: &str) -> Vec<UnifiedMessa
                 cache_write: payload.cache_writes,
                 reasoning: 0,
             },
-            payload.cost,
+            cost,
             agent.clone(),
         );
-        // RooCode 日志中 api_req_started 的 cost 是原始数据直接给出的金额，标记为
-        // 供应商报告成本，避免在 lenient submission 中被误归零。
-        if payload.cost > 0.0 {
+        // RooCode 日志中 api_req_started 的 cost 是原始数据直接给出的金额；只要存在
+        // 有限且非负的 cost（包括显式 0）就标记为供应商报告成本，避免免费请求被
+        // 外部模型价格覆盖。
+        if payload.cost.is_some() && cost.is_finite() && cost >= 0.0 {
             message.mark_provider_reported_cost();
         }
         messages.push(message);
@@ -182,7 +184,9 @@ fn parse_entry_timestamp(ts: Option<&Value>) -> Option<i64> {
 }
 
 struct ApiReqStartedPayload {
-    cost: f64,
+    /// 原始 `cost` 字段是否存在（包括显式 0）。用于区分供应商报告的免费请求与
+    /// 没有成本信息的请求。
+    cost: Option<f64>,
     tokens_in: i64,
     tokens_out: i64,
     cache_reads: i64,
@@ -194,7 +198,7 @@ fn parse_api_req_started_payload(text: &str) -> Option<ApiReqStartedPayload> {
     let mut bytes = text.as_bytes().to_vec();
     let value: Value = simd_json::from_slice(&mut bytes).ok()?;
 
-    let cost = extract_f64(value.get("cost")).unwrap_or(0.0).max(0.0);
+    let cost = extract_f64(value.get("cost"));
     let tokens_in = extract_i64(value.get("tokensIn")).unwrap_or(0).max(0);
     let tokens_out = extract_i64(value.get("tokensOut")).unwrap_or(0).max(0);
     let cache_reads = extract_i64(value.get("cacheReads")).unwrap_or(0).max(0);

--- a/crates/tokscale-core/src/sessions/roocode.rs
+++ b/crates/tokscale-core/src/sessions/roocode.rs
@@ -63,7 +63,7 @@ pub(crate) fn parse_roo_kilo_file(path: &Path, source: &str) -> Vec<UnifiedMessa
 
         let provider = provider_from_api_protocol(payload.api_protocol.as_deref());
 
-        messages.push(UnifiedMessage::new_with_agent(
+        let mut message = UnifiedMessage::new_with_agent(
             source,
             model_id.clone(),
             provider,
@@ -78,7 +78,13 @@ pub(crate) fn parse_roo_kilo_file(path: &Path, source: &str) -> Vec<UnifiedMessa
             },
             payload.cost,
             agent.clone(),
-        ));
+        );
+        // RooCode 日志中 api_req_started 的 cost 是原始数据直接给出的金额，标记为
+        // 供应商报告成本，避免在 lenient submission 中被误归零。
+        if payload.cost > 0.0 {
+            message.mark_provider_reported_cost();
+        }
+        messages.push(message);
     }
 
     messages

--- a/crates/tokscale-core/src/sessions/roocode.rs
+++ b/crates/tokscale-core/src/sessions/roocode.rs
@@ -63,7 +63,10 @@ pub(crate) fn parse_roo_kilo_file(path: &Path, source: &str) -> Vec<UnifiedMessa
 
         let provider = provider_from_api_protocol(payload.api_protocol.as_deref());
 
-        let cost = payload.cost.unwrap_or(0.0).max(0.0);
+        // 先用原始值判断 authority，再用 clamped 值构造消息，避免负数/非有限 cost
+        // 被 max(0.0) 洗白成权威免费请求。
+        let raw_cost = payload.cost;
+        let cost = raw_cost.unwrap_or(0.0).max(0.0);
         let mut message = UnifiedMessage::new_with_agent(
             source,
             model_id.clone(),
@@ -80,10 +83,9 @@ pub(crate) fn parse_roo_kilo_file(path: &Path, source: &str) -> Vec<UnifiedMessa
             cost,
             agent.clone(),
         );
-        // RooCode 日志中 api_req_started 的 cost 是原始数据直接给出的金额；只要存在
-        // 有限且非负的 cost（包括显式 0）就标记为供应商报告成本，避免免费请求被
-        // 外部模型价格覆盖。
-        if payload.cost.is_some() && cost.is_finite() && cost >= 0.0 {
+        // RooCode 日志中 api_req_started 的 cost 是原始数据直接给出的金额；只有原始
+        // 值存在、有限且非负时才标记为供应商报告成本，避免非法值被当成权威免费请求。
+        if raw_cost.is_some_and(|c| c.is_finite() && c >= 0.0) {
             message.mark_provider_reported_cost();
         }
         messages.push(message);

--- a/crates/tokscale-core/src/sessions/trae.rs
+++ b/crates/tokscale-core/src/sessions/trae.rs
@@ -76,8 +76,13 @@ fn parse_session(client: &str, session: &serde_json::Value) -> Option<UnifiedMes
     // `usage_time` near `i64::MAX` would panic in debug builds and silently
     // wrap to a negative timestamp in release builds.
     let timestamp_ms = usage_time.checked_mul(1000)?;
-    let cost = session["dollar_float"].as_f64().unwrap_or(0.0);
-    let has_reported_cost = session["dollar_float"].as_f64().is_some();
+    let raw_cost = session["dollar_float"].as_f64();
+    // 只接受有限且非负的 dollar_float；负值视为无效，保持 cost=0 且不标记为权威，
+    // 避免扭曲 totals。
+    let (cost, has_reported_cost) = match raw_cost {
+        Some(v) if v.is_finite() && v >= 0.0 => (v, true),
+        _ => (0.0, false),
+    };
 
     let extra = &session["extra_info"];
     let input = extra["input_token"].as_i64().unwrap_or(0);

--- a/crates/tokscale-core/src/sessions/trae.rs
+++ b/crates/tokscale-core/src/sessions/trae.rs
@@ -77,6 +77,7 @@ fn parse_session(client: &str, session: &serde_json::Value) -> Option<UnifiedMes
     // wrap to a negative timestamp in release builds.
     let timestamp_ms = usage_time.checked_mul(1000)?;
     let cost = session["dollar_float"].as_f64().unwrap_or(0.0);
+    let has_reported_cost = session["dollar_float"].as_f64().is_some();
 
     let extra = &session["extra_info"];
     let input = extra["input_token"].as_i64().unwrap_or(0);
@@ -90,7 +91,7 @@ fn parse_session(client: &str, session: &serde_json::Value) -> Option<UnifiedMes
 
     let dedup_key = Some(format!("trae:{}:{}", session_id, usage_time));
 
-    Some(UnifiedMessage::new_with_dedup(
+    let mut message = UnifiedMessage::new_with_dedup(
         client,
         model_id,
         provider,
@@ -105,7 +106,13 @@ fn parse_session(client: &str, session: &serde_json::Value) -> Option<UnifiedMes
         },
         cost,
         dedup_key,
-    ))
+    );
+    // Trae 用量 API 直接返回精确 dollar_float，标记为供应商报告成本，避免在
+    // lenient submission 中被误归零。
+    if has_reported_cost {
+        message.mark_provider_reported_cost();
+    }
+    Some(message)
 }
 
 /// Parse a cache file containing an array of sessions as returned by the API.

--- a/crates/tokscale-core/src/sessions/warp.rs
+++ b/crates/tokscale-core/src/sessions/warp.rs
@@ -71,6 +71,7 @@ fn usage_to_message(usage: &WarpAggregateUsage, timestamp: i64) -> Option<Unifie
         return None;
     }
 
+    let cost = cents_to_dollars(spend_cents);
     let mut message = UnifiedMessage::new(
         "warp",
         "aggregate-requests",
@@ -78,8 +79,13 @@ fn usage_to_message(usage: &WarpAggregateUsage, timestamp: i64) -> Option<Unifie
         "warp-aggregate-account",
         timestamp,
         TokenBreakdown::default(),
-        cents_to_dollars(spend_cents),
+        cost,
     );
+    // Warp usage cache 中的 spend_cents 是 Warp 直接报告的消费金额，标记为供应商
+    // 报告成本，避免在 lenient submission 中被误归零。
+    if cost > 0.0 {
+        message.mark_provider_reported_cost();
+    }
     message.message_count = requests;
     Some(message)
 }
@@ -97,6 +103,7 @@ fn workspace_to_message(workspace: &WarpWorkspaceUsage, timestamp: i64) -> Optio
         .map(sanitize_id)
         .filter(|id| !id.is_empty())
         .unwrap_or_else(|| "unknown".to_string());
+    let cost = cents_to_dollars(spend_cents);
     let mut message = UnifiedMessage::new(
         "warp",
         "aggregate-requests",
@@ -104,8 +111,13 @@ fn workspace_to_message(workspace: &WarpWorkspaceUsage, timestamp: i64) -> Optio
         format!("warp-aggregate-{workspace_id}"),
         timestamp,
         TokenBreakdown::default(),
-        cents_to_dollars(spend_cents),
+        cost,
     );
+    // Warp usage cache 中的 spend_cents 是 Warp 直接报告的消费金额，标记为供应商
+    // 报告成本，避免在 lenient submission 中被误归零。
+    if cost > 0.0 {
+        message.mark_provider_reported_cost();
+    }
     message.message_count = requests;
     message.set_workspace(
         workspace.id.clone().filter(|id| !id.trim().is_empty()),


### PR DESCRIPTION
Adds support for the `TOKSCALE_SKIP_EXTERNAL_PRICING` environment variable so that `tokscale submit` can succeed even when upstream pricing sources (LiteLLM, OpenRouter, models.dev) do not cover every model used, such as private or internal models.

When `TOKSCALE_SKIP_EXTERNAL_PRICING` is set to `1`, `true`, or `yes`:
- The submit path no longer fetches external pricing datasets over the network.
- Only `custom-pricing.json` is loaded.
- Messages whose model is not priced are reported with `cost = 0` instead of failing the whole submission with `pricing is unavailable for submitted token usage`.

The default behavior is unchanged: without the variable, `submit` still validates that every token-bearing message is covered by a known price.

A new unit test covers the skip path with a deliberately unpriced model, asserting that the graph builds successfully and costs are zero.

While preparing the test suite, two existing tests that call `build_graph_from_messages` directly were updated to pass the now-required `bucket_timezone` argument; this is a minimal compile fix with no production behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `tokscale submit` lenient by default so unpriced models no longer block submissions. Unpriced tokens are submitted at zero cost with warnings, and validated provider‑reported costs are preserved; strict pricing is opt‑in.

- **New Features**
  - Default lenient pricing: unpriced usage stays in the graph and is reported as cost = 0 with a provider/model warning; authoritative costs from parsers like `trae`, `hermes`, `warp`, `codebuff`, `kilo`, `amp`, `mux`, `openclaw`, `crush`, `cursor`, and `roocode` are preserved.
  - Strict opt-in: `--strict-pricing` or `TOKSCALE_STRICT_PRICING` requires priced models and fails otherwise; strict overrides `TOKSCALE_SKIP_EXTERNAL_PRICING`.
  - `TOKSCALE_SKIP_EXTERNAL_PRICING`: load only `custom-pricing.json` (no network) and allow submissions with unpriced usage at zero cost.

- **Bug Fixes**
  - Tightened authoritative cost detection and flag preservation: only mark provider‑reported when raw costs are present, finite, and non‑negative; keep explicit zero when reported (e.g., `amp`, `roocode`), and ignore invalid/negative values (`trae`, `kilo`, `openclaw`, `mux`, `warp`, `crush`, `codebuff`). For `cursor`, only the old CSV without a Kind column treats positive‑cost rows as authoritative; new formats never do. Cache versions for `roocode`/`kilo` were bumped to reparse and retain correct flags.

<sup>Written for commit 3ccca4033344f1245f61e58d927b57b42f97bab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

