### PR TITLE
fix(pricing): keep bare routing labels off model-part index fallbacks

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3027,10 +3027,22 @@ fn build_graph_from_messages(
     Ok(result)
 }
 
-const GEMINI_DEFAULT_UNPRICED_REASON: &str =
+const ROUTING_LABEL_UNPRICED_REASON: &str =
     "generic routing label has no authoritative model-to-price mapping";
 const MISSING_MODEL_PRICING_REASON: &str = "no authoritative model-to-price mapping";
 const INCOMPLETE_MODEL_PRICING_REASON: &str = "pricing does not cover every populated token bucket";
+
+/// Routing labels name the router that served the request, never the model
+/// that answered it, so they have no authoritative model-to-price mapping.
+/// They are the same labels `lookup::is_routing_label` (lookup.rs) refuses at
+/// the resolver top — `auto` (the unknown-model label Kiro emits and the
+/// default-model label Cursor/Copilot record) and Cursor's `agent_review` —
+/// plus the historical `gemini-default` pair.
+fn is_generic_routing_label(provider_id: &str, model_id: &str) -> bool {
+    (provider_id.eq_ignore_ascii_case("google") && model_id.eq_ignore_ascii_case("gemini-default"))
+        || model_id.eq_ignore_ascii_case("auto")
+        || model_id.eq_ignore_ascii_case("agent_review")
+}
 
 fn has_positive_token_usage(tokens: &TokenBreakdown) -> bool {
     tokens.input > 0
@@ -3062,10 +3074,8 @@ fn exclude_unpriced_submission_messages(
             );
 
         if is_unpriced {
-            let reason = if message.provider_id.eq_ignore_ascii_case("google")
-                && message.model_id.eq_ignore_ascii_case("gemini-default")
-            {
-                GEMINI_DEFAULT_UNPRICED_REASON
+            let reason = if is_generic_routing_label(&message.provider_id, &message.model_id) {
+                ROUTING_LABEL_UNPRICED_REASON
             } else if pricing
                 .lookup_with_source_and_provider(
                     &message.model_id,
@@ -4388,8 +4398,8 @@ mod tests {
         parse_local_clients, parsed_to_unified, paths, pricing, retain_for_requested_clients,
         scanner, select_local_parse_pricing, unified_to_parsed, validate_priced_messages, ClientId,
         GraphPricingRequirement, GroupBy, LocalParseOptions, ReportOptions, TokenBreakdown,
-        UnifiedMessage, UnpricedSubmissionExclusion, GEMINI_DEFAULT_UNPRICED_REASON,
-        INCOMPLETE_MODEL_PRICING_REASON, MISSING_MODEL_PRICING_REASON, UNKNOWN_WORKSPACE_LABEL,
+        UnifiedMessage, UnpricedSubmissionExclusion, INCOMPLETE_MODEL_PRICING_REASON,
+        MISSING_MODEL_PRICING_REASON, ROUTING_LABEL_UNPRICED_REASON, UNKNOWN_WORKSPACE_LABEL,
     };
     use serial_test::serial;
     use std::collections::{HashMap, HashSet};
@@ -8383,7 +8393,73 @@ mod tests {
                 model_id: "gemini-default".to_string(),
                 message_count: 7,
                 total_tokens: 18,
-                reason: GEMINI_DEFAULT_UNPRICED_REASON,
+                reason: ROUTING_LABEL_UNPRICED_REASON,
+            }
+        );
+    }
+
+    #[test]
+    fn submission_excludes_unpriced_auto_routing_label() {
+        // `auto` is the unknown-model label Kiro emits and the default-model
+        // label Cursor/Copilot record in usage rows. A models.dev `morph/auto`
+        // paid row exists, so before the resolver refused routing labels the
+        // bare label resolved to it and slipped through submission at morph's
+        // rates (#1062). The fixture quotes a cache-read rate precisely so the
+        // pre-fix fallback covers all three populated buckets (7 input, 11
+        // cache-read, 0 output) and submits the row — without it, the row
+        // would fail coverage on the missing cache rate and the test would
+        // pass even with the bug. The label must instead be excluded with the
+        // routing-label reason.
+        let mut models_dev = HashMap::new();
+        models_dev.insert(
+            "morph/auto".to_string(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(8.5e-7),
+                output_cost_per_token: Some(1.55e-6),
+                cache_read_input_token_cost: Some(1.6e-7),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new_with_custom_and_models_dev(
+            pricing::custom::CustomPricing::default(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+        let mut auto = UnifiedMessage::new(
+            "kiro",
+            "auto",
+            "amazon-bedrock",
+            "generic",
+            1_736_510_400_000,
+            TokenBreakdown {
+                input: 7,
+                cache_read: 11,
+                ..Default::default()
+            },
+            0.0,
+        );
+        auto.message_count = 7;
+
+        let graph = build_graph_from_messages(
+            vec![auto],
+            Some(&pricing),
+            GraphPricingRequirement::Submission,
+            std::time::Instant::now(),
+            &crate::bucket_tz::BucketTimezone::Local,
+        )
+        .expect("routing label must not abort submission");
+
+        assert_eq!(graph.summary.total_tokens, 0);
+        assert_eq!(graph.unpriced_submission_exclusions.len(), 1);
+        assert_eq!(
+            graph.unpriced_submission_exclusions[0],
+            UnpricedSubmissionExclusion {
+                provider_id: "amazon-bedrock".to_string(),
+                model_id: "auto".to_string(),
+                message_count: 7,
+                total_tokens: 18,
+                reason: ROUTING_LABEL_UNPRICED_REASON,
             }
         );
     }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3074,9 +3074,18 @@ fn exclude_unpriced_submission_messages(
             );
 
         if is_unpriced {
-            let reason = if is_generic_routing_label(&message.provider_id, &message.model_id) {
-                ROUTING_LABEL_UNPRICED_REASON
-            } else if pricing
+            // Resolution is consulted before the routing-label reason, not
+            // after. `custom-pricing.json` is read first by
+            // `lookup_with_source_and_provider`, and stating a rate for `auto`
+            // there is the user asserting the label does name something for
+            // them — the escape hatch `lookup::ROUTING_LABELS` documents.
+            // Checking the label first told that user their label "has no
+            // authoritative model-to-price mapping" while their own file held
+            // one, hiding the fixable gap (a bucket their entry omits).
+            // Nothing regresses for unpriced labels: the resolver refuses
+            // routing labels outright, so with no custom entry this returns
+            // None and the routing-label reason still applies.
+            let reason = if pricing
                 .lookup_with_source_and_provider(
                     &message.model_id,
                     None,
@@ -3085,6 +3094,8 @@ fn exclude_unpriced_submission_messages(
                 .is_some()
             {
                 INCOMPLETE_MODEL_PRICING_REASON
+            } else if is_generic_routing_label(&message.provider_id, &message.model_id) {
+                ROUTING_LABEL_UNPRICED_REASON
             } else {
                 MISSING_MODEL_PRICING_REASON
             };
@@ -8460,6 +8471,67 @@ mod tests {
                 message_count: 7,
                 total_tokens: 18,
                 reason: ROUTING_LABEL_UNPRICED_REASON,
+            }
+        );
+    }
+
+    #[test]
+    fn custom_priced_routing_label_reports_incomplete_pricing_not_missing_mapping() {
+        // A `custom-pricing.json` entry for a routing label is the user
+        // stating what their router actually costs them — the escape hatch
+        // `ROUTING_LABELS` documents. Telling that user the label "has no
+        // authoritative model-to-price mapping" contradicts the mapping they
+        // just wrote. Here the custom entry quotes an input rate but no cache
+        // rate, so the row still fails coverage; the reason must name the gap
+        // that is actually fixable (the missing cache-read rate), not deny the
+        // mapping exists.
+        let mut custom_models = HashMap::new();
+        custom_models.insert(
+            "auto".to_string(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(3e-6),
+                output_cost_per_token: Some(1.5e-5),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new_with_custom(
+            pricing::custom::CustomPricing::from_models(custom_models),
+            HashMap::new(),
+            HashMap::new(),
+        );
+        let mut auto = UnifiedMessage::new(
+            "kiro",
+            "auto",
+            "amazon-bedrock",
+            "generic",
+            1_736_510_400_000,
+            TokenBreakdown {
+                input: 7,
+                cache_read: 11,
+                ..Default::default()
+            },
+            0.0,
+        );
+        auto.message_count = 7;
+
+        let graph = build_graph_from_messages(
+            vec![auto],
+            Some(&pricing),
+            GraphPricingRequirement::Submission,
+            std::time::Instant::now(),
+            &crate::bucket_tz::BucketTimezone::Local,
+        )
+        .expect("routing label must not abort submission");
+
+        assert_eq!(graph.unpriced_submission_exclusions.len(), 1);
+        assert_eq!(
+            graph.unpriced_submission_exclusions[0],
+            UnpricedSubmissionExclusion {
+                provider_id: "amazon-bedrock".to_string(),
+                model_id: "auto".to_string(),
+                message_count: 7,
+                total_tokens: 18,
+                reason: INCOMPLETE_MODEL_PRICING_REASON,
             }
         );
     }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3034,14 +3034,17 @@ const INCOMPLETE_MODEL_PRICING_REASON: &str = "pricing does not cover every popu
 
 /// Routing labels name the router that served the request, never the model
 /// that answered it, so they have no authoritative model-to-price mapping.
-/// They are the same labels `lookup::is_routing_label` (lookup.rs) refuses at
-/// the resolver top — `auto` (the unknown-model label Kiro emits and the
-/// default-model label Cursor/Copilot record) and Cursor's `agent_review` —
-/// plus the historical `gemini-default` pair.
+/// This defers to `lookup::is_routing_label` (lookup.rs) rather than restating
+/// its `ROUTING_LABELS` list: the reason a row is excluded has to name the same
+/// labels the resolver refuses at its top, and a second copy of the list would
+/// drift the moment a label is added to one side. Trimming matches for the same
+/// reason — the resolver trims, so ` auto ` must not read as a routing label
+/// here while being refused there. The historical `gemini-default` pair is
+/// provider-scoped and lives only in this reason, not in the resolver gate.
 fn is_generic_routing_label(provider_id: &str, model_id: &str) -> bool {
-    (provider_id.eq_ignore_ascii_case("google") && model_id.eq_ignore_ascii_case("gemini-default"))
-        || model_id.eq_ignore_ascii_case("auto")
-        || model_id.eq_ignore_ascii_case("agent_review")
+    (provider_id.eq_ignore_ascii_case("google")
+        && model_id.trim().eq_ignore_ascii_case("gemini-default"))
+        || pricing::lookup::is_routing_label(model_id)
 }
 
 fn has_positive_token_usage(tokens: &TokenBreakdown) -> bool {
@@ -4404,13 +4407,14 @@ mod tests {
     use super::{
         aggregate_model_usage_entries, apply_pricing_if_available, build_graph_from_messages,
         dedupe_latest_trae_messages, filter_messages_for_report,
-        generate_graph_with_loaded_pricing, get_home_dir_string, message_cache,
-        normalize_model_for_grouping, parse_all_messages_with_pricing_with_env_strategy,
-        parse_local_clients, parsed_to_unified, paths, pricing, retain_for_requested_clients,
-        scanner, select_local_parse_pricing, unified_to_parsed, validate_priced_messages, ClientId,
-        GraphPricingRequirement, GroupBy, LocalParseOptions, ReportOptions, TokenBreakdown,
-        UnifiedMessage, UnpricedSubmissionExclusion, INCOMPLETE_MODEL_PRICING_REASON,
-        MISSING_MODEL_PRICING_REASON, ROUTING_LABEL_UNPRICED_REASON, UNKNOWN_WORKSPACE_LABEL,
+        generate_graph_with_loaded_pricing, get_home_dir_string, is_generic_routing_label,
+        message_cache, normalize_model_for_grouping,
+        parse_all_messages_with_pricing_with_env_strategy, parse_local_clients, parsed_to_unified,
+        paths, pricing, retain_for_requested_clients, scanner, select_local_parse_pricing,
+        unified_to_parsed, validate_priced_messages, ClientId, GraphPricingRequirement, GroupBy,
+        LocalParseOptions, ReportOptions, TokenBreakdown, UnifiedMessage,
+        UnpricedSubmissionExclusion, INCOMPLETE_MODEL_PRICING_REASON, MISSING_MODEL_PRICING_REASON,
+        ROUTING_LABEL_UNPRICED_REASON, UNKNOWN_WORKSPACE_LABEL,
     };
     use serial_test::serial;
     use std::collections::{HashMap, HashSet};
@@ -8472,6 +8476,71 @@ mod tests {
                 total_tokens: 18,
                 reason: ROUTING_LABEL_UNPRICED_REASON,
             }
+        );
+    }
+
+    #[test]
+    fn whitespace_padded_routing_label_is_classified_the_same_by_resolver_and_reason() {
+        // `lookup::is_routing_label` trims before comparing, so the resolver
+        // refuses to price ` auto `. The exclusion reason has to agree, or the
+        // row is reported as having no model-to-price mapping while the reason
+        // it is unpriced is that it names a router. Both paths now read the
+        // same list, so a label added to `lookup::ROUTING_LABELS` cannot drift
+        // out of the reason.
+        assert_eq!(
+            crate::pricing::lookup::is_routing_label(" auto "),
+            is_generic_routing_label("amazon-bedrock", " auto "),
+            "resolver and exclusion reason must classify a padded routing label alike"
+        );
+
+        // The models.dev `morph/auto` row is fully priced, so if the resolver
+        // did not refuse the padded label the row would submit at Morph rates
+        // (#1062) instead of reaching the exclusion path at all.
+        let mut models_dev = HashMap::new();
+        models_dev.insert(
+            "morph/auto".to_string(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(8.5e-7),
+                output_cost_per_token: Some(1.55e-6),
+                cache_read_input_token_cost: Some(1.6e-7),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new_with_custom_and_models_dev(
+            pricing::custom::CustomPricing::default(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+        let mut padded = UnifiedMessage::new(
+            "kiro",
+            " auto ",
+            "amazon-bedrock",
+            "generic",
+            1_736_510_400_000,
+            TokenBreakdown {
+                input: 7,
+                cache_read: 11,
+                ..Default::default()
+            },
+            0.0,
+        );
+        padded.message_count = 7;
+
+        let graph = build_graph_from_messages(
+            vec![padded],
+            Some(&pricing),
+            GraphPricingRequirement::Submission,
+            std::time::Instant::now(),
+            &crate::bucket_tz::BucketTimezone::Local,
+        )
+        .expect("routing label must not abort submission");
+
+        assert_eq!(graph.summary.total_tokens, 0);
+        assert_eq!(graph.unpriced_submission_exclusions.len(), 1);
+        assert_eq!(
+            graph.unpriced_submission_exclusions[0].reason, ROUTING_LABEL_UNPRICED_REASON,
+            "padded routing label must report the routing-label reason"
         );
     }
 

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -79,14 +79,22 @@ impl ModelPricing {
     /// This is a statement about the row, not about the deal. Rows that quote
     /// `0.0` for the buckets upstream bothered to list and omit the rest reach
     /// us from two different worlds and are indistinguishable in the data:
-    /// `kenari/nemotron-3-ultra-550b-a55b` is a genuinely free model, and
-    /// `kenari/claude-opus-4-7` is a premium model whose zeros mean "included
-    /// in your subscription" — both arrive as
+    /// `opencode/nemotron-3-ultra-free` is a genuinely free row, and
+    /// `kenari/claude-opus-4-7` is a premium model whose zeros mean
+    /// "included in your subscription" — both arrive as
     /// `{input_cost_per_token: 0.0, output_cost_per_token: 0.0}` with null
     /// cache fields, byte for byte. Nothing in the dataset separates them, so
     /// tokscale reports both at $0.00 and cannot do better from this input
     /// alone. If upstream ever publishes a plan/subscription marker, that is
     /// the signal to split these two cases apart.
+    ///
+    /// A zero row must not be read as "the model is free": kenari's entire
+    /// catalog is subscription-priced at zero (all 38 of its rows in models.dev
+    /// are `{0, 0}`, `grok-4-5` and `claude-fable-5` included), and the same
+    /// nemotron has 14 paid siblings — `nvidia/nvidia/...` at $0.50/$2.50,
+    /// `openrouter/...` at $0.60/$3.60 — so a resolution that lands on a
+    /// subscription row prices a paid model at $0.00. That is a lookup-quality
+    /// problem, tracked separately, not something this predicate decides.
     ///
     /// That limitation predates this predicate rather than arriving with it:
     /// `0.0` has always satisfied `valid_rate`, so a plan-priced row already

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2304,7 +2304,7 @@ fn prefers_model_part_key(candidate: &str, existing: &str) -> bool {
 /// knows their router's effective rate can still state it.
 const ROUTING_LABELS: &[&str] = &["auto", "agent_review"];
 
-fn is_routing_label(model_id: &str) -> bool {
+pub(crate) fn is_routing_label(model_id: &str) -> bool {
     let lower = model_id.trim().to_lowercase();
     ROUTING_LABELS.contains(&lower.as_str())
 }

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -996,7 +996,22 @@ impl PricingLookup {
     /// model-part equals `model_id`. A provider hint must take precedence over
     /// this (see `lookup_auto`), otherwise a hinted lookup leaks to a different
     /// provider's canonical key.
+    ///
+    /// The model-part index is a cross-provider fallback in the same trust
+    /// class as fuzzy matching: it lands the id on "some other provider's
+    /// model whose model-part equals this id". Generic tokens on the
+    /// `FUZZY_BLOCKLIST` carry no model identity, and #1070's resolver-top
+    /// `is_routing_label` guard already refuses the router labels it knows
+    /// (`auto`, `agent_review`). This blocklist gate is the second layer:
+    /// it covers generic tokens no parser emits today but any provider could
+    /// publish as a model part tomorrow (`default`, `router`, `mini`, ...),
+    /// and it protects any path that reaches the model-part index without
+    /// passing through that guard. Full-key matches, which are the id's own
+    /// canonical key, stay honored.
     fn exact_match_openrouter_model_part(&self, model_id: &str) -> Option<LookupResult> {
+        if FUZZY_BLOCKLIST.contains(&model_id) {
+            return None;
+        }
         let key = self.openrouter_model_part.get(model_id)?;
         let pricing = self.openrouter.get(key)?;
         lookup_result_if_usable(pricing, "OpenRouter", key)
@@ -1012,13 +1027,19 @@ impl PricingLookup {
                 });
             }
         }
-        if let Some(key) = self.models_dev_model_part.get(model_id) {
-            if let Some(pricing) = self.models_dev.get(key) {
-                return Some(LookupResult {
-                    pricing: pricing.clone(),
-                    source: "Models.dev".into(),
-                    matched_key: key.clone(),
-                });
+        // Same cross-provider fallback trust class as the OpenRouter model-part
+        // index: #1070's resolver-top guard plus this blocklist gate keep bare
+        // generic tokens off another provider's model part, while the id's own
+        // full dataset key (`morph/auto`) still resolves.
+        if !FUZZY_BLOCKLIST.contains(&model_id) {
+            if let Some(key) = self.models_dev_model_part.get(model_id) {
+                if let Some(pricing) = self.models_dev.get(key) {
+                    return Some(LookupResult {
+                        pricing: pricing.clone(),
+                        source: "Models.dev".into(),
+                        matched_key: key.clone(),
+                    });
+                }
             }
         }
         None
@@ -3441,6 +3462,58 @@ mod tests {
                 .unwrap()
                 .matched_key,
             "vertex_ai/claude-opus-4-7@default"
+        );
+    }
+
+    // Defense-in-depth beyond #1070: the resolver-top `is_routing_label`
+    // guard refuses the router labels parsers emit today (`auto`,
+    // `agent_review`), but the model-part index is a second, deeper place a
+    // bare id can elect another provider's row. Any provider may publish a
+    // generic `FUZZY_BLOCKLIST` token as a model part (`default`, `router`,
+    // `mini`, ...) — none do today, but a bare id carrying such a token names
+    // no model, so it must not land on whatever unrelated key shares the
+    // spelling. This guard covers shapes the label list does not enumerate;
+    // full dataset keys still resolve.
+    #[test]
+    fn model_part_index_does_not_resolve_bare_generic_tokens() {
+        let mut models_dev = HashMap::new();
+        models_dev.insert(
+            "someprovider/router".into(),
+            ModelPricing {
+                input_cost_per_token: Some(1e-6),
+                output_cost_per_token: Some(2e-6),
+                ..Default::default()
+            },
+        );
+        models_dev.insert(
+            "someprovider/default".into(),
+            ModelPricing {
+                input_cost_per_token: Some(1e-6),
+                output_cost_per_token: Some(2e-6),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        // A bare generic token must not resolve through another provider's
+        // model part.
+        assert!(lookup.lookup("router").is_none());
+        assert!(lookup.lookup("default").is_none());
+
+        // The tokens' own full dataset keys are still exact matches.
+        assert_eq!(
+            lookup.lookup("someprovider/router").unwrap().matched_key,
+            "someprovider/router"
+        );
+        assert_eq!(
+            lookup.lookup("someprovider/default").unwrap().matched_key,
+            "someprovider/default"
         );
     }
 


### PR DESCRIPTION
Defense-in-depth for #1062, rebased onto current main. The companion issue is #1071.

## What

The models.dev model-part index matched bare ids against "some other provider's model whose model-part equals this id" — the same cross-provider trust class as fuzzy matching — but only the fuzzy path consulted `FUZZY_BLOCKLIST`. A bare `auto` (the unknown-model label Kiro emits, and the default-model label Cursor/Copilot record) therefore elected `morph/auto` at $0.85/$1.55, because the model-part tie-break rejected it as spam. 519 of 5037 rows in one live cursor cache carried it.

#1070 already fixed the live case at the resolver top (`is_routing_label` refuses `auto`/`agent_review` before the model-part index is consulted, and the tie-break prefers original vendors). This PR lands the second layer inside the model-part helpers themselves and keeps submission reporting honest.

## Changes

- `crates/tokscale-core/src/pricing/lookup.rs`: both model-part index fallbacks (`exact_match_models_dev`, `exact_match_openrouter_model_part`) skip `FUZZY_BLOCKLIST` tokens, as defense-in-depth; full dataset keys still resolve. A future provider publishing `someone/default` as a model part is caught here even though no parser emits a bare `default` today, and any path reaching the index without passing the resolver-top guard is covered.
- `crates/tokscale-core/src/lib.rs`: `GEMINI_DEFAULT_UNPRICED_REASON` generalized to `ROUTING_LABEL_UNPRICED_REASON` via `is_generic_routing_label`, aligning with `lookup.rs`'s `ROUTING_LABELS` (`auto`, `agent_review`) plus the historical `gemini-default` pair — so the submitted exclusion reason tells users "this label never named a model" instead of "your model is missing from the dataset".
- `crates/tokscale-core/src/pricing/litellm.rs`: the zero-row doc comment no longer calls kenari's nemotron row a "genuinely free model" — kenari's entire catalog is subscription-priced at zero (all 38 models.dev rows), and the same nemotron has 14 paid siblings.

## Verification

- New tests: `model_part_index_does_not_resolve_bare_generic_tokens` (red-green verified: fails without the gate, passes with it) and `submission_excludes_unpriced_auto_routing_label` (fixture quotes a cache-read rate so the pre-fix fallback would submit, making the test actually detect the regression).
- `cargo test -p tokscale-core --lib`: 1496 passed, 1 ignored; `cargo fmt --check` clean; clippy clean.
- Live CLI: `pricing auto` and `pricing agent_review` report "Model not found"; `morph/auto` full key and real models (`nvidia/nemotron-3-ultra-550b-a55b`, `openai/codex-auto-review`) resolve exactly as before.

The `github-copilot/` prefix gap, the `nvidia/` zero-rate tie-break election, and `codex-auto-review` attribution remain separate open issues (#1021, #1035) with different root causes, untouched by this PR.