### PR TITLE
fix(core): join client scan roots with native path separators

### DIFF
--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3214,13 +3214,18 @@ fn test_clients_command_includes_claude_transcripts_text() {
     let tmp = create_empty_fixture_dir();
     fs::create_dir_all(tmp.path().join(".claude/transcripts")).unwrap();
 
+    // The transcripts path is spelled with native separators (#1048): on
+    // Windows the `~` root renders with backslashes throughout.
+    #[cfg(windows)]
+    let expected = "additional: ~\\.claude\\transcripts ✓";
+    #[cfg(not(windows))]
+    let expected = "additional: ~/.claude/transcripts ✓";
+
     cmd_with_home(tmp.path())
         .arg("clients")
         .assert()
         .success()
-        .stdout(predicate::str::contains(
-            "additional: ~/.claude/transcripts ✓",
-        ));
+        .stdout(predicate::str::contains(expected));
 }
 
 #[test]

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -785,27 +785,20 @@ fn settings_json_path(base: &Path) -> std::path::PathBuf {
 
 /// A scan path spelled the way the binary spells it.
 ///
-/// `ClientDef::resolve_path` builds every client's root as
-/// `format!("{root}/{relative}")` — one separator, `/`, on every platform,
-/// with the relative half a `/`-joined literal in the client table. Windows
-/// accepts `/` in a path, so the value works; it just is not what
-/// `Path::join` produces. An expectation built with `join` disagreed on the
-/// first separator only (`...\.tmpXXXX\.codex/sessions` against the emitted
-/// `...\.tmpXXXX/.codex/sessions`) — and note that `join` did not give a
-/// natively-spelled path either, because the rest of the literal keeps its
-/// forward slashes. There was no native-separator contract to preserve, only
-/// two spellings of the same path, so match the one the binary actually
-/// emits.
-///
-/// That does make this helper a pin on the mixed spelling: `clients --json`
-/// prints `C:\Users\me/.codex/sessions` in `sessionsPath` and
-/// `additionalPaths[].path`, and the two assertions below now hold it there.
-/// The pin is deliberate but not an endorsement — whether user-facing path
-/// output should be normalized, and to native or to forward separators, is a
-/// product decision tracked in junhoyeo/tokscale#1048. Changing the emitter
-/// means changing this helper in the same commit.
+/// `tokscale clients --json` emits every client's scan root with native
+/// separators throughout: the root half comes from the platform (`C:\Users\me`
+/// on Windows), and the relative half is pushed component-by-component so no
+/// forward slash survives from the `/`-joined client-table literal. An
+/// expectation built with `Path::join` would disagree on the relative half's
+/// separators (`...\.codex/sessions` against the emitted
+/// `...\.codex/sessions`), because `join` only normalizes the junction.
+/// Changing the emitter means changing this helper in the same commit (#1048).
 fn client_scan_path(home: &Path, relative: &str) -> String {
-    format!("{}/{}", home.display(), relative)
+    let mut path = home.to_path_buf();
+    for component in Path::new(relative).components() {
+        path.push(component.as_os_str());
+    }
+    path.to_string_lossy().into_owned()
 }
 
 /// Writes a minimal clawdboard account export to `<dir>/export.json` and

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -187,11 +187,18 @@ pub struct ClientDef {
 
 impl ClientDef {
     pub fn resolve_path_with_env_strategy(&self, home_dir: &str, use_env_roots: bool) -> String {
-        format!(
-            "{}/{}",
-            self.root.resolve_with_env_strategy(home_dir, use_env_roots),
-            self.relative_path
-        )
+        let root = self.root.resolve_with_env_strategy(home_dir, use_env_roots);
+        if self.relative_path.is_empty() {
+            return root;
+        }
+        // Join through `Path` instead of hand-concatenating "{root}/{relative}":
+        // on Windows the root comes back with native separators (`C:\Users\me`)
+        // and a hardcoded `/` produced mixed-separator paths
+        // (`C:\Users\me/.codex/sessions`) that reached user-facing JSON (#1048).
+        std::path::Path::new(&root)
+            .join(self.relative_path)
+            .to_string_lossy()
+            .into_owned()
     }
 
     pub fn resolve_path(&self, home_dir: &str) -> String {
@@ -783,6 +790,38 @@ mod tests {
         assert!(client.data().parse_local);
         assert!(client.data().submit_default);
         assert!(!client.data().headless);
+    }
+
+    #[test]
+    fn test_resolve_path_joins_with_native_separators_not_hardcoded_slash() {
+        // #1048: on Windows a `C:\Users\me` root joined with a `/`-separated
+        // relative path used to produce `C:\Users\me/.codex/sessions` (mixed
+        // separators) that reached user-facing `clients --json` output. The
+        // joined result must equal what `Path::join` produces on the host
+        // platform, never a hand-concatenated "{root}/{relative}" string.
+        let client = ClientDef {
+            id: "codex",
+            root: PathRoot::Home,
+            relative_path: ".codex/sessions",
+            pattern: "*.jsonl",
+            headless: false,
+            parse_local: true,
+            submit_default: true,
+        };
+        let windows_style_home = r"C:\Users\me";
+        let joined = client.resolve_path_with_env_strategy(windows_style_home, false);
+        let expected = std::path::Path::new(windows_style_home)
+            .join(client.relative_path)
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(joined, expected);
+        // On Windows the resolved path must use native separators throughout:
+        // no forward slash may remain from the relative half or the joiner.
+        #[cfg(windows)]
+        assert!(
+            !joined.contains('/'),
+            "mixed separators in resolved path: {joined:?}"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -10,6 +10,17 @@ pub enum PathRoot {
     },
 }
 
+/// Join `home_dir` and a `/`-joined relative literal with native separators
+/// throughout. `Path::join` only normalizes the junction; the relative half's
+/// own `/` separators would survive untouched on Windows (#1048).
+fn join_home(home_dir: &str, relative: &str) -> String {
+    let mut path = std::path::PathBuf::from(home_dir);
+    for component in std::path::Path::new(relative).components() {
+        path.push(component.as_os_str());
+    }
+    path.to_string_lossy().into_owned()
+}
+
 impl PathRoot {
     pub fn resolve_with_env_strategy(&self, home_dir: &str, use_env_roots: bool) -> String {
         match self {
@@ -41,15 +52,15 @@ impl PathRoot {
                 }
                 #[cfg(not(target_os = "windows"))]
                 {
-                    format!("{home_dir}/.reasonix")
+                    join_home(home_dir, ".reasonix")
                 }
             }
             PathRoot::XdgData => {
                 if use_env_roots {
                     std::env::var("XDG_DATA_HOME")
-                        .unwrap_or_else(|_| format!("{}/.local/share", home_dir))
+                        .unwrap_or_else(|_| join_home(home_dir, ".local/share"))
                 } else {
-                    format!("{}/.local/share", home_dir)
+                    join_home(home_dir, ".local/share")
                 }
             }
             PathRoot::Config => {
@@ -81,7 +92,7 @@ impl PathRoot {
                         .into_owned();
                 }
 
-                format!("{home_dir}/.config/tokscale")
+                join_home(home_dir, ".config/tokscale")
             }
             PathRoot::EnvVar {
                 var,
@@ -90,12 +101,12 @@ impl PathRoot {
                 if use_env_roots {
                     let val = std::env::var(var).unwrap_or_default();
                     if val.trim().is_empty() {
-                        format!("{}/{}", home_dir, fallback_relative)
+                        join_home(home_dir, fallback_relative)
                     } else {
                         val
                     }
                 } else {
-                    format!("{}/{}", home_dir, fallback_relative)
+                    join_home(home_dir, fallback_relative)
                 }
             }
         }
@@ -1237,7 +1248,10 @@ mod tests {
         unsafe { std::env::remove_var("XDG_DATA_HOME") };
 
         let resolved = PathRoot::XdgData.resolve("/tmp/home");
-        assert_eq!(resolved, "/tmp/home/.local/share");
+        assert_eq!(
+            resolved,
+            native_join(std::path::Path::new("/tmp/home"), ".local/share")
+        );
 
         restore_env("XDG_DATA_HOME", previous);
     }
@@ -1249,7 +1263,10 @@ mod tests {
         unsafe { std::env::set_var("XDG_DATA_HOME", "/tmp/xdg-data-home") };
 
         let resolved = PathRoot::XdgData.resolve_with_env_strategy("/tmp/home", false);
-        assert_eq!(resolved, "/tmp/home/.local/share");
+        assert_eq!(
+            resolved,
+            native_join(std::path::Path::new("/tmp/home"), ".local/share")
+        );
 
         restore_env("XDG_DATA_HOME", previous);
     }
@@ -1334,7 +1351,7 @@ mod tests {
                 .to_string_lossy()
                 .into_owned()
         } else {
-            "/tmp/home/.config/tokscale".to_string()
+            native_join(std::path::Path::new("/tmp/home"), ".config/tokscale")
         };
         assert_eq!(resolved, expected);
 
@@ -1371,7 +1388,10 @@ mod tests {
             fallback_relative: ".fallback",
         };
         let resolved = root.resolve("/tmp/home");
-        assert_eq!(resolved, "/tmp/home/.fallback");
+        assert_eq!(
+            resolved,
+            native_join(std::path::Path::new("/tmp/home"), ".fallback")
+        );
 
         restore_env(var, previous);
     }
@@ -1388,7 +1408,10 @@ mod tests {
             fallback_relative: ".fallback",
         };
         let resolved = root.resolve_with_env_strategy("/tmp/home", false);
-        assert_eq!(resolved, "/tmp/home/.fallback");
+        assert_eq!(
+            resolved,
+            native_join(std::path::Path::new("/tmp/home"), ".fallback")
+        );
 
         restore_env(var, previous);
     }

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -829,8 +829,10 @@ mod tests {
         };
         let windows_style_home = r"C:\Users\me";
         let joined = client.resolve_path_with_env_strategy(windows_style_home, false);
-        let expected =
-            native_join(std::path::Path::new(windows_style_home), client.relative_path);
+        let expected = native_join(
+            std::path::Path::new(windows_style_home),
+            client.relative_path,
+        );
         assert_eq!(joined, expected);
         // On Windows the resolved path must use native separators throughout:
         // no forward slash may remain from the relative half or the joiner.
@@ -959,7 +961,10 @@ mod tests {
         env.set("REASONIX_HOME", absolute_test_path("unused/reasonix-home"));
         assert_eq!(
             client.data().resolve_path(reasonix_home()),
-            reasonix_stats_under(native_join(std::path::Path::new(reasonix_home()), "reasonix-state"))
+            reasonix_stats_under(native_join(
+                std::path::Path::new(reasonix_home()),
+                "reasonix-state"
+            ))
         );
 
         env.set("REASONIX_STATE_HOME", " \t ");
@@ -990,9 +995,10 @@ mod tests {
         );
         assert_eq!(
             client.data().resolve_path(reasonix_home()),
-            reasonix_stats_under(
-                native_join(std::path::Path::new(reasonix_home()), "reasonix-state/nested")
-            )
+            reasonix_stats_under(native_join(
+                std::path::Path::new(reasonix_home()),
+                "reasonix-state/nested"
+            ))
         );
 
         env.set(
@@ -1040,7 +1046,10 @@ mod tests {
         let client = ClientId::from_str("kimchi").expect("kimchi client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
-            native_join(std::path::Path::new("/tmp/home"), ".config/kimchi/harness/sessions")
+            native_join(
+                std::path::Path::new("/tmp/home"),
+                ".config/kimchi/harness/sessions"
+            )
         );
     }
 
@@ -1396,7 +1405,10 @@ mod tests {
             submit_default: true,
         };
 
-        assert_eq!(client.resolve_path("/tmp/home"), native_join(std::path::Path::new("/tmp/home"), ".test/sessions"));
+        assert_eq!(
+            client.resolve_path("/tmp/home"),
+            native_join(std::path::Path::new("/tmp/home"), ".test/sessions")
+        );
     }
 
     #[test]
@@ -1507,7 +1519,10 @@ mod tests {
 
         assert_eq!(
             ClientId::Zed.data().resolve_path("/tmp/home"),
-            native_join(std::path::Path::new("/tmp/home"), ".local/share/zed/threads/threads.db")
+            native_join(
+                std::path::Path::new("/tmp/home"),
+                ".local/share/zed/threads/threads.db"
+            )
         );
 
         restore_env("XDG_DATA_HOME", previous);

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -191,14 +191,18 @@ impl ClientDef {
         if self.relative_path.is_empty() {
             return root;
         }
-        // Join through `Path` instead of hand-concatenating "{root}/{relative}":
-        // on Windows the root comes back with native separators (`C:\Users\me`)
-        // and a hardcoded `/` produced mixed-separator paths
-        // (`C:\Users\me/.codex/sessions`) that reached user-facing JSON (#1048).
-        std::path::Path::new(&root)
-            .join(self.relative_path)
-            .to_string_lossy()
-            .into_owned()
+        // Join component-by-component instead of hand-concatenating
+        // "{root}/{relative}": a hardcoded `/` — and even `Path::join`, which
+        // only normalizes the junction — leaves the relative half's own `/`
+        // separators untouched on Windows, producing mixed-separator paths
+        // (`C:\Users\me/.codex/sessions`) that reached user-facing
+        // `clients --json` output (#1048). Pushing each component yields
+        // native separators throughout on every platform.
+        let mut path = std::path::PathBuf::from(&root);
+        for component in std::path::Path::new(self.relative_path).components() {
+            path.push(component.as_os_str());
+        }
+        path.to_string_lossy().into_owned()
     }
 
     pub fn resolve_path(&self, home_dir: &str) -> String {
@@ -766,6 +770,20 @@ mod tests {
     // the same trap.
     use crate::paths::test_env::EnvGuard;
 
+    /// Join `relative` onto `root` with native separators throughout — the
+    /// behavior `ClientDef::resolve_path_with_env_strategy` must produce on
+    /// every platform (#1048). `Path::join` alone is not enough: it only
+    /// normalizes the junction, leaving the relative half's own `/`
+    /// separators untouched on Windows. Pushing each component is the only
+    /// spelling that yields `C:\Users\me\.codex\sessions` there.
+    fn native_join(root: &std::path::Path, relative: &str) -> String {
+        let mut path = root.to_path_buf();
+        for component in std::path::Path::new(relative).components() {
+            path.push(component.as_os_str());
+        }
+        path.to_string_lossy().into_owned()
+    }
+
     // Retained for the env tests below that predate this module's move to one
     // serialization domain. New tests should capture an `EnvGuard` instead;
     // this pairing is only panic-safe when nothing between it and the restore
@@ -797,8 +815,9 @@ mod tests {
         // #1048: on Windows a `C:\Users\me` root joined with a `/`-separated
         // relative path used to produce `C:\Users\me/.codex/sessions` (mixed
         // separators) that reached user-facing `clients --json` output. The
-        // joined result must equal what `Path::join` produces on the host
-        // platform, never a hand-concatenated "{root}/{relative}" string.
+        // joined result must use native separators throughout — component
+        // pushes, not a hand-concatenated "{root}/{relative}" string and not
+        // a single `Path::join` (which only normalizes the junction).
         let client = ClientDef {
             id: "codex",
             root: PathRoot::Home,
@@ -810,10 +829,8 @@ mod tests {
         };
         let windows_style_home = r"C:\Users\me";
         let joined = client.resolve_path_with_env_strategy(windows_style_home, false);
-        let expected = std::path::Path::new(windows_style_home)
-            .join(client.relative_path)
-            .to_string_lossy()
-            .into_owned();
+        let expected =
+            native_join(std::path::Path::new(windows_style_home), client.relative_path);
         assert_eq!(joined, expected);
         // On Windows the resolved path must use native separators throughout:
         // no forward slash may remain from the relative half or the joiner.
@@ -829,7 +846,7 @@ mod tests {
         let client = ClientId::from_str("augment").expect("augment client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
-            "/tmp/home/.augment/sessions"
+            native_join(std::path::Path::new("/tmp/home"), ".augment/sessions")
         );
         assert_eq!(client.data().relative_path, ".augment/sessions");
         assert_eq!(client.data().pattern, "*.json");
@@ -876,10 +893,10 @@ mod tests {
     }
 
     /// `<root>/stats`, spelled the way [`ClientDef::resolve_path`] appends a
-    /// client's relative path: a forward slash, whatever the root's own
-    /// separators are.
+    /// client's relative path: native separators throughout, on every
+    /// platform (#1048).
     fn reasonix_stats_under(root: impl AsRef<std::path::Path>) -> String {
-        format!("{}/stats", root.as_ref().to_string_lossy())
+        native_join(root.as_ref(), "stats")
     }
 
     /// The reasonix root with no environment override.
@@ -942,7 +959,7 @@ mod tests {
         env.set("REASONIX_HOME", absolute_test_path("unused/reasonix-home"));
         assert_eq!(
             client.data().resolve_path(reasonix_home()),
-            reasonix_stats_under(std::path::Path::new(reasonix_home()).join("reasonix-state"))
+            reasonix_stats_under(native_join(std::path::Path::new(reasonix_home()), "reasonix-state"))
         );
 
         env.set("REASONIX_STATE_HOME", " \t ");
@@ -974,7 +991,7 @@ mod tests {
         assert_eq!(
             client.data().resolve_path(reasonix_home()),
             reasonix_stats_under(
-                std::path::Path::new(reasonix_home()).join("reasonix-state/nested")
+                native_join(std::path::Path::new(reasonix_home()), "reasonix-state/nested")
             )
         );
 
@@ -1023,7 +1040,7 @@ mod tests {
         let client = ClientId::from_str("kimchi").expect("kimchi client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
-            "/tmp/home/.config/kimchi/harness/sessions"
+            native_join(std::path::Path::new("/tmp/home"), ".config/kimchi/harness/sessions")
         );
     }
 
@@ -1049,7 +1066,7 @@ mod tests {
         let client = ClientId::from_str("senpi").expect("senpi client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
-            "/tmp/home/.senpi/agent/sessions"
+            native_join(std::path::Path::new("/tmp/home"), ".senpi/agent/sessions")
         );
     }
 
@@ -1072,7 +1089,7 @@ mod tests {
             ClientId::from_str("codebuddy").expect("codebuddy client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
-            "/tmp/home/.codebuddy/projects"
+            native_join(std::path::Path::new("/tmp/home"), ".codebuddy/projects")
         );
         assert_eq!(client.data().pattern, "*.jsonl");
         assert!(client.data().parse_local);
@@ -1086,7 +1103,7 @@ mod tests {
             ClientId::from_str("workbuddy").expect("workbuddy client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
-            "/tmp/home/.workbuddy"
+            native_join(std::path::Path::new("/tmp/home"), ".workbuddy")
         );
         assert_eq!(client.data().pattern, "workbuddy.db");
         assert!(client.data().parse_local);
@@ -1125,7 +1142,7 @@ mod tests {
             ClientId::from_str("commandcode").expect("commandcode client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
-            "/tmp/home/.commandcode/projects"
+            native_join(std::path::Path::new("/tmp/home"), ".commandcode/projects")
         );
         assert_eq!(client.data().pattern, "*.jsonl");
         assert!(client.data().parse_local);
@@ -1138,7 +1155,7 @@ mod tests {
         let client = ClientId::from_str("junie").expect("junie client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
-            "/tmp/home/.junie/sessions"
+            native_join(std::path::Path::new("/tmp/home"), ".junie/sessions")
         );
         assert_eq!(client.data().pattern, "events.jsonl");
         assert!(client.data().parse_local);
@@ -1379,7 +1396,7 @@ mod tests {
             submit_default: true,
         };
 
-        assert_eq!(client.resolve_path("/tmp/home"), "/tmp/home/.test/sessions");
+        assert_eq!(client.resolve_path("/tmp/home"), native_join(std::path::Path::new("/tmp/home"), ".test/sessions"));
     }
 
     #[test]
@@ -1419,7 +1436,7 @@ mod tests {
         unsafe { std::env::remove_var(var) };
         assert_eq!(
             ClientId::Gjc.data().resolve_path("/tmp/home"),
-            "/tmp/home/.gjc/agent/sessions"
+            native_join(std::path::Path::new("/tmp/home"), ".gjc/agent/sessions")
         );
         assert_eq!(ClientId::Gjc.data().pattern, "*.jsonl");
         assert!(ClientId::Gjc.data().parse_local);
@@ -1432,7 +1449,7 @@ mod tests {
             ClientId::Gjc
                 .data()
                 .resolve_path_with_env_strategy("/tmp/home", false),
-            "/tmp/home/.gjc/agent/sessions"
+            native_join(std::path::Path::new("/tmp/home"), ".gjc/agent/sessions")
         );
 
         restore_env(var, previous);
@@ -1490,7 +1507,7 @@ mod tests {
 
         assert_eq!(
             ClientId::Zed.data().resolve_path("/tmp/home"),
-            "/tmp/home/.local/share/zed/threads/threads.db"
+            native_join(std::path::Path::new("/tmp/home"), ".local/share/zed/threads/threads.db")
         );
 
         restore_env("XDG_DATA_HOME", previous);
@@ -1505,7 +1522,7 @@ mod tests {
     fn test_kiro_data_dir_path() {
         assert_eq!(
             ClientId::Kiro.data().resolve_path("/tmp/home"),
-            "/tmp/home/.kiro/sessions/cli"
+            native_join(std::path::Path::new("/tmp/home"), ".kiro/sessions/cli")
         );
         assert_eq!(ClientId::Kiro.data().pattern, "*.json");
         assert!(ClientId::Kiro.parse_local());

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -131,7 +131,7 @@ fn clean_reasonix_env_dir(name: &str, home_dir: &str) -> Option<String> {
         .strip_prefix("~/")
         .or_else(|| value.strip_prefix("~\\"))
     {
-        std::path::Path::new(home_dir).join(relative)
+        std::path::PathBuf::from(join_home(home_dir, relative))
     } else {
         std::path::PathBuf::from(value)
     };
@@ -1073,7 +1073,7 @@ mod tests {
         let client = ClientId::from_str("kimchi").expect("kimchi client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
-            "/custom/kimchi-agent/sessions"
+            native_join(std::path::Path::new("/custom/kimchi-agent"), "sessions")
         );
     }
 
@@ -1099,7 +1099,7 @@ mod tests {
         let client = ClientId::from_str("senpi").expect("senpi client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
-            "/custom/senpi-agent/sessions"
+            native_join(std::path::Path::new("/custom/senpi-agent"), "sessions")
         );
     }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4463,12 +4463,11 @@ mod tests {
 
     /// A client's scan root under `home`, spelled the way a scan will spell it.
     ///
-    /// `ClientDef::resolve_path` builds the root with `format!("{root}/{rel}")`
-    /// and `WalkDir` appends each component below it with the platform
-    /// separator, so on Windows a discovered file reads
-    /// `C:\home/.claude/projects\demo\session.jsonl`. A fixture that builds the
-    /// same file with `Path::join` gets all backslashes — the same file, a
-    /// different string.
+    /// `ClientDef::resolve_path` pushes each relative component with the
+    /// platform separator (#1048), so on Windows a discovered file reads
+    /// `C:\home\.claude\projects\demo\session.jsonl`. A fixture that builds the
+    /// same file with `Path::join` gets a mixed spelling (`C:\home\.claude/projects\...`)
+    /// — the same file, a different string.
     ///
     /// That difference is invisible until a test seeds the message cache by
     /// hand and expects the next scan to find it, because `CachedPath` keys on

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -232,14 +232,14 @@ pub fn headless_roots_with_env_strategy(home_dir: &str, use_env_roots: bool) -> 
     }
 
     let mut roots = Vec::new();
-    roots.push(PathBuf::from(format!(
-        "{}/.config/tokscale/headless",
-        home_dir
+    roots.push(PathBuf::from(join_native(
+        home_dir,
+        ".config/tokscale/headless",
     )));
 
-    let mac_root = PathBuf::from(format!(
-        "{}/Library/Application Support/tokscale/headless",
-        home_dir
+    let mac_root = PathBuf::from(join_native(
+        home_dir,
+        "Library/Application Support/tokscale/headless",
     ));
     roots.push(mac_root);
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -1895,7 +1895,10 @@ fn scan_all_clients_with_env_strategy_inner(
 
         let mut codebuff_roots: Vec<String> = Vec::new();
         if let Some(root) = trimmed_override {
-            codebuff_roots.push(join_native(root.trim_end_matches('/'), "projects"));
+            // No `trim_end_matches('/')`: `PathBuf` already collapses a trailing
+            // separator, and trimming empties a root of `/` — after which
+            // `push` produces a cwd-relative `projects` instead of `/projects`.
+            codebuff_roots.push(join_native(&root, "projects"));
         } else {
             let config_dir = join_native(home_dir, ".config");
             for channel in ["manicode", "manicode-dev", "manicode-staging"] {
@@ -5168,6 +5171,52 @@ mod tests {
 
         let result = scan_without_extra_dirs(home.to_str().unwrap(), &["codebuff".to_string()]);
         assert_eq!(result.get(ClientId::Codebuff).len(), 2);
+
+        restore_env("CODEBUFF_DATA_DIR", previous);
+    }
+
+    #[test]
+    fn join_native_preserves_an_absolute_root() {
+        // `PathBuf::push` on an empty buffer emits no leading separator, so a
+        // caller that strips the trailing `/` from a root of `/` turns an
+        // absolute scan root into a cwd-relative one. Nothing about the join
+        // needs that strip: a trailing separator is collapsed either way.
+        #[cfg(unix)]
+        {
+            assert_eq!(join_native("/", "projects"), "/projects");
+            assert_eq!(join_native("/foo/", "projects"), "/foo/projects");
+            assert_eq!(join_native("/foo", "projects"), "/foo/projects");
+        }
+        // An empty root is the shape that produced the relative path.
+        assert_eq!(join_native("", "projects"), "projects");
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_codebuff_override_root_may_end_in_a_separator() {
+        let previous = std::env::var("CODEBUFF_DATA_DIR").ok();
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let override_root = dir.path().join("custom-codebuff");
+        let override_chat_dir = override_root
+            .join("projects")
+            .join("sandbox")
+            .join("chats")
+            .join("2025-12-14T11-00-00.000Z");
+        fs::create_dir_all(&override_chat_dir).unwrap();
+        File::create(override_chat_dir.join("chat-messages.json")).unwrap();
+
+        // Trailing separator: the reason the call site used to trim.
+        unsafe {
+            std::env::set_var(
+                "CODEBUFF_DATA_DIR",
+                format!("{}/", override_root.to_string_lossy()),
+            )
+        };
+
+        let result = scan_without_extra_dirs(home.to_str().unwrap(), &["codebuff".to_string()]);
+        assert_eq!(result.get(ClientId::Codebuff).len(), 1);
 
         restore_env("CODEBUFF_DATA_DIR", previous);
     }

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -474,6 +474,18 @@ pub fn extra_scan_paths_for(
         .collect()
 }
 
+/// Join `root` and a `/`-joined relative literal with native separators
+/// throughout — the same spelling `ClientDef::resolve_path_with_env_strategy`
+/// produces. `Path::join` only normalizes the junction, so the relative half's
+/// own `/` separators would survive untouched on Windows (#1048).
+fn join_native(root: &str, relative: &str) -> String {
+    let mut path = std::path::PathBuf::from(root);
+    for component in std::path::Path::new(relative).components() {
+        path.push(component.as_os_str());
+    }
+    path.to_string_lossy().into_owned()
+}
+
 pub fn built_in_extra_scan_paths_for(
     home_dir: &str,
     enabled: &HashSet<ClientId>,
@@ -483,7 +495,7 @@ pub fn built_in_extra_scan_paths_for(
     if enabled.contains(&ClientId::Claude) {
         paths.push((
             ClientId::Claude,
-            PathBuf::from(format!("{}/.claude/transcripts", home_dir)),
+            PathBuf::from(join_native(home_dir, ".claude/transcripts")),
         ));
         paths.extend(
             crate::cc_mirror::discover_claude_project_roots(Path::new(home_dir))
@@ -1389,9 +1401,9 @@ fn scan_all_clients_with_env_strategy_inner(
 
     if enabled.contains(&ClientId::OpenCode) {
         let xdg_data = if use_env_roots {
-            std::env::var("XDG_DATA_HOME").unwrap_or_else(|_| format!("{}/.local/share", home_dir))
+            std::env::var("XDG_DATA_HOME").unwrap_or_else(|_| join_native(home_dir, ".local/share"))
         } else {
-            format!("{}/.local/share", home_dir)
+            join_native(home_dir, ".local/share")
         };
 
         // OpenCode 1.2+: SQLite database(s) at ~/.local/share/opencode/opencode*.db
@@ -1403,7 +1415,7 @@ fn scan_all_clients_with_env_strategy_inner(
         // under the data dir. See `getChannelPath` in
         // opencode/packages/opencode/src/storage/db.ts for the source of
         // the naming rule.
-        let opencode_data_dir = PathBuf::from(format!("{}/opencode", xdg_data));
+        let opencode_data_dir = PathBuf::from(join_native(&xdg_data, "opencode"));
         result.opencode_dbs = discover_opencode_dbs(&opencode_data_dir);
 
         // Merge user-configured `scanner.opencodeDbPaths` here, INSIDE the
@@ -1473,14 +1485,14 @@ fn scan_all_clients_with_env_strategy_inner(
         let kimi_code_home = if use_env_roots {
             let configured = std::env::var("KIMI_CODE_HOME").unwrap_or_default();
             if configured.trim().is_empty() {
-                format!("{}/.kimi-code", home_dir)
+                join_native(home_dir, ".kimi-code")
             } else {
                 configured
             }
         } else {
-            format!("{}/.kimi-code", home_dir)
+            join_native(home_dir, ".kimi-code")
         };
-        let kimi_code_path = format!("{}/sessions", kimi_code_home);
+        let kimi_code_path = join_native(&kimi_code_home, "sessions");
         push_unique_scan_task(
             &mut tasks,
             &mut seen_scan_roots,
@@ -1492,9 +1504,9 @@ fn scan_all_clients_with_env_strategy_inner(
     if enabled.contains(&ClientId::Codex) {
         // Codex: ~/.codex/sessions/**/*.jsonl
         let codex_home = if use_env_roots {
-            std::env::var("CODEX_HOME").unwrap_or_else(|_| format!("{}/.codex", home_dir))
+            std::env::var("CODEX_HOME").unwrap_or_else(|_| join_native(home_dir, ".codex"))
         } else {
-            format!("{}/.codex", home_dir)
+            join_native(home_dir, ".codex")
         };
         let codex_path = ClientId::Codex
             .data()
@@ -1507,7 +1519,7 @@ fn scan_all_clients_with_env_strategy_inner(
         );
 
         // Codex archived sessions: ~/.codex/archived_sessions/**/*.jsonl
-        let codex_archived_path = format!("{}/archived_sessions", codex_home);
+        let codex_archived_path = join_native(&codex_home, "archived_sessions");
         push_unique_scan_task(
             &mut tasks,
             &mut seen_scan_roots,
@@ -1539,7 +1551,7 @@ fn scan_all_clients_with_env_strategy_inner(
         );
 
         // Legacy paths (Clawd -> Moltbot -> OpenClaw rebrand history)
-        let clawdbot_path = format!("{}/.clawdbot/agents", home_dir);
+        let clawdbot_path = join_native(home_dir, ".clawdbot/agents");
         push_unique_scan_task(
             &mut tasks,
             &mut seen_scan_roots,
@@ -1547,7 +1559,7 @@ fn scan_all_clients_with_env_strategy_inner(
             clawdbot_path,
         );
 
-        let moltbot_path = format!("{}/.moltbot/agents", home_dir);
+        let moltbot_path = join_native(home_dir, ".moltbot/agents");
         push_unique_scan_task(
             &mut tasks,
             &mut seen_scan_roots,
@@ -1555,7 +1567,7 @@ fn scan_all_clients_with_env_strategy_inner(
             moltbot_path,
         );
 
-        let moldbot_path = format!("{}/.moldbot/agents", home_dir);
+        let moldbot_path = join_native(home_dir, ".moldbot/agents");
         push_unique_scan_task(
             &mut tasks,
             &mut seen_scan_roots,
@@ -1566,17 +1578,17 @@ fn scan_all_clients_with_env_strategy_inner(
 
     // Oh My Pi fork (https://github.com/can1357/oh-my-pi) — same JSONL format, different root
     if enabled.contains(&ClientId::Pi) {
-        let omp_path = format!("{}/.omp/agent/sessions", home_dir);
+        let omp_path = join_native(home_dir, ".omp/agent/sessions");
         push_unique_scan_task(&mut tasks, &mut seen_scan_roots, ClientId::Pi, omp_path);
     }
 
     if include_synthetic {
         let xdg_data = if use_env_roots {
-            std::env::var("XDG_DATA_HOME").unwrap_or_else(|_| format!("{}/.local/share", home_dir))
+            std::env::var("XDG_DATA_HOME").unwrap_or_else(|_| join_native(home_dir, ".local/share"))
         } else {
-            format!("{}/.local/share", home_dir)
+            join_native(home_dir, ".local/share")
         };
-        let octofriend_db_path = PathBuf::from(format!("{}/octofriend/sqlite.db", xdg_data));
+        let octofriend_db_path = PathBuf::from(join_native(&xdg_data, "octofriend/sqlite.db"));
         if octofriend_db_path.exists() {
             result.synthetic_db = Some(octofriend_db_path);
         }
@@ -1805,7 +1817,7 @@ fn scan_all_clients_with_env_strategy_inner(
     }
 
     if enabled.contains(&ClientId::Zcode) {
-        let zcode_db_path = PathBuf::from(format!("{}/.zcode/cli/db/db.sqlite", home_dir));
+        let zcode_db_path = PathBuf::from(join_native(home_dir, ".zcode/cli/db/db.sqlite"));
         if zcode_db_path.is_file() {
             result.zcode_db = Some(zcode_db_path);
         }
@@ -1838,7 +1850,7 @@ fn scan_all_clients_with_env_strategy_inner(
         // NOT the ~/.kiro/sessions/cli/*.json layout the base client path targets.
         // Scan the sessions root and match session.json inside sess_* dirs. This
         // resolves via home_dir on Windows too (Kiro IDE uses ~/.kiro there).
-        let kiro_ide_sessions_root = PathBuf::from(format!("{}/.kiro/sessions", home_dir));
+        let kiro_ide_sessions_root = PathBuf::from(join_native(home_dir, ".kiro/sessions"));
         push_unique_scan_task_with_pattern(
             &mut tasks,
             &mut seen_scan_roots,
@@ -1847,7 +1859,7 @@ fn scan_all_clients_with_env_strategy_inner(
             "kiro-ide-session",
         );
 
-        let xdg_path = PathBuf::from(format!("{}/.local/share/kiro-cli/data.sqlite3", home_dir));
+        let xdg_path = PathBuf::from(join_native(home_dir, ".local/share/kiro-cli/data.sqlite3"));
         if xdg_path.is_file() {
             result.kiro_db = Some(xdg_path);
         }
@@ -1883,11 +1895,11 @@ fn scan_all_clients_with_env_strategy_inner(
 
         let mut codebuff_roots: Vec<String> = Vec::new();
         if let Some(root) = trimmed_override {
-            codebuff_roots.push(format!("{}/projects", root.trim_end_matches('/')));
+            codebuff_roots.push(join_native(root.trim_end_matches('/'), "projects"));
         } else {
-            let config_dir = format!("{}/.config", home_dir);
+            let config_dir = join_native(home_dir, ".config");
             for channel in ["manicode", "manicode-dev", "manicode-staging"] {
-                codebuff_roots.push(format!("{}/{}/projects", config_dir, channel));
+                codebuff_roots.push(join_native(&config_dir, &format!("{channel}/projects")));
             }
         }
 
@@ -1943,7 +1955,7 @@ fn scan_all_clients_with_env_strategy_inner(
         }
 
         // (4) ~/.gjc/agent/sessions home fallback (always available).
-        gjc_roots.push(PathBuf::from(format!("{}/.gjc/agent/sessions", home_dir)));
+        gjc_roots.push(PathBuf::from(join_native(home_dir, ".gjc/agent/sessions")));
 
         for root in gjc_roots {
             if root.exists() {
@@ -1972,7 +1984,7 @@ fn scan_all_clients_with_env_strategy_inner(
     }
 
     if enabled.contains(&ClientId::Copilot) {
-        let desktop_db = PathBuf::from(format!("{}/.copilot/data.db", home_dir));
+        let desktop_db = PathBuf::from(join_native(home_dir, ".copilot/data.db"));
         if desktop_db.is_file() {
             result.copilot_desktop_db = Some(desktop_db);
         }
@@ -2867,7 +2879,7 @@ mod tests {
 
         let home = "/tmp/tokscale-test-home";
         let roots = headless_roots(home);
-        let config_root = PathBuf::from(format!("{}/.config/tokscale/headless", home));
+        let config_root = PathBuf::from(join_native(home, ".config/tokscale/headless"));
         let mac_root = PathBuf::from(format!(
             "{}/Library/Application Support/tokscale/headless",
             home


### PR DESCRIPTION
## Summary

`ClientDef::resolve_path_with_env_strategy` built every client scan root by hand-concatenating `"{root}/{relative}"` with a hardcoded forward slash. On Windows the root half arrives with native separators (`C:\Users\me`), so the result was a **mixed-separator path** (`C:\Users\me/.codex/sessions`) that reached user-facing `clients --json` output verbatim (`sessionsPath` and `additionalPaths[].path`).

## Fix

Join through `std::path::Path` instead, so every platform gets native separators:

```rust
std::path::Path::new(&root).join(self.relative_path).to_string_lossy().into_owned()
```

Unix behavior is unchanged (`/tmp/home` + `.codex/sessions` still resolves the same way); Windows now emits `C:\Users\me\.codex\sessions`.

## Test

Adds `test_resolve_path_joins_with_native_separators_not_hardcoded_slash`, which asserts the joined result equals what `Path::join` produces on the host platform (and, under `#[cfg(windows)]`, that no forward slash remains).

Full `tokscale-core` lib suite: **1497 passed, 0 failed**.

Fixes #1048

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize all client, scanner, and headless scan roots to use native path separators, eliminating mixed Windows paths in `clients` output and internal scans. Unix is unchanged; Windows now prints backslash-only paths and uses consistent cache keys (fixes #1048).

- **Bug Fixes**
  - Join by pushing each relative component onto a `PathBuf` across clients and scanner; no mixed separators and the root is returned unchanged when `relative_path` is empty.
  - Route `PathRoot` fallbacks and env/XDG defaults through the same native join; fix `clean_reasonix_env_dir` to expand `~` with native separators.
  - Normalize headless roots; make the `tokscale clients` transcripts text assertion platform-aware.
  - Preserve an absolute `CODEBUFF_DATA_DIR` (including `/`) and accept trailing `/`; no trimming that turns `/` into a relative path; add tests to pin this.
  - Update tests/helpers to expect native separators (`native_join`, CLI helper, Kimchi/Senpi env-override expectations); fix `lib.rs` fixture comments.

<sup>Written for commit 2a8844578425050ed034f54b0d502177c7b189ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

