### PR TITLE
fix(pricing): treat `deepseek-ai` and `deepseek` as one vendor

### DIFF
--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2310,6 +2310,29 @@ fn key_root_matches_hint(key: &str, hint_tags: &[String]) -> bool {
         .any(|tag| hint_tags.iter().any(|hint| hint == tag))
 }
 
+/// Whether provider matching aliases a hosting platform's root to a different
+/// hinted vendor. Such aliases make the hosted row reachable, but do not make
+/// it the hinted vendor's own top-level row.
+fn key_root_is_cross_provider_alias(key: &str, provider_id: &str) -> bool {
+    let normalize_root = |value: &str| {
+        value
+            .trim()
+            .trim_end_matches('/')
+            .split('/')
+            .next()
+            .unwrap_or_default()
+            .to_lowercase()
+            .replace('-', "_")
+    };
+    let root = normalize_root(key);
+    let hint = normalize_root(provider_id);
+
+    matches!(
+        (root.as_str(), hint.as_str()),
+        ("vertex" | "vertex_ai", "anthropic")
+    )
+}
+
 fn is_reseller_provider(key: &str) -> bool {
     let lower = key.to_lowercase();
     RESELLER_PROVIDER_PREFIXES
@@ -2412,10 +2435,8 @@ fn select_best_match(
             // reseller, chosen for being spelled the other way and having a
             // longer key. Among equally spelled rows a non-reseller still wins.
             let by_root = candidates.iter().find(|k| {
-                // Some reseller aliases canonicalize to the hosted vendor
-                // (`vertex_ai` -> `anthropic`). They remain reseller roots,
-                // not the hinted vendor's own top-level row.
-                !is_reseller_provider(k) && key_root_matches_hint(k, &hint_tags)
+                key_root_matches_hint(k, &hint_tags)
+                    && !provider_id.is_some_and(|hint| key_root_is_cross_provider_alias(k, hint))
             });
             let by_spelling = provider_id.and_then(|hint| {
                 let spelled: Vec<&&String> = candidates
@@ -6734,36 +6755,76 @@ mod tests {
     }
 
     /// Vertex canonicalizes to Anthropic so an Anthropic hint can find Vertex's
-    /// hosted Claude rows. That alias must not make the reseller's root look
-    /// like Anthropic's own top-level row and outrank an exact-spelling row.
+    /// hosted Claude rows. That alias must not make the hosting platform's root
+    /// look like Anthropic's own top-level row and outrank an exact-spelling row.
     #[test]
     fn reseller_alias_root_does_not_outrank_exact_vendor_spelling() {
+        for vertex_root in ["vertex", "vertex_ai"] {
+            let hosted_key = format!("{vertex_root}/claude-sonnet-4");
+            let mut litellm = HashMap::new();
+            litellm.insert(
+                hosted_key.clone(),
+                ModelPricing {
+                    input_cost_per_token: Some(0.000003),
+                    output_cost_per_token: Some(0.000015),
+                    ..Default::default()
+                },
+            );
+            litellm.insert(
+                "host/anthropic/claude-sonnet-4".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(0.000004),
+                    output_cost_per_token: Some(0.000020),
+                    ..Default::default()
+                },
+            );
+            let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+            let anthropic = lookup
+                .lookup_with_provider("claude-sonnet-4", Some("anthropic"))
+                .expect("anthropic-hinted claude-sonnet-4 must price");
+            assert_eq!(
+                anthropic.matched_key, "host/anthropic/claude-sonnet-4",
+                "{vertex_root} must not impersonate Anthropic's own root"
+            );
+
+            let vertex = lookup
+                .lookup_with_provider("claude-sonnet-4", Some(vertex_root))
+                .unwrap_or_else(|| panic!("{vertex_root}-hinted claude-sonnet-4 must price"));
+            assert_eq!(
+                vertex.matched_key, hosted_key,
+                "a Vertex hint must still select Vertex's hosted row"
+            );
+        }
+    }
+
+    /// A root globally classified as a reseller can still be the hinted
+    /// provider's own top-level row. Together's row must retain the root tier
+    /// over a longer host that merely nests the Together spelling.
+    #[test]
+    fn reseller_classification_does_not_hide_hinted_provider_own_root() {
         let mut litellm = HashMap::new();
         litellm.insert(
-            "vertex_ai/claude-sonnet-4".to_string(),
+            "together_ai/model-x".to_string(),
             ModelPricing {
-                input_cost_per_token: Some(0.000003),
-                output_cost_per_token: Some(0.000015),
+                input_cost_per_token: Some(0.000001),
+                output_cost_per_token: Some(0.000002),
                 ..Default::default()
             },
         );
         litellm.insert(
-            "host/anthropic/claude-sonnet-4".to_string(),
+            "long-host/together/model-x".to_string(),
             ModelPricing {
-                input_cost_per_token: Some(0.000004),
-                output_cost_per_token: Some(0.000020),
+                input_cost_per_token: Some(0.000003),
+                output_cost_per_token: Some(0.000004),
                 ..Default::default()
             },
         );
         let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
 
         let result = lookup
-            .lookup_with_provider("claude-sonnet-4", Some("anthropic"))
-            .expect("anthropic-hinted claude-sonnet-4 must price");
-        assert_eq!(
-            result.matched_key, "host/anthropic/claude-sonnet-4",
-            "a reseller alias root must not impersonate the hinted vendor's own row"
-        );
-        assert_eq!(result.pricing.output_cost_per_token, Some(0.000020));
+            .lookup_with_provider("model-x", Some("together"))
+            .expect("together-hinted model-x must price");
+        assert_eq!(result.matched_key, "together_ai/model-x");
     }
 }

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2389,18 +2389,24 @@ fn select_best_match(
             // `cloudflare/@cf/deepseek-ai/...` at $0.497/$4.881 — a 16x output
             // rate on the same weights.
             //
-            // So prefer a row that spells the vendor exactly as the hint does
-            // over one that only matches after folding. Two rows outrank it and
-            // must not be displaced: a first-party row (handled by
-            // `is_original_provider` below) and the hinted provider's own
-            // top-level row. Without the second guard a `novita` hint on
-            // `kimi-k2.6` would leave Novita's own `novita-ai/moonshotai/...`
-            // at $0.80/$3.40 for `poe/novita/...` at $0.96/$4.04, which spells
-            // `novita` in a nested segment only because Poe is reselling it.
-            let has_root_match = candidates
+            // So the pool is ranked explicitly instead of leaning on key
+            // order. A first-party row wins outright. Next comes the hinted
+            // vendor's own top-level row: `novita-ai/moonshotai/kimi-k2.6` at
+            // $0.80/$3.40 is Novita's own, while `poe/novita/kimi-k2.6` at
+            // $0.96/$4.04 spells `novita` in a nested segment only because Poe
+            // is reselling it. Ranking that row rather than merely detecting it
+            // matters, because candidates are ordered longest key first and the
+            // vendor's own row is usually the shorter one:
+            // `vercel_ai_gateway/zai/glm-4.6` at $0.45/$1.80 would otherwise be
+            // billed for a `zai` hint that Z.ai itself publishes at
+            // `zai/glm-4.6`, $0.60/$2.20.
+            //
+            // A row that spells the vendor exactly as the hint does comes
+            // next, in preference to one that only matches after folding.
+            let by_root = candidates
                 .iter()
-                .any(|k| key_root_matches_hint(k, &hint_tags));
-            let by_spelling = provider_id.filter(|_| !has_root_match).and_then(|hint| {
+                .find(|k| key_root_matches_hint(k, &hint_tags));
+            let by_spelling = provider_id.and_then(|hint| {
                 candidates.iter().find(|k| {
                     !is_reseller_provider(k)
                         && provider_identity::matches_provider_spelling(k, hint)
@@ -2409,6 +2415,7 @@ fn select_best_match(
             candidates
                 .iter()
                 .find(|k| is_original_provider(k))
+                .or(by_root)
                 .or(by_spelling)
                 .or_else(|| candidates.iter().find(|k| !is_reseller_provider(k)))
                 .or_else(|| candidates.first())
@@ -6629,5 +6636,45 @@ mod tests {
                 "{hint:?} is dropped by normalize_provider_hint and must match the unhinted result"
             );
         }
+    }
+
+    /// `key_root_matches_hint` recognises the hinted vendor's own top-level
+    /// row, and that row has to be *selected*, not merely used to switch the
+    /// spelling preference off. Z.ai publishes `zai/glm-4.6` at $0.60/$2.20 per
+    /// MTok and Vercel's gateway resells it at $0.45/$1.80 under
+    /// `vercel_ai_gateway/zai/glm-4.6`; neither key is in
+    /// `ORIGINAL_PROVIDER_PREFIXES` (Z.ai's first-party spelling there is
+    /// `z-ai/`) nor in `RESELLER_PROVIDER_PREFIXES`, and candidates are ordered
+    /// longest key first, so a `zai` hint must not be billed at the gateway's
+    /// sheet just because its key is longer.
+    #[test]
+    fn hinted_vendor_own_row_wins_over_a_longer_row_that_only_nests_the_vendor() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "zai/glm-4.6".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000006),
+                output_cost_per_token: Some(0.0000022),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "vercel_ai_gateway/zai/glm-4.6".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000045),
+                output_cost_per_token: Some(0.0000018),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        let result = lookup
+            .lookup_with_provider("glm-4.6", Some("zai"))
+            .expect("zai-hinted glm-4.6 must price");
+        assert_eq!(
+            result.matched_key, "zai/glm-4.6",
+            "Z.ai's own row must win over a gateway that nests `zai` in a longer key"
+        );
+        assert_eq!(result.pricing.output_cost_per_token, Some(0.0000022));
     }
 }

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -519,9 +519,10 @@ impl PricingLookup {
                     return Some(result);
                 }
             } else {
-                if let Some(result) = choose_best_source_result(
+                if let Some(result) = choose_best_source_result_with_models_dev(
                     self.exact_match_litellm_for_provider(stripped, provider_id),
                     self.exact_match_openrouter_for_provider(stripped, provider_id),
+                    self.exact_match_models_dev_for_provider(stripped, provider_id),
                     provider_id,
                 ) {
                     return Some(result);
@@ -542,9 +543,10 @@ impl PricingLookup {
             return exact_litellm;
         }
 
-        if let Some(result) = choose_best_source_result(
+        if let Some(result) = choose_best_source_result_with_models_dev(
             self.exact_match_litellm_for_provider(model_id, provider_id),
             self.exact_match_openrouter_for_provider(model_id, provider_id),
+            self.exact_match_models_dev_for_provider(model_id, provider_id),
             provider_id,
         ) {
             return Some(result);
@@ -587,9 +589,10 @@ impl PricingLookup {
         // for UNhinted lookups: the provider-scoped passes above and below
         // keep provider-hinted resolutions pinned to the hinted provider.
         if let Some(version_normalized) = normalize_version_separator(model_id) {
-            if let Some(result) = choose_best_source_result(
+            if let Some(result) = choose_best_source_result_with_models_dev(
                 self.exact_match_litellm_for_provider(&version_normalized, provider_id),
                 self.exact_match_openrouter_for_provider(&version_normalized, provider_id),
+                self.exact_match_models_dev_for_provider(&version_normalized, provider_id),
                 provider_id,
             ) {
                 return Some(result);
@@ -621,9 +624,10 @@ impl PricingLookup {
         }
 
         if let Some(normalized) = normalize_model_name(model_id) {
-            if let Some(result) = choose_best_source_result(
+            if let Some(result) = choose_best_source_result_with_models_dev(
                 self.exact_match_litellm_for_provider(&normalized, provider_id),
                 self.exact_match_openrouter_for_provider(&normalized, provider_id),
+                self.exact_match_models_dev_for_provider(&normalized, provider_id),
                 provider_id,
             ) {
                 return Some(result);
@@ -2327,10 +2331,8 @@ fn key_root_is_cross_provider_alias(key: &str, provider_id: &str) -> bool {
     let root = normalize_root(key);
     let hint = normalize_root(provider_id);
 
-    matches!(
-        (root.as_str(), hint.as_str()),
-        ("vertex" | "vertex_ai", "anthropic") | ("anthropic", "vertex" | "vertex_ai")
-    )
+    let is_claude_endpoint = |value: &str| matches!(value, "anthropic" | "vertex" | "vertex_ai");
+    root != hint && is_claude_endpoint(&root) && is_claude_endpoint(&hint)
 }
 
 fn key_root_matches_provider_hint(key: &str, provider_id: &str) -> bool {
@@ -2614,6 +2616,30 @@ fn choose_best_source_result(
         (Some(_), None) => litellm_result,
         (None, Some(_)) => openrouter_result,
         (None, None) => None,
+    }
+}
+
+/// Run the normal LiteLLM/OpenRouter arbitration, but let a literal
+/// provider-root match from Models.dev displace an alias-only winner. Models.dev
+/// otherwise remains the long-tail fallback at its established precedence.
+fn choose_best_source_result_with_models_dev(
+    litellm_result: Option<LookupResult>,
+    openrouter_result: Option<LookupResult>,
+    models_dev_result: Option<LookupResult>,
+    provider_id: Option<&str>,
+) -> Option<LookupResult> {
+    let primary = choose_best_source_result(litellm_result, openrouter_result, provider_id);
+    let models_dev_matches_root = models_dev_result.as_ref().is_some_and(|result| {
+        provider_id.is_some_and(|hint| key_root_matches_provider_hint(&result.matched_key, hint))
+    });
+    let primary_is_cross_provider_alias = primary.as_ref().is_some_and(|result| {
+        provider_id.is_some_and(|hint| key_root_is_cross_provider_alias(&result.matched_key, hint))
+    });
+
+    if models_dev_matches_root && primary_is_cross_provider_alias {
+        models_dev_result
+    } else {
+        primary
     }
 }
 
@@ -6891,6 +6917,156 @@ mod tests {
                 .expect("anthropic-hinted claude-sonnet-4 must price");
             assert_eq!(anthropic.matched_key, "anthropic/claude-sonnet-4");
             assert_eq!(anthropic.source, "OpenRouter");
+        }
+    }
+
+    /// `vertex` and `vertex_ai` share a provider tag for fallback reachability,
+    /// but are distinct billing endpoints. The literal root must win in either
+    /// direction even though the longer `vertex_ai` key is ordered first.
+    #[test]
+    fn vertex_endpoint_aliases_do_not_impersonate_each_others_own_root() {
+        let mut litellm = HashMap::new();
+        for key in ["vertex/claude-sonnet-4", "vertex_ai/claude-sonnet-4"] {
+            litellm.insert(
+                key.to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(0.000003),
+                    output_cost_per_token: Some(0.000015),
+                    ..Default::default()
+                },
+            );
+        }
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        for hint in ["vertex", "vertex_ai"] {
+            let result = lookup
+                .lookup_with_provider("claude-sonnet-4", Some(hint))
+                .unwrap_or_else(|| panic!("{hint}-hinted claude-sonnet-4 must price"));
+            assert_eq!(result.matched_key, format!("{hint}/claude-sonnet-4"));
+        }
+    }
+
+    #[test]
+    fn vertex_endpoint_literal_root_survives_cross_source_arbitration() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "vertex/claude-sonnet-4".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000003),
+                output_cost_per_token: Some(0.000015),
+                ..Default::default()
+            },
+        );
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "vertex_ai/claude-sonnet-4".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000004),
+                output_cost_per_token: Some(0.000020),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(litellm, openrouter, HashMap::new());
+
+        for (hint, key, source) in [
+            ("vertex", "vertex/claude-sonnet-4", "LiteLLM"),
+            ("vertex_ai", "vertex_ai/claude-sonnet-4", "OpenRouter"),
+        ] {
+            let result = lookup
+                .lookup_with_provider("claude-sonnet-4", Some(hint))
+                .unwrap_or_else(|| panic!("{hint}-hinted claude-sonnet-4 must price"));
+            assert_eq!(result.matched_key, key);
+            assert_eq!(result.source, source);
+        }
+    }
+
+    /// A literal provider root in Models.dev must participate in the same
+    /// arbitration as LiteLLM and OpenRouter instead of losing to their
+    /// alias-only row merely because Models.dev is normally the long-tail
+    /// fallback. Exercise both directions of the Anthropic/Vertex relation.
+    #[test]
+    fn models_dev_literal_root_outranks_cross_source_endpoint_alias() {
+        for (hint, own_root, alias_root) in [
+            ("vertex", "vertex", "anthropic"),
+            ("vertex_ai", "vertex_ai", "anthropic"),
+            ("anthropic", "anthropic", "vertex"),
+            ("anthropic", "anthropic", "vertex_ai"),
+        ] {
+            let mut litellm = HashMap::new();
+            litellm.insert(
+                format!("{alias_root}/claude-sonnet-4"),
+                ModelPricing {
+                    input_cost_per_token: Some(0.000003),
+                    output_cost_per_token: Some(0.000015),
+                    ..Default::default()
+                },
+            );
+            let mut models_dev = HashMap::new();
+            let own_key = format!("{own_root}/claude-sonnet-4");
+            models_dev.insert(
+                own_key.clone(),
+                ModelPricing {
+                    input_cost_per_token: Some(0.000004),
+                    output_cost_per_token: Some(0.000020),
+                    ..Default::default()
+                },
+            );
+            let lookup = PricingLookup::new_with_models_dev(
+                litellm,
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::new(),
+                models_dev,
+            );
+
+            let result = lookup
+                .lookup_with_provider("claude-sonnet-4", Some(hint))
+                .unwrap_or_else(|| panic!("{hint}-hinted claude-sonnet-4 must price"));
+            assert_eq!(result.matched_key, own_key);
+            assert_eq!(result.source, "Models.dev");
+        }
+    }
+
+    #[test]
+    fn normalized_models_dev_literal_root_outranks_cross_source_endpoint_alias() {
+        for (hint, own_root, alias_root) in [
+            ("vertex", "vertex", "anthropic"),
+            ("vertex_ai", "vertex_ai", "anthropic"),
+            ("anthropic", "anthropic", "vertex"),
+            ("anthropic", "anthropic", "vertex_ai"),
+        ] {
+            let mut openrouter = HashMap::new();
+            openrouter.insert(
+                format!("{alias_root}/claude-sonnet-4-6"),
+                ModelPricing {
+                    input_cost_per_token: Some(0.000003),
+                    output_cost_per_token: Some(0.000015),
+                    ..Default::default()
+                },
+            );
+            let mut models_dev = HashMap::new();
+            let own_key = format!("{own_root}/claude-sonnet-4-6");
+            models_dev.insert(
+                own_key.clone(),
+                ModelPricing {
+                    input_cost_per_token: Some(0.000004),
+                    output_cost_per_token: Some(0.000020),
+                    ..Default::default()
+                },
+            );
+            let lookup = PricingLookup::new_with_models_dev(
+                HashMap::new(),
+                openrouter,
+                HashMap::new(),
+                HashMap::new(),
+                models_dev,
+            );
+
+            let result = lookup
+                .lookup_with_provider("claude-sonnet-4.6", Some(hint))
+                .unwrap_or_else(|| panic!("normalized {hint}-hinted Claude must price"));
+            assert_eq!(result.matched_key, own_key);
+            assert_eq!(result.source, "Models.dev");
         }
     }
 

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2310,9 +2310,9 @@ fn key_root_matches_hint(key: &str, hint_tags: &[String]) -> bool {
         .any(|tag| hint_tags.iter().any(|hint| hint == tag))
 }
 
-/// Whether provider matching aliases a hosting platform's root to a different
-/// hinted vendor. Such aliases make the hosted row reachable, but do not make
-/// it the hinted vendor's own top-level row.
+/// Whether provider-tag folding makes the key root and hint match despite
+/// naming different billing endpoints. The alias keeps fallback rows reachable,
+/// but neither endpoint's root is the other endpoint's own top-level row.
 fn key_root_is_cross_provider_alias(key: &str, provider_id: &str) -> bool {
     let normalize_root = |value: &str| {
         value
@@ -2329,8 +2329,13 @@ fn key_root_is_cross_provider_alias(key: &str, provider_id: &str) -> bool {
 
     matches!(
         (root.as_str(), hint.as_str()),
-        ("vertex" | "vertex_ai", "anthropic")
+        ("vertex" | "vertex_ai", "anthropic") | ("anthropic", "vertex" | "vertex_ai")
     )
+}
+
+fn key_root_matches_provider_hint(key: &str, provider_id: &str) -> bool {
+    let hint_tags = provider_identity::provider_tags(provider_id);
+    key_root_matches_hint(key, &hint_tags) && !key_root_is_cross_provider_alias(key, provider_id)
 }
 
 fn is_reseller_provider(key: &str) -> bool {
@@ -2413,16 +2418,18 @@ fn select_best_match(
             // rate on the same weights.
             //
             // So the pool is ranked explicitly instead of leaning on key
-            // order. A first-party row wins outright. Next comes the hinted
-            // vendor's own top-level row: `novita-ai/moonshotai/kimi-k2.6` at
-            // $0.80/$3.40 is Novita's own, while `poe/novita/kimi-k2.6` at
-            // $0.96/$4.04 spells `novita` in a nested segment only because Poe
-            // is reselling it. Ranking that row rather than merely detecting it
-            // matters, because candidates are ordered longest key first and the
-            // vendor's own row is usually the shorter one:
-            // `vercel_ai_gateway/zai/glm-4.6` at $0.45/$1.80 would otherwise be
-            // billed for a `zai` hint that Z.ai itself publishes at
-            // `zai/glm-4.6`, $0.60/$2.20.
+            // order. The hinted vendor's own top-level row wins first:
+            // `novita-ai/moonshotai/kimi-k2.6` at $0.80/$3.40 is Novita's own,
+            // while `poe/novita/kimi-k2.6` at $0.96/$4.04 spells `novita` in a
+            // nested segment only because Poe is reselling it. Ranking that row
+            // rather than merely detecting it matters, because candidates are
+            // ordered longest key first and the vendor's own row is usually the
+            // shorter one: `vercel_ai_gateway/zai/glm-4.6` at $0.45/$1.80 would
+            // otherwise be billed for a `zai` hint that Z.ai itself publishes
+            // at `zai/glm-4.6`, $0.60/$2.20. A raw Vertex hint similarly keeps
+            // Vertex's hosted row ahead of Anthropic's row, while an Anthropic
+            // hint excludes that cross-provider root alias. A first-party row
+            // is the next tier.
             //
             // Then comes a row that spells the vendor exactly as the hint does,
             // in preference to one that only matches after folding. That row is
@@ -2449,10 +2456,8 @@ fn select_best_match(
                     .find(|k| !is_reseller_provider(k))
                     .or_else(|| spelled.first().copied())
             });
-            candidates
-                .iter()
-                .find(|k| is_original_provider(k))
-                .or(by_root)
+            by_root
+                .or_else(|| candidates.iter().find(|k| is_original_provider(k)))
                 .or(by_spelling)
                 .or_else(|| candidates.iter().find(|k| !is_reseller_provider(k)))
                 .or_else(|| candidates.first())
@@ -2572,6 +2577,17 @@ fn choose_best_source_result(
                 return litellm_result;
             }
             if o_matches_provider && !l_matches_provider {
+                return openrouter_result;
+            }
+
+            let l_matches_root = provider_id
+                .is_some_and(|hint| key_root_matches_provider_hint(&l.matched_key, hint));
+            let o_matches_root = provider_id
+                .is_some_and(|hint| key_root_matches_provider_hint(&o.matched_key, hint));
+            if l_matches_root && !o_matches_root {
+                return litellm_result;
+            }
+            if o_matches_root && !l_matches_root {
                 return openrouter_result;
             }
 
@@ -6795,6 +6811,86 @@ mod tests {
                 vertex.matched_key, hosted_key,
                 "a Vertex hint must still select Vertex's hosted row"
             );
+        }
+    }
+
+    /// Direct Vertex hints must keep Vertex's hosted pricing even when an
+    /// Anthropic first-party row is also available. The canonical provider tag
+    /// makes both candidates reachable; the raw hint decides which root owns
+    /// the usage.
+    #[test]
+    fn direct_vertex_hint_outranks_anthropic_first_party_alias() {
+        for vertex_root in ["vertex", "vertex_ai"] {
+            let hosted_key = format!("{vertex_root}/claude-sonnet-4");
+            let mut litellm = HashMap::new();
+            litellm.insert(
+                hosted_key.clone(),
+                ModelPricing {
+                    input_cost_per_token: Some(0.000003),
+                    output_cost_per_token: Some(0.000015),
+                    ..Default::default()
+                },
+            );
+            litellm.insert(
+                "anthropic/claude-sonnet-4".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(0.000004),
+                    output_cost_per_token: Some(0.000020),
+                    ..Default::default()
+                },
+            );
+            let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+            let vertex = lookup
+                .lookup_with_provider("claude-sonnet-4", Some(vertex_root))
+                .unwrap_or_else(|| panic!("{vertex_root}-hinted claude-sonnet-4 must price"));
+            assert_eq!(vertex.matched_key, hosted_key);
+
+            let anthropic = lookup
+                .lookup_with_provider("claude-sonnet-4", Some("anthropic"))
+                .expect("anthropic-hinted claude-sonnet-4 must price");
+            assert_eq!(anthropic.matched_key, "anthropic/claude-sonnet-4");
+        }
+    }
+
+    /// The same explicit-root preference must survive source arbitration;
+    /// otherwise each dataset selects correctly and the later cross-source
+    /// first-party tier silently changes the winner back to Anthropic.
+    #[test]
+    fn direct_vertex_hint_outranks_cross_source_anthropic_alias() {
+        for vertex_root in ["vertex", "vertex_ai"] {
+            let hosted_key = format!("{vertex_root}/claude-sonnet-4");
+            let mut litellm = HashMap::new();
+            litellm.insert(
+                hosted_key.clone(),
+                ModelPricing {
+                    input_cost_per_token: Some(0.000003),
+                    output_cost_per_token: Some(0.000015),
+                    ..Default::default()
+                },
+            );
+            let mut openrouter = HashMap::new();
+            openrouter.insert(
+                "anthropic/claude-sonnet-4".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(0.000004),
+                    output_cost_per_token: Some(0.000020),
+                    ..Default::default()
+                },
+            );
+            let lookup = PricingLookup::new(litellm, openrouter, HashMap::new());
+
+            let vertex = lookup
+                .lookup_with_provider("claude-sonnet-4", Some(vertex_root))
+                .unwrap_or_else(|| panic!("{vertex_root}-hinted claude-sonnet-4 must price"));
+            assert_eq!(vertex.matched_key, hosted_key);
+            assert_eq!(vertex.source, "LiteLLM");
+
+            let anthropic = lookup
+                .lookup_with_provider("claude-sonnet-4", Some("anthropic"))
+                .expect("anthropic-hinted claude-sonnet-4 must price");
+            assert_eq!(anthropic.matched_key, "anthropic/claude-sonnet-4");
+            assert_eq!(anthropic.source, "OpenRouter");
         }
     }
 

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2401,16 +2401,29 @@ fn select_best_match(
             // billed for a `zai` hint that Z.ai itself publishes at
             // `zai/glm-4.6`, $0.60/$2.20.
             //
-            // A row that spells the vendor exactly as the hint does comes
-            // next, in preference to one that only matches after folding.
+            // Then comes a row that spells the vendor exactly as the hint does,
+            // in preference to one that only matches after folding. That row is
+            // taken even when it starts with a reseller prefix, because the
+            // property that matters is the spelling, not the publisher: the
+            // pre-fold match for a `deepseek-ai` hint on `deepseek-r1` is
+            // `together_ai/deepseek-ai/DeepSeek-R1` at $3.00/$7.00, and
+            // discarding it for being a reseller just hands the lookup to
+            // `vercel_ai_gateway/deepseek/deepseek-r1` at $0.55/$2.19 — another
+            // reseller, chosen for being spelled the other way and having a
+            // longer key. Among equally spelled rows a non-reseller still wins.
             let by_root = candidates
                 .iter()
                 .find(|k| key_root_matches_hint(k, &hint_tags));
             let by_spelling = provider_id.and_then(|hint| {
-                candidates.iter().find(|k| {
-                    !is_reseller_provider(k)
-                        && provider_identity::matches_provider_spelling(k, hint)
-                })
+                let spelled: Vec<&&String> = candidates
+                    .iter()
+                    .filter(|k| provider_identity::matches_provider_spelling(k, hint))
+                    .collect();
+                spelled
+                    .iter()
+                    .copied()
+                    .find(|k| !is_reseller_provider(k))
+                    .or_else(|| spelled.first().copied())
             });
             candidates
                 .iter()
@@ -6676,5 +6689,44 @@ mod tests {
             "Z.ai's own row must win over a gateway that nests `zai` in a longer key"
         );
         assert_eq!(result.pricing.output_cost_per_token, Some(0.0000022));
+    }
+
+    /// The spelling preference exists to keep a hinted vendor on the row that
+    /// spells the vendor its way, so it must not throw that row away for
+    /// starting with a reseller prefix. Before the fold, a `deepseek-ai` hint
+    /// matched only `together_ai/deepseek-ai/DeepSeek-R1` ($3.00/$7.00 per
+    /// MTok); folding `deepseek-ai` into `deepseek` pulled
+    /// `vercel_ai_gateway/deepseek/deepseek-r1` ($0.55/$2.19) into the same
+    /// pool, and it wins on key length alone. That is the fold moving usage
+    /// between two resellers, which is precisely what the preference is for.
+    #[test]
+    fn exact_vendor_spelling_wins_even_when_that_row_is_a_reseller() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "together_ai/deepseek-ai/DeepSeek-R1".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000003),
+                output_cost_per_token: Some(0.000007),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "vercel_ai_gateway/deepseek/deepseek-r1".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000055),
+                output_cost_per_token: Some(0.00000219),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        let result = lookup
+            .lookup_with_provider("deepseek-r1", Some("deepseek-ai"))
+            .expect("deepseek-ai-hinted deepseek-r1 must price");
+        assert_eq!(
+            result.matched_key, "together_ai/deepseek-ai/DeepSeek-R1",
+            "the row spelling the vendor the hint's way must win even though it is a reseller"
+        );
+        assert_eq!(result.pricing.output_cost_per_token, Some(0.000007));
     }
 }

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2295,6 +2295,21 @@ fn is_original_provider(key: &str) -> bool {
         .any(|prefix| lower.starts_with(prefix))
 }
 
+/// Whether the dataset key's leading segment *is* the hinted vendor, rather
+/// than a reseller that merely nests the vendor deeper in the key.
+///
+/// `poe/novita/kimi-k2.6` and `novita-ai/moonshotai/kimi-k2.6` both carry the
+/// tag `novita`, but only the second is Novita's own row; the first is Poe
+/// reselling it at $0.96/$4.04 per MTok against Novita's $0.80/$3.40.
+fn key_root_matches_hint(key: &str, hint_tags: &[String]) -> bool {
+    let Some(root) = key.split('/').next() else {
+        return false;
+    };
+    provider_identity::provider_tags(root)
+        .iter()
+        .any(|tag| hint_tags.iter().any(|hint| hint == tag))
+}
+
 fn is_reseller_provider(key: &str) -> bool {
     let lower = key.to_lowercase();
     RESELLER_PROVIDER_PREFIXES
@@ -2361,9 +2376,40 @@ fn select_best_match(
                 .find(|k| is_reseller_provider(k))
                 .or_else(|| candidates.first())
         } else {
+            // The vendor-spelling fold (`deepseek-ai` -> `deepseek`) widens
+            // this pool: a `deepseek` hint now matches both
+            // `novita/deepseek/<model>` and `cloudflare/@cf/deepseek-ai/<model>`,
+            // two resellers with different price sheets for the same weights.
+            // Nothing below tells them apart, so the winner falls out of key
+            // ordering — which is length-descending over a HashMap's key
+            // iteration, and therefore not even stable between processes for
+            // equal-length keys. `deepseek-r1-distill-qwen-32b` with the
+            // `deepseek` hint that `inferred_provider_from_model` synthesizes
+            // moved off `novita/deepseek/...` at $0.30/$0.30 per MTok onto
+            // `cloudflare/@cf/deepseek-ai/...` at $0.497/$4.881 — a 16x output
+            // rate on the same weights.
+            //
+            // So prefer a row that spells the vendor exactly as the hint does
+            // over one that only matches after folding. Two rows outrank it and
+            // must not be displaced: a first-party row (handled by
+            // `is_original_provider` below) and the hinted provider's own
+            // top-level row. Without the second guard a `novita` hint on
+            // `kimi-k2.6` would leave Novita's own `novita-ai/moonshotai/...`
+            // at $0.80/$3.40 for `poe/novita/...` at $0.96/$4.04, which spells
+            // `novita` in a nested segment only because Poe is reselling it.
+            let has_root_match = candidates
+                .iter()
+                .any(|k| key_root_matches_hint(k, &hint_tags));
+            let by_spelling = provider_id.filter(|_| !has_root_match).and_then(|hint| {
+                candidates.iter().find(|k| {
+                    !is_reseller_provider(k)
+                        && provider_identity::matches_provider_spelling(k, hint)
+                })
+            });
             candidates
                 .iter()
                 .find(|k| is_original_provider(k))
+                .or(by_spelling)
                 .or_else(|| candidates.iter().find(|k| !is_reseller_provider(k)))
                 .or_else(|| candidates.first())
         };
@@ -6434,5 +6480,154 @@ mod tests {
             "ab/some-model",
             "abcd/some-model"
         ));
+    }
+
+    /// Folding `deepseek-ai` into `deepseek` widens the provider-hint
+    /// candidate pool, and `deepseek` is exactly the hint
+    /// `inferred_provider_from_model` synthesizes for every model named
+    /// `deepseek-*` whose client reports no provider. Both rows below then
+    /// match the hint, they disagree by 16x on output, and nothing else in
+    /// `select_best_match` tells them apart — the winner would fall out of key
+    /// ordering, which is length-descending over a HashMap's key iteration and
+    /// so not stable between processes for equal-length keys. The row spelling
+    /// the vendor the way the hint does has to win.
+    #[test]
+    fn vendor_spelling_fold_does_not_move_pricing_onto_another_reseller() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "novita/deepseek/deepseek-r1-distill-qwen-32b".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000003),
+                output_cost_per_token: Some(0.0000003),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "cloudflare/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000000497),
+                output_cost_per_token: Some(0.000004881),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        let result = lookup
+            .lookup_with_provider("deepseek-r1-distill-qwen-32b", Some("deepseek"))
+            .expect("deepseek-hinted distill must price");
+        assert_eq!(
+            result.matched_key, "novita/deepseek/deepseek-r1-distill-qwen-32b",
+            "a `deepseek` hint must not cross onto the `deepseek-ai`-spelled reseller row"
+        );
+        assert_eq!(result.pricing.output_cost_per_token, Some(0.0000003));
+    }
+
+    /// The other direction of the same fold, which the spelling preference must
+    /// not break: a `deepseek-ai` hint exists so it can reach rows spelled
+    /// `deepseek`, and DeepSeek's own first-party row is the whole point. A
+    /// reseller row that happens to spell the vendor the hint's way must not
+    /// displace it.
+    #[test]
+    fn vendor_spelling_preference_never_displaces_the_first_party_row() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "deepseek/deepseek-v3".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000027),
+                output_cost_per_token: Some(0.0000011),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "hyperbolic/deepseek-ai/DeepSeek-V3".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000002),
+                output_cost_per_token: Some(0.0000002),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        for hint in ["deepseek-ai", "deepseek_ai", "DeepSeek-AI", "deepseek"] {
+            let result = lookup
+                .lookup_with_provider("deepseek-v3", Some(hint))
+                .unwrap_or_else(|| panic!("{hint}-hinted deepseek-v3 must price"));
+            assert_eq!(
+                result.matched_key, "deepseek/deepseek-v3",
+                "{hint} must still reach DeepSeek's own row"
+            );
+        }
+    }
+
+    /// The spelling preference is a tiebreak among rows that merely nest the
+    /// vendor, so it must yield to the hinted provider's own top-level row.
+    /// `poe/novita/kimi-k2.6` spells `novita` only because Poe is reselling
+    /// Novita's endpoint, and it charges $0.96/$4.04 per MTok against Novita's
+    /// own $0.80/$3.40.
+    #[test]
+    fn hinted_provider_own_row_outranks_a_nested_spelling_match() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "novita-ai/moonshotai/kimi-k2.6".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000008),
+                output_cost_per_token: Some(0.0000034),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "poe/novita/kimi-k2.6".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00000096),
+                output_cost_per_token: Some(0.00000404),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        let result = lookup
+            .lookup_with_provider("kimi-k2.6", Some("novita"))
+            .expect("novita-hinted kimi-k2.6 must price");
+        assert_eq!(
+            result.matched_key, "novita-ai/moonshotai/kimi-k2.6",
+            "Novita's own row must win over Poe reselling it"
+        );
+    }
+
+    /// Kimi, Warp, Kiro, Codebuff and Tencent Buddy report the literal string
+    /// `unknown` when they cannot name a provider, and `normalize_provider_hint`
+    /// drops it, so the unhinted path is reached in production. It has no
+    /// vendor spelling to prefer and must resolve exactly as a missing hint
+    /// does.
+    #[test]
+    fn unhinted_lookup_is_unchanged_by_the_vendor_spelling_preference() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "novita/deepseek/deepseek-r1-distill-qwen-32b".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000003),
+                output_cost_per_token: Some(0.0000003),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "cloudflare/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000000497),
+                output_cost_per_token: Some(0.000004881),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        let bare = lookup.lookup_with_provider("deepseek-r1-distill-qwen-32b", None);
+        for hint in [Some("unknown"), Some("UNKNOWN"), Some(""), Some("  ")] {
+            let hinted = lookup.lookup_with_provider("deepseek-r1-distill-qwen-32b", hint);
+            assert_eq!(
+                hinted.map(|r| r.matched_key),
+                bare.as_ref().map(|r| r.matched_key.clone()),
+                "{hint:?} is dropped by normalize_provider_hint and must match the unhinted result"
+            );
+        }
     }
 }

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2411,9 +2411,12 @@ fn select_best_match(
             // `vercel_ai_gateway/deepseek/deepseek-r1` at $0.55/$2.19 — another
             // reseller, chosen for being spelled the other way and having a
             // longer key. Among equally spelled rows a non-reseller still wins.
-            let by_root = candidates
-                .iter()
-                .find(|k| key_root_matches_hint(k, &hint_tags));
+            let by_root = candidates.iter().find(|k| {
+                // Some reseller aliases canonicalize to the hosted vendor
+                // (`vertex_ai` -> `anthropic`). They remain reseller roots,
+                // not the hinted vendor's own top-level row.
+                !is_reseller_provider(k) && key_root_matches_hint(k, &hint_tags)
+            });
             let by_spelling = provider_id.and_then(|hint| {
                 let spelled: Vec<&&String> = candidates
                     .iter()
@@ -6728,5 +6731,39 @@ mod tests {
             "the row spelling the vendor the hint's way must win even though it is a reseller"
         );
         assert_eq!(result.pricing.output_cost_per_token, Some(0.000007));
+    }
+
+    /// Vertex canonicalizes to Anthropic so an Anthropic hint can find Vertex's
+    /// hosted Claude rows. That alias must not make the reseller's root look
+    /// like Anthropic's own top-level row and outrank an exact-spelling row.
+    #[test]
+    fn reseller_alias_root_does_not_outrank_exact_vendor_spelling() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "vertex_ai/claude-sonnet-4".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000003),
+                output_cost_per_token: Some(0.000015),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "host/anthropic/claude-sonnet-4".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000004),
+                output_cost_per_token: Some(0.000020),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        let result = lookup
+            .lookup_with_provider("claude-sonnet-4", Some("anthropic"))
+            .expect("anthropic-hinted claude-sonnet-4 must price");
+        assert_eq!(
+            result.matched_key, "host/anthropic/claude-sonnet-4",
+            "a reseller alias root must not impersonate the hinted vendor's own row"
+        );
+        assert_eq!(result.pricing.output_cost_per_token, Some(0.000020));
     }
 }

