### PR TITLE
fix(antigravity_cli): resolve aliases before rejecting ambiguous display labels in SessionModels

### DIFF
--- a/crates/tokscale-core/src/sessions/antigravity_cli.rs
+++ b/crates/tokscale-core/src/sessions/antigravity_cli.rs
@@ -116,9 +116,12 @@ pub fn parse_antigravity_cli_file(path: &Path) -> Vec<UnifiedMessage> {
 /// localizable labels.
 #[derive(Default)]
 struct SessionModels {
-    /// `#21` display label → the `#19` machine id seen alongside it. Labels
-    /// that appear with more than one id are dropped: an ambiguous label is no
-    /// better evidence than no label at all.
+    /// `#21` display label → the `#19` machine id seen alongside it. A label
+    /// that appears with two ids naming *different* priced models is dropped:
+    /// an ambiguous label is no better evidence than no label at all. Ids that
+    /// differ only in spelling but share an alias target (Antigravity's
+    /// `gemini-pro-default` / `gemini-pro-agent`) are not ambiguous, and the
+    /// first id observed is kept.
     by_display: HashMap<String, String>,
     /// The file's only `#19` value — set only when every row carrying one
     /// agrees *and* every label in the file was identified by some row. Serves
@@ -149,10 +152,20 @@ impl SessionModels {
                     .entry(label)
                     .and_modify(|resolved| {
                         if let Some(existing) = *resolved {
+                            // Antigravity swaps between several `#19` machine ids
+                            // under one display label within a single conversation
+                            // (`gemini-pro-default` and `gemini-pro-agent` both
+                            // appear as "Gemini 3.1 Pro (High)"). Those are the same
+                            // priced model, so comparing the raw strings reports a
+                            // false ambiguity and drops the label — which later
+                            // leaves `#19`-less rows as `unknown` and aborts
+                            // `submit`. Compare canonical alias targets instead, so
+                            // only a genuinely different model clears the mapping.
                             if existing != model {
-                                let existing_canon = crate::pricing::aliases::resolve_alias(existing).unwrap_or(existing);
-                                let new_canon = crate::pricing::aliases::resolve_alias(model).unwrap_or(model);
-                                
+                                let existing_canon =
+                                    pricing::aliases::resolve_alias(existing).unwrap_or(existing);
+                                let new_canon =
+                                    pricing::aliases::resolve_alias(model).unwrap_or(model);
                                 if existing_canon != new_canon {
                                     *resolved = None;
                                 }
@@ -836,6 +849,39 @@ mod tests {
         let messages = parse_antigravity_cli_file(&path);
         assert_eq!(messages.len(), 3);
         assert_eq!(messages[2].model_id, "unknown");
+    }
+
+    #[test]
+    fn two_spellings_of_one_priced_model_are_not_an_ambiguous_label() {
+        // Antigravity swaps machine ids mid-conversation without changing the
+        // display label: `gemini-pro-default` and `gemini-pro-agent` are both
+        // "Gemini 3.1 Pro (High)" and both price as `gemini-3.1-pro`. Comparing
+        // the raw ids called that ambiguous and discarded the label, so the
+        // continuation row below resolved to `unknown` — which has no pricing
+        // and aborted `tokscale submit` outright (#1058).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("aliased.db");
+        write_conversation(
+            &path,
+            &[
+                build_row(
+                    Some("gemini-pro-default"),
+                    Some("Gemini 3.1 Pro (High)"),
+                    "resp-0",
+                ),
+                build_row(
+                    Some("gemini-pro-agent"),
+                    Some("Gemini 3.1 Pro (High)"),
+                    "resp-1",
+                ),
+                build_row(None, Some("Gemini 3.1 Pro (High)"), "resp-2"),
+            ],
+        );
+
+        let messages = parse_antigravity_cli_file(&path);
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[2].model_id, "gemini-3.1-pro");
+        assert_ne!(messages[2].model_id, "unknown");
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/antigravity_cli.rs
+++ b/crates/tokscale-core/src/sessions/antigravity_cli.rs
@@ -148,8 +148,8 @@ impl SessionModels {
                 by_display
                     .entry(label)
                     .and_modify(|resolved| {
-                        if let Some(existing) = resolved {
-                            if existing != &model {
+                        if let Some(existing) = *resolved {
+                            if existing != model {
                                 let existing_canon = crate::pricing::aliases::resolve_alias(existing).unwrap_or(existing);
                                 let new_canon = crate::pricing::aliases::resolve_alias(model).unwrap_or(model);
                                 

--- a/crates/tokscale-core/src/sessions/antigravity_cli.rs
+++ b/crates/tokscale-core/src/sessions/antigravity_cli.rs
@@ -148,8 +148,15 @@ impl SessionModels {
                 by_display
                     .entry(label)
                     .and_modify(|resolved| {
-                        if *resolved != Some(model) {
-                            *resolved = None;
+                        if let Some(existing) = resolved {
+                            if existing != &model {
+                                let existing_canon = crate::pricing::aliases::resolve_alias(existing).unwrap_or(existing);
+                                let new_canon = crate::pricing::aliases::resolve_alias(model).unwrap_or(model);
+                                
+                                if existing_canon != new_canon {
+                                    *resolved = None;
+                                }
+                            }
                         }
                     })
                     .or_insert(Some(model));


### PR DESCRIPTION
## Bug Report & Root Cause Analysis

**Symptom**  
When running `tokscale submit`, users who use Antigravity CLI may encounter the following fatal error, which aborts the submission process:
```text
  Tokscale - Submit Usage Data

  Scanning local session data...
Error: pricing is unavailable for submitted token usage: antigravity/unknown (x2)
```

**Root Cause Analysis**  
The error stems from how `tokscale` handles missing machine IDs (`#19` field) in Antigravity CLI's SQLite databases (`gen_metadata`).
1. **Missing `#19` fields**: In certain continuation turns (e.g., when reading cache with short outputs), the Antigravity CLI omits the `#19` machine ID (e.g. `gemini-pro-default`), but still logs the `#21` display label (e.g. `Gemini 3.1 Pro (High)`).
2. **Recovery Mechanism**: `tokscale` uses `SessionModels::from_blobs` to map these `#21` display labels back to their corresponding `#19` machine IDs by looking at other rows within the same database file.
3. **The Flaw (False Ambiguity)**: Sometimes, the CLI uses *multiple different* raw `#19` machine IDs under the exact same display label within a single conversation (e.g., using both `gemini-pro-default` and `gemini-pro-agent` for the `Gemini 3.1 Pro (High)` label). 
   When `SessionModels::from_blobs` encounters this, it strictly compares the raw string values (`*resolved != Some(model)`). Since `"gemini-pro-default" != "gemini-pro-agent"`, it marks the display label as "ambiguous" and aggressively assigns it to `None`.
4. **The Crash**: Later, when parsing the continuation turns that lack the `#19` field, `SessionModels::recover` looks up the display label, finds `None`, and falls back to `"unknown"`. Since `"unknown"` has no pricing data, `tokscale submit` crashes.

## Proposed Solution

The ambiguity check is currently too strict. Both `gemini-pro-default` and `gemini-pro-agent` ultimately resolve to the **exact same canonical model** (`gemini-3.1-pro`) in `pricing::aliases::resolve_alias`. 

Therefore, rejecting them as ambiguous is a false positive. 

**Changes in this PR:**
This PR updates the `SessionModels::from_blobs` ambiguity check. Before deciding to discard a display label mapping (`*resolved = None;`), it first resolves both the existing raw ID and the newly encountered raw ID into their canonical aliases (`crate::pricing::aliases::resolve_alias`).
If both raw IDs point to the identical canonical pricing tier (which is usually the case for Antigravity's internal model swapping), we consider it a safe match and keep the mapping, avoiding the `antigravity/unknown` crash.

## Changes / Diff

```diff
--- a/crates/tokscale-core/src/sessions/antigravity_cli.rs
+++ b/crates/tokscale-core/src/sessions/antigravity_cli.rs
@@ -148,8 +148,15 @@ impl SessionModels {
                 by_display
                     .entry(label)
                     .and_modify(|resolved| {
-                        if *resolved != Some(model) {
-                            *resolved = None;
+                        if let Some(existing) = *resolved {
+                            if existing != model {
+                                // Check if both raw models resolve to the same canonical pricing model
+                                let existing_canon = crate::pricing::aliases::resolve_alias(existing).unwrap_or(existing);
+                                let new_canon = crate::pricing::aliases::resolve_alias(model).unwrap_or(model);
+                                
+                                if existing_canon != new_canon {
+                                    *resolved = None;
+                                }
+                            }
                         }
                     })
                     .or_insert(Some(model));
```

## Testing
- Verified that databases containing both `gemini-pro-default` and `gemini-pro-agent` for the `Gemini 3.1 Pro (High)` label now successfully map to `gemini-3.1-pro` instead of falling back to `unknown`.
- Prevents `tokscale submit` from panicking with `pricing is unavailable for submitted token usage: antigravity/unknown`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve model aliases before marking display labels as ambiguous in Antigravity CLI sessions. Prevents falling back to `antigravity/unknown` pricing when `#19` is missing and multiple raw IDs share a label.

- **Bug Fixes**
  - Update `SessionModels::from_blobs` to compare canonical IDs via `pricing::aliases::resolve_alias` before discarding a label mapping.
  - Keep the mapping when different raw IDs resolve to the same canonical model (e.g., `gemini-pro-default` and `gemini-pro-agent` -> `gemini-3.1-pro`).
  - Continuation turns without `#19` now resolve correctly using `#21` labels; a regression test pins the `Gemini 3.1 Pro (High)` case.

<sup>Written for commit 4699c0083fecf04f944022af97e8bcb7211ac6f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

