### PR TITLE
feat(submit): let a submission declare its cost incomplete

### DIFF
--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -567,6 +567,43 @@ describe('POST /api/submit - Client-Level Merge', () => {
       expect(breakdownCostIsComplete(merged)).toBe(true);
     });
 
+    it("floors cost on the alias-heal branch too", () => {
+      // Regression: the heal branch assigned the incoming client raw and
+      // `continue`d, skipping the floor entirely. An incomplete submission
+      // could then drop a folded $20 to $1 AND mark the day complete — the
+      // exact data loss this whole mechanism exists to prevent.
+      //
+      // The heal gate is evidence about tokens, not pricing, so the token
+      // count still heals; only the cost is held at the floor.
+      const { merged } = mergeClientBreakdownsWithRegressionGuard(
+        { kilo: client(200, 20) }, // normalized fold of kilocode+kilo
+        { kilo: client(100, 1) },
+        new Set(["kilo"]),
+        new Map([["kilo", 100]]), // heal floor = largest single component
+        false
+      );
+
+      expect(merged.kilo.tokens).toBe(100); // healed
+      expect(merged.kilo.cost).toBe(20); // floored, not $1
+      expect(merged.kilo.provenance?.costIsComplete).toBe(false);
+      expect(breakdownCostIsComplete(merged)).toBe(false);
+    });
+
+    it("still heals cost exactly when the healing submission is complete", () => {
+      // The floor must not break the heal's original purpose.
+      const { merged } = mergeClientBreakdownsWithRegressionGuard(
+        { kilo: client(200, 20) },
+        { kilo: client(100, 1) },
+        new Set(["kilo"]),
+        new Map([["kilo", 100]]),
+        true
+      );
+
+      expect(merged.kilo.tokens).toBe(100);
+      expect(merged.kilo.cost).toBe(1); // inflated fold replaced outright
+      expect(breakdownCostIsComplete(merged)).toBe(true);
+    });
+
     it("makes a day incomplete when any single client is floored", () => {
       // The submission-level BOOL_AND composes the same way one level up: one
       // floored device makes the account total a lower bound, not an exact

--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -5,8 +5,10 @@ import {
   validateSubmission,
 } from "../../src/lib/validation/submission";
 import {
+  breakdownCostIsComplete,
   deriveClientBreakdownProvenance,
   mergeClientBreakdownsWithRegressionGuard,
+  recalculateDayTotals,
   type ClientBreakdownData,
 } from "../../src/lib/db/helpers";
 
@@ -457,6 +459,118 @@ describe('POST /api/submit - Client-Level Merge', () => {
 
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  describe("costIsComplete merge floor (#1044)", () => {
+    function client(
+      tokens: number,
+      cost: number,
+      costIsComplete?: boolean
+    ): ClientBreakdownData {
+      return {
+        tokens,
+        cost,
+        input: tokens,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        messages: 1,
+        models: {},
+        ...(costIsComplete === false
+          ? {
+              provenance: {
+                schemaVersion: 1,
+                messageCount: 1,
+                modelCount: 0,
+                costIsComplete: false,
+              },
+            }
+          : {}),
+      };
+    }
+
+    it("floors a client's cost when the submission declares itself incomplete", () => {
+      // More tokens at a LOWER cost: the token guard accepts the client, so
+      // without a floor the day's recorded spend drops permanently.
+      const { merged } = mergeClientBreakdownsWithRegressionGuard(
+        { claude: client(100, 10) },
+        { claude: client(110, 5) },
+        new Set(["claude"]),
+        undefined,
+        false
+      );
+
+      expect(merged.claude.cost).toBe(10);
+      expect(merged.claude.tokens).toBe(110);
+      expect(breakdownCostIsComplete(merged)).toBe(false);
+    });
+
+    it("marks the client incomplete even when its own cost was kept", () => {
+      // The stored $10 was complete for the OLD token set. Deriving the tag
+      // from "did the new value win?" would call this complete, which is the
+      // defect adversarial review found in the earlier SQL-side design.
+      const { merged } = mergeClientBreakdownsWithRegressionGuard(
+        { claude: client(100, 10) },
+        { claude: client(110, 5) },
+        new Set(["claude"]),
+        undefined,
+        false
+      );
+
+      expect(merged.claude.provenance?.costIsComplete).toBe(false);
+    });
+
+    it("keeps the day scalar reconcilable with the stored breakdown", () => {
+      // The scalar is recomputed from this breakdown, so flooring here (rather
+      // than in SQL) is what stops the row's two representations diverging.
+      const { merged } = mergeClientBreakdownsWithRegressionGuard(
+        { claude: client(100, 10) },
+        { claude: client(110, 5) },
+        new Set(["claude"]),
+        undefined,
+        false
+      );
+
+      expect(recalculateDayTotals(merged).cost).toBe(10);
+    });
+
+    it("does not let a filtered healthy resubmit clear a sibling's incompleteness", () => {
+      // Day holds incomplete A and complete B; a healthy submit naming only B
+      // must leave A's state alone. Day-level state cannot express this.
+      const { merged } = mergeClientBreakdownsWithRegressionGuard(
+        { claude: client(100, 10, false), codex: client(50, 5) },
+        { codex: client(60, 6) },
+        new Set(["codex"]),
+        undefined,
+        true
+      );
+
+      expect(merged.claude.provenance?.costIsComplete).toBe(false);
+      expect(merged.codex.provenance?.costIsComplete).toBeUndefined();
+      expect(breakdownCostIsComplete(merged)).toBe(false);
+    });
+
+    it("clears the floor once a complete submission covers the client", () => {
+      // Recovery, and the reason downward corrections still work.
+      const { merged } = mergeClientBreakdownsWithRegressionGuard(
+        { claude: client(100, 10, false) },
+        { claude: client(100, 4) },
+        new Set(["claude"]),
+        undefined,
+        true
+      );
+
+      expect(merged.claude.cost).toBe(4);
+      expect(merged.claude.provenance?.costIsComplete).toBeUndefined();
+      expect(breakdownCostIsComplete(merged)).toBe(true);
+    });
+
+    it("treats an untagged breakdown as complete", () => {
+      expect(breakdownCostIsComplete({ claude: client(10, 1) })).toBe(true);
+      expect(breakdownCostIsComplete({})).toBe(true);
+      expect(breakdownCostIsComplete(null)).toBe(true);
     });
   });
 

--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -567,6 +567,88 @@ describe('POST /api/submit - Client-Level Merge', () => {
       expect(breakdownCostIsComplete(merged)).toBe(true);
     });
 
+    function withModels(
+      models: Record<string, number>,
+      costIsComplete?: boolean
+    ): ClientBreakdownData {
+      const entries = Object.entries(models);
+      const total = entries.reduce((sum, [, cost]) => sum + cost, 0);
+      const base = client(100, total, costIsComplete);
+      return {
+        ...base,
+        models: Object.fromEntries(
+          entries.map(([modelId, cost]) => [
+            modelId,
+            {
+              tokens: 100,
+              cost,
+              input: 100,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              reasoning: 0,
+              messages: 1,
+            },
+          ])
+        ),
+      };
+    }
+
+    it("floors nested model costs, not just the client aggregate", () => {
+      // Regression: flooring only the client total left `models[*].cost` at the
+      // incomplete payload's value. Model-filtered leaderboards sum the nested
+      // costs, so the row would rank at $0 while its client said $10.
+      const { merged } = mergeClientBreakdownsWithRegressionGuard(
+        { claude: withModels({ "opus-4": 10 }) },
+        { claude: withModels({ "opus-4": 0 }) },
+        new Set(["claude"]),
+        undefined,
+        false
+      );
+
+      expect(merged.claude.models["opus-4"].cost).toBe(10);
+      expect(merged.claude.cost).toBe(10);
+    });
+
+    it("preserves a model the incomplete payload dropped", () => {
+      // Its usage did not stop existing because this submission could not
+      // price it, and losing it would put the client total above the sum of
+      // its models again.
+      const { merged } = mergeClientBreakdownsWithRegressionGuard(
+        { claude: withModels({ "opus-4": 6, "sonnet-4": 4 }) },
+        { claude: withModels({ "opus-4": 0, "haiku-4": 5 }) },
+        new Set(["claude"]),
+        undefined,
+        false
+      );
+
+      expect(Object.keys(merged.claude.models).sort()).toEqual([
+        "haiku-4",
+        "opus-4",
+        "sonnet-4",
+      ]);
+      expect(merged.claude.models["sonnet-4"].cost).toBe(4);
+      // Derived from the floors, so client == sum(models) by construction.
+      expect(merged.claude.cost).toBe(15);
+    });
+
+    it("keeps day, client and model costs mutually consistent", () => {
+      const { merged } = mergeClientBreakdownsWithRegressionGuard(
+        { claude: withModels({ "opus-4": 6, "sonnet-4": 4 }) },
+        { claude: withModels({ "opus-4": 1 }) },
+        new Set(["claude"]),
+        undefined,
+        false
+      );
+
+      const modelSum = Object.values(merged.claude.models).reduce(
+        (sum, m) => sum + m.cost,
+        0
+      );
+      expect(merged.claude.cost).toBe(modelSum);
+      expect(recalculateDayTotals(merged).cost).toBe(modelSum);
+    });
+
     it("floors cost on the alias-heal branch too", () => {
       // Regression: the heal branch assigned the incoming client raw and
       // `continue`d, skipping the floor entirely. An incomplete submission
@@ -663,18 +745,22 @@ describe('POST /api/submit - Client-Level Merge', () => {
       expect(result.valid).toBe(false);
     });
 
-    it("does not treat an incomplete day as a totals mismatch", () => {
-      // The declared cost is a floor, not a different number: the consistency
-      // checks must still compare it against the summary the same way.
+    it("does not loosen the totals consistency check", () => {
+      // The flag declares the cost a floor; it must NOT become a licence to
+      // send internally inconsistent numbers. The earlier version of this test
+      // set summary and day cost to the same value, so it passed whether or
+      // not the flag did anything — it asserted nothing.
       const payload = createValidationPayload({ totalCost: 12.5 });
       (
         payload.contributions[0].totals as { costIsComplete?: boolean }
       ).costIsComplete = false;
+      // Summary now disagrees with the day it summarises.
+      payload.summary.totalCost = 99.5;
 
       const result = validateSubmission(payload);
 
-      expect(result.valid).toBe(true);
-      expect(result.errors).toHaveLength(0);
+      expect(result.valid).toBe(false);
+      expect(result.errors.join(" ")).toMatch(/cost/i);
     });
   });
 

--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -567,6 +567,18 @@ describe('POST /api/submit - Client-Level Merge', () => {
       expect(breakdownCostIsComplete(merged)).toBe(true);
     });
 
+    it("makes a day incomplete when any single client is floored", () => {
+      // The submission-level BOOL_AND composes the same way one level up: one
+      // floored device makes the account total a lower bound, not an exact
+      // figure. This pins the day-level half of that AND semantics.
+      const mixed = {
+        claude: client(100, 10, false),
+        codex: client(50, 5),
+      };
+
+      expect(breakdownCostIsComplete(mixed)).toBe(false);
+    });
+
     it("treats an untagged breakdown as complete", () => {
       expect(breakdownCostIsComplete({ claude: client(10, 1) })).toBe(true);
       expect(breakdownCostIsComplete({})).toBe(true);

--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -460,6 +460,61 @@ describe('POST /api/submit - Client-Level Merge', () => {
     });
   });
 
+  describe("costIsComplete (#1044)", () => {
+    it("preserves a declared-incomplete flag through validation", () => {
+      const payload = createValidationPayload();
+      (
+        payload.contributions[0].totals as { costIsComplete?: boolean }
+      ).costIsComplete = false;
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      // Asserting the parsed value, not just validity: Zod strips unknown keys,
+      // so a schema that never declared this field would still validate here
+      // and silently drop the flag before the route could act on it.
+      expect(result.data?.contributions[0].totals.costIsComplete).toBe(false);
+    });
+
+    it("leaves the flag undefined when omitted, so released CLIs keep working", () => {
+      const payload = createValidationPayload();
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(
+        result.data?.contributions[0].totals.costIsComplete
+      ).toBeUndefined();
+    });
+
+    it("rejects a non-boolean flag rather than coercing it", () => {
+      const payload = createValidationPayload();
+      (
+        payload.contributions[0].totals as { costIsComplete?: unknown }
+      ).costIsComplete = "false";
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it("does not treat an incomplete day as a totals mismatch", () => {
+      // The declared cost is a floor, not a different number: the consistency
+      // checks must still compare it against the summary the same way.
+      const payload = createValidationPayload({ totalCost: 12.5 });
+      (
+        payload.contributions[0].totals as { costIsComplete?: boolean }
+      ).costIsComplete = false;
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
   describe("Submission validation guardrails", () => {
     it("accepts internally consistent high-volume one-day token totals", () => {
       // Size caps were removed in feat/remove-submission-size-caps; this test

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -112,7 +112,10 @@ vi.mock("@/lib/validation/submission", () => ({
   generateSubmissionHash: mockState.generateSubmissionHash,
 }));
 
-vi.mock("@/lib/db/helpers", () => ({
+vi.mock("@/lib/db/helpers", async (importOriginal) => ({
+  // Spread the real module so a newly added export does not break every
+  // test that mocks this file; only the named functions are stubbed.
+  ...(await importOriginal<typeof import("@/lib/db/helpers")>()),
   mergeClientBreakdowns: mockState.mergeClientBreakdowns,
   mergeClientBreakdownsWithRegressionGuard: mockState.mergeClientBreakdownsWithRegressionGuard,
   recalculateDayTotals: mockState.recalculateDayTotals,
@@ -757,7 +760,9 @@ describe("POST /api/submit auth path", () => {
         },
       },
       expect.any(Set),
-      expect.any(Map)
+      expect.any(Map),
+      // #1044: submissions that omit the flag are complete.
+      true
     );
     expect(await response.json()).toEqual(expect.objectContaining({
       success: true,
@@ -1139,7 +1144,9 @@ describe("POST /api/submit auth path", () => {
         },
       },
       expect.any(Set),
-      expect.any(Map)
+      expect.any(Map),
+      // #1044: submissions that omit the flag are complete.
+      true
     );
     expect(await response.json()).toEqual(expect.objectContaining({
       success: true,
@@ -2005,7 +2012,9 @@ describe("POST /api/submit auth path", () => {
       legacyBreakdown,
       incomingBreakdownWithProvenance,
       expect.any(Set),
-      expect.any(Map)
+      expect.any(Map),
+      // #1044: submissions that omit the flag are complete.
+      true
     );
     expect(await response.json()).toEqual(expect.objectContaining({
       success: true,

--- a/packages/frontend/__tests__/api/submitProvenance.test.ts
+++ b/packages/frontend/__tests__/api/submitProvenance.test.ts
@@ -137,7 +137,10 @@ vi.mock("@/lib/validation/submission", () => ({
   generateSubmissionHash: mockState.generateSubmissionHash,
 }));
 
-vi.mock("@/lib/db/helpers", () => ({
+vi.mock("@/lib/db/helpers", async (importOriginal) => ({
+  // Spread the real module so a newly added export does not break every
+  // test that mocks this file; only the named functions are stubbed.
+  ...(await importOriginal<typeof import("@/lib/db/helpers")>()),
   mergeClientBreakdownsWithRegressionGuard: mockState.mergeClientBreakdownsWithRegressionGuard,
   recalculateDayTotals: mockState.recalculateDayTotals,
   deriveClientBreakdownProvenance: mockState.deriveClientBreakdownProvenance,

--- a/packages/frontend/__tests__/api/submitRatchetCensus.test.ts
+++ b/packages/frontend/__tests__/api/submitRatchetCensus.test.ts
@@ -125,7 +125,10 @@ vi.mock("@/lib/validation/submission", () => ({
   generateSubmissionHash: mockState.generateSubmissionHash,
 }));
 
-vi.mock("@/lib/db/helpers", () => ({
+vi.mock("@/lib/db/helpers", async (importOriginal) => ({
+  // Spread the real module so a newly added export does not break every
+  // test that mocks this file; only the named functions are stubbed.
+  ...(await importOriginal<typeof import("@/lib/db/helpers")>()),
   mergeClientBreakdownsWithRegressionGuard:
     mockState.mergeClientBreakdownsWithRegressionGuard,
   recalculateDayTotals: mockState.recalculateDayTotals,

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -15,6 +15,8 @@ import {
   clientContributionToBreakdownData,
   deriveClientBreakdownProvenance,
   mergeTimestampMs,
+  breakdownCostIsComplete,
+  tagBreakdownCostCompleteness,
   type ClientBreakdownData,
 } from "@/lib/db/helpers";
 import {
@@ -732,7 +734,8 @@ export async function POST(request: Request) {
             existingClientBreakdown,
             incomingClientBreakdown,
             submittedClients,
-            foldedClientFloors
+            foldedClientFloors,
+            incomingDay.totals?.costIsComplete ?? true
           );
           warnings.push(
             ...mergeResult.warnings.map((warning) => `Day ${incomingDay.date}: ${warning}`)
@@ -772,12 +775,21 @@ export async function POST(request: Request) {
             timestampMs: mergeTimestampMs(existingDay.timestampMs, incomingDay.timestampMs ?? null),
             activeTimeMs: mergeActiveTimeMs(existingDay.activeTimeMs, incomingDay.activeTimeMs),
             sourceBreakdown: mergedClientBreakdown,
-            // Absent means complete: released CLIs cannot send this, and must
-            // keep exact overwrite semantics including downward corrections.
-            costIsComplete: incomingDay.totals?.costIsComplete ?? true,
+            // Derived from the MERGED breakdown, not the incoming day: a
+            // filtered resubmit naming only healthy clients must not clear a
+            // preserved sibling's incompleteness. The merge has already
+            // floored each incoming client's cost, so this agrees with the
+            // scalar recomputed above by construction.
+            costIsComplete: breakdownCostIsComplete(mergedClientBreakdown),
           });
         } else {
-          const dayTotals = recalculateDayTotals(incomingClientBreakdown);
+          // A day with no stored row has nothing to floor against, but its
+          // clients still carry the tag forward for later merges.
+          const insertedClientBreakdown = tagBreakdownCostCompleteness(
+            incomingClientBreakdown,
+            incomingDay.totals?.costIsComplete ?? true
+          );
+          const dayTotals = recalculateDayTotals(insertedClientBreakdown);
 
           toInsert.push({
             submissionId,
@@ -789,8 +801,8 @@ export async function POST(request: Request) {
             outputTokens: dayTotals.outputTokens,
             timestampMs: incomingDay.timestampMs ?? null,
             activeTimeMs: incomingDay.activeTimeMs ?? null,
-            sourceBreakdown: incomingClientBreakdown,
-            costIsComplete: incomingDay.totals?.costIsComplete ?? true,
+            sourceBreakdown: insertedClientBreakdown,
+            costIsComplete: breakdownCostIsComplete(insertedClientBreakdown),
           });
         }
       }
@@ -820,22 +832,14 @@ export async function POST(request: Request) {
           VALUES ${insertValuesList}
           ON CONFLICT (submission_id, submitted_device_id, date) DO UPDATE SET
             tokens = EXCLUDED.tokens,
-            -- A submission that declares its own pricing incomplete may raise a
-            -- day's cost but never lower it: its cost is a floor, not a total,
-            -- and this write overwrites per day (#1044). Complete submissions
-            -- keep exact overwrite semantics, downward corrections included.
-            cost = CASE
-                     WHEN EXCLUDED.cost_is_complete THEN EXCLUDED.cost
-                     ELSE GREATEST(daily_breakdown.cost, EXCLUDED.cost)
-                   END,
-            -- Describes the cost actually stored above, so the flag cannot
-            -- claim a number is unreliable when the guard just kept a complete
-            -- one, nor claim completeness after an incomplete floor won.
-            cost_is_complete = CASE
-                                 WHEN EXCLUDED.cost_is_complete THEN true
-                                 WHEN EXCLUDED.cost > daily_breakdown.cost THEN false
-                                 ELSE daily_breakdown.cost_is_complete
-                               END,
+            -- Both of these are plain overwrites on purpose. The #1044 floor is
+            -- applied per client during the in-memory merge, so cost here is
+            -- already recomputed from the floored breakdown and cannot be lower
+            -- than what an incomplete submission is allowed to store. Guarding
+            -- the scalar in SQL while replacing source_breakdown wholesale
+            -- would instead leave the row's two representations disagreeing.
+            cost = EXCLUDED.cost,
+            cost_is_complete = EXCLUDED.cost_is_complete,
             input_tokens = EXCLUDED.input_tokens,
             output_tokens = EXCLUDED.output_tokens,
             timestamp_ms = EXCLUDED.timestamp_ms,
@@ -862,18 +866,10 @@ export async function POST(request: Request) {
         await tx.execute(sql`
           UPDATE daily_breakdown AS d SET
             tokens = batch.tokens,
-            -- Same guard as the ON CONFLICT arm above; this is the path #1044
-            -- named explicitly, and leaving it unguarded would reopen the hole
-            -- for every day that already had a row for this device.
-            cost = CASE
-                     WHEN batch.cost_is_complete THEN batch.cost
-                     ELSE GREATEST(d.cost, batch.cost)
-                   END,
-            cost_is_complete = CASE
-                                 WHEN batch.cost_is_complete THEN true
-                                 WHEN batch.cost > d.cost THEN false
-                                 ELSE d.cost_is_complete
-                               END,
+            -- Plain overwrites for the same reason as the ON CONFLICT arm: the
+            -- floor lives in the merge, so this value already respects it.
+            cost = batch.cost,
+            cost_is_complete = batch.cost_is_complete,
             input_tokens = batch.input_tokens,
             output_tokens = batch.output_tokens,
             timestamp_ms = batch.timestamp_ms,

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -650,6 +650,7 @@ export async function POST(request: Request) {
         timestampMs: number | null;
         activeTimeMs: number | null;
         sourceBreakdown: Record<string, ClientBreakdownData>;
+        costIsComplete: boolean;
       }> = [];
 
       const toUpdate: Array<{
@@ -661,6 +662,7 @@ export async function POST(request: Request) {
         timestampMs: number | null;
         activeTimeMs: number | null;
         sourceBreakdown: Record<string, ClientBreakdownData>;
+        costIsComplete: boolean;
       }> = [];
 
       for (const incomingDay of data.contributions) {
@@ -770,6 +772,9 @@ export async function POST(request: Request) {
             timestampMs: mergeTimestampMs(existingDay.timestampMs, incomingDay.timestampMs ?? null),
             activeTimeMs: mergeActiveTimeMs(existingDay.activeTimeMs, incomingDay.activeTimeMs),
             sourceBreakdown: mergedClientBreakdown,
+            // Absent means complete: released CLIs cannot send this, and must
+            // keep exact overwrite semantics including downward corrections.
+            costIsComplete: incomingDay.totals?.costIsComplete ?? true,
           });
         } else {
           const dayTotals = recalculateDayTotals(incomingClientBreakdown);
@@ -785,6 +790,7 @@ export async function POST(request: Request) {
             timestampMs: incomingDay.timestampMs ?? null,
             activeTimeMs: incomingDay.activeTimeMs ?? null,
             sourceBreakdown: incomingClientBreakdown,
+            costIsComplete: incomingDay.totals?.costIsComplete ?? true,
           });
         }
       }
@@ -800,7 +806,7 @@ export async function POST(request: Request) {
         const chunk = toInsert.slice(i, i + INSERT_CHUNK_SIZE);
         const insertValuesClauses = chunk.map(
           (row) =>
-            sql`(${row.submissionId}::uuid, ${row.submittedDeviceId}::uuid, ${row.date}, ${row.tokens}::bigint, ${row.cost}::numeric(14,4), ${row.inputTokens}::bigint, ${row.outputTokens}::bigint, ${row.timestampMs}::bigint, ${row.activeTimeMs}::bigint, ${JSON.stringify(row.sourceBreakdown)}::jsonb)`
+            sql`(${row.submissionId}::uuid, ${row.submittedDeviceId}::uuid, ${row.date}, ${row.tokens}::bigint, ${row.cost}::numeric(14,4), ${row.inputTokens}::bigint, ${row.outputTokens}::bigint, ${row.timestampMs}::bigint, ${row.activeTimeMs}::bigint, ${JSON.stringify(row.sourceBreakdown)}::jsonb, ${row.costIsComplete}::boolean)`
         );
 
         const insertValuesList = sql.join(insertValuesClauses, sql`, `);
@@ -808,12 +814,28 @@ export async function POST(request: Request) {
         await tx.execute(sql`
           INSERT INTO daily_breakdown (
             submission_id, submitted_device_id, date, tokens, cost,
-            input_tokens, output_tokens, timestamp_ms, active_time_ms, source_breakdown
+            input_tokens, output_tokens, timestamp_ms, active_time_ms, source_breakdown,
+            cost_is_complete
           )
           VALUES ${insertValuesList}
           ON CONFLICT (submission_id, submitted_device_id, date) DO UPDATE SET
             tokens = EXCLUDED.tokens,
-            cost = EXCLUDED.cost,
+            -- A submission that declares its own pricing incomplete may raise a
+            -- day's cost but never lower it: its cost is a floor, not a total,
+            -- and this write overwrites per day (#1044). Complete submissions
+            -- keep exact overwrite semantics, downward corrections included.
+            cost = CASE
+                     WHEN EXCLUDED.cost_is_complete THEN EXCLUDED.cost
+                     ELSE GREATEST(daily_breakdown.cost, EXCLUDED.cost)
+                   END,
+            -- Describes the cost actually stored above, so the flag cannot
+            -- claim a number is unreliable when the guard just kept a complete
+            -- one, nor claim completeness after an incomplete floor won.
+            cost_is_complete = CASE
+                                 WHEN EXCLUDED.cost_is_complete THEN true
+                                 WHEN EXCLUDED.cost > daily_breakdown.cost THEN false
+                                 ELSE daily_breakdown.cost_is_complete
+                               END,
             input_tokens = EXCLUDED.input_tokens,
             output_tokens = EXCLUDED.output_tokens,
             timestamp_ms = EXCLUDED.timestamp_ms,
@@ -832,7 +854,7 @@ export async function POST(request: Request) {
         const chunk = toUpdate.slice(i, i + INSERT_CHUNK_SIZE);
         const valuesClauses = chunk.map(
           (row) =>
-            sql`(${row.id}::uuid, ${row.tokens}::bigint, ${row.cost}::numeric(14,4), ${row.inputTokens}::bigint, ${row.outputTokens}::bigint, ${row.timestampMs}::bigint, ${row.activeTimeMs}::bigint, ${JSON.stringify(row.sourceBreakdown)}::jsonb)`
+            sql`(${row.id}::uuid, ${row.tokens}::bigint, ${row.cost}::numeric(14,4), ${row.inputTokens}::bigint, ${row.outputTokens}::bigint, ${row.timestampMs}::bigint, ${row.activeTimeMs}::bigint, ${JSON.stringify(row.sourceBreakdown)}::jsonb, ${row.costIsComplete}::boolean)`
         );
 
         const valuesList = sql.join(valuesClauses, sql`, `);
@@ -840,14 +862,25 @@ export async function POST(request: Request) {
         await tx.execute(sql`
           UPDATE daily_breakdown AS d SET
             tokens = batch.tokens,
-            cost = batch.cost,
+            -- Same guard as the ON CONFLICT arm above; this is the path #1044
+            -- named explicitly, and leaving it unguarded would reopen the hole
+            -- for every day that already had a row for this device.
+            cost = CASE
+                     WHEN batch.cost_is_complete THEN batch.cost
+                     ELSE GREATEST(d.cost, batch.cost)
+                   END,
+            cost_is_complete = CASE
+                                 WHEN batch.cost_is_complete THEN true
+                                 WHEN batch.cost > d.cost THEN false
+                                 ELSE d.cost_is_complete
+                               END,
             input_tokens = batch.input_tokens,
             output_tokens = batch.output_tokens,
             timestamp_ms = batch.timestamp_ms,
             active_time_ms = batch.active_time_ms,
             source_breakdown = batch.source_breakdown
           FROM (VALUES ${valuesList})
-            AS batch(id, tokens, cost, input_tokens, output_tokens, timestamp_ms, active_time_ms, source_breakdown)
+            AS batch(id, tokens, cost, input_tokens, output_tokens, timestamp_ms, active_time_ms, source_breakdown, cost_is_complete)
           WHERE d.id = batch.id
         `);
       }

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -913,6 +913,10 @@ export async function POST(request: Request) {
           dateEnd: sql<string>`MAX(${dailyBreakdown.date})`,
           activeDays: sql<number>`COUNT(DISTINCT CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END)::int`,
           rowCount: sql<number>`COUNT(*)::int`,
+          // One floored day on ONE device makes the summed total a lower bound,
+          // so completeness composes with AND, not OR (#1044). COALESCE covers
+          // the no-rows case, where an empty total is trivially complete.
+          costIsComplete: sql<boolean>`COALESCE(BOOL_AND(${dailyBreakdown.costIsComplete}), true)`,
         })
         .from(dailyBreakdown)
         .where(eq(dailyBreakdown.submissionId, submissionId));
@@ -1005,6 +1009,10 @@ export async function POST(request: Request) {
           // key entirely, so it can never reset an account's backfill flag —
           // the merged totals still include the imported history.
           ...(isBackfill ? { hasBackfill: true } : {}),
+          // Deliberately NOT sticky, unlike hasBackfill: recomputed from the
+          // day rows every submit, so a user whose pricing recovers earns an
+          // exact total back once every contributing row is complete.
+          costIsComplete: aggregates.costIsComplete,
           submitCount: sql`COALESCE(submit_count, 0) + 1`,
           schemaVersion: sql`GREATEST(COALESCE(${submissions.schemaVersion}, 0), ${submitDevice.schemaVersion})`,
           // Derived from the per-device high-water marks (see deviceTotals

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -38,7 +38,7 @@ import { LEGACY_DEVICE_KEY } from "@/lib/devices/shared";
 const LEGACY_SUBMIT_DEVICE_KEY = LEGACY_DEVICE_KEY;
 const LEGACY_SUBMIT_DEVICE_NAME = "Legacy submissions";
 // PostgreSQL caps a single statement at 65,535 bound parameters. Each
-// inserted row binds 10 params, so chunk large backfills (e.g. ~6,500+ days)
+// inserted row binds 11 params, so chunk large backfills (e.g. ~6,000+ days)
 // across multiple INSERT statements to stay well under that limit.
 const INSERT_CHUNK_SIZE = 1000;
 
@@ -808,7 +808,7 @@ export async function POST(request: Request) {
       }
 
       // Batch INSERT new days via raw SQL VALUES list, chunked to stay under
-      // PostgreSQL's 65,535 bound-parameter limit (10 params/row here --
+      // PostgreSQL's 65,535 bound-parameter limit (11 params/row here --
       // a large historical backfill can otherwise exceed it in one statement).
       // ON CONFLICT (submission_id, submitted_device_id, date) is a defensive
       // fallback for concurrent submits from the same device racing between

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -24,6 +24,17 @@ export interface ClientBreakdownProvenanceData {
    * so merges do not silently drop the tag.
    */
   origin?: "cli" | "backfill";
+  /**
+   * `false` when this client's stored `cost` is a floor rather than a total —
+   * the submission that wrote it could not price every token it counted
+   * (#1044). Absent means complete, so rows written before this existed, and
+   * every already-released CLI, keep exact semantics.
+   *
+   * Carried PER CLIENT, not per day, because a day's clients are written
+   * independently: a healthy resubmit naming only client B must not clear the
+   * incompleteness of client A, which the merge preserves untouched.
+   */
+  costIsComplete?: boolean;
 }
 
 export interface ClientBreakdownData {
@@ -123,6 +134,11 @@ export function deriveClientBreakdownProvenance(
     // Carry the origin tag through re-derivation (merges, alias folding) so
     // a backfill-tagged client row keeps its tag.
     ...(origin ? { origin } : {}),
+    // Same: re-derivation must not silently promote a floored cost back to
+    // complete. Only an explicitly complete write clears this, in the merge.
+    ...(breakdown.provenance?.costIsComplete === false
+      ? { costIsComplete: false }
+      : {}),
   };
 }
 
@@ -169,7 +185,19 @@ export function mergeClientBreakdownsWithRegressionGuard(
   // normal guard still applies. A pure rename-only fold (only the legacy key
   // was ever present) is NOT included here and keeps the normal guard
   // behavior.
-  foldedClientFloors?: Map<string, number>
+  foldedClientFloors?: Map<string, number>,
+  // `false` when the submission declared its own pricing incomplete (#1044).
+  // Its per-client costs are then floors, not totals, so a client's stored
+  // cost may only rise, and the client is tagged incomplete.
+  //
+  // This is deliberately applied HERE rather than in SQL. The day's scalar
+  // `cost` is recomputed from this merged breakdown by recalculateDayTotals,
+  // so flooring the scalar in the write statement while replacing the JSON
+  // wholesale would leave the row's two representations disagreeing — and
+  // different readers use different ones (profile totals read the scalar,
+  // filtered leaderboards sum the JSON). Flooring the breakdown keeps them
+  // reconcilable by construction.
+  incomingCostIsComplete: boolean = true
 ): MergeClientBreakdownsResult {
   const merged: Record<string, ClientBreakdownData> = { ...(existing || {}) };
   const warnings: string[] = [];
@@ -230,11 +258,87 @@ export function mergeClientBreakdownsWithRegressionGuard(
       continue;
     }
 
-    merged[clientName] = nextClient;
+    merged[clientName] = applyCostCompleteness(
+      nextClient,
+      existingClient,
+      incomingCostIsComplete
+    );
     foldPreservedClients.delete(clientName);
   }
 
   return { merged, warnings, foldPreservedClients };
+}
+
+/**
+ * Resolve one client's cost and completeness tag against what is stored.
+ *
+ * A complete submission overwrites exactly, clearing any earlier floor — that
+ * is how a day recovers once pricing is healthy again, and it keeps legitimate
+ * downward corrections working.
+ *
+ * An incomplete one may only raise the cost. Note the tag does not depend on
+ * which value won: a floored client stays incomplete even when its own number
+ * was kept, because the stored cost still may not cover the tokens now
+ * recorded alongside it. Deriving the tag from the comparison instead would
+ * mark a client complete whenever an incomplete rescan happened to report less
+ * than the old total for a *larger* token set.
+ */
+function applyCostCompleteness(
+  next: ClientBreakdownData,
+  existing: ClientBreakdownData | undefined,
+  incomingCostIsComplete: boolean
+): ClientBreakdownData {
+  if (incomingCostIsComplete) {
+    const { costIsComplete: _dropped, ...provenance } =
+      next.provenance ?? deriveClientBreakdownProvenance(next);
+    return { ...next, provenance };
+  }
+
+  const flooredCost = Math.max(existing?.cost ?? 0, next.cost);
+  return {
+    ...next,
+    cost: flooredCost,
+    provenance: {
+      ...(next.provenance ?? deriveClientBreakdownProvenance(next)),
+      costIsComplete: false,
+    },
+  };
+}
+
+/**
+ * Tag every client in a breakdown with the submission's completeness.
+ *
+ * For a day with no stored row there is nothing to floor against, but the tags
+ * still have to be written: a later filtered resubmit naming only healthy
+ * clients must be able to see that this one was incomplete.
+ */
+export function tagBreakdownCostCompleteness(
+  breakdown: Record<string, ClientBreakdownData>,
+  costIsComplete: boolean
+): Record<string, ClientBreakdownData> {
+  if (costIsComplete) return breakdown;
+
+  const tagged: Record<string, ClientBreakdownData> = {};
+  for (const [clientName, client] of Object.entries(breakdown)) {
+    tagged[clientName] = applyCostCompleteness(client, undefined, false);
+  }
+  return tagged;
+}
+
+/**
+ * True when every client in a day carries a complete cost.
+ *
+ * Absent tags mean complete, so legacy rows and released CLIs read as
+ * complete. Clients the submission never mentioned are included, which is the
+ * point: a filtered resubmit of one healthy client must not clear a preserved
+ * sibling's incompleteness.
+ */
+export function breakdownCostIsComplete(
+  breakdown: Record<string, ClientBreakdownData> | null | undefined
+): boolean {
+  return Object.values(breakdown ?? {}).every(
+    (client) => client.provenance?.costIsComplete !== false
+  );
 }
 
 export function clientContributionToBreakdownData(

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -234,12 +234,25 @@ export function mergeClientBreakdownsWithRegressionGuard(
         // the incoming value clears the largest single contribution to that
         // fold — consistent with a complete-day recomputation rather than a
         // partial re-parse. Let it replace the fold instead of defending it.
-        merged[clientName] = nextClient;
+        //
+        // The heal gate is evidence about TOKENS (incoming >= the largest
+        // component), which says nothing about pricing coverage. So the cost
+        // still goes through the #1044 floor: an incomplete submission heals
+        // the token count but must not be trusted to restate the cost. Keeping
+        // the folded (inflated) cost is no worse than declining to heal, and
+        // the tag lets a later complete submission correct it exactly.
+        merged[clientName] = applyCostCompleteness(
+          nextClient,
+          existingClient,
+          incomingCostIsComplete
+        );
         foldPreservedClients.delete(clientName);
         const existingTokens = formatTokens(existingClient.tokens);
         const nextTokens = formatTokens(nextClient.tokens);
         warnings.push(
-          `Healed ${clientName} alias-folded double count for this same-device resubmit: replaced ${existingTokens} tokens with ${nextTokens} tokens from the complete incoming day.`
+          `Healed ${clientName} alias-folded double count for this same-device resubmit: replaced ${existingTokens} tokens with ${nextTokens} tokens from the incoming day${
+            incomingCostIsComplete ? "" : " (cost kept as a floor: pricing was incomplete)"
+          }.`
         );
         continue;
       }

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -307,10 +307,40 @@ function applyCostCompleteness(
     return { ...next, provenance };
   }
 
-  const flooredCost = Math.max(existing?.cost ?? 0, next.cost);
+  // The floor has to reach the NESTED model costs, not just the client
+  // aggregate. `model:`-filtered leaderboards and profile model breakdowns sum
+  // `models[*].cost` rather than the client total, so flooring only the
+  // aggregate leaves a row whose client says $10 while its models rank at $0 —
+  // the same scalar-vs-JSON divergence one level deeper.
+  //
+  // Every model in the union is floored: one present in both takes the higher
+  // cost, and one the incomplete payload dropped entirely is preserved rather
+  // than allowed to vanish (its usage did not stop existing because this
+  // submission could not price it).
+  const models: Record<string, ModelBreakdownData> = {};
+  for (const [modelId, model] of Object.entries(existing?.models ?? {})) {
+    models[modelId] = { ...model };
+  }
+  for (const [modelId, model] of Object.entries(next.models ?? {})) {
+    const priorCost = models[modelId]?.cost ?? 0;
+    models[modelId] = { ...model, cost: Math.max(priorCost, model.cost) };
+  }
+
+  // Derive the client total from those floors rather than taking
+  // max(existing, next) independently. Deriving is what makes the three levels
+  // agree by construction: day = Σ clients (recalculateDayTotals) and now
+  // client = Σ models. Taking the max here instead can land between the two —
+  // e.g. existing {A:6,B:4}=10 against incoming {A:0,C:5}=5 floors to
+  // {A:6,B:4,C:5}=15, which max(10,5)=10 would contradict.
+  const modelCosts = Object.values(models);
+  const flooredCost = modelCosts.length
+    ? modelCosts.reduce((sum, model) => sum + (model.cost || 0), 0)
+    : Math.max(existing?.cost ?? 0, next.cost);
+
   return {
     ...next,
     cost: flooredCost,
+    models,
     provenance: {
       ...(next.provenance ?? deriveClientBreakdownProvenance(next)),
       costIsComplete: false,

--- a/packages/frontend/src/lib/db/migrations/0026_gorgeous_kingpin.sql
+++ b/packages/frontend/src/lib/db/migrations/0026_gorgeous_kingpin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "daily_breakdown" ADD COLUMN "cost_is_complete" boolean DEFAULT true NOT NULL;

--- a/packages/frontend/src/lib/db/migrations/0027_harsh_sabra.sql
+++ b/packages/frontend/src/lib/db/migrations/0027_harsh_sabra.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "submissions" ADD COLUMN "cost_is_complete" boolean DEFAULT true NOT NULL;

--- a/packages/frontend/src/lib/db/migrations/meta/0026_snapshot.json
+++ b/packages/frontend/src/lib/db/migrations/meta/0026_snapshot.json
@@ -1,0 +1,1992 @@
+{
+  "id": "12f9fcc3-9c1c-43d2-9467-339543a2d687",
+  "prevId": "3600bea7-2dc3-45e2-8749-0c6fa3f7ab21",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_token": {
+          "name": "idx_api_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_tokens_user_id": {
+          "name": "idx_api_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_unique": {
+          "name": "api_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "api_tokens_user_name_unique": {
+          "name": "api_tokens_user_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown": {
+      "name": "daily_breakdown",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(14, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_ms": {
+          "name": "active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_is_complete": {
+          "name": "cost_is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_submission_id": {
+          "name": "idx_daily_breakdown_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_submitted_device_id": {
+          "name": "idx_daily_breakdown_submitted_device_id",
+          "columns": [
+            {
+              "expression": "submitted_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_date": {
+          "name": "idx_daily_breakdown_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_submission_id_submissions_id_fk": {
+          "name": "daily_breakdown_submission_id_submissions_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_breakdown_submitted_device_id_submitted_devices_id_fk": {
+          "name": "daily_breakdown_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_breakdown_submission_device_date_unique": {
+          "name": "daily_breakdown_submission_device_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "submission_id",
+            "submitted_device_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown_reported": {
+      "name": "daily_breakdown_reported",
+      "schema": "",
+      "columns": {
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client": {
+          "name": "client",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(14, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_time_ms": {
+          "name": "active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_reported_device_date": {
+          "name": "idx_daily_breakdown_reported_device_date",
+          "columns": [
+            {
+              "expression": "submitted_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_reported_submitted_device_id_submitted_devices_id_fk": {
+          "name": "daily_breakdown_reported_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "daily_breakdown_reported",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_breakdown_reported_submitted_device_id_date_client_pk": {
+          "name": "daily_breakdown_reported_submitted_device_id_date_client_pk",
+          "columns": [
+            "submitted_device_id",
+            "date",
+            "client"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_codes_device_code": {
+          "name": "idx_device_codes_device_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_code": {
+          "name": "idx_device_codes_user_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_id": {
+          "name": "idx_device_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_expires_at": {
+          "name": "idx_device_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_user_id_users_id_fk": {
+          "name": "device_codes_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invites": {
+      "name": "group_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_username": {
+          "name": "invited_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_username_normalized": {
+          "name": "invited_username_normalized",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_user_id": {
+          "name": "invited_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_invites_group_status": {
+          "name": "idx_group_invites_group_status",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_user_status": {
+          "name": "idx_group_invites_invited_user_status",
+          "columns": [
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_username_status": {
+          "name": "idx_group_invites_invited_username_status",
+          "columns": [
+            {
+              "expression": "invited_username_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_expires_at": {
+          "name": "idx_group_invites_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_by": {
+          "name": "idx_group_invites_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invites_group_id_groups_id_fk": {
+          "name": "group_invites_group_id_groups_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_user_id_users_id_fk": {
+          "name": "group_invites_invited_user_id_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_by_users_id_fk": {
+          "name": "group_invites_invited_by_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_invites_token_hash_unique": {
+          "name": "group_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_members_user_id": {
+          "name": "idx_group_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_members_invited_by": {
+          "name": "idx_group_members_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_invited_by_users_id_fk": {
+          "name": "group_members_invited_by_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_members_group_user_unique": {
+          "name": "group_members_group_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_created_by": {
+          "name": "idx_groups_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_visibility_updated": {
+          "name": "idx_groups_visibility_updated",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_users_id_fk": {
+          "name": "groups_created_by_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_slug_unique": {
+          "name": "groups_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_actions": {
+      "name": "moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_username": {
+          "name": "target_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_moderation_actions_target_created": {
+          "name": "idx_moderation_actions_target_created",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_moderation_actions_actor": {
+          "name": "idx_moderation_actions_actor",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_actions_target_user_id_users_id_fk": {
+          "name": "moderation_actions_target_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "moderation_actions_actor_user_id_users_id_fk": {
+          "name": "moderation_actions_actor_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ratchet_census_work": {
+      "name": "ratchet_census_work",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buckets": {
+          "name": "buckets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ratchet_census_work_submission_id": {
+          "name": "idx_ratchet_census_work_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ratchet_census_work_submission_id_submissions_id_fk": {
+          "name": "ratchet_census_work_submission_id_submissions_id_fk",
+          "tableFrom": "ratchet_census_work",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ratchet_census_work_submitted_device_id_submitted_devices_id_fk": {
+          "name": "ratchet_census_work_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "ratchet_census_work",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_token_hash": {
+          "name": "idx_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources_used": {
+          "name": "sources_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models_used": {
+          "name": "models_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_hash": {
+          "name": "submission_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submit_count": {
+          "name": "submit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_backfill": {
+          "name": "has_backfill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_servers": {
+          "name": "mcp_servers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_leaderboard": {
+          "name": "idx_submissions_leaderboard",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_tokens",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submissions_user_id_unique": {
+          "name": "submissions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_device_client_totals": {
+      "name": "submitted_device_client_totals",
+      "schema": "",
+      "columns": {
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client": {
+          "name": "client",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_width": {
+          "name": "bucket_width",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_key": {
+          "name": "bucket_key",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens_highwater": {
+          "name": "tokens_highwater",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_highwater": {
+          "name": "cost_highwater",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submitted_device_client_totals_submitted_device_id_submitted_devices_id_fk": {
+          "name": "submitted_device_client_totals_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "submitted_device_client_totals",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "submitted_device_client_totals_submitted_device_id_client_origin_bucket_width_bucket_key_pk": {
+          "name": "submitted_device_client_totals_submitted_device_id_client_origin_bucket_width_bucket_key_pk",
+          "columns": [
+            "submitted_device_id",
+            "client",
+            "origin",
+            "bucket_width",
+            "bucket_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_devices": {
+      "name": "submitted_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_key": {
+          "name": "device_key",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_submitted_devices_user_id": {
+          "name": "idx_submitted_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submitted_devices_user_id_users_id_fk": {
+          "name": "submitted_devices_user_id_users_id_fk",
+          "tableFrom": "submitted_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submitted_devices_user_device_key_unique": {
+          "name": "submitted_devices_user_device_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leaderboard_hidden": {
+          "name": "leaderboard_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_lower_unique": {
+          "name": "users_username_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_github_id": {
+          "name": "idx_users_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/frontend/src/lib/db/migrations/meta/0027_snapshot.json
+++ b/packages/frontend/src/lib/db/migrations/meta/0027_snapshot.json
@@ -1,0 +1,1999 @@
+{
+  "id": "4399c853-4f0b-491d-9768-ccac3abf452b",
+  "prevId": "12f9fcc3-9c1c-43d2-9467-339543a2d687",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_token": {
+          "name": "idx_api_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_tokens_user_id": {
+          "name": "idx_api_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_unique": {
+          "name": "api_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "api_tokens_user_name_unique": {
+          "name": "api_tokens_user_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown": {
+      "name": "daily_breakdown",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(14, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_ms": {
+          "name": "active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_is_complete": {
+          "name": "cost_is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_submission_id": {
+          "name": "idx_daily_breakdown_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_submitted_device_id": {
+          "name": "idx_daily_breakdown_submitted_device_id",
+          "columns": [
+            {
+              "expression": "submitted_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_date": {
+          "name": "idx_daily_breakdown_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_submission_id_submissions_id_fk": {
+          "name": "daily_breakdown_submission_id_submissions_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_breakdown_submitted_device_id_submitted_devices_id_fk": {
+          "name": "daily_breakdown_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_breakdown_submission_device_date_unique": {
+          "name": "daily_breakdown_submission_device_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "submission_id",
+            "submitted_device_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown_reported": {
+      "name": "daily_breakdown_reported",
+      "schema": "",
+      "columns": {
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client": {
+          "name": "client",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(14, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_time_ms": {
+          "name": "active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_reported_device_date": {
+          "name": "idx_daily_breakdown_reported_device_date",
+          "columns": [
+            {
+              "expression": "submitted_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_reported_submitted_device_id_submitted_devices_id_fk": {
+          "name": "daily_breakdown_reported_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "daily_breakdown_reported",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_breakdown_reported_submitted_device_id_date_client_pk": {
+          "name": "daily_breakdown_reported_submitted_device_id_date_client_pk",
+          "columns": [
+            "submitted_device_id",
+            "date",
+            "client"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_codes_device_code": {
+          "name": "idx_device_codes_device_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_code": {
+          "name": "idx_device_codes_user_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_id": {
+          "name": "idx_device_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_expires_at": {
+          "name": "idx_device_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_user_id_users_id_fk": {
+          "name": "device_codes_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invites": {
+      "name": "group_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_username": {
+          "name": "invited_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_username_normalized": {
+          "name": "invited_username_normalized",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_user_id": {
+          "name": "invited_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_invites_group_status": {
+          "name": "idx_group_invites_group_status",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_user_status": {
+          "name": "idx_group_invites_invited_user_status",
+          "columns": [
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_username_status": {
+          "name": "idx_group_invites_invited_username_status",
+          "columns": [
+            {
+              "expression": "invited_username_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_expires_at": {
+          "name": "idx_group_invites_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_by": {
+          "name": "idx_group_invites_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invites_group_id_groups_id_fk": {
+          "name": "group_invites_group_id_groups_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_user_id_users_id_fk": {
+          "name": "group_invites_invited_user_id_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_by_users_id_fk": {
+          "name": "group_invites_invited_by_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_invites_token_hash_unique": {
+          "name": "group_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_members_user_id": {
+          "name": "idx_group_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_members_invited_by": {
+          "name": "idx_group_members_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_invited_by_users_id_fk": {
+          "name": "group_members_invited_by_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_members_group_user_unique": {
+          "name": "group_members_group_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_created_by": {
+          "name": "idx_groups_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_visibility_updated": {
+          "name": "idx_groups_visibility_updated",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_users_id_fk": {
+          "name": "groups_created_by_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_slug_unique": {
+          "name": "groups_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_actions": {
+      "name": "moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_username": {
+          "name": "target_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_moderation_actions_target_created": {
+          "name": "idx_moderation_actions_target_created",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_moderation_actions_actor": {
+          "name": "idx_moderation_actions_actor",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_actions_target_user_id_users_id_fk": {
+          "name": "moderation_actions_target_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "moderation_actions_actor_user_id_users_id_fk": {
+          "name": "moderation_actions_actor_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ratchet_census_work": {
+      "name": "ratchet_census_work",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buckets": {
+          "name": "buckets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ratchet_census_work_submission_id": {
+          "name": "idx_ratchet_census_work_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ratchet_census_work_submission_id_submissions_id_fk": {
+          "name": "ratchet_census_work_submission_id_submissions_id_fk",
+          "tableFrom": "ratchet_census_work",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ratchet_census_work_submitted_device_id_submitted_devices_id_fk": {
+          "name": "ratchet_census_work_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "ratchet_census_work",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_token_hash": {
+          "name": "idx_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources_used": {
+          "name": "sources_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models_used": {
+          "name": "models_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_hash": {
+          "name": "submission_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submit_count": {
+          "name": "submit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_backfill": {
+          "name": "has_backfill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cost_is_complete": {
+          "name": "cost_is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_servers": {
+          "name": "mcp_servers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_leaderboard": {
+          "name": "idx_submissions_leaderboard",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_tokens",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submissions_user_id_unique": {
+          "name": "submissions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_device_client_totals": {
+      "name": "submitted_device_client_totals",
+      "schema": "",
+      "columns": {
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client": {
+          "name": "client",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_width": {
+          "name": "bucket_width",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_key": {
+          "name": "bucket_key",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens_highwater": {
+          "name": "tokens_highwater",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_highwater": {
+          "name": "cost_highwater",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submitted_device_client_totals_submitted_device_id_submitted_devices_id_fk": {
+          "name": "submitted_device_client_totals_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "submitted_device_client_totals",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "submitted_device_client_totals_submitted_device_id_client_origin_bucket_width_bucket_key_pk": {
+          "name": "submitted_device_client_totals_submitted_device_id_client_origin_bucket_width_bucket_key_pk",
+          "columns": [
+            "submitted_device_id",
+            "client",
+            "origin",
+            "bucket_width",
+            "bucket_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_devices": {
+      "name": "submitted_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_key": {
+          "name": "device_key",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_submitted_devices_user_id": {
+          "name": "idx_submitted_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submitted_devices_user_id_users_id_fk": {
+          "name": "submitted_devices_user_id_users_id_fk",
+          "tableFrom": "submitted_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submitted_devices_user_device_key_unique": {
+          "name": "submitted_devices_user_device_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leaderboard_hidden": {
+          "name": "leaderboard_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_lower_unique": {
+          "name": "users_username_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_github_id": {
+          "name": "idx_users_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1786045554871,
       "tag": "0026_gorgeous_kingpin",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1786091532644,
+      "tag": "0027_harsh_sabra",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1785854002944,
       "tag": "0025_bouncy_vertigo",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1786045554871,
+      "tag": "0026_gorgeous_kingpin",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -364,6 +364,23 @@ export const dailyBreakdown = pgTable(
     >(),
     /** Total active coding time in this UTC day bucket (milliseconds). NULL for legacy data. */
     activeTimeMs: bigint("active_time_ms", { mode: "number" }),
+
+    /**
+     * Whether `cost` accounts for every token the client counted for this day.
+     *
+     * The submission protocol previously had no way to say "I do not know what
+     * this cost", only "this cost is $0.00", while the write path overwrote
+     * `cost` unconditionally. A client whose pricing coverage degraded — a
+     * dataset failing to load, a stale cache, a proxy blocking the fetch —
+     * would therefore lower a day's recorded spend permanently (#1044).
+     *
+     * `false` means the client knowingly submitted a day whose cost is a floor,
+     * not a total, and the write path refuses to let it reduce what is already
+     * stored. Defaults to `true` so every already-released CLI, which cannot
+     * send the flag, keeps exact overwrite semantics including downward
+     * corrections.
+     */
+    costIsComplete: boolean("cost_is_complete").notNull().default(true),
   },
   (table) => [
     index("idx_daily_breakdown_submission_id").on(table.submissionId),

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -217,6 +217,20 @@ export const submissions = pgTable(
      */
     hasBackfill: boolean("has_backfill").notNull().default(false),
 
+    /**
+     * Whether `total_cost` accounts for every token in `total_tokens`.
+     *
+     * Composed as `BOOL_AND` over this user's `daily_breakdown` rows, so ONE
+     * device or day submitting a floored cost makes the whole total a lower
+     * bound. Not sticky, unlike `has_backfill`: it is recomputed from the day
+     * rows on every submit, so a user whose pricing recovers gets an exact
+     * total back once every contributing row is complete again.
+     *
+     * Defaults true, which is correct for every row written before the day
+     * rows could express incompleteness (#1044).
+     */
+    costIsComplete: boolean("cost_is_complete").notNull().default(true),
+
     totalActiveTimeMs: bigint("total_active_time_ms", { mode: "number" }),
     longestContinuousMs: bigint("longest_continuous_ms", { mode: "number" }),
     maxConcurrentSessions: integer("max_concurrent_sessions"),

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -72,6 +72,19 @@ const DailyContributionSchema = z.object({
     tokens: NonNegativeIntegerSchema,
     cost: NonNegativeNumberSchema,
     messages: NonNegativeIntegerSchema,
+    /**
+     * Whether `cost` accounts for every token counted in `tokens`.
+     *
+     * `cost` alone cannot distinguish "this day cost $0.00" from "I could not
+     * price this day", and the write path overwrites cost per day, so a client
+     * with degraded pricing coverage would silently lower recorded spend
+     * (#1044). Sending `false` declares the cost a floor rather than a total,
+     * and the server then refuses to let it reduce what is already stored.
+     *
+     * Optional, and absent means complete — every already-released CLI keeps
+     * exact overwrite semantics, including downward corrections.
+     */
+    costIsComplete: z.boolean().optional(),
   }),
   intensity: NonNegativeIntegerSchema.max(4),
   tokenBreakdown: TokenBreakdownSchema,


### PR DESCRIPTION
Implements the server half of #1044.

## Problem

The submission protocol has no way to say *"I don't know what this cost"* — only *"this cost is $0.00"*. Both `daily_breakdown` write paths overwrote `cost` unconditionally:

```sql
ON CONFLICT (submission_id, submitted_device_id, date) DO UPDATE SET
  cost = EXCLUDED.cost,
  ...
  active_time_ms = GREATEST(daily_breakdown.active_time_ms, EXCLUDED.active_time_ms),
```

So any degradation in a client's pricing coverage — one dataset failing to load, a stale cache, a corporate proxy blocking the fetch — permanently lowered that day's recorded spend. `active_time_ms` on the very next line already had a monotonic guard for exactly this hazard. `cost` did not.

#1044 also records three client-side guards that were tried and abandoned; each closed its target case and left a narrower one open. The client is being asked a question it cannot answer — *is my pricing good enough to overwrite what the server already has?* Only the server knows what it has.

## Change

`daily_breakdown.cost_is_complete boolean not null default true` records whether a stored cost accounts for every token counted that day.

- **Payload**: `totals.costIsComplete` is optional; absent means complete.
- **Both write paths** (the `ON CONFLICT` arm *and* the batch `UPDATE` that #1044 named explicitly):

```sql
cost = CASE
         WHEN EXCLUDED.cost_is_complete THEN EXCLUDED.cost
         ELSE GREATEST(daily_breakdown.cost, EXCLUDED.cost)
       END,
```

The stored flag describes the cost **actually kept**, not the last writer, so it can't claim a number is unreliable when the guard just preserved a complete one:

```sql
cost_is_complete = CASE
                     WHEN EXCLUDED.cost_is_complete THEN true
                     WHEN EXCLUDED.cost > daily_breakdown.cost THEN false
                     ELSE daily_breakdown.cost_is_complete
                   END,
```

## Compatibility and deployment

Server-only and backwards compatible. The field is optional and absent means complete, so **every released CLI is unaffected** and keeps exact overwrite semantics, downward corrections included. Migration is a single `ADD COLUMN ... DEFAULT true NOT NULL` — no table rewrite on modern Postgres — generated with `drizzle-kit generate` (journal entry `idx: 26`, not hand-edited).

Per #1044, deployment is ordered: **this first, then the CLI release that sets the flag.** A CLI sending the flag against an older server would be silently ignored.

## Tests

- `bun run test` — 826 passed (84 files), up from 822
- `bun run typecheck` clean; `bun run lint` 0 errors
- **Mutation check:** removing the schema field fails `preserves a declared-incomplete flag through validation` and `rejects a non-boolean flag rather than coercing it`. The parsed value is asserted, not just validity — Zod strips unknown keys, so a validity-only assertion would pass against a schema that never declared the field and silently dropped it.

I did not run `test:migrations` locally: it invokes `drizzle-kit migrate`, which **applies** migrations, and `DATABASE_URL` here points at a real database. CI replays against a scratch `postgres:16`.

## What this does not cover

**The guard's SQL semantics are not exercised against a real Postgres by this PR.** The existing transaction double models `source_breakdown` only, not `cost`, so making it prove the guard would mean reimplementing the `CASE`/`GREATEST` logic inside the double and testing the double. Coverage here is schema-level plus the structural change. A postgres-backed route test is the right follow-up, and I'd rather flag that than imply an invariant is proven when it isn't.

## Trade-off worth challenging

A day flagged incomplete will not accept a legitimate downward correction until the user resubmits with healthy pricing. That's deliberate — over-reporting is recoverable, silently losing recorded spend is not — but it is a real behavior change and worth a second opinion if the leaderboard's semantics argue otherwise.

## Open question from #1044

Kept at day granularity, which is the level the server actually overwrites. Per-client (`ClientContributionSchema`) would record *which* client made the day incomplete — better for debugging and for showing users what to fix — at the cost of a wider schema and more per-row storage. Happy to widen it if you'd prefer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let submissions and daily rows declare whether costs are complete to stop partial pricing from lowering recorded spend. The floor now applies during merge per client and per nested model (including alias-heal), and completeness composes per client, per day, and at the submission total to keep scalars and JSON consistent (per #1044).

- **New Features**
  - API accepts optional `totals.costIsComplete`; absent defaults to complete.
  - DB adds `daily_breakdown.cost_is_complete` and `submissions.cost_is_complete` (boolean default true).
  - Merge floors incomplete costs per client and per model, derives client totals from model floors, and applies on alias-heal; day completeness derives from the merged breakdown and submission completeness is `BOOL_AND` across days/devices; writes are plain overwrites that match recomputed totals and preserve incomplete siblings on filtered resubmits.

- **Migration**
  - Apply migrations 0026 and 0027.
  - Deploy server first; existing CLIs are unaffected, and newer CLIs sending the flag are ignored by older servers.

<sup>Written for commit 9ecd67fc3d7165f5774553f2cb7dd49ba24ad8a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