--- a/crates/tokscale-core/src/provider_identity.rs
+++ b/crates/tokscale-core/src/provider_identity.rs
@@ -163,9 +163,22 @@ pub(crate) fn matches_provider_spelling(dataset_key: &str, provider_id: &str) ->
         return false;
     }
 
+    // The final component is the model name, but an AWS-style id carries the
+    // provider in a dotted prefix of it — `amazon-bedrock/us.deepseek.r1-v1:0`
+    // is DeepSeek's row, not Amazon's own model. `key_provider_tags` already
+    // splits that component on `.` for exactly this reason, so read the same
+    // segments here: dropping them lets a `deepseek` hint miss the row that
+    // spells the vendor its way and fall through to a differently spelled
+    // reseller. Only the dotted *prefix* counts; the trailing piece is the
+    // model name and is never a vendor spelling.
+    let last = key_parts[key_parts.len() - 1];
+    let dotted_provider_prefix = last.rsplit_once('.').map(|(prefix, _)| prefix);
+
     key_parts[..key_parts.len() - 1]
         .iter()
-        .flat_map(|segment| raw_provider_segments(segment))
+        .copied()
+        .chain(dotted_provider_prefix)
+        .flat_map(raw_provider_segments)
         .any(|key_segment| hint_segments.iter().any(|hint| hint == &key_segment))
 }
 
