### PR TITLE
fix(pricing): resolve Anthropic moving aliases and Cursor's free cache creation

### DIFF
--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -89,6 +89,21 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("claude-opus-4.6", "claude-opus-4-6");
     m.insert("claude-sonnet-4.6", "claude-sonnet-4-6");
     m.insert("claude-haiku-4.6", "claude-haiku-4-6");
+    // Anthropic's "-0" suffix is their documented moving alias for the latest
+    // snapshot of a model line (claude-opus-4-0 -> newest Opus 4). Datasets
+    // publish the dated key instead, so the alias form resolved to nothing and
+    // real first-party usage was excluded from submission as unpriced.
+    m.insert("claude-opus-4-0", "claude-opus-4");
+    m.insert("claude-sonnet-4-0", "claude-sonnet-4");
+    // GitHub Copilot reports Claude 4.1 without the separator. Copilot usage is
+    // priced at the underlying model's rates (its own $0.00 subscription rows
+    // are filtered out by EXCLUDED_LITELLM_PREFIXES), so this must resolve the
+    // same way github_copilot/gpt-4o already resolves to gpt-4o.
+    // Deliberately opus-only: `claude-sonnet-4-1` currently resolves to
+    // `databricks/databricks-claude-sonnet-4-1` via a cross-vendor fuzzy match
+    // (#1062), so aliasing the Copilot spelling onto it would route Sonnet 4.1
+    // usage to Databricks rates. Add it once #1062 makes that target safe.
+    m.insert("claude-opus-41", "claude-opus-4-1");
     m.insert("anthropic/claude-4-5-opus", "claude-opus-4-5");
     m.insert("anthropic/claude-4-5-sonnet", "claude-sonnet-4-5");
     m.insert("anthropic/claude-4-5-haiku", "claude-haiku-4-5");
