### PR TITLE
fix(report): stop summaries rendering an empty cost as "-0.00"

### DIFF
--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -110,9 +110,13 @@ pub fn calculate_summary(contributions: &[DailyContribution]) -> DataSummary {
         .fold(0i64, i64::saturating_add);
     // @keep: the trailing `+ 0.0` looks redundant and is not.
     // `Sum for f64` folds from `-0.0`, the additive identity that preserves the
-    // sign of every addend, so summing an empty (or all-zero) set yields `-0.0`
-    // and `{:.2}` renders it as "-0.00". Adding `+0.0` normalizes the sign
-    // without changing any other value, matching the report aggregators.
+    // sign of every addend, so an empty set sums to `-0.0` and `{:.2}` renders
+    // it as "-0.00". Adding `+0.0` normalizes that sign without changing any
+    // other value, matching the report aggregators.
+    //
+    // Only an empty set, or one whose addends are exclusively `-0.0`, reaches
+    // the fold's identity unchanged. A single `+0.0` contribution already
+    // produced `+0.0` before this fix, since `-0.0 + 0.0 == +0.0`.
     let total_cost: f64 = contributions.iter().map(|c| c.totals.cost).sum::<f64>() + 0.0;
     let active_days = contributions
         .iter()
@@ -899,6 +903,26 @@ mod tests {
     #[test]
     fn empty_summary_cost_does_not_format_as_negative_zero() {
         let summary = calculate_summary(&[]);
+        assert_eq!(format!("${:.2}", summary.total_cost), "$0.00");
+    }
+
+    /// Pins the boundary the `+ 0.0` comment describes. Only the empty fold
+    /// (and an all-`-0.0` one) ever reached the `-0.0` identity: a single
+    /// `+0.0` addend already normalized it, because `-0.0 + 0.0 == +0.0`.
+    /// Without this, "all-zero" reads as if every zero-cost day was affected.
+    #[test]
+    fn a_positive_zero_contribution_was_never_the_negative_zero_case() {
+        let messages = vec![mock_unified_message(
+            "2024-01-01",
+            0,
+            0.0,
+            "claude-sonnet-4-20250514",
+            "claude",
+        )];
+        let contributions = aggregate_by_date(messages);
+        let summary = calculate_summary(&contributions);
+
+        assert!(!summary.total_cost.is_sign_negative());
         assert_eq!(format!("${:.2}", summary.total_cost), "$0.00");
     }
 

--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -108,7 +108,12 @@ pub fn calculate_summary(contributions: &[DailyContribution]) -> DataSummary {
         .iter()
         .map(|c| c.totals.tokens)
         .fold(0i64, i64::saturating_add);
-    let total_cost: f64 = contributions.iter().map(|c| c.totals.cost).sum();
+    // @keep: the trailing `+ 0.0` looks redundant and is not.
+    // `Sum for f64` folds from `-0.0`, the additive identity that preserves the
+    // sign of every addend, so summing an empty (or all-zero) set yields `-0.0`
+    // and `{:.2}` renders it as "-0.00". Adding `+0.0` normalizes the sign
+    // without changing any other value, matching the report aggregators.
+    let total_cost: f64 = contributions.iter().map(|c| c.totals.cost).sum::<f64>() + 0.0;
     let active_days = contributions
         .iter()
         .filter(|c| c.totals.tokens > 0 || c.totals.cost > 0.0 || c.totals.messages > 0)
@@ -882,6 +887,19 @@ mod tests {
         assert_eq!(summary.active_days, 0);
         assert_eq!(summary.average_per_day, 0.0);
         assert_eq!(summary.max_cost_in_single_day, 0.0);
+        // `-0.0 == 0.0` under IEEE, so the assertion above cannot catch a
+        // negative zero. The CLI formats this straight through, and "$-0.00"
+        // is what the user sees when every row was excluded from a submission.
+        assert!(
+            !summary.total_cost.is_sign_negative(),
+            "an empty summary must not carry a negative zero cost"
+        );
+    }
+
+    #[test]
+    fn empty_summary_cost_does_not_format_as_negative_zero() {
+        let summary = calculate_summary(&[]);
+        assert_eq!(format!("${:.2}", summary.total_cost), "$0.00");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`calculate_summary` returns `-0.0` for an empty or all-zero contribution set, and the CLI renders it as **`$-0.00`**.

Reproduced end-to-end on `main` (healthy pricing, every row excluded from the submission):

```
  Warning: excluded 1 unpriced weird/totally-unpriced-model message(s) (150 tokens): no authoritative model-to-price mapping.
    Total tokens: 0
    Total cost: $-0.00
  No usage data found to submit.
```

## Cause

Rust's `impl Sum for f64` folds from `-0.0`, not `0.0`. That is deliberate upstream: `-0.0` is the additive identity that preserves the sign of every addend (`-0.0 + x == x` for all `x`, whereas `0.0 + -0.0 == +0.0` would discard it). So `[].iter().sum::<f64>()` is `-0.0` — bits `0x8000000000000000` — and `{:.2}` prints `-0.00`.

The three report aggregators in `lib.rs` already normalize this with a trailing `+ 0.0`. `calculate_summary` in `aggregator.rs` was the one site that missed the idiom.

## Why no test caught it

`test_calculate_summary_empty` asserted:

```rust
assert_eq!(summary.total_cost, 0.0);
```

`-0.0 == 0.0` is true under IEEE 754, so that assertion passes on the buggy value. It now additionally asserts the sign bit, and a companion test pins the rendered string.

## Tests

- `cargo test -p tokscale-core --lib` — 1,489 passed, 0 failed
- `cargo fmt --all --check` clean
- **Mutation check:** dropping the `+ 0.0` again makes `test_calculate_summary_empty` fail; with it, all 5 `calculate_summary` tests pass

## Note

Found while auditing the batch merged in #1037, #1045, #1051 and #1055 — it is pre-existing and independent of all four.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes summary cost rendering so empty summaries show "$0.00", not "$-0.00". Normalizes the `f64` sum and tightens tests and comments to prevent regressions.

- **Bug Fixes**
  - Normalize `calculate_summary` total cost with `sum::<f64>() + 0.0`; clarify only empty sets (or all `-0.0`) would format as negative zero.
  - Add tests in `tokscale-core` for non-negative zero and "$0.00" on empty summaries, plus a boundary test proving a single `+0.0` contribution already yields `+0.0`.

<sup>Written for commit f09abf8c2db6e11bdccf0dd07138617110b92a87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