@@ -642,6 +655,42 @@ mod tests {
         assert!(!matches_provider_spelling(
             "some-vendor/deepseek",
             "deepseek"
+        ));
+    }
+
+    #[test]
+    fn provider_spelling_reads_the_dotted_prefix_of_the_final_key_component() {
+        // AWS-style ids carry the provider in a dotted prefix of the final key
+        // component, which is why `key_provider_tags` splits it on `.`. The
+        // spelling predicate has to read the same segments, or a `deepseek`
+        // hint fails to recognise the row that spells the vendor its way and
+        // falls through to a differently spelled reseller.
+        assert_eq!(
+            key_provider_tags("amazon-bedrock/us.deepseek.r1-v1:0"),
+            vec!["amazon_bedrock", "us", "deepseek"]
+        );
+        assert!(matches_provider_spelling(
+            "amazon-bedrock/us.deepseek.r1-v1:0",
+            "deepseek"
+        ));
+        assert!(matches_provider_spelling(
+            "bedrock/us-east-1/deepseek.v3.2",
+            "deepseek"
+        ));
+        assert!(!matches_provider_spelling(
+            "amazon-bedrock/us.deepseek.r1-v1:0",
+            "deepseek-ai"
+        ));
+
+        // The trailing piece is still the model name, not a vendor spelling,
+        // and an undotted final component contributes nothing at all.
+        assert!(!matches_provider_spelling(
+            "amazon-bedrock/us.deepseek.r1-v1:0",
+            "r1-v1:0"
+        ));
+        assert!(!matches_provider_spelling(
+            "some-router/deepseek-ai",
+            "deepseek-ai"
         ));
     }
 }

