### PR TITLE
fix(tui): gate Apple Terminal truecolor on TERM_PROGRAM_VERSION

### DIFF
--- a/crates/tokscale-cli/src/tui/themes.rs
+++ b/crates/tokscale-cli/src/tui/themes.rs
@@ -7,6 +7,11 @@ pub(crate) enum TerminalColorMode {
 }
 
 impl TerminalColorMode {
+    // Terminal 2.15 (build 464, shipped with macOS 26 Tahoe) is the first
+    // Terminal.app that renders 24-bit SGR reliably. Older builds garble RGB
+    // sequences into saturated color blocks (see #559 and #1060).
+    const APPLE_TERMINAL_TRUECOLOR_VERSION: u32 = 464;
+
     pub(crate) fn from_env<I, K, V>(env: I) -> Self
     where
         I: IntoIterator<Item = (K, V)>,
@@ -15,6 +20,8 @@ impl TerminalColorMode {
     {
         let mut term = String::new();
         let mut colorterm = String::new();
+        let mut term_program = String::new();
+        let mut term_program_version = String::new();
         let mut no_color = false;
 
         for (key, value) in env {
@@ -23,17 +30,13 @@ impl TerminalColorMode {
             match key {
                 "TERM" => term = value.to_ascii_lowercase(),
                 "COLORTERM" => colorterm = value.to_ascii_lowercase(),
+                "TERM_PROGRAM" => term_program = value.to_ascii_lowercase(),
+                "TERM_PROGRAM_VERSION" => term_program_version = value.to_string(),
                 "NO_COLOR" => no_color = true,
                 _ => {}
             }
         }
 
-        // `TERM_PROGRAM == "Apple_Terminal"` used to land here too. Terminal.app
-        // does render 24-bit SGR colors (verified: `ESC[38;2;255;80;0m` paints
-        // its own orange, distinct from indexed 208), and it never sets
-        // COLORTERM, so blacklisting it dropped Terminal.app to `Compatible`,
-        // which overwrites every theme with one palette and made theme
-        // switching a no-op there. Re-test before reinstating it.
         if no_color || term == "dumb" {
             return Self::Compatible;
         }
@@ -45,7 +48,22 @@ impl TerminalColorMode {
             return Self::FullColor;
         }
 
-        Self::FullColor
+        // Terminal.app never sets COLORTERM, and only modern builds (macOS 26+)
+        // render 24-bit SGR. Gate on the version so old builds fall back to the
+        // named-color palette instead of garbling every theme into blocks.
+        if term_program == "apple_terminal" {
+            let version = term_program_version
+                .split('.')
+                .next()
+                .and_then(|v| v.parse::<u32>().ok());
+            if version.is_some_and(|v| v >= Self::APPLE_TERMINAL_TRUECOLOR_VERSION) {
+                return Self::FullColor;
+            }
+        }
+
+        // No positive evidence of truecolor support: prefer the named-color
+        // palette over raw RGB, which non-truecolor terminals garble.
+        Self::Compatible
     }
 }
 
@@ -547,6 +565,7 @@ mod tests {
     fn apple_terminal_keeps_full_color_and_per_theme_palettes() {
         let mode = TerminalColorMode::from_env(env(&[
             ("TERM_PROGRAM", "Apple_Terminal"),
+            ("TERM_PROGRAM_VERSION", "487"),
             ("TERM", "xterm-256color"),
         ]));
 
@@ -558,6 +577,41 @@ mod tests {
         let green = Theme::from_name_with_color_mode(ThemeName::Green, mode);
         let blue = Theme::from_name_with_color_mode(ThemeName::Blue, mode);
         assert_ne!(green.colors, blue.colors);
+    }
+
+    #[test]
+    fn old_apple_terminal_falls_back_to_compatible_colors() {
+        let mode = TerminalColorMode::from_env(env(&[
+            ("TERM_PROGRAM", "Apple_Terminal"),
+            ("TERM_PROGRAM_VERSION", "455"),
+            ("TERM", "xterm-256color"),
+        ]));
+
+        assert_eq!(mode, TerminalColorMode::Compatible);
+    }
+
+    #[test]
+    fn apple_terminal_without_version_uses_compatible_colors() {
+        let mode = TerminalColorMode::from_env(env(&[
+            ("TERM_PROGRAM", "Apple_Terminal"),
+            ("TERM", "xterm-256color"),
+        ]));
+
+        assert_eq!(mode, TerminalColorMode::Compatible);
+    }
+
+    #[test]
+    fn xterm_256_without_truecolor_evidence_uses_compatible_colors() {
+        let mode = TerminalColorMode::from_env(env(&[("TERM", "xterm-256color")]));
+
+        assert_eq!(mode, TerminalColorMode::Compatible);
+    }
+
+    #[test]
+    fn screen_without_truecolor_evidence_uses_compatible_colors() {
+        let mode = TerminalColorMode::from_env(env(&[("TERM", "screen-256color")]));
+
+        assert_eq!(mode, TerminalColorMode::Compatible);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/ui/usage.rs
+++ b/crates/tokscale-cli/src/tui/ui/usage.rs
@@ -1130,7 +1130,7 @@ fn provider_summary_line(
         Span::styled(
             format!("  {}", truncate_string(group.provider, 18)),
             Style::default()
-                .fg(get_provider_shade(group.provider, 0))
+                .fg(app.theme.color(get_provider_shade(group.provider, 0)))
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(format!("  {summary}"), app.theme.subtle_text_style()),
@@ -2013,7 +2013,7 @@ fn account_table_row(app: &App, output: &UsageOutput, index: usize) -> Row<'stat
         table_text_cell(
             output.provider.clone(),
             Style::default()
-                .fg(get_provider_shade(&output.provider, 0))
+                .fg(app.theme.color(get_provider_shade(&output.provider, 0)))
                 .add_modifier(Modifier::BOLD),
         ),
         table_text_cell(row.account, app.theme.secondary_text_style()),
@@ -2501,6 +2501,7 @@ mod tests {
     };
     use crate::tui::app::{Tab, TuiConfig};
     use crate::tui::data::UsageData;
+    use crate::tui::themes::{TerminalColorMode, Theme, ThemeName};
     use chrono::{Duration, Utc};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::{backend::TestBackend, Terminal};
@@ -2625,6 +2626,30 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    /// Renders the usage view and returns every distinct `Color::Rgb` present
+    /// in the frame's cell foregrounds/backgrounds.
+    fn render_rgb_colors(app: &mut App, width: u16, height: u16) -> Vec<Color> {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app, Rect::new(0, 0, width, height)))
+            .unwrap();
+        let mut rgb: Vec<Color> = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .flat_map(|cell| [cell.fg, cell.bg])
+            .filter(|color| matches!(color, Color::Rgb(..)))
+            .collect();
+        rgb.sort_by_key(|color| match color {
+            Color::Rgb(r, g, b) => (*r, *g, *b),
+            _ => (0, 0, 0),
+        });
+        rgb.dedup();
+        rgb
     }
 
     fn line_text(line: &Line<'_>) -> String {
@@ -2817,6 +2842,50 @@ mod tests {
         assert_eq!(groups[0].outputs[1].0, 2);
         assert_eq!(groups[1].provider, "Claude");
         assert_eq!(groups[1].outputs.len(), 1);
+    }
+
+    /// In `Compatible` mode the theme palette is collapsed to named colors so
+    /// terminals without truecolor support never receive 24-bit SGR. The
+    /// provider summary and the account table color provider labels from the
+    /// vendor shade ramps, which are RGB regardless of theme, so they have to
+    /// be routed through `Theme::color` too — otherwise those cells still emit
+    /// raw RGB and render as garbled blocks (#559, #1060).
+    #[test]
+    fn compatible_color_mode_emits_no_rgb_in_usage_view() {
+        let mut app = make_app();
+        app.theme =
+            Theme::from_name_with_color_mode(ThemeName::Blue, TerminalColorMode::Compatible);
+        app.selected_index = 0;
+        app.subscription_usage = vec![
+            output(
+                "Anthropic",
+                Some(UsageAccount {
+                    id: "acct_work".to_string(),
+                    label: Some("work".to_string()),
+                    is_active: true,
+                }),
+            ),
+            output(
+                "OpenAI",
+                Some(UsageAccount {
+                    id: "acct_personal".to_string(),
+                    label: Some("personal".to_string()),
+                    is_active: false,
+                }),
+            ),
+        ];
+
+        // Sanity: the provider summary and account table actually rendered.
+        let body = render_body(&mut app, 150, 32);
+        assert!(body.contains("Anthropic"), "{body}");
+        assert!(body.contains("OpenAI"), "{body}");
+        assert!(body.contains("Accounts"), "{body}");
+
+        let rgb = render_rgb_colors(&mut app, 150, 32);
+        assert!(
+            rgb.is_empty(),
+            "Compatible mode must not emit any Color::Rgb, found: {rgb:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Issue #1060 reports the same saturated solid-color blocks as #559/#404: the TUI renders fine in some terminals but as solid green/blue fills in others. The root cause is in `TerminalColorMode::from_env` (`crates/tokscale-cli/src/tui/themes.rs`): without positive truecolor evidence (`COLORTERM` / `TERM`) the old code fell back to `FullColor` and emitted 24-bit SGR unconditionally. Terminals that cannot render 24-bit color misparse those sequences into saturated color blocks.

PR #983 removed the Terminal.app blacklist because Terminal.app on newer macOS renders 24-bit SGR correctly and never sets `COLORTERM`, which collapsed every theme onto one palette in `Compatible` mode. This PR keeps that fix for modern Terminal.app while restoring safe output for old builds and for terminals with no truecolor evidence:

- `Apple_Terminal` now gates on `TERM_PROGRAM_VERSION`: >= 464 (Terminal 2.15, macOS 26 Tahoe era) keeps `FullColor`; older builds fall back to the named-color palette.
- Terminals without any truecolor evidence (no `COLORTERM`, plain `TERM`) now default to `Compatible` instead of emitting raw RGB, matching the ecosystem default used by e.g. termenv and neovim.

Closes #1060

## Reproduction / verification

Running the TUI under `TERM=xterm-256color` with no `COLORTERM` now emits zero `38;2` / `48;2` sequences, while `TERM_PROGRAM=Apple_Terminal TERM_PROGRAM_VERSION=487` still emits truecolor and `455` does not.

- 15 theme unit tests pass, including 5 new cases for the version gate and no-evidence fallback.
- Focused `cargo test -p tokscale-cli compatible_color_mode_emits_no_rgb_in_usage_view`: passed.
- `cargo fmt --all -- --check`: passed.
- Full `cargo test -p tokscale-cli` in this sandbox: 1014 passed, 14 failed, 1 ignored; all 14 failures were existing tests blocked by sandbox `Operation not permitted` errors while binding local test sockets, unrelated to this change. A non-sandbox rerun was not available.

Note: the 464 threshold maps Terminal 2.15 (build 464, macOS 26 Tahoe) per the Terminal.app release history; I also asked for the reporter's environment on #1060 to confirm.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes saturated color blocks by gating Apple Terminal truecolor on `TERM_PROGRAM_VERSION` and ensuring the usage view does not emit raw RGB in `Compatible` mode. Modern Terminal.app keeps 24‑bit color; older builds and terminals without evidence use the safer named‑color palette.

- **Bug Fixes**
  - Enable truecolor only for `Apple_Terminal` with `TERM_PROGRAM_VERSION >= 464`; otherwise default to `Compatible` when `COLORTERM` is unset and `TERM` provides no truecolor signal.
  - Route provider label colors in the usage view through `Theme::color` (provider summary and account table) to map RGB to named colors in `Compatible` mode.
  - Added tests for the version gate, no-evidence fallback, and no-RGB rendering in the usage view.

<sup>Written for commit c869df149aef85cf15ec68593bc45392b040bdc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

