### PR TITLE
docs(ci): stop crediting the windows leg with two defects it did not find

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -56,11 +56,26 @@ jobs:
   # *executed* a test there, so Windows-only defects reached users unseen.
   #
   # The leg was advisory (`continue-on-error`) while the 33 pre-existing
-  # failures that first run exposed were worked through: six unrelated root
-  # causes, including two real Windows product defects (the crush registry
-  # scan returning nothing, cc-mirror attributing the wrong provider). Those
-  # landed in #1007, #1012 and #1046, and the suite now completes green across
-  # all 11 binaries.
+  # failures that first run exposed were worked through, across six unrelated
+  # root causes (#1014). Those landed in #1007, #1012 and #1046, and the suite
+  # now completes green across all 11 binaries.
+  #
+  # Most of the 33 were the harness lying, not the product: fixtures built
+  # JSON with `format!` and dropped a raw path inside a string, so on Windows
+  # `C:\Users\RUNNER~1\...` put `\U` and `\A` in the document and serde_json
+  # rejected it. Both readers treat unparseable config as absent, so the Crush
+  # registry scan returned nothing and cc-mirror sessions fell back to plain
+  # Claude - failures that read like product defects several files from the
+  # cause. The real writers (Go `encoding/json`, Node `JSON.stringify`) escape
+  # correctly, so only the tests ever emitted invalid JSON.
+  #
+  # Four genuine Windows product defects did surface underneath: lock and PID
+  # probes silently failing off Unix (#1007), TZ leaving a device unpinnable,
+  # the bare `default` token fuzzy-matching a priced key, and a cache entry
+  # keyed by path separator rather than by file (all #1046). The `default` one
+  # is the same class of bug as #1062 - a generic token with no model identity
+  # electing some provider's priced row - found here only because the Windows
+  # leg ran the test that caught it.
   #
   # It is a HARD GATE as of this change. The advisory phase was explicitly
   # temporary - an advisory job nobody reads is how #997 happened in the first

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -58,7 +58,7 @@ jobs:
   # The leg was advisory (`continue-on-error`) while the 33 pre-existing
   # failures that first run exposed were worked through, across six unrelated
   # root causes (#1014). Those landed in #1007, #1012 and #1046, and the suite
-  # now completes green across all 11 binaries.
+  # now completes green across all 10 test binaries.
   #
   # Most of the 33 were the harness lying, not the product: fixtures built
   # JSON with `format!` and dropped a raw path inside a string, so on Windows
@@ -69,13 +69,25 @@ jobs:
   # cause. The real writers (Go `encoding/json`, Node `JSON.stringify`) escape
   # correctly, so only the tests ever emitted invalid JSON.
   #
-  # Four genuine Windows product defects did surface underneath: lock and PID
-  # probes silently failing off Unix (#1007), TZ leaving a device unpinnable,
-  # the bare `default` token fuzzy-matching a priced key, and a cache entry
-  # keyed by path separator rather than by file (all #1046). The `default` one
-  # is the same class of bug as #1062 - a generic token with no model identity
-  # electing some provider's priced row - found here only because the Windows
-  # leg ran the test that caught it.
+  # Genuine product defects surfaced by the Windows leg did turn up
+  # underneath. From #1007: a contended lock classified as an error instead
+  # of "already running", so a scheduled autosubmit recorded a failure;
+  # `pid_is_alive` hardcoded false off Unix, so every sync lock looked stale
+  # and overlapping syncs could delete each other's artifacts; and manifest
+  # artifact paths rendered with the native separator, which the
+  # cache-relative validator rejected - so any Windows sync with an artifact
+  # to retire failed after the manifest was already written. From #1046: TZ
+  # leaving a device permanently unpinnable, the bare `default` token
+  # fuzzy-matching a priced key, and one file cached under two keys because
+  # the scan root joins with `/` while `WalkDir` appends `\`.
+  #
+  # The `default` one is the same class of bug as #1062 - a generic token
+  # with no model identity electing some provider's priced row - and it was
+  # never Windows-only: it mispriced on every platform. Its test is ungated
+  # and ran on the Ubuntu leg every PR, where the fixture's empty catalog
+  # starved the fuzzy matcher. What exposed it was the sandbox escape above,
+  # the child reading the runner's real `%APPDATA%` catalog and hitting real
+  # prices - a harness defect making a product defect visible.
   #
   # It is a HARD GATE as of this change. The advisory phase was explicitly
   # temporary - an advisory job nobody reads is how #997 happened in the first


### PR DESCRIPTION
Closes the factual half of #1066.

## What is wrong today

The comment above the `tests` job — which I rewrote in #1068 while flipping the gate — says:

> six unrelated root causes, **including two real Windows product defects** (the crush registry scan returning nothing, cc-mirror attributing the wrong provider)

Both were fixture artefacts, not product defects. #1046's `test(core): escape paths written into JSON fixtures` is explicit:

> Nine fixtures assembled a config file with `format!` and dropped a raw filesystem path inside a JSON string: the Crush `projects.json` registries in `scanner.rs` and every cc-mirror `variant.json` […] **The real writers escape correctly** (Crush is Go `encoding/json`, cc-mirror is Node `JSON.stringify`), so **invalid JSON was only ever produced here.**

On Windows the temp dir is `C:\Users\RUNNER~1\AppData\Local\Temp\...`, so the fixture contains `\U`, `\A`, `\L`, `\T` — none of which are JSON escapes. Both readers treat unparseable config as absent rather than as an error, so the bug surfaced as eleven assertions about discovery finding nothing, several files from the cause.

## Why it was easy to get backwards

#1046's subject line says "the three product bugs it was hiding", which invites reading the headline failures as the product bugs. They are not the same three. Checking the sub-commits:

| | |
|---|---|
| `test(core): escape paths written into JSON fixtures` | crush + cc-mirror — **fixtures** |
| `fix(timezone): stop TZ from making a Windows device unpinnable` | product |
| `fix(pricing): stop the bare \`default\` token from fuzzy-matching a priced key` | product |
| `fix(cache): key a Windows cache entry by the file, not by the separator used` | product |

Plus #1007 (`fix(windows): stop lock and PID probes silently failing off Unix`). Four product defects; crush and cc-mirror are in none of them.

## Why this is worth a commit

This comment is what a future reader consults before touching the leg. "Two real Windows product defects" is the sentence that stops someone from deleting a test whose fixture merely looks wrong — and it points at the wrong two.

The correction also notes that the `default` defect is #1062's class (a contentless token electing a priced row), since that is now the second time this repo has paid for that shape and this is the first place a reader is likely to meet it.

## Relationship to #1066

@NickAme03 diagnosed this correctly in #1066 and is credited as co-author. That PR cannot merge as written: it was opened against the pre-#1068 tree, so it keeps `continue-on-error` and states "the leg stays advisory until the two un-redirected config roots are swept" — which stopped being true when #1068 landed. The factual correction is theirs; only the framing changed.

No behavior change. One comment block.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Windows CI leg comment in `.github/workflows/test_coverage.yml` to stop misattributing two fixture-caused failures as product bugs, explicitly list the real defects surfaced by the leg, and correct the test binary count to 10. Aligns attribution with #1007, #1012, #1046, and #1014; no behavior or gating changes.

<sup>Written for commit ac457d0cb51e6211ba79532f4e909203b87f3841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