--- a/crates/tokscale-core/src/provider_identity.rs
+++ b/crates/tokscale-core/src/provider_identity.rs
@@ -23,6 +23,31 @@ fn canonicalize_provider_segment(segment: &str) -> Option<String> {
         "minimax" | "minimaxai" | "minimax_ai" => "minimax",
         "mistral" | "mistralai" => "mistralai",
         "ai21" => "ai21",
+        // The `-ai` suffix is a spelling of the vendor, not a different
+        // vendor. DeepSeek is the case that actually costs us: the live
+        // datasets split the same model almost evenly between the two
+        // spellings depending on who is reselling it —
+        // `zenmux/deepseek/deepseek-v3.2-exp` and `kilo/deepseek/...` against
+        // `nano-gpt/deepseek-ai/deepseek-v3.2-exp` and `siliconflow/...` — so
+        // whether usage of one model carried the vendor tag `deepseek` or
+        // `deepseek_ai` was decided by which reseller served it.
+        //
+        // Folding is only safe because the two spellings never name the same
+        // row: no reseller in either dataset lists a model under both, and
+        // `deepseek-ai` is never a top-level provider (it is the HuggingFace
+        // org name, always a nested segment), so nothing here collapses two
+        // separately-priced rows into one.
+        "deepseek" | "deepseek_ai" => "deepseek",
+        "novita" | "novita_ai" => "novita",
+        "stepfun" | "stepfun_ai" => "stepfun",
+        // A `-cn` suffix is NOT a spelling variant and must never be folded in
+        // here, however much it looks like one. It marks a regional endpoint
+        // with its own price sheet: `alibaba` and `alibaba-cn` share 45 models
+        // and disagree on 41 of them, with `qwen-max` at $1.60/$6.40 against
+        // $0.345/$1.377 — a 4.6x error in whichever direction the fold went.
+        // `siliconflow` and `siliconflow-cn` disagree on 7 of 35. Adding those
+        // arms to "finish the pattern" would silently misprice every user on
+        // the endpoint that lost the fold.
         // For unknown segments, reject if they contain digits — those are
         // almost certainly model-name fragments (e.g., "gpt-4", "claude-3")
         // rather than provider identifiers.
@@ -474,5 +499,50 @@ mod tests {
         // misattributing it. This guards the unknown-provider passthrough path.
         assert_eq!(canonical_provider("gjc-model-4o"), None);
         assert_eq!(canonical_provider("<unset>"), None);
+    }
+
+    #[test]
+    fn vendor_ai_suffix_is_one_vendor() {
+        // The datasets split the same DeepSeek model between two vendor
+        // spellings depending on the reseller, so before this fold the tag a
+        // user's usage carried was decided by who served it.
+        for spelling in ["deepseek", "deepseek-ai", "deepseek_ai", "DeepSeek-AI"] {
+            assert_eq!(
+                canonical_provider(spelling),
+                Some("deepseek".into()),
+                "{spelling} must canonicalize to deepseek"
+            );
+        }
+
+        // Real dataset keys, where the vendor sits in a nested segment.
+        assert_eq!(
+            provider_tags("nano-gpt/deepseek-ai/deepseek-v3.2-exp"),
+            vec!["nano_gpt", "deepseek"]
+        );
+        assert_eq!(
+            provider_tags("zenmux/deepseek/deepseek-v3.2-exp"),
+            vec!["zenmux", "deepseek"]
+        );
+
+        assert_eq!(canonical_provider("novita-ai"), Some("novita".into()));
+        assert_eq!(canonical_provider("stepfun-ai"), Some("stepfun".into()));
+    }
+
+    #[test]
+    fn regional_cn_endpoint_is_not_folded_into_the_global_one() {
+        // Guards the comment above the `-ai` arms. `-cn` reads like the same
+        // kind of suffix and is not: alibaba and alibaba-cn share 45 models
+        // and disagree on 41, qwen-max among them at $1.60/$6.40 against
+        // $0.345/$1.377. Folding these would misprice by 4.6x, so they must
+        // stay distinct providers.
+        assert_ne!(
+            canonical_provider("alibaba-cn"),
+            canonical_provider("alibaba")
+        );
+        assert_ne!(
+            canonical_provider("siliconflow-cn"),
+            canonical_provider("siliconflow")
+        );
+        assert_eq!(canonical_provider("alibaba-cn"), Some("alibaba_cn".into()));
     }
 }