@@ -235,5 +250,36 @@ mod tests {
 
         assert_eq!(m187_result.matched_key, "google/gemini-3.5-flash");
         assert_eq!(m20_result.matched_key, "google/gemini-3.5-flash");
+    }
+
+    /// Regression: Anthropic's "-0" suffix is a documented moving alias for the
+    /// latest snapshot of a model line, and GitHub Copilot reports 4.1 without
+    /// the separator. Neither form resolved, so real first-party usage was
+    /// excluded from submission as unpriced — 41M tokens of claude-opus-4-0 in
+    /// one reported case.
+    #[test]
+    fn anthropic_moving_aliases_and_copilot_spelling_resolve() {
+        assert_eq!(
+            super::resolve_alias("claude-opus-4-0"),
+            Some("claude-opus-4")
+        );
+        assert_eq!(
+            super::resolve_alias("claude-sonnet-4-0"),
+            Some("claude-sonnet-4")
+        );
+        assert_eq!(
+            super::resolve_alias("claude-opus-41"),
+            Some("claude-opus-4-1")
+        );
+        // Case-insensitive, since clients report mixed casing.
+        assert_eq!(
+            super::resolve_alias("Claude-Opus-4-0"),
+            Some("claude-opus-4")
+        );
+
+        // Deliberately absent: `claude-sonnet-4-1` resolves cross-vendor to
+        // `databricks/databricks-claude-sonnet-4-1` today (#1062), so aliasing
+        // the Copilot spelling onto it would route usage to the wrong rates.
+        assert_eq!(super::resolve_alias("claude-sonnet-41"), None);
     }
 }

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -107,43 +107,63 @@ impl PricingService {
     // so real upstream entries (including provider-prefixed like openai/gpt-5.3-codex)
     // always win. Source citations are required for audit trail.
     fn build_cursor_overrides() -> HashMap<String, ModelPricing> {
-        let entries: &[(&str, f64, f64, Option<f64>)] = &[
+        // @keep: the difference between `None` and `Some(0.0)` here is load-bearing.
+        // The 5th field is cache CREATION. `None` means "rate unknown", and
+        // `covers_usage` then reports the row as not covering any usage that
+        // populates cache_write — which excludes it from submission entirely.
+        // `Some(0.0)` means "documented free". `compute_cost` already reads an
+        // absent rate as 0.0, so the two produce an identical cost; only the
+        // coverage verdict differs. Set it ONLY where Cursor documents cache
+        // creation as free — guessing a rate would invent spend.
+        /// `(model id, input, output, cache read, cache creation)`, per token.
+        ///
+        /// Both cache rates distinguish "unknown" from "free": `None` means the
+        /// rate is undocumented, `Some(0.0)` means Cursor publishes it as free.
+        type CursorRateRow = (&'static str, f64, f64, Option<f64>, Option<f64>);
+
+        let entries: &[CursorRateRow] = &[
             // GPT-5.3 family: $1.75/$14.00 per 1M tokens, $0.175 cache read
             // Source: Cursor docs (cursor.com/en-US/docs/models), llm-stats.com
-            ("gpt-5.3", 0.00000175, 0.000014, Some(1.75e-7)),
-            ("gpt-5.3-codex", 0.00000175, 0.000014, Some(1.75e-7)),
-            ("gpt-5.3-codex-spark", 0.00000175, 0.000014, Some(1.75e-7)),
+            ("gpt-5.3", 0.00000175, 0.000014, Some(1.75e-7), None),
+            ("gpt-5.3-codex", 0.00000175, 0.000014, Some(1.75e-7), None),
+            (
+                "gpt-5.3-codex-spark",
+                0.00000175,
+                0.000014,
+                Some(1.75e-7),
+                None,
+            ),
             // Composer 1: $1.25/$10.00 per 1M tokens, $0.125 cache read
             // Source: Cursor docs (cursor.com/docs/models#model-pricing)
-            ("composer 1", 0.00000125, 0.00001, Some(1.25e-7)),
-            ("composer-1", 0.00000125, 0.00001, Some(1.25e-7)),
+            ("composer 1", 0.00000125, 0.00001, Some(1.25e-7), None),
+            ("composer-1", 0.00000125, 0.00001, Some(1.25e-7), None),
             // Composer 1.5: $3.50/$17.50 per 1M tokens, $0.35 cache read
             // Source: Cursor docs (cursor.com/docs/models#model-pricing), issue #276
-            ("composer 1.5", 0.0000035, 0.0000175, Some(3.5e-7)),
-            ("composer-1.5", 0.0000035, 0.0000175, Some(3.5e-7)),
+            ("composer 1.5", 0.0000035, 0.0000175, Some(3.5e-7), None),
+            ("composer-1.5", 0.0000035, 0.0000175, Some(3.5e-7), None),
             // Composer 2: $0.50/$2.50 per 1M input/output, $0.20/M cache read; cache creation free
             // Composer 2 Fast: $1.50/$7.50 per 1M, $0.35/M cache read; cache creation free
             // Source: Cursor docs (cursor.com/docs/models#model-pricing)
-            ("composer 2", 5e-7, 2.5e-6, Some(2e-7)),
-            ("composer-2", 5e-7, 2.5e-6, Some(2e-7)),
-            ("composer 2 fast", 1.5e-6, 7.5e-6, Some(3.5e-7)),
-            ("composer-2-fast", 1.5e-6, 7.5e-6, Some(3.5e-7)),
+            ("composer 2", 5e-7, 2.5e-6, Some(2e-7), Some(0.0)),
+            ("composer-2", 5e-7, 2.5e-6, Some(2e-7), Some(0.0)),
+            ("composer 2 fast", 1.5e-6, 7.5e-6, Some(3.5e-7), Some(0.0)),
+            ("composer-2-fast", 1.5e-6, 7.5e-6, Some(3.5e-7), Some(0.0)),
             // Composer 2: $0.50/$2.50 per 1M input/output, $0.20/M cache read; cache creation free
             // Composer 2 Fast: $1.50/$7.50 per 1M, $0.35/M cache read; cache creation free
             // Source: Cursor docs (cursor.com/docs/models#model-pricing)
-            ("composer-2.5", 5e-7, 2.5e-6, Some(2e-7)),
-            ("composer-2.5-fast", 1.5e-6, 7.5e-6, Some(3.5e-7)),
+            ("composer-2.5", 5e-7, 2.5e-6, Some(2e-7), Some(0.0)),
+            ("composer-2.5-fast", 1.5e-6, 7.5e-6, Some(3.5e-7), Some(0.0)),
         ];
 
         let mut overrides = HashMap::with_capacity(entries.len());
-        for (model_id, input, output, cache_read) in entries {
+        for (model_id, input, output, cache_read, cache_creation) in entries {
             overrides.insert(
                 model_id.to_string(),
                 ModelPricing {
                     input_cost_per_token: Some(*input),
                     output_cost_per_token: Some(*output),
                     cache_read_input_token_cost: *cache_read,
-                    cache_creation_input_token_cost: None,
+                    cache_creation_input_token_cost: *cache_creation,
                     ..Default::default()
                 },
             );
@@ -1165,7 +1185,10 @@ mod tests {
         assert_eq!(result.pricing.input_cost_per_token, Some(5e-7));
         assert_eq!(result.pricing.output_cost_per_token, Some(2.5e-6));
         assert_eq!(result.pricing.cache_read_input_token_cost, Some(2e-7));
-        assert_eq!(result.pricing.cache_creation_input_token_cost, None);
+        // Cursor documents cache creation as FREE for the Composer 2 family.
+        // Some(0.0) and None compute the same cost, but only Some(0.0)
+        // makes covers_usage accept cache_write usage for submission.
+        assert_eq!(result.pricing.cache_creation_input_token_cost, Some(0.0));
     }
 
     #[test]
@@ -1185,7 +1208,10 @@ mod tests {
         assert_eq!(result.pricing.input_cost_per_token, Some(1.5e-6));
         assert_eq!(result.pricing.output_cost_per_token, Some(7.5e-6));
         assert_eq!(result.pricing.cache_read_input_token_cost, Some(3.5e-7));
-        assert_eq!(result.pricing.cache_creation_input_token_cost, None);
+        // Cursor documents cache creation as FREE for the Composer 2 family.
+        // Some(0.0) and None compute the same cost, but only Some(0.0)
+        // makes covers_usage accept cache_write usage for submission.
+        assert_eq!(result.pricing.cache_creation_input_token_cost, Some(0.0));
     }
 
     #[test]
@@ -1240,7 +1266,10 @@ mod tests {
         assert_eq!(result.pricing.input_cost_per_token, Some(5e-7));
         assert_eq!(result.pricing.output_cost_per_token, Some(2.5e-6));
         assert_eq!(result.pricing.cache_read_input_token_cost, Some(2e-7));
-        assert_eq!(result.pricing.cache_creation_input_token_cost, None);
+        // Cursor documents cache creation as FREE for the Composer 2 family.
+        // Some(0.0) and None compute the same cost, but only Some(0.0)
+        // makes covers_usage accept cache_write usage for submission.
+        assert_eq!(result.pricing.cache_creation_input_token_cost, Some(0.0));
     }
 
     #[test]
@@ -1254,7 +1283,10 @@ mod tests {
         assert_eq!(result.pricing.input_cost_per_token, Some(1.5e-6));
         assert_eq!(result.pricing.output_cost_per_token, Some(7.5e-6));
         assert_eq!(result.pricing.cache_read_input_token_cost, Some(3.5e-7));
-        assert_eq!(result.pricing.cache_creation_input_token_cost, None);
+        // Cursor documents cache creation as FREE for the Composer 2 family.
+        // Some(0.0) and None compute the same cost, but only Some(0.0)
+        // makes covers_usage accept cache_write usage for submission.
+        assert_eq!(result.pricing.cache_creation_input_token_cost, Some(0.0));
     }
 
     #[test]
@@ -1326,6 +1358,36 @@ mod tests {
             lower.unwrap().pricing.input_cost_per_token,
             upper.unwrap().pricing.input_cost_per_token
         );
+    }
+
+    /// Regression: Composer 2's cache creation is documented FREE, but it was
+    /// encoded as `None` ("rate unknown"), so `covers_usage` reported the row
+    /// as not covering any usage with cache_write and submission excluded it.
+    /// The cost is unchanged either way — `compute_cost` reads an absent rate
+    /// as 0.0 — so this is purely about the coverage verdict.
+    #[test]
+    fn cursor_documented_free_cache_creation_covers_cache_write_usage() {
+        let overrides = PricingService::build_cursor_overrides();
+        let usage = crate::TokenBreakdown {
+            input: 1_000,
+            output: 500,
+            cache_read: 200,
+            cache_write: 300,
+            ..Default::default()
+        };
+
+        let composer2 = overrides.get("composer-2").expect("composer-2 override");
+        assert_eq!(composer2.cache_creation_input_token_cost, Some(0.0));
+        assert!(
+            composer2.covers_usage(&usage),
+            "documented-free cache creation must count as covered"
+        );
+
+        // Composer 1 has no documented cache-creation rate, so it stays unknown
+        // rather than being guessed at zero. Excluding it is the honest answer.
+        let composer1 = overrides.get("composer-1").expect("composer-1 override");
+        assert_eq!(composer1.cache_creation_input_token_cost, None);
+        assert!(!composer1.covers_usage(&usage));
     }
 
     #[test]


### PR DESCRIPTION
Found by running every model from a real `submit` run — which excluded **150,981,677 tokens** as unpriced — through the actual lookup instead of reasoning from names.

## Alias gaps — 41,531,388 tokens, models that were already priced

```
claude-opus-4-0        -> Model not found       (41,145,036 tokens in that run)
claude-opus-4-20250514 -> $15.00 / 1M (LiteLLM)   ...the same model

claude-opus-41         -> Model not found       (386,352 tokens)
claude-opus-4-1        -> $15.00 / 1M (LiteLLM)   ...the same model
```

`-0` is Anthropic's documented moving alias for the latest snapshot of a line; datasets publish the dated key. `claude-opus-41` is Copilot's unpunctuated spelling of Opus 4.1.

Aliasing the Copilot form is deliberate, not incidental: Copilot's own `$0.00` subscription rows are dropped by `EXCLUDED_LITELLM_PREFIXES` *precisely so* usage prices at the underlying model's rates — which is already how `github_copilot/gpt-4o` resolves to `gpt-4o` at $2.50/1M.

**`claude-sonnet-41` is deliberately omitted.** `claude-sonnet-4-1` currently resolves cross-vendor to `databricks/databricks-claude-sonnet-4-1` (#1062), so aliasing the Copilot spelling onto it would route Sonnet 4.1 usage to Databricks rates — creating an instance of the bug rather than fixing one. The test asserts its absence so nobody "completes the set" later without checking.

## Cursor cache creation: free encoded as unknown

The override table had **no cache-creation column at all** — it hard-coded `None` for every row, two lines below a comment reading *"cache creation free"*.

`None` means *rate unknown*, so `covers_usage` reports the row as not covering any usage that populates `cache_write`, and submission excludes it. `compute_cost` already reads an absent rate as `0.0`, so `Some(0.0)` computes an **identical cost** — only the coverage verdict changes. No total moves.

Applied only to the Composer 2 family, which Cursor documents as free. Composer 1 / 1.5 / GPT-5.3 keep `None`, because their cache-creation rate genuinely isn't documented and guessing one would invent spend.

## Three things I checked and did NOT change

- **`sakana/fugu`** (3,920,834 tokens) — `mod.rs` documents it as a router billed at "the standard rate of the underlying top-tier model", unrecoverable from the session log. Any fixed rate would be wrong. Deliberately unpriced, working as intended.
- **`opencode/big-pickle`** (22,693,771 tokens) — already an intentional alias to `glm-4.7` (`aliases.rs:6`). Its exclusion is a cache-coverage gap on `z-ai/glm-4.7`, not a bad match.
- **`cursor/composer-1`** (4,247,317 tokens) — *not* fixed here. Cursor documents cache-creation-free for Composer 2 but not Composer 1, so this needs the real rate, not a code change.

## Tests

- `cargo test -p tokscale-core --lib` — 1,492 passed, 0 failed
- `cargo fmt --all --check` clean; `cargo clippy --all-targets -- -D warnings` clean
- New: `anthropic_moving_aliases_and_copilot_spelling_resolve`, `cursor_documented_free_cache_creation_covers_cache_write_usage` (asserts Composer 2 covers cache_write **and** that Composer 1 still does not)
- Four existing `test_cursor_returns_pricing_for_composer_2*` tests updated — they pinned `None` without a rationale; the comment now explains why `Some(0.0)` is the meaningful value

Verified end-to-end after the change: both aliases resolve.

Remaining exclusions from that run are #1062 (cross-vendor fuzzy matches) and routing labels like `cursor/auto` and `cursor/agent_review` that have no priceable identity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic alias resolution and Cursor Composer 2 cache-creation pricing so previously excluded usage is covered in submissions. Restores coverage without changing any cost totals.

- **Bug Fixes**
  - Resolve Anthropic moving aliases and Copilot spelling:
    - `claude-opus-4-0` → `claude-opus-4`, `claude-sonnet-4-0` → `claude-sonnet-4`, and `claude-opus-41` → `claude-opus-4-1`.
    - Intentionally omit `claude-sonnet-41` to avoid routing Sonnet 4.1 to Databricks rates.
  - Encode Cursor Composer 2/2.5 cache creation as `Some(0.0)` so `cache_write` usage is covered; Composer 1/1.5/`gpt-5.3` remain `None` (undocumented).
  - Add regression tests for alias resolution and Cursor coverage; update existing Composer 2 tests.

<sup>Written for commit 36e2bb8d2f2512422ffde401ae68cdce03bb0145. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

