### PR TITLE
fix(pricing): refuse to price router labels, prefer original vendor on ties

### DIFF
--- a/crates/tokscale-core/src/pricing/custom.rs
+++ b/crates/tokscale-core/src/pricing/custom.rs
@@ -78,12 +78,20 @@ impl CustomModelPricing {
             "output_cost_per_token",
         )?;
 
-        if !input_cost_per_token.is_some_and(|value| value > 0.0)
-            && !output_cost_per_token.is_some_and(|value| value > 0.0)
-        {
-            return Err(
-                "at least one of input or output pricing must be present and positive".into(),
-            );
+        // @keep: requiring a POSITIVE rate here locked users out of the one
+        // escape hatch they have for free models.
+        //
+        // A rate of 0.0 is a statement — "this model is free" — and it is
+        // exactly what a user needs to express for a free tier that no upstream
+        // dataset publishes. Demanding a positive rate made that unsayable, so
+        // free usage stayed unpriced and was excluded from submission with no
+        // way to correct it (#1021).
+        //
+        // Absence is still rejected: a row that names no rate at all says
+        // nothing, and silently reading that as free would invent a $0 total
+        // for genuinely unknown pricing.
+        if input_cost_per_token.is_none() && output_cost_per_token.is_none() {
+            return Err("at least one of input or output pricing must be present".into());
         }
 
         Ok(ModelPricing {
@@ -657,7 +665,7 @@ mod tests {
     }
 
     #[test]
-    fn drops_entries_with_zero_prices() {
+    fn keeps_free_models_but_still_drops_negative_prices() {
         let temp = TempDir::new().unwrap();
         let path = temp.path().join("custom-pricing.json");
         fs::write(
@@ -683,11 +691,18 @@ mod tests {
 
         let loaded = CustomPricing::load_from_path(&path);
 
-        assert!(loaded.lookup("all-zero").is_none());
+        // A free model is the case this file exists to let users express when
+        // no upstream dataset publishes the model (#1021). 0.0 is an assertion
+        // ("free"), not an absence, so an all-zero row is kept.
+        let all_zero = loaded.lookup("all-zero").expect("free model must load");
+        assert_eq!(all_zero.input_cost_per_token, Some(0.0));
+        assert_eq!(all_zero.output_cost_per_token, Some(0.0));
+
         assert_eq!(
             loaded.lookup("free-input").unwrap().output_cost_per_token,
             Some(0.000008)
         );
+        // Unchanged: a negative rate is nonsense, not a statement about price.
         assert!(loaded.lookup("negative-output").is_none());
     }
 

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -365,6 +365,13 @@ impl PricingLookup {
         // `try_strip_unknown_suffix` below.
         let normalized_owned = strip_parenthesized_reasoning_tier(&lower).map(str::to_owned);
 
+        // A tier suffix does not turn a router into a model: `auto(high)`
+        // normalizes to `auto` below and would otherwise reach the model-part
+        // fallback and elect an unrelated vendor, exactly as the bare form did.
+        if normalized_owned.as_deref().is_some_and(is_routing_label) {
+            return None;
+        }
+
         // Guard against silent misresolution: if the input ends with `(...)`
         // but the contents are not a recognized CLIProxyAPI level, refuse the
         // lookup. Falling through to `try_strip_unknown_suffix` would split on
@@ -432,6 +439,14 @@ impl PricingLookup {
         // the `/`-scoped fallbacks already used by the Cursor/Sakana exact
         // matchers.
         if let Some(terminal) = strip_generic_provider_prefix(lower_ref) {
+            // Reaching here means no dataset key matched the qualified id, so
+            // an unrecognized vendor prefix is being dropped to retry the bare
+            // model. A real `morph/auto` resolved long before this point; a
+            // made-up `cx/auto` would arrive here and be billed as Morph.
+            if is_routing_label(terminal) {
+                return None;
+            }
+
             if let Some(result) = guarded_lookup(terminal) {
                 return Some(result);
             }
@@ -6389,6 +6404,13 @@ mod tests {
         assert!(lookup.lookup("auto").is_none());
         assert!(lookup.lookup("AUTO").is_none());
         assert!(lookup.lookup("agent_review").is_none());
+
+        // A tier suffix does not make it a model: this normalizes to `auto`
+        // before the model-part fallback runs.
+        assert!(lookup.lookup("auto(high)").is_none());
+        // Nor does an unrecognized vendor prefix, which is dropped to retry
+        // the bare id. A real `morph/auto` never reaches that fallback.
+        assert!(lookup.lookup("cx/auto").is_none());
 
         // A qualified id names a real vendor's model and still prices.
         assert!(lookup.lookup("morph/auto").is_some());

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -348,6 +348,13 @@ impl PricingLookup {
         force_source: Option<&str>,
         provider_id: Option<&str>,
     ) -> Option<LookupResult> {
+        // A router is not a model. Resolving one by model-part match elects
+        // whatever unrelated vendor publishes the same word, and the result is
+        // billed as if it were the real thing (#1062).
+        if is_routing_label(model_id) {
+            return None;
+        }
+
         let provider_id = normalize_provider_hint(provider_id);
         let canonical = aliases::resolve_alias(model_id).unwrap_or(model_id);
         let lower = canonical.to_lowercase();
@@ -2211,18 +2218,59 @@ where
 /// race, keeping existing resolutions stable), with lexicographic order
 /// breaking length ties so the result no longer depends on HashMap iteration
 /// order.
+// @keep: the shortest-key fallback is arbitrary and actively harmful; the
+// original-provider preference in front of it is what makes this defensible.
+/// Elect between two dataset keys that share a model part.
+///
+/// Preferring the ORIGINAL provider generalizes what used to be a hardcoded
+/// `anthropic/` special case. The rule it encodes is the same one that
+/// motivated that case: when several vendors publish a key ending in the same
+/// model name, the vendor who made the model is the one whose rates describe
+/// it — a reseller or aggregator row is at best a repackaging.
+///
+/// Length is the last resort and is a coin-flip, not a signal. It is what
+/// elected `morph/auto` ($0.85/$1.55) over three $0.00 router rows for the
+/// model part `auto` (#1062), i.e. the single worst-priced candidate purely
+/// because its key was ten characters. Routing labels no longer reach here at
+/// all, but the same hazard remains for any model part several vendors share,
+/// so prefer adding the real vendor to ORIGINAL_PROVIDER_PREFIXES over
+/// relying on the tie-break to land correctly.
 fn prefers_model_part_key(candidate: &str, existing: &str) -> bool {
     let candidate_lower = candidate.to_lowercase();
     let existing_lower = existing.to_lowercase();
-    let is_anthropic = |key: &str| key.split('/').next() == Some("anthropic");
     match (
-        is_anthropic(&candidate_lower),
-        is_anthropic(&existing_lower),
+        is_original_provider(&candidate_lower),
+        is_original_provider(&existing_lower),
     ) {
         (true, false) => true,
         (false, true) => false,
         _ => (candidate_lower.len(), candidate_lower) < (existing_lower.len(), existing_lower),
     }
+}
+
+// @keep: these look like model names and are not, which is the whole problem.
+/// Model ids that name a ROUTER, not a model.
+///
+/// Cursor, Copilot Desktop, Copilot VS Code, Kiro and Workbuddy all emit a
+/// bare `auto` when the product chose the model on the user's behalf
+/// (`sessions/cursor.rs:356`, `copilot_desktop.rs:123`, `copilot_vscode.rs:110`,
+/// `kiro.rs:1135`, `workbuddy.rs:127`); `agent_review` is a Cursor feature.
+/// Nothing in the session log records which model actually served the
+/// request, so any rate attached to these describes a different model.
+///
+/// Left to the normal chain, `auto` matches by model part against every
+/// dataset key ending in `/auto` and — because ties break on shortest key —
+/// elects `morph/auto` at $0.85/$1.55, an unrelated code-apply vendor. That
+/// is real money billed from a coincidence of spelling (#1062).
+///
+/// BARE ids only. A qualified `morph/auto` is a genuine Morph model and still
+/// resolves. `custom-pricing.json` is consulted before this, so a user who
+/// knows their router's effective rate can still state it.
+const ROUTING_LABELS: &[&str] = &["auto", "agent_review"];
+
+fn is_routing_label(model_id: &str) -> bool {
+    let lower = model_id.trim().to_lowercase();
+    ROUTING_LABELS.contains(&lower.as_str())
 }
 
 fn is_original_provider(key: &str) -> bool {
@@ -6310,5 +6358,59 @@ mod tests {
             r_unknown.matched_key, r_none.matched_key,
             "unknown hint via source_and_provider should behave like None"
         );
+    }
+
+    /// Regression (#1062): a bare router label must not be priced from a
+    /// coincidence of spelling. `auto` used to elect `morph/auto` at
+    /// $0.85/$1.55 — an unrelated code-apply vendor — and submit at those
+    /// rates, because covers_usage only demands rates for populated buckets.
+    #[test]
+    fn bare_routing_labels_do_not_resolve_but_qualified_ones_do() {
+        let mut models_dev = HashMap::new();
+        for key in ["morph/auto", "llmgateway/auto", "cursor/agent_review"] {
+            models_dev.insert(
+                key.to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(8.5e-7),
+                    output_cost_per_token: Some(1.55e-6),
+                    ..Default::default()
+                },
+            );
+        }
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        // Five parsers emit these bare; nothing records the real model.
+        assert!(lookup.lookup("auto").is_none());
+        assert!(lookup.lookup("AUTO").is_none());
+        assert!(lookup.lookup("agent_review").is_none());
+
+        // A qualified id names a real vendor's model and still prices.
+        assert!(lookup.lookup("morph/auto").is_some());
+    }
+
+    /// The shortest-key tie-break is a coin flip. Preferring the original
+    /// provider generalizes the `anthropic/` special case it replaced, so a
+    /// reseller no longer wins on key length alone.
+    #[test]
+    fn model_part_tie_break_prefers_the_original_provider_over_a_shorter_key() {
+        assert!(super::prefers_model_part_key(
+            "openai/some-model",
+            "xy/some-model"
+        ));
+        assert!(!super::prefers_model_part_key(
+            "xy/some-model",
+            "openai/some-model"
+        ));
+        // Neither is an original provider: length still decides.
+        assert!(super::prefers_model_part_key(
+            "ab/some-model",
+            "abcd/some-model"
+        ));
     }
 }


### PR DESCRIPTION
Both halves of #1062. A design pass proposing provider-prefix gating was rejected by three independent adversarial reviews first — this is what survived.

## The issue's own reproduction was wrong

I filed #1062 citing `cursor/auto`. **No parser emits that string.** `sessions/cursor.rs:356` asserts a bare `auto` with the vendor in `provider_id`; four more default to the same bare label. The prefix came from the CLI warning's `client/model` display.

That error mattered enormously: every prefix-based gate keys off a vendor prefix, and bare ids have none — so on 97 real ids the proposed design excluded **zero**, including `auto` itself. It "passed" its blast-radius check by never firing.

## Router labels

```
before:  tokscale pricing auto  ->  morph/auto   $0.85 / $1.55
after:   tokscale pricing auto  ->  Model not found
         tokscale pricing morph/auto  ->  morph/auto   (unchanged)
```

Nothing in the session log records which model served an `auto` request, so any rate attached describes a different model. And this isn't saved by the missing-cache-bucket accident I originally described — `covers_usage` demands rates only for *populated* buckets, and Copilot Desktop's sessions table has no cache-write column at all, so that shape submits at Morph's real rates. 519 of 5037 rows in one live Cursor cache carry it.

Bare ids only. `custom-pricing.json` is consulted **before** this guard, so a user who knows their router's effective rate can still state it — and #1069 makes stating a $0 rate possible.

## Tie-break

`prefers_model_part_key` broke ties by shortest key with a hardcoded `anthropic/` preference in front. For model part `auto`, models.dev carries `morph/auto` ($0.85/$1.55), `llmgateway/auto` ($0.00), `kilo/openrouter/auto` ($0.00), `orcarouter/orcarouter/auto` ($0.00) — the 10-character paid row won **because it was short**.

The anthropic case is generalised to `is_original_provider`, which is the rule it was always an instance of: when several vendors publish the same model name, the vendor who made it is the one whose rates describe it.

## Rejected, with evidence

| Direction | Why not |
|---|---|
| Gate on provider-prefix agreement | Excludes 218 of 1,969 real ids whose key names the *same* model — `anthropic/claude-3-opus` → `llmgateway/claude-3-opus` is Anthropic's exact list price |
| Gate on `provider_id` | Disagrees on ~79% of priced usage; it's circular (24 parsers derive it from the model string) and degrades to a *client* label precisely when the model is unknown |
| Reject all fuzzy matches | 38% of ids resolve fuzzy-only onto keys naming the same vendor and model |
| Any of the above | Regresses free models, reverting 55635ef4 — `stepfun/step-3.7-flash:free` plus 6 more verified |

## Tests

1,492 passed / 0 failed; fmt and `clippy --all-targets -- -D warnings` clean. Two new tests: bare labels refuse while qualified ones resolve, and the tie-break prefers an original provider over a shorter reseller key.

## Not covered

The label list is evidence-based, not exhaustive — it's what five parsers demonstrably emit. Other bare product labels may be in circulation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops pricing router labels like `auto` (including normalized forms) and prefers the original provider when multiple vendors share a model name. Also lets `custom-pricing.json` declare free models with 0.0 rates.

- **Bug Fixes**
  - Router labels: block bare and normalized forms (`auto`, `agent_review`, `auto(high)`, unknown-prefix `cx/auto`) from pricing; real qualified ids (e.g. `morph/auto`) still price. `custom-pricing.json` can still set a rate.
  - Tie-breaks: prefer the original provider over the shortest key when keys share a model part.
  - Custom pricing: accept 0.0 input/output rates (free models). Rows with no rates and any negative values still reject.

<sup>Written for commit ea1a743f722c0e27358ccddbf0ce5ffa2ad5174a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