--- a/crates/tokscale-core/src/provider_identity.rs
+++ b/crates/tokscale-core/src/provider_identity.rs
@@ -109,6 +109,66 @@ pub fn key_provider_tags(dataset_key: &str) -> Vec<String> {
     tags
 }
 
+/// Provider segments a value names *verbatim*, with no alias folding.
+///
+/// Lowercased and underscore-normalized so `DeepSeek-AI`, `deepseek-ai` and
+/// `deepseek_ai` compare equal, but `deepseek` and `deepseek_ai` do not.
+fn raw_provider_segments(value: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut push = |segment: &str| {
+        let normalized = segment
+            .trim()
+            .trim_end_matches('/')
+            .to_lowercase()
+            .replace('-', "_");
+        if normalized.is_empty() || segments.iter().any(|existing| existing == &normalized) {
+            return;
+        }
+        segments.push(normalized);
+    };
+
+    for segment in value.trim().trim_end_matches('/').split('/') {
+        push(segment);
+        if segment.contains('.') {
+            for dotted in segment.split('.') {
+                push(dotted);
+            }
+        }
+    }
+
+    segments
+}
+
+/// Whether `dataset_key` spells a vendor exactly the way `provider_id` does.
+///
+/// `canonicalize_provider_segment` folds spelling variants of one vendor
+/// together (`deepseek-ai` -> `deepseek`) so a hint can reach rows that spell
+/// the vendor the other way. That fold also widens the candidate pool: a
+/// `deepseek` hint now matches both `novita/deepseek/<model>` and
+/// `cloudflare/@cf/deepseek-ai/<model>`, which are two resellers with
+/// different price sheets for the same weights. When the hinted vendor
+/// publishes no first-party row for the model, nothing else in
+/// `select_best_match` distinguishes those two, and the winner falls out of
+/// dataset key ordering. This predicate is the tiebreak that keeps the fold
+/// from re-rolling that choice: a row spelling the vendor exactly as the hint
+/// does wins over one that only matches after folding.
+pub(crate) fn matches_provider_spelling(dataset_key: &str, provider_id: &str) -> bool {
+    let hint_segments = raw_provider_segments(provider_id);
+    if hint_segments.is_empty() {
+        return false;
+    }
+
+    let key_parts: Vec<&str> = dataset_key.split('/').collect();
+    if key_parts.len() < 2 {
+        return false;
+    }
+
+    key_parts[..key_parts.len() - 1]
+        .iter()
+        .flat_map(|segment| raw_provider_segments(segment))
+        .any(|key_segment| hint_segments.iter().any(|hint| hint == &key_segment))
+}
+
 pub fn matches_provider_hint(dataset_key: &str, provider_id: Option<&str>) -> bool {
     let Some(provider_id) = provider_id else {
         return false;
@@ -544,5 +604,44 @@ mod tests {
             canonical_provider("siliconflow")
         );
         assert_eq!(canonical_provider("alibaba-cn"), Some("alibaba_cn".into()));
+    }
+
+    #[test]
+    fn provider_spelling_match_is_exact_where_canonicalization_is_not() {
+        // canonical_provider folds the two spellings together; this predicate
+        // deliberately does not, so `select_best_match` can prefer the row that
+        // spells the vendor the way the hint does.
+        assert_eq!(
+            canonical_provider("deepseek-ai"),
+            canonical_provider("deepseek")
+        );
+
+        assert!(matches_provider_spelling(
+            "novita/deepseek/deepseek-r1-distill-qwen-32b",
+            "deepseek"
+        ));
+        assert!(!matches_provider_spelling(
+            "cloudflare/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
+            "deepseek"
+        ));
+
+        // Case and `-`/`_` are spelling noise, not a different spelling.
+        for hint in ["deepseek-ai", "deepseek_ai", "DeepSeek-AI"] {
+            assert!(
+                matches_provider_spelling("hyperbolic/deepseek-ai/DeepSeek-V3", hint),
+                "{hint} spells the vendor the way this key does"
+            );
+            assert!(!matches_provider_spelling(
+                "novita/deepseek/deepseek-v3-0324",
+                hint
+            ));
+        }
+
+        // The last segment is the model name, never a vendor spelling.
+        assert!(!matches_provider_spelling("deepseek-ai", "deepseek-ai"));
+        assert!(!matches_provider_spelling(
+            "some-vendor/deepseek",
+            "deepseek"
+        ));
     }
 }


