### PR TITLE
docs(claude): correct the synthetic-placeholder guard's stated failure mode

### DIFF
--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -1016,8 +1016,13 @@ fn extract_claude_tool_result_message(
         // arrived in a different transcript (a subagent sidechain resets the
         // per-file suppression flag), so re-check the inherited value instead of
         // trusting `suppress_unattributed` alone. Without this, the placeholder
-        // becomes a `model_id` carrying a char-based estimate and submission
-        // fails with "pricing is unavailable for submitted token usage".
+        // becomes a `model_id` carrying a char-based estimate.
+        //
+        // That used to abort the whole submission with "pricing is unavailable
+        // for submitted token usage". Since #1053 it no longer does: the row is
+        // excluded with a warning and the rest is submitted, so the fabricated
+        // usage fails quietly rather than loudly. The guard matters more for it,
+        // not less — a regression here is now invisible in normal use.
         None => match context.last_model {
             Some(model) if is_claude_synthetic_placeholder_model(model) => return None,
             Some(model) => model.to_string(),

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -1015,14 +1015,20 @@ fn extract_claude_tool_result_message(
         // still be Claude Code's local `<synthetic>` notice when the placeholder
         // arrived in a different transcript (a subagent sidechain resets the
         // per-file suppression flag), so re-check the inherited value instead of
-        // trusting `suppress_unattributed` alone. Without this, the placeholder
-        // becomes a `model_id` carrying a char-based estimate.
+        // trusting `suppress_unattributed` alone.
         //
-        // That used to abort the whole submission with "pricing is unavailable
-        // for submitted token usage". Since #1053 it no longer does: the row is
-        // excluded with a warning and the rest is submitted, so the fabricated
-        // usage fails quietly rather than loudly. The guard matters more for it,
-        // not less — a regression here is now invisible in normal use.
+        // Without this the row is emitted as `unknown/<synthetic>`. Production
+        // passes `allow_char_estimate: false`, so it carries tokens only when
+        // the tool result declared them explicitly; a text-only result yields
+        // no usage and is dropped before reaching submission.
+        //
+        // What that costs depends on pricing coverage, and neither outcome is
+        // the "aborts the whole submission" this comment once claimed:
+        //   - dataset loaded but not covering the model — #1053 excludes the
+        //     row with a named warning and submits the priced remainder, if any
+        //   - no pricing dataset loaded at all — #1055 fails the submission
+        // The first is a warning in a long run rather than a hard stop, so a
+        // regression here is easy to miss. Keep the guard.
         None => match context.last_model {
             Some(model) if is_claude_synthetic_placeholder_model(model) => return None,
             Some(model) => model.to_string(),
@@ -2353,9 +2359,10 @@ mod tests {
     fn test_inherited_synthetic_model_does_not_price_a_tool_result() {
         // A `<synthetic>` notice that is not immediately followed by the tool
         // result in the same transcript still leaves the placeholder as the
-        // inherited carrier model. The estimate must be dropped rather than
-        // emitted as `unknown/<synthetic>`, which submission rejects as
-        // unpriceable usage.
+        // inherited carrier model. The usage must be dropped rather than
+        // emitted as `unknown/<synthetic>`: submission cannot price that model,
+        // so it either excludes the row or fails outright depending on pricing
+        // coverage. See the guard in `extract_claude_tool_result_message`.
         let context = ClaudeToolResultContext {
             entry: &ClaudeEntry {
                 entry_type: "user".to_string(),


### PR DESCRIPTION
## Summary

Comment-only. The `<synthetic>` guard in `extract_claude_tool_result_message` (added in #1045) documents its failure mode as:

> the placeholder becomes a `model_id` carrying a char-based estimate and submission fails with "pricing is unavailable for submitted token usage"

That was accurate when #1045 was written, but #1053 landed first and replaced the whole-batch abort with per-model exclusion. An unguarded `unknown/<synthetic>` row is now dropped with a warning while the rest of the batch submits.

The consequence inverts, which is the part worth recording: the guard matters **more** now, because a regression in it no longer announces itself — the fabricated usage just disappears from the leaderboard.

## Tests

No behavior change. `cargo fmt --all --check` clean, `cargo build -p tokscale-core` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the `<synthetic>` guard comment in `extract_claude_tool_result_message`. It now notes per-model exclusion with a warning when pricing is loaded, full submission failure when none is loaded, and that `allow_char_estimate: false` drops text-only results; also fixed a stale test comment.

<sup>Written for commit 137d06ae538151f267480870ea7c9cae868ccd79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

