### PR TITLE
fix(cache): defer TUI warnings until terminal restore

### DIFF
--- a/crates/tokscale-cli/src/tui/mod.rs
+++ b/crates/tokscale-cli/src/tui/mod.rs
@@ -240,7 +240,6 @@ pub fn run(
 }
 
 fn restore_terminal_best_effort() {
-    tokscale_core::tui_signal::set_tui_active(false);
     let _ = execute!(
         io::stdout(),
         LeaveAlternateScreen,
@@ -248,10 +247,12 @@ fn restore_terminal_best_effort() {
         SetTitle("")
     );
     let _ = disable_raw_mode();
+    // Flush diagnostics that were deferred while the TUI owned raw mode only
+    // after normal stderr is visible again.
+    tokscale_core::tui_signal::set_tui_active(false);
 }
 
 fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) {
-    tokscale_core::tui_signal::set_tui_active(false);
     let _ = disable_raw_mode();
     let _ = execute!(
         terminal.backend_mut(),
@@ -260,6 +261,9 @@ fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) {
         SetTitle("")
     );
     let _ = terminal.show_cursor();
+    // set_tui_active(false) drains deferred stderr, so it must be the last
+    // restoration step rather than writing into the alternate screen.
+    tokscale_core::tui_signal::set_tui_active(false);
 }
 
 fn run_loop_with_background(

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -102,6 +102,12 @@ fn ensure_cache_dir(dir: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+static WARNED_CONTEXTS: OnceLock<Mutex<HashSet<&'static str>>> = OnceLock::new();
+
+fn warned_contexts() -> &'static Mutex<HashSet<&'static str>> {
+    WARNED_CONTEXTS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
 fn warn_cache_failure_once(context: &'static str, path: &Path, error: &impl std::fmt::Display) {
     tracing::warn!(path = %path.display(), %error, %context, "source message cache failure");
 
@@ -112,9 +118,15 @@ fn warn_cache_failure_once(context: &'static str, path: &Path, error: &impl std:
     // there corrupts the rendered display. Defer that fallback until the TUI
     // restores the terminal instead of consuming the once-only warning while
     // leaving the user with no visible diagnostic (#941).
-    static WARNED_CONTEXTS: OnceLock<Mutex<HashSet<&'static str>>> = OnceLock::new();
-    let warned = WARNED_CONTEXTS.get_or_init(|| Mutex::new(HashSet::new()));
-    if warned.lock().is_ok_and(|mut warned| warned.insert(context)) {
+    // Recover from a poisoned set the way tui_signal does: an unrelated panic
+    // elsewhere must not be what silences the diagnostic this block exists to
+    // guarantee. The set only tracks which contexts were already reported, so
+    // its contents stay meaningful across an unwind.
+    if warned_contexts()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(context)
+    {
         crate::tui_signal::emit_or_defer_stderr(format!(
             "tokscale: warning: {context} ({}): {error}",
             path.display()
@@ -1905,6 +1917,50 @@ mod tests {
                 path.display()
             )],
             "a repeated failure should leave one complete warning for terminal restore"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cache_warning_survives_a_poisoned_once_only_set() {
+        const CONTEXT: &str = "test source cache warning after poisoning";
+        let previous = crate::tui_signal::is_tui_active();
+        assert!(
+            crate::tui_signal::take_deferred_stderr_for_test().is_empty(),
+            "the test must not inherit deferred diagnostics"
+        );
+
+        // An unrelated panic while the once-only set is locked poisons the
+        // mutex for the rest of the process. The warning must still reach the
+        // user instead of being silently swallowed by the poison.
+        let hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let poisoned = std::panic::catch_unwind(|| {
+            let _guard = warned_contexts().lock().expect("set is not yet poisoned");
+            panic!("unrelated panic while holding the once-only set");
+        });
+        std::panic::set_hook(hook);
+        assert!(poisoned.is_err(), "the helper panic must have unwound");
+        assert!(
+            warned_contexts().is_poisoned(),
+            "the once-only set must be poisoned for this test to mean anything"
+        );
+
+        crate::tui_signal::set_tui_active(true);
+        let path = Path::new("cache-warning-poison-test");
+        let error = std::io::Error::other("simulated cache failure");
+        warn_cache_failure_once(CONTEXT, path, &error);
+        warn_cache_failure_once(CONTEXT, path, &error);
+        let deferred = crate::tui_signal::take_deferred_stderr_for_test();
+        crate::tui_signal::set_tui_active(previous);
+
+        assert_eq!(
+            deferred,
+            vec![format!(
+                "tokscale: warning: {CONTEXT} ({}): {error}",
+                path.display()
+            )],
+            "a poisoned once-only set must still defer exactly one warning"
         );
     }
 

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -109,15 +109,16 @@ fn warn_cache_failure_once(context: &'static str, path: &Path, error: &impl std:
     // subscriber. Surface persistence failures directly once per process so a
     // permanently cold cache can never fail silently again. The TUI owns raw
     // mode and the alternate screen for its whole run, so a raw stdio write
-    // there corrupts the rendered display instead of being visible as a log
-    // line — suppress it in that case and rely on tracing::warn! (or the
-    // TUI's own status/error UI) instead.
+    // there corrupts the rendered display. Defer that fallback until the TUI
+    // restores the terminal instead of consuming the once-only warning while
+    // leaving the user with no visible diagnostic (#941).
     static WARNED_CONTEXTS: OnceLock<Mutex<HashSet<&'static str>>> = OnceLock::new();
     let warned = WARNED_CONTEXTS.get_or_init(|| Mutex::new(HashSet::new()));
-    if warned.lock().is_ok_and(|mut warned| warned.insert(context))
-        && !crate::tui_signal::is_tui_active()
-    {
-        eprintln!("tokscale: warning: {context} ({}): {error}", path.display());
+    if warned.lock().is_ok_and(|mut warned| warned.insert(context)) {
+        crate::tui_signal::emit_or_defer_stderr(format!(
+            "tokscale: warning: {context} ({}): {error}",
+            path.display()
+        ));
     }
 }
 
@@ -1878,6 +1879,34 @@ mod tests {
     use crate::TokenBreakdown;
     use std::io::Write;
     use tempfile::{NamedTempFile, TempDir};
+
+    #[test]
+    #[serial_test::serial]
+    fn cache_warning_is_deferred_once_while_the_tui_is_active() {
+        const CONTEXT: &str = "test source cache warning deferral";
+        let previous = crate::tui_signal::is_tui_active();
+        assert!(
+            crate::tui_signal::take_deferred_stderr_for_test().is_empty(),
+            "the test must not inherit deferred diagnostics"
+        );
+
+        crate::tui_signal::set_tui_active(true);
+        let path = Path::new("cache-warning-test");
+        let error = std::io::Error::other("simulated cache failure");
+        warn_cache_failure_once(CONTEXT, path, &error);
+        warn_cache_failure_once(CONTEXT, path, &error);
+        let deferred = crate::tui_signal::take_deferred_stderr_for_test();
+        crate::tui_signal::set_tui_active(previous);
+
+        assert_eq!(
+            deferred,
+            vec![format!(
+                "tokscale: warning: {CONTEXT} ({}): {error}",
+                path.display()
+            )],
+            "a repeated failure should leave one complete warning for terminal restore"
+        );
+    }
 
     #[test]
     fn from_roo_path_invalidates_on_history_only_change() {

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -109,6 +109,21 @@ fn warned_contexts() -> &'static Mutex<HashSet<&'static str>> {
 }
 
 fn warn_cache_failure_once(context: &'static str, path: &Path, error: &impl std::fmt::Display) {
+    warn_cache_failure_once_in(warned_contexts(), context, path, error);
+}
+
+/// The once-only set is a parameter purely so the poisoned-set regression test
+/// can supply its own. Mutex poisoning is irreversible, so a test that poisoned
+/// the process-global set would leave every later test in the binary depending
+/// on the very recovery it is checking. Production has exactly one caller and
+/// it always passes `warned_contexts()`, so the once-per-process,
+/// once-per-context semantics are unchanged.
+fn warn_cache_failure_once_in(
+    warned: &Mutex<HashSet<&'static str>>,
+    context: &'static str,
+    path: &Path,
+    error: &impl std::fmt::Display,
+) {
     tracing::warn!(path = %path.display(), %error, %context, "source message cache failure");
 
     // Most non-TUI commands (including `submit`) do not install a tracing
@@ -122,7 +137,7 @@ fn warn_cache_failure_once(context: &'static str, path: &Path, error: &impl std:
     // elsewhere must not be what silences the diagnostic this block exists to
     // guarantee. The set only tracks which contexts were already reported, so
     // its contents stay meaningful across an unwind.
-    if warned_contexts()
+    if warned
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .insert(context)
@@ -1896,22 +1911,23 @@ mod tests {
     #[serial_test::serial]
     fn cache_warning_is_deferred_once_while_the_tui_is_active() {
         const CONTEXT: &str = "test source cache warning deferral";
-        let previous = crate::tui_signal::is_tui_active();
+        let mut tui = crate::tui_signal::TuiActiveGuard::capture();
         assert!(
             crate::tui_signal::take_deferred_stderr_for_test().is_empty(),
             "the test must not inherit deferred diagnostics"
         );
 
-        crate::tui_signal::set_tui_active(true);
+        // Deliberately the real process-global set, so the production entry
+        // point and its once-per-context bookkeeping stay covered. The
+        // poisoning test below is the one that needs an isolated set.
+        tui.set(true);
         let path = Path::new("cache-warning-test");
         let error = std::io::Error::other("simulated cache failure");
         warn_cache_failure_once(CONTEXT, path, &error);
         warn_cache_failure_once(CONTEXT, path, &error);
-        let deferred = crate::tui_signal::take_deferred_stderr_for_test();
-        crate::tui_signal::set_tui_active(previous);
 
         assert_eq!(
-            deferred,
+            crate::tui_signal::take_deferred_stderr_for_test(),
             vec![format!(
                 "tokscale: warning: {CONTEXT} ({}): {error}",
                 path.display()
@@ -1924,38 +1940,44 @@ mod tests {
     #[serial_test::serial]
     fn cache_warning_survives_a_poisoned_once_only_set() {
         const CONTEXT: &str = "test source cache warning after poisoning";
-        let previous = crate::tui_signal::is_tui_active();
+        let mut tui = crate::tui_signal::TuiActiveGuard::capture();
         assert!(
             crate::tui_signal::take_deferred_stderr_for_test().is_empty(),
             "the test must not inherit deferred diagnostics"
         );
 
+        // Poison a set scoped to this test rather than the process-global one:
+        // poisoning cannot be undone, so poisoning the real set would make
+        // every later test in this binary depend on the recovery under test.
+        let warned: Mutex<HashSet<&'static str>> = Mutex::new(HashSet::new());
+
         // An unrelated panic while the once-only set is locked poisons the
-        // mutex for the rest of the process. The warning must still reach the
-        // user instead of being silently swallowed by the poison.
-        let hook = std::panic::take_hook();
-        std::panic::set_hook(Box::new(|_| {}));
+        // mutex. The warning must still reach the user instead of being
+        // silently swallowed by the poison.
+        //
+        // No panic hook is installed here. The hook is process-global, so
+        // swapping it would suppress the diagnostics of whatever else runs in
+        // parallel; this unwind happens on the test's own thread, which
+        // libtest already captures, so the expected panic message is only
+        // printed if this test fails.
         let poisoned = std::panic::catch_unwind(|| {
-            let _guard = warned_contexts().lock().expect("set is not yet poisoned");
+            let _guard = warned.lock().expect("set is not yet poisoned");
             panic!("unrelated panic while holding the once-only set");
         });
-        std::panic::set_hook(hook);
         assert!(poisoned.is_err(), "the helper panic must have unwound");
         assert!(
-            warned_contexts().is_poisoned(),
+            warned.is_poisoned(),
             "the once-only set must be poisoned for this test to mean anything"
         );
 
-        crate::tui_signal::set_tui_active(true);
+        tui.set(true);
         let path = Path::new("cache-warning-poison-test");
         let error = std::io::Error::other("simulated cache failure");
-        warn_cache_failure_once(CONTEXT, path, &error);
-        warn_cache_failure_once(CONTEXT, path, &error);
-        let deferred = crate::tui_signal::take_deferred_stderr_for_test();
-        crate::tui_signal::set_tui_active(previous);
+        warn_cache_failure_once_in(&warned, CONTEXT, path, &error);
+        warn_cache_failure_once_in(&warned, CONTEXT, path, &error);
 
         assert_eq!(
-            deferred,
+            crate::tui_signal::take_deferred_stderr_for_test(),
             vec![format!(
                 "tokscale: warning: {CONTEXT} ({}): {error}",
                 path.display()

--- a/crates/tokscale-core/src/tui_signal.rs
+++ b/crates/tokscale-core/src/tui_signal.rs
@@ -77,10 +77,14 @@ pub(crate) fn take_deferred_stderr_for_test() -> Vec<String> {
 /// failure with nothing to do with what it asserts. This mirrors
 /// `paths::test_env::EnvGuard`, which exists for the same reason.
 ///
-/// `Drop` also drains whatever the test deferred. Restoring through
-/// `set_tui_active` would instead `eprintln!` the test's synthetic
-/// diagnostics onto the real stderr, and leaving them queued would surface in
-/// the next test's `take_deferred_stderr_for_test`.
+/// `Drop` restores through `transition_tui_active`, which makes the queue
+/// follow the state being restored. Restoring to inactive drains whatever the
+/// test deferred: restoring through `set_tui_active` would instead `eprintln!`
+/// the test's synthetic diagnostics onto the real stderr, and leaving them
+/// queued would surface in the next test's `take_deferred_stderr_for_test`.
+/// Restoring to *active* leaves the queue alone, because an enclosing active
+/// scope still owns the terminal and its deferred diagnostics are owed to the
+/// eventual restore, not to this guard.
 #[cfg(test)]
 pub(crate) struct TuiActiveGuard {
     previous: bool,
@@ -105,7 +109,11 @@ impl TuiActiveGuard {
 #[cfg(test)]
 impl Drop for TuiActiveGuard {
     fn drop(&mut self) {
-        let _discarded = transition_tui_active(false);
+        // One transition, so the queue's fate matches the state actually being
+        // restored. Draining unconditionally first would discard diagnostics an
+        // enclosing active scope had deferred and still owes its user, turning
+        // "restore the previous value" into a silent teardown of state this
+        // guard never owned.
         let _discarded = transition_tui_active(self.previous);
     }
 }
@@ -170,6 +178,45 @@ mod tests {
             take_deferred_stderr_for_test().is_empty(),
             "TuiActiveGuard must drain what the probe deferred instead of \
              leaving it for the next test"
+        );
+    }
+
+    /// Restoring is not the same as tearing down. When the captured previous
+    /// value is active, an enclosing scope still owns the terminal, and the
+    /// diagnostics queued for its eventual restore must outlive this guard.
+    #[test]
+    #[serial]
+    fn tui_active_guard_restoring_an_active_scope_keeps_the_deferred_queue() {
+        // The outermost guard is what cleans up: its own previous value is
+        // inactive, so its drop drains the queue and clears TUI_ACTIVE however
+        // this test exits.
+        let mut outer = TuiActiveGuard::capture();
+        assert!(
+            take_deferred_stderr_for_test().is_empty(),
+            "the test must not inherit deferred diagnostics"
+        );
+        outer.set(true);
+
+        let marker = "deferred inside a nested capture".to_string();
+        {
+            let mut nested = TuiActiveGuard::capture();
+            assert!(
+                nested.previous,
+                "the nested guard must capture the enclosing active state"
+            );
+            nested.set(true);
+            assert!(route_stderr(marker.clone()).is_none());
+        }
+
+        assert!(
+            is_tui_active(),
+            "restoring an active previous value must leave the TUI active"
+        );
+        assert_eq!(
+            take_deferred_stderr_for_test(),
+            vec![marker],
+            "restoring an active scope must not discard the diagnostics that \
+             scope still owes its eventual terminal restore"
         );
     }
 }

--- a/crates/tokscale-core/src/tui_signal.rs
+++ b/crates/tokscale-core/src/tui_signal.rs
@@ -67,6 +67,49 @@ pub(crate) fn take_deferred_stderr_for_test() -> Vec<String> {
     std::mem::take(&mut *deferred)
 }
 
+/// Sets `TUI_ACTIVE` for the duration of a test and restores the previous
+/// value on `Drop`, so an unwind restores it too.
+///
+/// `TUI_ACTIVE` and the deferred queue behind it are process-global. Restoring
+/// them by hand just before a test's final assertion leaks the mutation into
+/// every later test in the binary if anything in between panics, and the next
+/// test to run then defers diagnostics it expected to see on stderr — a
+/// failure with nothing to do with what it asserts. This mirrors
+/// `paths::test_env::EnvGuard`, which exists for the same reason.
+///
+/// `Drop` also drains whatever the test deferred. Restoring through
+/// `set_tui_active` would instead `eprintln!` the test's synthetic
+/// diagnostics onto the real stderr, and leaving them queued would surface in
+/// the next test's `take_deferred_stderr_for_test`.
+#[cfg(test)]
+pub(crate) struct TuiActiveGuard {
+    previous: bool,
+}
+
+#[cfg(test)]
+impl TuiActiveGuard {
+    pub(crate) fn capture() -> Self {
+        Self {
+            previous: is_tui_active(),
+        }
+    }
+
+    /// Takes `&mut self` for the same reason `EnvGuard::set` does: it reads
+    /// correctly for a method whose whole purpose is to mutate process-global
+    /// state, and it keeps the guard's owner from being aliased away.
+    pub(crate) fn set(&mut self, active: bool) {
+        let _discarded = transition_tui_active(active);
+    }
+}
+
+#[cfg(test)]
+impl Drop for TuiActiveGuard {
+    fn drop(&mut self) {
+        let _discarded = transition_tui_active(false);
+        let _discarded = transition_tui_active(self.previous);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -75,7 +118,7 @@ mod tests {
     #[test]
     #[serial]
     fn defers_stderr_until_the_tui_is_inactive() {
-        let previous = is_tui_active();
+        let _restore = TuiActiveGuard::capture();
 
         assert!(
             transition_tui_active(false).is_empty(),
@@ -94,7 +137,39 @@ mod tests {
             route_stderr("immediate diagnostic".to_string()),
             Some("immediate diagnostic".to_string())
         );
+    }
 
-        let _ = transition_tui_active(previous);
+    /// The guard's whole reason to exist, mirroring
+    /// `paths::test_env::EnvGuard`'s equivalent proof: a panic between
+    /// mutating `TUI_ACTIVE` and restoring it must not leak the mutation into
+    /// the next test scheduled in this binary.
+    #[test]
+    #[serial]
+    fn tui_active_guard_restores_even_when_the_probe_panics() {
+        // Practise what the test preaches: restore on the way out however
+        // this test exits.
+        let _restore = TuiActiveGuard::capture();
+        let _discarded = transition_tui_active(false);
+
+        // The panic below is deliberate. It unwinds on this test's own thread,
+        // which libtest already captures, so no process-global panic hook is
+        // swapped to keep it out of the output.
+        let outcome = std::panic::catch_unwind(|| {
+            let mut tui = TuiActiveGuard::capture();
+            tui.set(true);
+            assert!(route_stderr("deferred by the probe".to_string()).is_none());
+            panic!("simulated assertion failure");
+        });
+
+        assert!(outcome.is_err(), "the probe closure must have panicked");
+        assert!(
+            !is_tui_active(),
+            "TuiActiveGuard must restore the previous value while unwinding"
+        );
+        assert!(
+            take_deferred_stderr_for_test().is_empty(),
+            "TuiActiveGuard must drain what the probe deferred instead of \
+             leaving it for the next test"
+        );
     }
 }

--- a/crates/tokscale-core/src/tui_signal.rs
+++ b/crates/tokscale-core/src/tui_signal.rs
@@ -1,20 +1,70 @@
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 // Some diagnostics (e.g. cache save failures) fall back to a direct
 // eprintln! when no tracing subscriber is guaranteed to be installed, so
 // non-TUI commands still surface them. The TUI owns raw mode and the
 // crossterm alternate screen for its whole lifetime, and a stray stdio
 // write there corrupts the rendered display instead of being visible as a
-// normal log line. This flag lets that diagnostic code suppress the raw
-// stdio fallback while the TUI holds the terminal.
+// normal log line. Diagnostics routed through this module are held until the
+// TUI releases the terminal, then written once the normal screen is restored.
 static TUI_ACTIVE: AtomicBool = AtomicBool::new(false);
+static DEFERRED_STDERR: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+fn deferred_stderr() -> &'static Mutex<Vec<String>> {
+    DEFERRED_STDERR.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn transition_tui_active(active: bool) -> Vec<String> {
+    // Coordinate the state transition with routing a diagnostic. Without the
+    // shared lock, a writer could observe active, lose a race with the flush,
+    // and enqueue a message after the queue had already been drained.
+    let mut deferred = deferred_stderr()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    TUI_ACTIVE.store(active, Ordering::Relaxed);
+
+    if active {
+        Vec::new()
+    } else {
+        std::mem::take(&mut *deferred)
+    }
+}
 
 pub fn set_tui_active(active: bool) {
-    TUI_ACTIVE.store(active, Ordering::Relaxed);
+    for message in transition_tui_active(active) {
+        eprintln!("{message}");
+    }
 }
 
 pub fn is_tui_active() -> bool {
     TUI_ACTIVE.load(Ordering::Relaxed)
+}
+
+fn route_stderr(message: String) -> Option<String> {
+    let mut deferred = deferred_stderr()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if is_tui_active() {
+        deferred.push(message);
+        None
+    } else {
+        Some(message)
+    }
+}
+
+pub(crate) fn emit_or_defer_stderr(message: String) {
+    if let Some(message) = route_stderr(message) {
+        eprintln!("{message}");
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn take_deferred_stderr_for_test() -> Vec<String> {
+    let mut deferred = deferred_stderr()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    std::mem::take(&mut *deferred)
 }
 
 #[cfg(test)]
@@ -24,12 +74,27 @@ mod tests {
 
     #[test]
     #[serial]
-    fn round_trips() {
+    fn defers_stderr_until_the_tui_is_inactive() {
         let previous = is_tui_active();
-        set_tui_active(true);
+
+        assert!(
+            transition_tui_active(false).is_empty(),
+            "the test must not inherit deferred diagnostics"
+        );
+        assert!(transition_tui_active(true).is_empty());
         assert!(is_tui_active());
-        set_tui_active(false);
+
+        let marker = "deferred TUI diagnostic".to_string();
+        assert!(route_stderr(marker.clone()).is_none());
+
+        assert_eq!(transition_tui_active(false), vec![marker]);
         assert!(!is_tui_active());
-        set_tui_active(previous);
+        assert!(transition_tui_active(false).is_empty());
+        assert_eq!(
+            route_stderr("immediate diagnostic".to_string()),
+            Some("immediate diagnostic".to_string())
+        );
+
+        let _ = transition_tui_active(previous);
     }
 }


### PR DESCRIPTION
## What changed

- defer cache persistence warnings while the TUI owns raw mode and the alternate screen
- flush deferred warnings after terminal restoration while preserving once-per-context behavior
- coordinate warning routing and TUI state changes to prevent enqueue-after-flush races
- add regression coverage for warning deferral, formatting, and deduplication

## Why

`warn_cache_failure_once` previously recorded the warning context before checking whether the TUI was active. A cache failure during a TUI session therefore consumed the once-per-process warning while suppressing its only visible output, leaving users with repeated cold reparses and no diagnostic.

This addresses the cache-warning subtask in #941 without closing the umbrella issue.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-features -- -D warnings`
- targeted cache-warning and TUI deferral regression tests
- `cargo test --workspace --all-features`: 2,665 tests passed; one unrelated permission test fails under a root container because root can read a `chmod 000` fixture. The failure reproduces on clean `upstream/main`, and the same test passes as a non-root user.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers cache warnings while the TUI owns the terminal and flushes them after restore, preventing screen corruption and ensuring the once-per-context warning shows. Hardens the warning path against a poisoned once-only set, and fixes the test guard to preserve deferred output in nested active scopes.

- **Bug Fixes**
  - Route cache warning fallback via `tui_signal::emit_or_defer_stderr`; keep once-per-context behavior without consuming it during TUI.
  - Flush deferred stderr on restore by calling `set_tui_active(false)` last; coordinate state and queue behind a shared lock to avoid enqueue-after-flush races.
  - Recover from a poisoned once-only set using `unwrap_or_else(...into_inner())`; factor `warn_cache_failure_once_in` so tests isolate a poisoned set.
  - Add `TuiActiveGuard`; restore previous state in a single transition so nested active scopes keep their deferred diagnostics; add regression test.

<sup>Written for commit 314435d0951d38127c3394c705ebab33171311fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