### PR DESCRIPTION
Second of the two items I left open on #1062's territory.

## The gap

`canonicalize_provider_segment` folds nine vendor spelling pairs — `x-ai`/`xai`, `minimax`/`minimax-ai`, `mistral`/`mistralai`, `together`/`together-ai` and so on. DeepSeek has no arm. Since the function lowercases and maps `-` to `_`, `deepseek-ai` falls through to the passthrough arm and becomes the tag `deepseek_ai`, distinct from `deepseek`:

```
deepseek-ai/DeepSeek-V3                 -> canonical=Some("deepseek_ai")  tags=["deepseek_ai"]
deepseek/deepseek-v3.2-exp              -> canonical=Some("deepseek")     tags=["deepseek"]
nano-gpt/deepseek-ai/deepseek-v3.2-exp  -> tags=["nano_gpt", "deepseek_ai"]
kilo/deepseek/deepseek-v3.2-exp         -> tags=["kilo", "deepseek"]
```

## Why it matters in practice

Both live datasets carry the vendor under both spellings, and the spelling is chosen by the reseller, not by the model. The same DeepSeek model:

| `deepseek/` | `deepseek-ai/` |
|---|---|
| `kilo/deepseek/deepseek-v3.2-exp` | `nano-gpt/deepseek-ai/deepseek-v3.2-exp` |
| `zenmux/deepseek/deepseek-v3.2-exp` | `siliconflow/deepseek-ai/DeepSeek-V3.2-Exp` |
| `openrouter/deepseek/deepseek-v3.2-exp` | `meganova/deepseek-ai/DeepSeek-V3.2-Exp` |
| `novita-ai/deepseek/deepseek-v3.2-exp` | |
| `qiniu-ai/deepseek/deepseek-v3.2-exp` | |

