### PR TITLE
fix(submit): reject exclusions no pricing dataset backs

### DIFF
--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -26,6 +26,35 @@ fn prime_pricing_cache(base: &Path) {
     }
 }
 
+// @keep: the empty `data` in prime_pricing_cache is easy to mistake for real pricing.
+/// Prime the LiteLLM cache with an actual priced model.
+///
+/// `prime_pricing_cache` writes `"data":{}`, so the pricing service loads
+/// successfully holding nothing. That is indistinguishable from a total upstream
+/// outage, and the submission path now rejects exclusions made against it. Tests
+/// that need "pricing loaded fine, it just does not cover *this* model" must
+/// prime a non-empty dataset with this.
+fn prime_pricing_cache_with_a_priced_model(base: &Path) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_secs();
+    let payload = format!(
+        r#"{{"timestamp":{},"data":{{"gpt-4o":{{"input_cost_per_token":0.0000025,"output_cost_per_token":0.00001,"cache_read_input_token_cost":0.00000125,"cache_creation_input_token_cost":0.000003125}}}}}}"#,
+        now
+    );
+
+    for dir in [
+        base.join("Library/Caches/tokscale"),
+        base.join(".cache/tokscale"),
+        base.join(".config/tokscale/cache"),
+    ] {
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("pricing-litellm.json"), &payload).unwrap();
+        fs::write(dir.join("pricing-openrouter.json"), &payload).unwrap();
+    }
+}
+
 fn prime_override_pricing_cache(config_dir: &Path) {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -3621,6 +3650,10 @@ fn test_root_with_group_by() {
 #[test]
 fn test_submit_excludes_unpriced_usage_and_keeps_the_rest() {
     let tmp = create_temp_fixture_dir();
+    // Healthy pricing that does not happen to cover the unpriced model below.
+    // Without this the fixture holds no pricing at all, which is a different
+    // (fatal) condition — see test_submit_offline_without_pricing_cache_fails.
+    prime_pricing_cache_with_a_priced_model(tmp.path());
     write_fake_credentials(tmp.path());
     let unpriced_dir = tmp
         .path()
@@ -3670,6 +3703,65 @@ fn test_submit_excludes_unpriced_usage_and_keeps_the_rest() {
     assert!(
         stdout.contains("Dry run - not submitting data."),
         "dry-run must complete without submitting: {stdout}"
+    );
+}
+
+/// Regression: a cold cache with no network must not look like "no usage".
+///
+/// Every fetchable upstream is unreachable here and nothing is cached, so the
+/// pricing service loads empty and covers nothing. Excluding on that basis would
+/// consume the whole batch and exit 0 reporting no usage to submit, which is
+/// indistinguishable from an empty history and reads as success to autosubmit.
+#[test]
+fn test_submit_offline_without_pricing_cache_fails() {
+    let tmp = create_temp_fixture_dir_without_pricing_cache();
+    write_fake_credentials(tmp.path());
+    // Cost 0 keeps these messages non-authoritative, so they depend on pricing.
+    // The stock fixture's messages carry a positive OpenCode cost, which is
+    // provider-reported and would bypass pricing entirely.
+    let unpriced_dir = tmp
+        .path()
+        .join(".local/share/opencode/storage/message/needs-pricing");
+    fs::create_dir_all(&unpriced_dir).unwrap();
+    fs::write(
+        unpriced_dir.join("needs-pricing.json"),
+        r#"{
+            "id": "needs-pricing",
+            "sessionID": "needs-pricing",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4-20250514",
+            "providerID": "anthropic",
+            "cost": 0,
+            "tokens": { "input": 1000, "output": 500, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+            "time": { "created": 1736510400000.0 }
+        }"#,
+    )
+    .unwrap();
+
+    let output = offline_cmd_with_home(tmp.path())
+        .args([
+            "--no-spinner",
+            "submit",
+            "--client",
+            "opencode",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "a total pricing outage must fail loudly, not report an empty submission;\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("pricing data is unavailable for submission"),
+        "the failure must name the pricing outage: {stderr}"
+    );
+    assert!(
+        !stdout.contains("No usage data found to submit."),
+        "usage exists; it must not be reported as absent: {stdout}"
     );
 }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2997,6 +2997,7 @@ fn build_graph_from_messages(
         GraphPricingRequirement::Lenient => (filtered, Vec::new()),
         GraphPricingRequirement::Submission => {
             let (submitted, exclusions) = exclude_unpriced_submission_messages(filtered, pricing);
+            require_trustworthy_exclusions(pricing, &exclusions)?;
             validate_priced_messages(&submitted, pricing)?;
             (submitted, exclusions)
         }
@@ -3167,12 +3168,51 @@ pub async fn generate_local_graph_report(options: ReportOptions) -> Result<Graph
     .await
 }
 
+const UNAVAILABLE_SUBMISSION_PRICING: &str = "pricing data is unavailable for submission";
+
+// @keep: the two conditions are load-bearing together; either alone is wrong.
+/// Refuse to act on exclusions that no pricing dataset backs.
+///
+/// `exclude_unpriced_submission_messages` drops what the pricing service cannot
+/// cover, but a service with no dataset covers *nothing*, so "unpriced" and "we
+/// have no prices" produce identical exclusions. Left alone, a cold cache with
+/// no network excludes the entire batch, leaves `total_tokens == 0`, and lets
+/// the CLI print "No usage data found to submit" and exit 0 — indistinguishable
+/// from genuinely having no usage, and reported as success to autosubmit.
+///
+/// Both conditions matter:
+///
+/// - Only when something was excluded. A batch whose messages all carry
+///   provider-reported costs never consults pricing, so a missing dataset is
+///   irrelevant and must not block it.
+/// - Only when no dataset loaded. A populated dataset that simply lacks a price
+///   for some model is the case #1053 exists to handle; failing there would
+///   break autosubmit for anyone whose usage is legitimately unpriceable, which
+///   is the trap #1044 documents.
+///
+/// This runs after exclusion because the exclusion list is the signal. It
+/// cannot move into `validate_priced_messages`, which sees only the survivors —
+/// and when everything is excluded that slice is empty and validates trivially.
+fn require_trustworthy_exclusions(
+    pricing: Option<&pricing::PricingService>,
+    exclusions: &[UnpricedSubmissionExclusion],
+) -> Result<(), String> {
+    if exclusions.is_empty() {
+        return Ok(());
+    }
+
+    match pricing {
+        Some(pricing) if pricing.has_pricing_data() => Ok(()),
+        _ => Err(UNAVAILABLE_SUBMISSION_PRICING.to_string()),
+    }
+}
+
 fn validate_priced_messages(
     messages: &[UnifiedMessage],
     pricing: Option<&pricing::PricingService>,
 ) -> Result<(), String> {
     let Some(pricing) = pricing else {
-        return Err("pricing data is unavailable for submission".to_string());
+        return Err(UNAVAILABLE_SUBMISSION_PRICING.to_string());
     };
 
     // Counted rather than listed per message: a real submission repeats the
@@ -8164,7 +8204,9 @@ mod tests {
             },
             0.0,
         );
-        let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
+        // Populated but not covering this model: an empty service would instead
+        // trip the "no pricing dataset loaded" guard, which is a different case.
+        let pricing = pricing::PricingService::new(unrelated_litellm_dataset(), HashMap::new());
 
         let report = build_graph_from_messages(
             vec![message.clone()],
@@ -8192,6 +8234,24 @@ mod tests {
         );
     }
 
+    /// A dataset that loaded successfully but prices an unrelated model.
+    ///
+    /// Tests asserting "this model is unpriced" must use this rather than an
+    /// empty service: an empty service means *no dataset loaded*, which is a
+    /// separate, fatal condition on the submission path.
+    fn unrelated_litellm_dataset() -> HashMap<String, pricing::ModelPricing> {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "gpt-4o".to_string(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(1e-6),
+                output_cost_per_token: Some(2e-6),
+                ..Default::default()
+            },
+        );
+        litellm
+    }
+
     #[test]
     fn submission_without_any_pricing_data_still_fails() {
         let message = UnifiedMessage::new(
@@ -8207,16 +8267,62 @@ mod tests {
             0.0,
         );
 
-        let error = build_graph_from_messages(
+        // `None` is unreachable from `generate_submission_graph`, which always
+        // passes `Some(..)` because `PricingService::get_or_init` degrades every
+        // failed source to an empty map rather than erroring. The reachable
+        // shape of "no pricing dataset loaded" is a populated-with-nothing
+        // service, so both must fail identically.
+        let empty = pricing::PricingService::new(HashMap::new(), HashMap::new());
+        for (label, pricing) in [
+            ("no service at all", None),
+            ("a service with no dataset", Some(&empty)),
+        ] {
+            let Err(error) = build_graph_from_messages(
+                vec![message.clone()],
+                pricing,
+                GraphPricingRequirement::Submission,
+                std::time::Instant::now(),
+                &crate::bucket_tz::BucketTimezone::Local,
+            ) else {
+                panic!("submission must fail with {label}");
+            };
+
+            assert_eq!(error, "pricing data is unavailable for submission");
+        }
+    }
+
+    /// A missing pricing dataset only matters if something needed pricing.
+    /// Provider-reported costs are authoritative, so a batch made entirely of
+    /// them must still submit during a total upstream outage.
+    #[test]
+    fn submission_without_pricing_data_still_accepts_provider_reported_usage() {
+        let mut message = UnifiedMessage::new(
+            "opencode",
+            "some-model",
+            "anthropic",
+            "provider-reported",
+            1_736_510_400_000,
+            TokenBreakdown {
+                input: 1_000,
+                output: 500,
+                ..Default::default()
+            },
+            0.05,
+        );
+        message.mark_provider_reported_cost();
+        let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
+
+        let graph = build_graph_from_messages(
             vec![message],
-            None,
+            Some(&pricing),
             GraphPricingRequirement::Submission,
             std::time::Instant::now(),
             &crate::bucket_tz::BucketTimezone::Local,
         )
-        .expect_err("submission must still fail when no pricing dataset loaded");
+        .expect("authoritative costs must not need a pricing dataset");
 
-        assert_eq!(error, "pricing data is unavailable for submission");
+        assert_eq!(graph.summary.total_tokens, 1_500);
+        assert!(graph.unpriced_submission_exclusions.is_empty());
     }
 
     #[test]
@@ -8296,7 +8402,8 @@ mod tests {
             },
             0.0,
         );
-        let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
+        // Populated but not covering this model — see `unrelated_litellm_dataset`.
+        let pricing = pricing::PricingService::new(unrelated_litellm_dataset(), HashMap::new());
 
         let graph = build_graph_from_messages(
             vec![concrete],

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -158,6 +158,17 @@ impl PricingLookup {
         Self::new_with_models_dev(litellm, openrouter, cursor, HashMap::new(), HashMap::new())
     }
 
+    // @keep: the omission of cursor/sakana is the whole point and reads like a bug otherwise.
+    /// True when at least one *fetchable* upstream dataset loaded.
+    ///
+    /// The `cursor` and `sakana` tables are compiled-in constants that are
+    /// present on every run, so they are deliberately not consulted: counting
+    /// them would report healthy pricing during a total upstream outage, which
+    /// is exactly the condition callers use this to detect.
+    pub fn has_upstream_dataset(&self) -> bool {
+        !self.litellm.is_empty() || !self.openrouter.is_empty() || !self.models_dev.is_empty()
+    }
+
     pub fn new_with_models_dev(
         litellm: HashMap<String, ModelPricing>,
         openrouter: HashMap<String, ModelPricing>,

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -294,6 +294,20 @@ impl PricingService {
         ))
     }
 
+    /// True when this service holds pricing from at least one source that can
+    /// fail to load — the three fetchable upstreams, or the user's
+    /// `custom-pricing.json`.
+    ///
+    /// Mirrors the signal `from_cached_datasets` uses to decide a cached
+    /// service is worth building at all. Callers that must distinguish "this
+    /// model has no published price" from "no pricing dataset loaded" need
+    /// this, because an empty service answers `false` to every coverage
+    /// question and is otherwise indistinguishable from healthy pricing that
+    /// happens not to cover the model in hand.
+    pub fn has_pricing_data(&self) -> bool {
+        !self.custom.is_empty() || self.lookup.has_upstream_dataset()
+    }
+
     pub fn load_cached_any_age() -> Option<Self> {
         Self::from_cached_datasets(
             litellm::load_cached_any_age(),


### PR DESCRIPTION
## Summary

Follow-up to #1053. That PR made submission exclude any token-bearing message the pricing service cannot cover. A service with **no dataset** covers nothing, so a cold cache with no network excluded the whole batch, left `total_tokens` at 0, and let the CLI print `No usage data found to submit` and **exit 0** — indistinguishable from an empty history, and reported as success to autosubmit.

Verified against `3ab58f58` (pre-#1053): the same fixture exits 1 there with `Error: pricing is unavailable for submitted token usage`.

Exclusions are now rejected when no dataset loaded. **Both** conditions are required:

- **Only when something was excluded.** A batch whose costs are all provider-reported never consults pricing and must still submit during a total outage.
- **Only when no dataset loaded.** A populated dataset that merely lacks a price for some model stays non-fatal — that is the case #1053 exists to handle, and failing there would break autosubmit for anyone whose usage is legitimately unpriceable, which is the trap #1044 documents.

`has_pricing_data()` deliberately ignores the compiled-in `cursor`/`sakana` tables. They are present on every run, so counting them would report healthy pricing during a total upstream outage — exactly the condition being detected.

## Why the existing guard never fired

The check runs *after* exclusion, because the exclusion list is the signal. It cannot live in `validate_priced_messages`, which sees only survivors — and when everything is excluded that slice is empty and validates trivially.

That is also why the existing hard-fail path was dead: `generate_submission_graph` always passes `Some(..)`, since `PricingService::get_or_init` degrades each failed source to an empty map rather than erroring (`combine_fetched_sources` returns `Ok` on every path). So `submission_without_any_pricing_data_still_fails` was guarding an unreachable `None`. It now covers both shapes.

## Test fixtures that hid this

- Two #1053 core tests used an empty `PricingService` to mean "this model is unpriced" — the same conflation the product had.
- `prime_pricing_cache` writes `"data":{}`, so `test_submit_excludes_unpriced_usage_and_keeps_the_rest` ran with **no pricing data at all**. It passed only because OpenCode marks its positive `cost` values provider-reported, so the "priced" remainder survived on authoritative costs rather than pricing coverage.

All three now use a populated, non-covering dataset via a new `prime_pricing_cache_with_a_priced_model` helper.

Added `test_submit_offline_without_pricing_cache_fails` (end-to-end, restoring the intent of the test #1053 repurposed) and a core test for the authoritative-costs-without-pricing case.

## Tests

- `cargo test -p tokscale-core -p tokscale-cli` — 1,479 core lib + 1,023 CLI unit + 153 CLI integration + all integration suites, 0 failures
- `cargo fmt --all --check` clean
- `cargo clippy --all-targets -- -D warnings` clean (note `--all-targets` lints test code, which CI omits)
- **Mutation check:** with the guard call removed, both the core and the CLI regression test fail; with it restored, all pass

## Not addressed

**#1044 is untouched.** Partial degradation — one upstream cached, two empty — passes the predicate, excludes a subset, and still under-reports that day's tokens and cost against the unconditional `cost = EXCLUDED.cost` upsert. That remains the `costIsComplete` protocol change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject exclusions when no pricing dataset is loaded to prevent empty submissions from being reported as success. The CLI now fails with "pricing data is unavailable for submission" instead of printing "No usage data found to submit" in this scenario.

- **Bug Fixes**
  - Added a post-exclusion guard in `tokscale-core`: if any messages were excluded and pricing has no upstream/custom dataset, error with "pricing data is unavailable for submission".
  - Implemented `PricingService::has_pricing_data()` and `PricingLookup::has_upstream_dataset()` that ignore compiled-in `cursor`/`sakana` tables to detect real outages.
  - Preserved behavior: batches with only provider-reported costs still submit during outages; populated-but-non-covering datasets remain non-fatal.
  - Updated `tokscale-cli` tests with `prime_pricing_cache_with_a_priced_model` and added an offline regression test that asserts the failure path.

<sup>Written for commit f772082968eb8cedc3d519c1f2c38a0278498636. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

