### PR TITLE
fix(pricing): alias bare minimax-m3 spelling to first-party key

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -9117,31 +9117,88 @@ mod tests {
 
     #[test]
     fn test_apply_pricing_if_available_prices_minimax_m3_bare_id_via_alias() {
-        // #935: Ollama Cloud and other routers report MiniMax M3 with the
-        // bare lowercase id `minimax-m3`. The authoritative litellm key is
-        // `minimax/MiniMax-M3`; the alias in aliases.rs must route the bare
-        // id there instead of leaving it to fuzzy matching (which can land
-        // on the separate `fireworks_ai/minimax-m3` hosted row).
+        // #935: routers report MiniMax M3 as the bare lowercase id `minimax-m3`,
+        // which is not a key in any dataset. When the session record carries no
+        // usable provider hint — parsers emit `unknown` for an absent provider
+        // and `normalize_provider_hint` drops it — nothing pins the lookup to
+        // MiniMax's catalog, so the bare id falls through to model-part/fuzzy
+        // matching over every row whose model part is `minimax-m3`.
+        //
+        // models.dev publishes that model part under dozens of third parties,
+        // several of them at 0.0/0.0 (`kenari/minimax-m3` and
+        // `nvidia/minimaxai/minimax-m3` both do today). Electing one of those
+        // prices real usage at exactly $0 — which is what "pricing missing"
+        // in #935 looks like from the user's side, since a row of explicit
+        // zeros still counts as "priced" downstream. The alias must pin the
+        // canonical first-party `minimax/MiniMax-M3` key instead.
         let mut litellm = HashMap::new();
+        // Real first-party rates.
         litellm.insert(
             "minimax/MiniMax-M3".into(),
             pricing::ModelPricing {
-                input_cost_per_token: Some(1e-7),
-                output_cost_per_token: Some(2e-7),
+                input_cost_per_token: Some(3e-7),
+                output_cost_per_token: Some(1.2e-6),
                 ..Default::default()
             },
         );
-        let pricing = pricing::PricingService::new(litellm, HashMap::new());
+        // The hosted reseller row that ships alongside it, at a deliberately
+        // far-apart rate so electing it could not be mistaken for the
+        // first-party result.
+        litellm.insert(
+            "fireworks_ai/minimax-m3".into(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(3e-5),
+                output_cost_per_token: Some(1.2e-4),
+                ..Default::default()
+            },
+        );
+        // The zero-cost third-party row that the bare id actually elects
+        // without the alias.
+        let mut models_dev = HashMap::new();
+        models_dev.insert(
+            "kenari/minimax-m3".to_string(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(0.0),
+                output_cost_per_token: Some(0.0),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new_with_custom_and_models_dev(
+            Default::default(),
+            litellm,
+            HashMap::new(),
+            models_dev,
+        );
+
+        // Fixture guards: both competing rows must really be in the dataset and
+        // resolvable, or this test would pass for the wrong reason.
+        let competing_zero = pricing
+            .lookup_with_source_and_provider("kenari/minimax-m3", None, None)
+            .expect("competing zero-cost models.dev row must be present");
+        assert_eq!(competing_zero.matched_key, "kenari/minimax-m3");
+        assert_eq!(competing_zero.pricing.input_cost_per_token, Some(0.0));
+        let competing_hosted = pricing
+            .lookup_with_source_and_provider("minimax-m3", None, Some("fireworks_ai"))
+            .expect("competing fireworks_ai row must resolve under its own hint");
+        assert_eq!(competing_hosted.matched_key, "fireworks_ai/minimax-m3");
+
+        // The behavior the alias exists to guarantee: the bare id resolves to
+        // the canonical first-party key, not to either competitor.
+        let resolved = pricing
+            .lookup_with_source_and_provider("minimax-m3", None, Some("unknown"))
+            .expect("bare `minimax-m3` must resolve");
+        assert_eq!(resolved.matched_key, "minimax/MiniMax-M3");
+        assert_eq!(resolved.source, "LiteLLM");
 
         let mut msg = UnifiedMessage::new(
             "ollama",
             "minimax-m3",
-            "minimax",
+            "unknown",
             "session-1",
             1_776_000_000_000,
             TokenBreakdown {
-                input: 10,
-                output: 5,
+                input: 1_000_000,
+                output: 100_000,
                 cache_read: 0,
                 cache_write: 0,
                 reasoning: 0,
@@ -9151,8 +9208,14 @@ mod tests {
 
         apply_pricing_if_available(&mut msg, Some(&pricing));
 
-        // 10 * 1e-7 + 5 * 2e-7 = 2e-6
-        assert!((msg.cost - 2e-6).abs() < 1e-12);
+        // First-party: 1_000_000 * 3e-7 + 100_000 * 1.2e-6 = 0.42.
+        // The zero-cost row would give 0.0; the fireworks row would give 42.0.
+        let expected = 1_000_000.0 * 3e-7 + 100_000.0 * 1.2e-6;
+        assert!(
+            (msg.cost - expected).abs() < 1e-12,
+            "expected first-party minimax/MiniMax-M3 cost {expected}, got {}",
+            msg.cost
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -9116,6 +9116,46 @@ mod tests {
     }
 
     #[test]
+    fn test_apply_pricing_if_available_prices_minimax_m3_bare_id_via_alias() {
+        // #935: Ollama Cloud and other routers report MiniMax M3 with the
+        // bare lowercase id `minimax-m3`. The authoritative litellm key is
+        // `minimax/MiniMax-M3`; the alias in aliases.rs must route the bare
+        // id there instead of leaving it to fuzzy matching (which can land
+        // on the separate `fireworks_ai/minimax-m3` hosted row).
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "minimax/MiniMax-M3".into(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(1e-7),
+                output_cost_per_token: Some(2e-7),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new(litellm, HashMap::new());
+
+        let mut msg = UnifiedMessage::new(
+            "ollama",
+            "minimax-m3",
+            "minimax",
+            "session-1",
+            1_776_000_000_000,
+            TokenBreakdown {
+                input: 10,
+                output: 5,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            0.0,
+        );
+
+        apply_pricing_if_available(&mut msg, Some(&pricing));
+
+        // 10 * 1e-7 + 5 * 2e-7 = 2e-6
+        assert!((msg.cost - 2e-6).abs() < 1e-12);
+    }
+
+    #[test]
     fn test_apply_pricing_if_available_prices_claude_code_minimax_model() {
         let mut litellm = HashMap::new();
         litellm.insert(

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -18,11 +18,14 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
 
     // MiniMax M3: Ollama Cloud and other routers report the model with the
     // lowercase bare id `minimax-m3` (and mixed-case variants), while the
-    // authoritative dataset key is `minimax/MiniMax-M3` (litellm) with a
-    // separate `fireworks_ai/minimax-m3` hosted row. A bare id has no exact
-    // hit and would fall through to fuzzy matching, which can land on the
-    // fireworks_ai hosted rate; pin the canonical first-party key so the id
-    // prices deterministically (#935).
+    // authoritative dataset key is `minimax/MiniMax-M3` (litellm). The bare id
+    // has no exact hit in any dataset, so with no usable provider hint it falls
+    // through to model-part matching across every row whose model part is
+    // `minimax-m3` — and models.dev publishes that model part under dozens of
+    // third parties, several at 0.0/0.0 (`kenari/minimax-m3`,
+    // `nvidia/minimaxai/minimax-m3`). Electing one of those prices real usage
+    // at exactly $0, which is the "pricing missing" symptom in #935. Pin the
+    // canonical first-party key so the id prices deterministically.
     m.insert("minimax-m3", "minimax/MiniMax-M3");
 
     m.insert("model_placeholder_m26", "claude-opus-4-6");
@@ -261,17 +264,15 @@ mod tests {
         assert_eq!(m20_result.matched_key, "google/gemini-3.5-flash");
     }
 
-    /// Regression: Anthropic's "-0" suffix is a documented moving alias for the
-    /// latest snapshot of a model line, and GitHub Copilot reports 4.1 without
-    /// the separator. Neither form resolved, so real first-party usage was
-    /// excluded from submission as unpriced — 41M tokens of claude-opus-4-0 in
-    /// one reported case.
+    /// Regression: Ollama Cloud and other routers report MiniMax M3 as the
+    /// bare lowercase id `minimax-m3`, which matches no dataset key exactly.
+    /// Unhinted, it fell through to the model-part fallback and could elect any
+    /// third-party row publishing that model part — including the 0.0/0.0 rows
+    /// models.dev carries — instead of the first-party `minimax/MiniMax-M3`
+    /// key (#935).
     #[test]
     fn resolves_minimax_m3_bare_and_case_variants() {
-        // #935: `minimax-m3` (bare lowercase, as Ollama Cloud and other
-        // routers report it) must resolve to the canonical first-party litellm
-        // key, never fall through to fuzzy matching or the fireworks_ai
-        // hosted row. resolve_alias is case-insensitive.
+        // resolve_alias is case-insensitive, since clients report mixed casing.
         assert_eq!(
             super::resolve_alias("minimax-m3"),
             Some("minimax/MiniMax-M3")
@@ -289,6 +290,11 @@ mod tests {
         assert_eq!(super::resolve_alias("minimax/minimax-m3"), None);
     }
 
+    /// Regression: Anthropic's "-0" suffix is a documented moving alias for the
+    /// latest snapshot of a model line, and GitHub Copilot reports 4.1 without
+    /// the separator. Neither form resolved, so real first-party usage was
+    /// excluded from submission as unpriced — 41M tokens of claude-opus-4-0 in
+    /// one reported case.
     #[test]
     fn anthropic_moving_aliases_and_copilot_spelling_resolve() {
         assert_eq!(

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -16,6 +16,15 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("kimi-for-coding-highspeed", "kimi-k2.7-code-highspeed");
     m.insert("k3", "kimi-k3");
 
+    // MiniMax M3: Ollama Cloud and other routers report the model with the
+    // lowercase bare id `minimax-m3` (and mixed-case variants), while the
+    // authoritative dataset key is `minimax/MiniMax-M3` (litellm) with a
+    // separate `fireworks_ai/minimax-m3` hosted row. A bare id has no exact
+    // hit and would fall through to fuzzy matching, which can land on the
+    // fireworks_ai hosted rate; pin the canonical first-party key so the id
+    // prices deterministically (#935).
+    m.insert("minimax-m3", "minimax/MiniMax-M3");
+
     m.insert("model_placeholder_m26", "claude-opus-4-6");
     m.insert("model_placeholder_m35", "claude-sonnet-4-6");
     m.insert("model_placeholder_m36", "gemini-3.1-pro");
@@ -257,6 +266,29 @@ mod tests {
     /// the separator. Neither form resolved, so real first-party usage was
     /// excluded from submission as unpriced — 41M tokens of claude-opus-4-0 in
     /// one reported case.
+    #[test]
+    fn resolves_minimax_m3_bare_and_case_variants() {
+        // #935: `minimax-m3` (bare lowercase, as Ollama Cloud and other
+        // routers report it) must resolve to the canonical first-party litellm
+        // key, never fall through to fuzzy matching or the fireworks_ai
+        // hosted row. resolve_alias is case-insensitive.
+        assert_eq!(
+            super::resolve_alias("minimax-m3"),
+            Some("minimax/MiniMax-M3")
+        );
+        assert_eq!(
+            super::resolve_alias("MiniMax-M3"),
+            Some("minimax/MiniMax-M3")
+        );
+        assert_eq!(
+            super::resolve_alias("MINIMAX-M3"),
+            Some("minimax/MiniMax-M3")
+        );
+        // The qualified id already resolves via exact match; aliasing it too
+        // would be harmless, but the bare form is the reported gap.
+        assert_eq!(super::resolve_alias("minimax/minimax-m3"), None);
+    }
+
     #[test]
     fn anthropic_moving_aliases_and_copilot_spelling_resolve() {
         assert_eq!(


### PR DESCRIPTION
## Summary

`tokscale submit`/pricing reported **"pricing is unavailable"** (or silently mispriced) for MiniMax M3. Ollama Cloud and other routers record the model with the bare lowercase id `minimax-m3`, but the authoritative dataset key is `minimax/MiniMax-M3` (litellm), with a separate `fireworks_ai/minimax-m3` hosted row. A bare id has no exact hit in the lookup indexes, so it fell through to fuzzy matching — which can land on the fireworks_ai hosted rate instead of the first-party one.

## Fix

Adds an alias in `pricing/aliases.rs`:

```rust
m.insert("minimax-m3", "minimax/MiniMax-M3");
```

`resolve_alias` is case-insensitive, so `minimax-m3`, `MiniMax-M3` and `MINIMAX-M3` all resolve deterministically to the first-party litellm key. Qualified ids (`minimax/minimax-m3`) already resolve via exact match and are deliberately left unaliased.

## Tests

- `resolves_minimax_m3_bare_and_case_variants` — alias unit test.
- `test_apply_pricing_if_available_prices_minimax_m3_bare_id_via_alias` — integration test proving a bare `minimax-m3` message gets priced through the alias.

Full `tokscale-core` lib suite: **1497 passed, 0 failed**.

Fixes #935

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Alias the bare MiniMax M3 id `minimax-m3` to the canonical `minimax/MiniMax-M3` so pricing chooses the first‑party rate, even without a provider hint. Fixes #935 and prevents “pricing unavailable”, $0 totals, or hosted mispricing when routers send the bare id.

- **Bug Fixes**
  - Map `minimax-m3` (case-insensitive) to `minimax/MiniMax-M3`, avoiding `fireworks_ai/minimax-m3` and zero‑cost third‑party `models.dev` rows.
  - Tests: Added alias unit test and rebuilt the apply‑pricing integration test to cover the unhinted bare‑id path; it now asserts the resolved key/source and cost. Qualified ids like `minimax/minimax-m3` are unchanged.

<sup>Written for commit 287bb9f1bf3b2cef04b33b0235e23f9510aacc79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