Counting vendor segments across LiteLLM (2,988 rows) and models.dev (6,231 rows): **`deepseek` 147, `deepseek_ai` 137** — an almost even split of one vendor.

Two consequences. A `provider_id` of `"deepseek"` fails `provider_hint_matches_scoped_provider` against a `deepseek-ai/...` model path, so the lookup drops out of the provider-scoped tier into a weaker one. And because provider identity is also what the report groups by, the same vendor could occupy two rows in a user's breakdown depending on which reseller served them.

## Why folding is safe here specifically

- **No reseller lists a model under both spellings.** Checked pairwise across both datasets: 0 collisions. Nothing collapses two separately-priced rows into one.
- **`deepseek-ai` is never a top-level provider.** It is the HuggingFace org name and appears only as a nested segment — 0 top-level `deepseek-ai/` keys in LiteLLM, no `deepseek-ai` provider in models.dev. `deepseek` is a real top-level provider in both.

`novita`/`novita-ai` and `stepfun`/`stepfun-ai` fold on the same evidence — 79 and 8 paired keys, price-identical once LiteLLM's per-token and models.dev's per-million units are normalized. (My first pass flagged all 79 novita pairs as divergent; that was the unit mismatch in my own comparison, not the data.)

## `-cn` deliberately does not fold

