### PR TITLE
docs(ci): describe the windows leg as it is today, not as it was on 08-03

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -57,16 +57,21 @@ jobs:
   #
   # The windows leg is advisory (`continue-on-error`) and Ubuntu stays a hard
   # gate. That split is deliberate and temporary. Running the suite for the
-  # first time found 33 pre-existing failures that no one has ever seen,
+  # first time found 33 pre-existing failures that no one had ever seen,
   # because cargo used to stop at the first failing binary and nine of the ten
-  # never ran at all. They are not one bug: they span at least six unrelated
-  # root causes, and two of those groups (the crush registry scan returning
-  # nothing, cc-mirror attributing the wrong provider) look like real Windows
-  # defects rather than test artefacts. Blocking every PR on them would mean
-  # either reverting this job or landing a 30-plus-fix change nobody can
-  # review, so the signal goes in first and the failures get fixed against a
-  # visible baseline. See #1014 for the enumerated groups.
+  # never ran at all. They spanned six unrelated root causes, enumerated in
+  # #1014, and all six have since been addressed: the leg is green on main,
+  # 2,679 passed / 0 failed across all 11 binaries.
   #
+  # Two of those groups were first read as real Windows product defects: the
+  # crush registry scan returning nothing, and cc-mirror attributing the wrong
+  # provider. Both turned out to be fixture artefacts. The tests built their
+  # JSON by interpolating a path into a string literal, and on Windows the
+  # backslashes land unescaped, so `serde_json` rejected the fixture and the
+  # parse error was swallowed into an empty result. Crush discovery was
+  # additionally verified working against a real Windows install. See #1014.
+  #
+  # The leg stays advisory until the two un-redirected config roots are swept.
   # This must not become permanent: an advisory job nobody reads is how #997
   # happened. Flip `continue-on-error` off as soon as #1014 closes.
   tests:


### PR DESCRIPTION
Item 3 of the remaining work listed in #1014: the comment block above the
`tests` job still describes the state of 2026-08-03.

It currently says the six root causes are open, that 33 failures are
outstanding, and that two of the groups "look like real Windows defects rather
than test artefacts". All three are now false. The leg is green on main, and
those two groups were traced to fixtures that built their JSON by interpolating
a path into a string literal, which produces unescaped backslashes and an
unparseable fixture on Windows only.

That matters beyond tidiness, for the reason given in the issue: this comment is
what a future reader consults before touching the leg.

What changed:

- the six groups are described as addressed, with the current numbers
- the two suspected product defects are described as what they turned out to be,
  with the mechanism in one sentence rather than a bare pointer
- the condition for flipping the gate is now stated: the leg stays advisory
  until the two un-redirected config roots are swept

What did not change: `continue-on-error` is untouched, and so is the closing
instruction to flip it when #1014 closes. Sweeping the config roots is item 1 on
your list and comes before the flip, so this PR does not pre-empt either.

No code, one comment block.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Windows test leg comment in `.github/workflows/test_coverage.yml` to match the current state and gate policy. It notes all six groups from #1014 are resolved and the leg is green on `main` (2,679 passed, 0 failed), clarifies the two suspected defects were fixture artefacts (`serde_json` rejecting unescaped Windows backslashes), and states to keep `continue-on-error` until the two un-redirected config roots are swept, then flip it when #1014 closes.

<sup>Written for commit da7e8311a2eb7ebd9aca04359c33c845b76b3793. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

