### PR TITLE
ci(windows): make the windows-latest test leg a hard gate

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -55,24 +55,21 @@ jobs:
   # x86_64/aarch64-pc-windows-msvc artifacts - but until #997 nothing ever
   # *executed* a test there, so Windows-only defects reached users unseen.
   #
-  # The windows leg is advisory (`continue-on-error`) and Ubuntu stays a hard
-  # gate. That split is deliberate and temporary. Running the suite for the
-  # first time found 33 pre-existing failures that no one has ever seen,
-  # because cargo used to stop at the first failing binary and nine of the ten
-  # never ran at all. They are not one bug: they span at least six unrelated
-  # root causes, and two of those groups (the crush registry scan returning
-  # nothing, cc-mirror attributing the wrong provider) look like real Windows
-  # defects rather than test artefacts. Blocking every PR on them would mean
-  # either reverting this job or landing a 30-plus-fix change nobody can
-  # review, so the signal goes in first and the failures get fixed against a
-  # visible baseline. See #1014 for the enumerated groups.
+  # The leg was advisory (`continue-on-error`) while the 33 pre-existing
+  # failures that first run exposed were worked through: six unrelated root
+  # causes, including two real Windows product defects (the crush registry
+  # scan returning nothing, cc-mirror attributing the wrong provider). Those
+  # landed in #1007, #1012 and #1046, and the suite now completes green across
+  # all 11 binaries.
   #
-  # This must not become permanent: an advisory job nobody reads is how #997
-  # happened. Flip `continue-on-error` off as soon as #1014 closes.
+  # It is a HARD GATE as of this change. The advisory phase was explicitly
+  # temporary - an advisory job nobody reads is how #997 happened in the first
+  # place - so a Windows regression must now fail the build like any other.
+  # Do not reintroduce `continue-on-error` here to land a red PR; fix the
+  # failure or revert the change that caused it.
   tests:
     name: Tests
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       # Both platforms must report. Cancelling the Windows leg the moment
       # Ubuntu fails (or vice versa) would hide whether a failure is


### PR DESCRIPTION
Closes the last item on #997 and #1014.

## Why now

The job's own comment set the condition: *"This must not become permanent: an advisory job nobody reads is how #997 happened. Flip `continue-on-error` off as soon as #1014 closes."*

The 33 failures are fixed (#1007, #1012, #1046) and the suite completes green across all 11 binaries.

## Verified before flipping

I checked the actual job results rather than trusting the fix commits:

| commit | windows leg |
|---|---|
| `7c0dadfb` | success |
| `2e49fb0c` | success |
| `31ccae24` | success |
| `7433cc09` | success |
| `15cad3a6` | cancelled — concurrency eviction, not a failure |

That single `cancelled` is worth knowing about: four merges landing seconds apart put their queued runs in one concurrency group, and Actions keeps only one pending run per group, so each evicted its predecessor. It reads as `failure` at run level and is not one.

## Also rewrites the comment block

It was two PRs out of date — still describing the 33 failures as outstanding and naming the crush-registry and cc-mirror defects as suspected-but-unfixed. That block is what the next person reads before touching this job, so leaving it would actively mislead.

## Risk

If the two un-redirected config roots noted on #1014 can still make the leg flaky under CI-only conditions, this turns that into a visible failure. That is the intent — a silent advisory job is the failure mode #997 was about — but it does mean the first flake now blocks a PR rather than being ignored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `windows-latest` test leg a hard gate by removing `continue-on-error`, so Windows failures now fail CI. Update the workflow comment to reflect that the 33 Windows failures are fixed (#1007, #1012, #1046), addressing the last items from #997 and #1014.

- **Migration**
  - Windows test failures now block PRs. Do not re-add `continue-on-error`; fix the failure or revert.

<sup>Written for commit 2d60bbf15e83c66d879431e2594399ddb6399ea0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