This is the part I would most like a second pair of eyes on. `-cn` reads like the same kind of suffix and is not — it marks a regional endpoint with its own price sheet:

```
alibaba vs alibaba-cn:         shared models=45, different price=41
   qwen-max:   {'input': 1.6,  'output': 6.4}   vs  {'input': 0.345, 'output': 1.377}
   qwen-flash: {'input': 0.05, 'output': 0.4}   vs  {'input': 0.022, 'output': 0.216}
siliconflow vs siliconflow-cn: shared models=35, different price=7
```

A generic "strip the suffix" fix would have mispriced Alibaba usage by up to **4.6x**. There is now a test and a comment pinning that, because the natural next contribution to this function is to finish the pattern.

## Verification

- 2,707 tests pass across the workspace; clippy and fmt clean.
- Both new tests mutation-checked: dropping the deepseek arm fails `vendor_ai_suffix_is_one_vendor` and not the `-cn` guard; adding an `alibaba-cn` arm fails `regional_cn_endpoint_is_not_folded_into_the_global_one` and not the fold test.

## Note on the earlier report

I originally flagged this as living in a file called `provider_identity.rs:11-31` under `pricing/` — it is `crates/tokscale-core/src/provider_identity.rs`. I then briefly talked myself out of the finding entirely after grepping the datasets for `deepseek_ai` and getting zero hits; the datasets spell it `deepseek-ai`, and the underscore normalization happens inside the Rust function. The original call was right.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies `deepseek-ai` and `deepseek` under one vendor and fixes ranking so the fold never moves pricing to another reseller. Also ranks literal provider roots across catalogs so hosted aliases never outrank the hinted vendor’s own row.

- **Bug Fixes**
  - Fold `deepseek-ai`/`deepseek`; same for `novita`/`novita-ai` and `stepfun`/`stepfun-ai`; keep `-cn` endpoints distinct.
  - Selection order: first-party row; then the hinted vendor’s own top-level row (excluding hosted aliases like `vertex`/`vertex_ai` for `anthropic`, preferring direct roots over aliases across sources and catalogs, and allowing a Models.dev literal root to displace an alias-only LiteLLM/OpenRouter row); then an exact spelling match; unhinted lookups unchanged.
  - Read the dotted provider prefix in the final key segment for spelling checks (e.g., `amazon-bedrock/us.deepseek.r1-v1:0`).

<sup>Written for commit 73ecb0db2fecdeb5ddc7cdd0f4654763940546d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

