### PR TITLE
feat(codex): add OpenCode OAuth usage fallback

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -785,7 +785,7 @@ TUI では **Usage** タブに移動するとサブスクリプションデー�
 | プロバイダー | 認証方法 | メトリクス | セットアップ |
 |----------|-------------|---------|-------|
 | **Claude** | OAuth（資格情報ファイルまたは macOS Keychain） | Session（5時間）、Weekly、Opus クォータ | `claude` を実行してログイン |
-| **Codex**（OpenAI） | OAuth（`~/.config/codex/auth.json`、`~/.codex/auth.json`、または保存済み Tokscale アカウント） | Session、Weekly クォータ | TUI の Usage タブで `[Add Codex]` を使用するか、`codex` を実行してログイン、または `tokscale codex import --name work` で既存の認証をインポート |
+| **Codex**（OpenAI） | OAuth（Codex 認証、保存済み Tokscale アカウント、または OpenCode の `$XDG_DATA_HOME/opencode/auth.json`） | Session、Weekly クォータ | `[Add Codex]`、`codex`、`tokscale codex import --name work`、または OpenCode で OpenAI の ChatGPT Plus/Pro に接続 |
 | **Z.ai** | API キー（環境変数） | トークン上限、Web 検索 | `ZAI_API_KEY` または `GLM_API_KEY` を設定 |
 | **Amp** | API キー（`~/.local/share/amp/secrets.json`） | 無料枠残高、クレジット | `amp` を実行してログイン |
 | **GitHub Copilot** | GitHub トークン（keychain または `~/.config/gh/hosts.yml`） | プレミアムインタラクション、チャットクォータ | `gh auth login` を実行 |
@@ -826,6 +826,8 @@ tokscale codex status --name personal --json
 ```
 
 保存済みの Codex アカウントが存在する場合、`tokscale usage --json` は各 Codex エントリの構造化されたアカウントメタデータを含み、TUI はそれらのエントリを 1 つの Codex グループにまとめて表示します。保存済みアカウントがない場合、Tokscale は現在の Codex 認証検出パス（`CODEX_HOME/auth.json`、`~/.config/codex/auth.json`、`~/.codex/auth.json`、その後 macOS Keychain）にフォールバックします。
+
+これらのネイティブ Codex ソースから使用量を 1 件も取得できない場合、Tokscale は OpenCode の `$XDG_DATA_HOME/opencode/auth.json`（通常は `~/.local/share/opencode/auth.json`）にある `openai` OAuth エントリを読み取ります。OpenAI API キーのエントリは ChatGPT サブスクリプション資格情報ではないため無視されます。OpenCode の資格情報は読み取り専用で、Tokscale がインポート、更新、または書き換えることはありません。アクセストークンが拒否された場合は OpenCode を使用してログインを更新させるか、`/connect` で OpenAI に再接続してください。
 
 #### 出力例
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -782,7 +782,7 @@ TUI에서는 **Usage** 탭으로 이동해 구독 데이터를 확인하세요. 
 | 프로바이더 | 인증 방식 | 지표 | 설정 |
 |----------|-------------|---------|-------|
 | **Claude** | OAuth (자격 증명 파일 또는 macOS Keychain) | 세션(5시간), 주간, Opus 할당량 | `claude`를 실행해 로그인 |
-| **Codex** (OpenAI) | OAuth (`~/.config/codex/auth.json`, `~/.codex/auth.json`, 또는 저장된 Tokscale 계정) | 세션, 주간 할당량 | TUI Usage 탭에서 `[Add Codex]`를 사용하거나, `codex`를 실행해 로그인하거나, `tokscale codex import --name work`로 기존 인증을 가져오기 |
+| **Codex** (OpenAI) | OAuth (Codex 인증, 저장된 Tokscale 계정 또는 OpenCode의 `$XDG_DATA_HOME/opencode/auth.json`) | 세션, 주간 할당량 | `[Add Codex]`, `codex`, `tokscale codex import --name work` 또는 OpenCode에서 OpenAI ChatGPT Plus/Pro 연결 사용 |
 | **Z.ai** | API 키 (환경 변수) | 토큰 한도, 웹 검색 | `ZAI_API_KEY` 또는 `GLM_API_KEY` 설정 |
 | **Amp** | API 키 (`~/.local/share/amp/secrets.json`) | 무료 티어 잔액, 크레딧 | `amp`를 실행해 로그인 |
 | **GitHub Copilot** | GitHub 토큰 (keychain 또는 `~/.config/gh/hosts.yml`) | 프리미엄 상호작용, 채팅 할당량 | `gh auth login` 실행 |
@@ -823,6 +823,8 @@ tokscale codex status --name personal --json
 ```
 
 저장된 Codex 계정이 있으면 `tokscale usage --json`은 각 Codex 항목에 대한 구조화된 계정 메타데이터를 포함하며 TUI는 해당 항목들을 하나의 Codex 그룹 아래에 표시합니다. 저장된 계정이 없으면 Tokscale은 현재 Codex 인증 탐색 경로(`CODEX_HOME/auth.json`, `~/.config/codex/auth.json`, `~/.codex/auth.json`, 그리고 macOS Keychain)로 폴백합니다.
+
+이러한 네이티브 Codex 소스에서 성공한 사용량 결과가 없으면 Tokscale은 OpenCode의 `$XDG_DATA_HOME/opencode/auth.json`(일반적으로 `~/.local/share/opencode/auth.json`)에서 `openai` OAuth 항목을 읽습니다. OpenAI API 키 항목은 ChatGPT 구독 자격 증명이 아니므로 무시됩니다. OpenCode 자격 증명은 읽기 전용이며 Tokscale은 이를 가져오거나 갱신하거나 다시 쓰지 않습니다. 액세스 토큰이 거부되면 OpenCode를 사용해 로그인을 갱신하거나 `/connect`로 OpenAI를 다시 연결하세요.
 
 #### 예시 출력
 

--- a/README.md
+++ b/README.md
@@ -786,7 +786,7 @@ In the TUI, navigate to the **Usage** tab to see subscription data. Use `[Refres
 | Provider | Auth Method | Metrics | Setup |
 |----------|-------------|---------|-------|
 | **Claude** | OAuth (credentials file or macOS Keychain) | Session (5hr), Weekly, Opus quotas | Run `claude` to log in |
-| **Codex** (OpenAI) | OAuth (`~/.config/codex/auth.json`, `~/.codex/auth.json`, or saved Tokscale accounts) | Session, Weekly quotas | Use `[Add Codex]` in the TUI Usage tab, run `codex` to log in, or import an existing auth with `tokscale codex import --name work` |
+| **Codex** (OpenAI) | OAuth (Codex auth, saved Tokscale accounts, or OpenCode's `$XDG_DATA_HOME/opencode/auth.json`) | Session, Weekly quotas | Use `[Add Codex]`, run `codex`, import with `tokscale codex import --name work`, or connect OpenAI with ChatGPT Plus/Pro in OpenCode |
 | **Z.ai** | API key (env var) | Token limits, Web Searches | Set `ZAI_API_KEY` or `GLM_API_KEY` |
 | **Amp** | API key (`~/.local/share/amp/secrets.json`) | Free tier balance, Credits | Run `amp` to log in |
 | **GitHub Copilot** | GitHub token (keychain or `~/.config/gh/hosts.yml`) | Premium interactions, Chat quotas | Run `gh auth login` |
@@ -831,6 +831,8 @@ tokscale codex activity --json
 ```
 
 When saved Codex accounts exist, `tokscale usage --json` includes structured account metadata for each Codex entry and the TUI displays those entries under one Codex group. Without saved accounts, Tokscale falls back to the current Codex auth discovery path (`CODEX_HOME/auth.json`, `~/.config/codex/auth.json`, `~/.codex/auth.json`, then macOS Keychain).
+
+If those native Codex sources produce no successful usage result, Tokscale reads the `openai` OAuth entry from OpenCode's `$XDG_DATA_HOME/opencode/auth.json` (normally `~/.local/share/opencode/auth.json`). OpenAI API-key entries are not ChatGPT subscription credentials and are ignored. OpenCode credentials are read-only: Tokscale never imports, refreshes, or rewrites them. If the access token is rejected, use OpenCode so it can refresh the login, or reconnect OpenAI with `/connect`.
 
 `tokscale codex activity` uses only the installed Codex app-server's active authentication to fetch a timestamped, account-level snapshot. It is supplemental data: it is never included in local totals, reports, exports, submissions, or leaderboards.
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -784,7 +784,7 @@ tokscale usage --light
 | 提供商 | 认证方式 | 指标 | 设置 |
 |----------|-------------|---------|-------|
 | **Claude** | OAuth（凭据文件或 macOS 钥匙串） | Session（5 小时）、Weekly、Opus 配额 | 运行 `claude` 登录 |
-| **Codex**（OpenAI） | OAuth（`~/.config/codex/auth.json`、`~/.codex/auth.json`，或已保存的 Tokscale 账号） | Session、Weekly 配额 | 在 TUI Usage 标签中使用 `[Add Codex]`，运行 `codex` 登录，或用 `tokscale codex import --name work` 导入现有认证 |
+| **Codex**（OpenAI） | OAuth（Codex 认证、已保存的 Tokscale 账号，或 OpenCode 的 `$XDG_DATA_HOME/opencode/auth.json`） | Session、Weekly 配额 | 使用 `[Add Codex]`、运行 `codex`、通过 `tokscale codex import --name work` 导入，或在 OpenCode 中连接 OpenAI ChatGPT Plus/Pro |
 | **Z.ai** | API key（环境变量） | Token 限额、Web Searches | 设置 `ZAI_API_KEY` 或 `GLM_API_KEY` |
 | **Amp** | API key（`~/.local/share/amp/secrets.json`） | 免费额度余额、Credits | 运行 `amp` 登录 |
 | **GitHub Copilot** | GitHub token（钥匙串或 `~/.config/gh/hosts.yml`） | Premium interactions、Chat 配额 | 运行 `gh auth login` |
@@ -825,6 +825,8 @@ tokscale codex status --name personal --json
 ```
 
 当存在已保存的 Codex 账号时，`tokscale usage --json` 会为每个 Codex 条目包含结构化的账号元数据，TUI 会将这些条目显示在一个 Codex 分组下。若无已保存的账号，Tokscale 会回退到当前的 Codex 认证发现路径（`CODEX_HOME/auth.json`、`~/.config/codex/auth.json`、`~/.codex/auth.json`，然后是 macOS 钥匙串）。
+
+如果这些原生 Codex 来源均未产生成功的使用量结果，Tokscale 会读取 OpenCode 的 `$XDG_DATA_HOME/opencode/auth.json`（通常为 `~/.local/share/opencode/auth.json`）中的 `openai` OAuth 条目。OpenAI API key 条目并非 ChatGPT 订阅凭据，因此会被忽略。OpenCode 凭据仅以只读方式使用：Tokscale 永远不会导入、刷新或重写这些凭据。如果访问令牌被拒绝，请使用 OpenCode 让其刷新登录状态，或通过 `/connect` 重新连接 OpenAI。
 
 #### 示例输出
 

--- a/crates/tokscale-cli/src/commands/usage/amp.rs
+++ b/crates/tokscale-cli/src/commands/usage/amp.rs
@@ -182,6 +182,7 @@ pub fn fetch() -> Result<UsageOutput> {
         Ok(UsageOutput {
             provider: "Amp".into(),
             account: None,
+            credential_source: None,
             plan,
             email: None,
             metrics,

--- a/crates/tokscale-cli/src/commands/usage/claude.rs
+++ b/crates/tokscale-cli/src/commands/usage/claude.rs
@@ -162,6 +162,7 @@ fn fetch_blocking(usage_url: &str, read: CredentialReader) -> Result<UsageOutput
         Ok(UsageOutput {
             provider: "Claude".into(),
             account: None,
+            credential_source: None,
             plan,
             email: None,
             metrics,

--- a/crates/tokscale-cli/src/commands/usage/codex.rs
+++ b/crates/tokscale-cli/src/commands/usage/codex.rs
@@ -1117,12 +1117,21 @@ fn has_opencode_auth_candidate_at(path: &Path) -> bool {
     }
 }
 
-fn has_opencode_credentials_at(path: &Path) -> bool {
-    matches!(read_opencode_credentials_at(path), Ok(Some(_)))
+fn has_opencode_usage_candidate_at(path: &Path) -> bool {
+    if !has_opencode_auth_candidate_at(path) {
+        return false;
+    }
+
+    // Keep malformed or unreadable files active so the fetch path can report
+    // the owning path instead of silently suppressing Codex usage.
+    match read_opencode_credentials_at(path) {
+        Ok(Some(_)) | Err(_) => true,
+        Ok(None) => false,
+    }
 }
 
 pub fn has_credentials() -> bool {
-    has_native_credentials() || has_opencode_credentials_at(&opencode_auth_path())
+    has_native_credentials() || has_opencode_usage_candidate_at(&opencode_auth_path())
 }
 
 async fn refresh_token(client: &reqwest::Client, token_url: &str, rt: &str) -> Result<Refresh> {
@@ -3270,6 +3279,16 @@ mod tests {
         )?;
 
         assert!(!has_credentials());
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_opencode_auth_remains_a_usage_candidate() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let auth_path = tmp.path().join("auth.json");
+        std::fs::write(&auth_path, "not json")?;
+
+        assert!(has_opencode_usage_candidate_at(&auth_path));
         Ok(())
     }
 

--- a/crates/tokscale-cli/src/commands/usage/codex.rs
+++ b/crates/tokscale-cli/src/commands/usage/codex.rs
@@ -22,6 +22,24 @@ struct Auth {
     tokens: Option<Tokens>,
 }
 
+#[derive(Debug, Deserialize)]
+struct OpenCodeAuthDocument {
+    openai: Option<OpenCodeCredential>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum OpenCodeCredential {
+    #[serde(rename = "oauth")]
+    Oauth {
+        access: String,
+        #[serde(rename = "accountId")]
+        account_id: Option<String>,
+    },
+    #[serde(other)]
+    Other,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct Tokens {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -169,6 +187,7 @@ pub struct CodexAccountInfo {
 #[derive(Debug, Clone)]
 enum CredentialSource {
     File(PathBuf),
+    OpenCodeFile(PathBuf),
     Keychain,
     Store(String),
 }
@@ -178,9 +197,11 @@ impl CredentialSource {
     ///
     /// Only [`Self::Store`] qualifies: that is tokscale's own
     /// `<config>/codex-credentials.json`. [`Self::File`] is the codex CLI's
-    /// `auth.json` and [`Self::Keychain`] is its Keychain item -- writing either
-    /// destroys the codex-owned keys tokscale does not model (see
-    /// [`auth_document`]), which is #1001 made against the codex CLI.
+    /// `auth.json`, [`Self::Keychain`] is its Keychain item, and
+    /// [`Self::OpenCodeFile`] belongs to OpenCode. The OpenCode adapter does not
+    /// even deserialize its refresh token; writing either Codex-owned source
+    /// destroys keys tokscale does not model (see [`auth_document`]), which is
+    /// #1001 made against the codex CLI.
     ///
     /// This is ownership of the *file*, which is not the same as ownership of
     /// the OAuth grant, and the difference is not academic: a store entry can be
@@ -193,17 +214,29 @@ impl CredentialSource {
     fn refreshable_account_id(&self) -> Option<&str> {
         match self {
             Self::Store(account_id) => Some(account_id),
-            Self::File(_) | Self::Keychain => None,
+            Self::File(_) | Self::OpenCodeFile(_) | Self::Keychain => None,
         }
     }
 
-    /// Names the credential in user-facing errors, so "run codex" points at the
-    /// login that actually needs attention rather than at codex in general.
+    /// Names the credential in user-facing errors so recovery points at the
+    /// application that owns the rejected login.
     fn describe(&self) -> String {
         match self {
             Self::File(path) => path.display().to_string(),
+            Self::OpenCodeFile(path) => format!("OpenCode auth at {}", path.display()),
             Self::Keychain => "the Codex Keychain item".to_string(),
             Self::Store(account_id) => format!("tokscale account '{account_id}'"),
+        }
+    }
+
+    fn reauthentication_guidance(&self) -> &'static str {
+        match self {
+            Self::OpenCodeFile(_) => {
+                "Run OpenCode and reconnect OpenAI with '/connect', then retry."
+            }
+            Self::File(_) | Self::Keychain | Self::Store(_) => {
+                "Run 'codex' so the Codex CLI can refresh its own login, then retry."
+            }
         }
     }
 }
@@ -430,6 +463,48 @@ fn current_auth_paths() -> Vec<PathBuf> {
     paths.push(home.join(".config").join("codex").join("auth.json"));
     paths.push(home.join(".codex").join("auth.json"));
     paths
+}
+
+fn opencode_auth_path() -> PathBuf {
+    let data_dir = std::env::var_os("XDG_DATA_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            crate::paths::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(".local")
+                .join("share")
+        });
+    data_dir.join("opencode").join("auth.json")
+}
+
+fn read_opencode_credentials_at(path: &Path) -> Result<Option<(Auth, CredentialSource)>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read OpenCode auth from {}", path.display()))?;
+    let document = serde_json::from_str::<OpenCodeAuthDocument>(&content)
+        .with_context(|| format!("Failed to parse OpenCode auth from {}", path.display()))?;
+    let Some(OpenCodeCredential::Oauth {
+        access, account_id, ..
+    }) = document.openai
+    else {
+        return Ok(None);
+    };
+
+    if access.trim().is_empty() {
+        anyhow::bail!("OpenCode OAuth entry has no access token");
+    }
+
+    Ok(Some((
+        Auth {
+            tokens: Some(Tokens {
+                access_token: Some(access),
+                refresh_token: None,
+                account_id,
+                id_token: None,
+            }),
+        },
+        CredentialSource::OpenCodeFile(path.to_path_buf()),
+    )))
 }
 
 /// Where `switch` writes the codex CLI auth. Derived from
@@ -1024,7 +1099,7 @@ fn auth_from_account(account: &CodexAccount) -> Auth {
     }
 }
 
-pub fn has_credentials() -> bool {
+fn has_native_credentials() -> bool {
     if load_credentials_store()
         .map(|store| !store.accounts.is_empty())
         .unwrap_or(false)
@@ -1033,6 +1108,17 @@ pub fn has_credentials() -> bool {
     }
 
     read_current_credentials().is_ok()
+}
+
+fn has_opencode_auth_candidate_at(path: &Path) -> bool {
+    match std::fs::metadata(path) {
+        Ok(metadata) => metadata.is_file(),
+        Err(error) => error.kind() != std::io::ErrorKind::NotFound,
+    }
+}
+
+pub fn has_credentials() -> bool {
+    has_native_credentials() || has_opencode_auth_candidate_at(&opencode_auth_path())
 }
 
 async fn refresh_token(client: &reqwest::Client, token_url: &str, rt: &str) -> Result<Refresh> {
@@ -1313,8 +1399,9 @@ async fn fetch_with_auth_async(
             if source.refreshable_account_id().is_none() {
                 return Err(e.context(format!(
                     "Codex usage unavailable: the access token in {} was rejected. \
-                     Run 'codex' so the Codex CLI can refresh its own login, then retry.",
-                    source.describe()
+                     {}",
+                    source.describe(),
+                    source.reauthentication_guidance()
                 )));
             }
             let rt_str = tokens
@@ -1394,6 +1481,7 @@ async fn fetch_with_auth_async(
     Ok(UsageOutput {
         provider: provider_name,
         account,
+        credential_source: None,
         plan,
         email: resp.email,
         metrics,
@@ -1504,8 +1592,14 @@ fn active_account_id_for_usage(store: &mut CodexCredentialsStore) -> Option<Stri
     active_account_id
 }
 
-fn fetch_current_auth_report(diagnostics: Vec<UsageFetchDiagnostic>) -> UsageFetchReport {
-    match fetch() {
+fn fetch_current_auth_report_at(
+    diagnostics: Vec<UsageFetchDiagnostic>,
+    endpoints: &CodexEndpoints,
+) -> UsageFetchReport {
+    let result = read_current_credentials().and_then(|(auth, source)| {
+        fetch_with_auth_at(endpoints, auth, source, "Codex".into(), None)
+    });
+    match result {
         Ok(output) => UsageFetchReport {
             outputs: vec![output],
             diagnostics,
@@ -1521,6 +1615,42 @@ fn fetch_current_auth_report(diagnostics: Vec<UsageFetchDiagnostic>) -> UsageFet
     }
 }
 
+fn append_opencode_fallback_at(
+    mut report: UsageFetchReport,
+    auth_path: &Path,
+    endpoints: &CodexEndpoints,
+) -> UsageFetchReport {
+    if !report.outputs.is_empty() {
+        return report;
+    }
+
+    let credentials = match read_opencode_credentials_at(auth_path) {
+        Ok(credentials) => credentials,
+        Err(error) => {
+            report
+                .diagnostics
+                .push(UsageFetchDiagnostic::new("Codex", None, error.to_string()));
+            return report;
+        }
+    };
+    let Some((auth, source)) = credentials else {
+        return report;
+    };
+
+    match fetch_with_auth_at(endpoints, auth, source, "Codex".into(), None) {
+        Ok(mut output) => {
+            output.credential_source = Some("opencode".to_string());
+            report.outputs.push(output);
+        }
+        Err(error) => {
+            report
+                .diagnostics
+                .push(UsageFetchDiagnostic::new("Codex", None, error.to_string()))
+        }
+    }
+    report
+}
+
 pub fn fetch_all() -> Result<Vec<UsageOutput>> {
     let report = fetch_all_report();
     if report.outputs.is_empty() {
@@ -1532,11 +1662,39 @@ pub fn fetch_all() -> Result<Vec<UsageOutput>> {
 }
 
 pub fn fetch_all_report() -> UsageFetchReport {
-    fetch_all_report_inner(CodexFetchIntent::ReadOnly)
+    let endpoints = CodexEndpoints::production();
+    fetch_all_report_with_opencode_fallback_at(
+        CodexFetchIntent::ReadOnly,
+        &endpoints,
+        &opencode_auth_path(),
+    )
 }
 
 pub fn fetch_all_report_importing_current_auth() -> UsageFetchReport {
-    fetch_all_report_inner(CodexFetchIntent::SaveCurrentLogin)
+    let endpoints = CodexEndpoints::production();
+    fetch_all_report_with_opencode_fallback_at(
+        CodexFetchIntent::SaveCurrentLogin,
+        &endpoints,
+        &opencode_auth_path(),
+    )
+}
+
+fn fetch_all_report_with_opencode_fallback_at(
+    intent: CodexFetchIntent,
+    endpoints: &CodexEndpoints,
+    auth_path: &Path,
+) -> UsageFetchReport {
+    let report = if has_native_credentials() {
+        fetch_all_report_inner_at(intent, endpoints)
+    } else {
+        UsageFetchReport::default()
+    };
+
+    if has_opencode_auth_candidate_at(auth_path) {
+        append_opencode_fallback_at(report, auth_path, endpoints)
+    } else {
+        report
+    }
 }
 
 fn load_credentials_store_for_fetch_intent(
@@ -1551,7 +1709,10 @@ fn load_credentials_store_for_fetch_intent(
     }
 }
 
-fn fetch_all_report_inner(intent: CodexFetchIntent) -> UsageFetchReport {
+fn fetch_all_report_inner_at(
+    intent: CodexFetchIntent,
+    endpoints: &CodexEndpoints,
+) -> UsageFetchReport {
     let mut diagnostics = Vec::new();
     let current_auth_account = if intent == CodexFetchIntent::SaveCurrentLogin {
         match save_current_auth_account() {
@@ -1574,11 +1735,11 @@ fn fetch_all_report_inner(intent: CodexFetchIntent) -> UsageFetchReport {
     };
 
     let Some(mut store) = load_credentials_store_for_fetch_intent(intent) else {
-        return fetch_current_auth_report(diagnostics);
+        return fetch_current_auth_report_at(diagnostics, endpoints);
     };
 
     if store.accounts.is_empty() {
-        return fetch_current_auth_report(diagnostics);
+        return fetch_current_auth_report_at(diagnostics, endpoints);
     }
 
     let active_account_id = current_auth_account
@@ -1614,7 +1775,8 @@ fn fetch_all_report_inner(intent: CodexFetchIntent) -> UsageFetchReport {
         };
         let usage_account =
             usage_account_from_saved(&account_id, account, active_account_id.as_deref());
-        match fetch_with_auth(
+        match fetch_with_auth_at(
+            endpoints,
             auth_from_account(account),
             CredentialSource::Store(account_id.clone()),
             "Codex".into(),
@@ -3035,6 +3197,268 @@ mod tests {
   "bedrock_api_key": { "key": "codex-owned-bedrock-key" },
   "someKeyTokscaleDoesNotModel": { "keep": true }
 }"#;
+
+    const OPENCODE_AUTH_FIXTURE: &str = r#"{
+  "anthropic": {
+    "type": "api",
+    "key": "unrelated-provider-key"
+  },
+  "openai": {
+    "type": "oauth",
+    "refresh": "opencode-owned-refresh-token",
+    "access": "opencode-access-token",
+    "expires": 1786089600000,
+    "accountId": "acct_opencode"
+  }
+}"#;
+
+    #[test]
+    fn opencode_oauth_maps_only_read_only_usage_credentials() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let auth_path = tmp.path().join("auth.json");
+        std::fs::write(&auth_path, OPENCODE_AUTH_FIXTURE)?;
+
+        let (auth, source) = read_opencode_credentials_at(&auth_path)?
+            .expect("OpenCode OAuth credentials should be detected");
+        let tokens = auth.tokens.expect("mapped tokens");
+
+        assert_eq!(
+            tokens.access_token.as_deref(),
+            Some("opencode-access-token")
+        );
+        assert_eq!(tokens.account_id.as_deref(), Some("acct_opencode"));
+        assert!(tokens.refresh_token.is_none());
+        assert!(tokens.id_token.is_none());
+        assert!(matches!(source, CredentialSource::OpenCodeFile(path) if path == auth_path));
+        Ok(())
+    }
+
+    #[test]
+    fn opencode_api_key_is_not_a_chatgpt_usage_credential() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let auth_path = tmp.path().join("auth.json");
+        std::fs::write(
+            &auth_path,
+            r#"{"openai":{"type":"api","key":"sk-openai-api-key"}}"#,
+        )?;
+
+        assert!(read_opencode_credentials_at(&auth_path)?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_opencode_oauth_is_reported_with_its_path() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let auth_path = tmp.path().join("auth.json");
+        std::fs::write(
+            &auth_path,
+            r#"{"openai":{"type":"oauth","refresh":"refresh","expires":1}}"#,
+        )?;
+
+        let error = read_opencode_credentials_at(&auth_path)
+            .expect_err("OAuth without an access token must not be accepted");
+        assert!(error.to_string().contains("Failed to parse OpenCode auth"));
+        assert!(error.to_string().contains(&auth_path.display().to_string()));
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn opencode_auth_path_honors_xdg_data_home() -> Result<()> {
+        let xdg_data = TempDir::new()?;
+        let _guard = EnvVarGuard::set_path("XDG_DATA_HOME", xdg_data.path());
+
+        assert_eq!(
+            opencode_auth_path(),
+            xdg_data.path().join("opencode").join("auth.json")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn opencode_fallback_keeps_native_diagnostics_when_it_recovers_usage() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let auth_path = tmp.path().join("auth.json");
+        std::fs::write(&auth_path, OPENCODE_AUTH_FIXTURE)?;
+        let (endpoints, log) = spawn_codex_server(vec![200]);
+        let native_report = UsageFetchReport {
+            outputs: Vec::new(),
+            diagnostics: vec![UsageFetchDiagnostic::new(
+                "Codex",
+                None,
+                "saved account token refresh failed",
+            )],
+        };
+
+        let report = append_opencode_fallback_at(native_report, &auth_path, &endpoints);
+
+        assert_eq!(report.outputs.len(), 1);
+        assert_eq!(report.outputs[0].provider, "Codex");
+        assert_eq!(
+            report.outputs[0].credential_source.as_deref(),
+            Some("opencode")
+        );
+        assert_eq!(
+            report.outputs[0].email.as_deref(),
+            Some("codex@example.com")
+        );
+        assert_eq!(report.diagnostics.len(), 1);
+        assert_eq!(
+            report.diagnostics[0].message,
+            "saved account token refresh failed"
+        );
+        assert_eq!(
+            *log.lock().expect("request log"),
+            vec![Seen {
+                request: format!("GET {USAGE_PATH}"),
+                bearer: Some("opencode-access-token".to_string()),
+            }]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn successful_native_usage_suppresses_opencode_fallback() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let auth_path = tmp.path().join("auth.json");
+        std::fs::write(&auth_path, OPENCODE_AUTH_FIXTURE)?;
+        let (endpoints, log) = spawn_codex_server(vec![200]);
+        let native_output = fetch_with_auth_at(
+            &endpoints,
+            Auth {
+                tokens: Some(tokens("native-codex-access-token", Some("acct_native"))),
+            },
+            CredentialSource::Keychain,
+            "Codex".into(),
+            None,
+        )?;
+
+        let report = append_opencode_fallback_at(
+            UsageFetchReport {
+                outputs: vec![native_output],
+                diagnostics: Vec::new(),
+            },
+            &auth_path,
+            &endpoints,
+        );
+
+        assert_eq!(report.outputs.len(), 1);
+        assert!(report.outputs[0].credential_source.is_none());
+        assert_eq!(
+            *log.lock().expect("request log"),
+            vec![Seen {
+                request: format!("GET {USAGE_PATH}"),
+                bearer: Some("native-codex-access-token".to_string()),
+            }]
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn stale_saved_accounts_fall_back_to_opencode_without_hiding_the_failure() -> Result<()> {
+        let config_dir = TempDir::new()?;
+        let _config_guard = EnvVarGuard::set_path("TOKSCALE_CONFIG_DIR", config_dir.path());
+        let store_path = config_dir.path().join("codex-credentials.json");
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "acct_saved".to_string(),
+            CodexAccount {
+                tokens: Tokens {
+                    access_token: Some("stale-saved-access-token".to_string()),
+                    refresh_token: Some("stale-saved-refresh-token".to_string()),
+                    account_id: Some("acct_saved".to_string()),
+                    id_token: None,
+                },
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                label: Some("old".to_string()),
+            },
+        );
+        save_credentials_store_at_path(
+            &store_path,
+            &CodexCredentialsStore {
+                version: 1,
+                active_account_id: "acct_saved".to_string(),
+                accounts,
+            },
+        )?;
+        let store_before = std::fs::read(&store_path)?;
+
+        let opencode_dir = TempDir::new()?;
+        let auth_path = opencode_dir.path().join("auth.json");
+        std::fs::write(&auth_path, OPENCODE_AUTH_FIXTURE)?;
+        let auth_before = std::fs::read(&auth_path)?;
+
+        let (base, log) = spawn_server(|path, request_index| match (path, request_index) {
+            (USAGE_PATH, 0) => (401, "{}".to_string()),
+            (TOKEN_PATH, 1) => (401, "{}".to_string()),
+            (USAGE_PATH, 2) => (200, USAGE_BODY.to_string()),
+            _ => (404, "{}".to_string()),
+        });
+        let endpoints = CodexEndpoints {
+            usage: format!("{base}{USAGE_PATH}"),
+            reset_credits: format!("{base}{RESET_CREDITS_PATH}"),
+            token: format!("{base}{TOKEN_PATH}"),
+        };
+
+        let report = fetch_all_report_with_opencode_fallback_at(
+            CodexFetchIntent::ReadOnly,
+            &endpoints,
+            &auth_path,
+        );
+
+        assert_eq!(report.outputs.len(), 1);
+        assert_eq!(
+            report.outputs[0].credential_source.as_deref(),
+            Some("opencode")
+        );
+        assert_eq!(report.diagnostics.len(), 1);
+        assert_eq!(
+            report.diagnostics[0]
+                .account
+                .as_ref()
+                .map(|account| account.id.as_str()),
+            Some("acct_saved")
+        );
+        assert_eq!(
+            requests(&log),
+            vec![
+                format!("GET {USAGE_PATH}"),
+                format!("POST {TOKEN_PATH}"),
+                format!("GET {USAGE_PATH}"),
+            ]
+        );
+        assert_eq!(std::fs::read(&store_path)?, store_before);
+        assert_eq!(std::fs::read(&auth_path)?, auth_before);
+        Ok(())
+    }
+
+    #[test]
+    fn rejected_opencode_token_is_never_refreshed_or_rewritten() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let auth_path = tmp.path().join("auth.json");
+        std::fs::write(&auth_path, OPENCODE_AUTH_FIXTURE)?;
+        let before = std::fs::read(&auth_path)?;
+        let (endpoints, log) = spawn_codex_server(vec![401]);
+
+        let report =
+            append_opencode_fallback_at(UsageFetchReport::default(), &auth_path, &endpoints);
+
+        assert!(report.outputs.is_empty());
+        assert_eq!(std::fs::read(&auth_path)?, before);
+        assert_eq!(
+            requests(&log),
+            vec![format!("GET {USAGE_PATH}")],
+            "OpenCode-owned credentials must never reach the token endpoint"
+        );
+        let diagnostic = report
+            .diagnostics
+            .first()
+            .expect("rejected OpenCode token should be diagnosed");
+        assert!(diagnostic.message.contains("OpenCode"));
+        assert!(diagnostic.message.contains("/connect"));
+        Ok(())
+    }
 
     /// Path components mirror production so a recorded request line is the same
     /// string the real endpoints would produce.

--- a/crates/tokscale-cli/src/commands/usage/codex.rs
+++ b/crates/tokscale-cli/src/commands/usage/codex.rs
@@ -1117,8 +1117,12 @@ fn has_opencode_auth_candidate_at(path: &Path) -> bool {
     }
 }
 
+fn has_opencode_credentials_at(path: &Path) -> bool {
+    matches!(read_opencode_credentials_at(path), Ok(Some(_)))
+}
+
 pub fn has_credentials() -> bool {
-    has_native_credentials() || has_opencode_auth_candidate_at(&opencode_auth_path())
+    has_native_credentials() || has_opencode_credentials_at(&opencode_auth_path())
 }
 
 async fn refresh_token(client: &reqwest::Client, token_url: &str, rt: &str) -> Result<Refresh> {
@@ -3243,6 +3247,29 @@ mod tests {
         )?;
 
         assert!(read_opencode_credentials_at(&auth_path)?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    #[cfg(not(target_os = "macos"))]
+    fn opencode_api_key_does_not_activate_codex_usage() -> Result<()> {
+        let home = TempDir::new()?;
+        let config = TempDir::new()?;
+        let codex_home = TempDir::new()?;
+        let xdg_data = TempDir::new()?;
+        let _home_guard = EnvVarGuard::set_path("HOME", home.path());
+        let _config_guard = EnvVarGuard::set_path("TOKSCALE_CONFIG_DIR", config.path());
+        let _codex_guard = EnvVarGuard::set_path("CODEX_HOME", codex_home.path());
+        let _xdg_data_guard = EnvVarGuard::set_path("XDG_DATA_HOME", xdg_data.path());
+        let auth_path = xdg_data.path().join("opencode").join("auth.json");
+        std::fs::create_dir_all(auth_path.parent().expect("auth parent"))?;
+        std::fs::write(
+            &auth_path,
+            r#"{"openai":{"type":"api","key":"sk-openai-api-key"}}"#,
+        )?;
+
+        assert!(!has_credentials());
         Ok(())
     }
 

--- a/crates/tokscale-cli/src/commands/usage/copilot.rs
+++ b/crates/tokscale-cli/src/commands/usage/copilot.rs
@@ -289,6 +289,7 @@ pub fn fetch() -> Result<UsageOutput> {
         Ok(UsageOutput {
             provider: "Copilot".into(),
             account: None,
+            credential_source: None,
             plan,
             email: None,
             metrics,

--- a/crates/tokscale-cli/src/commands/usage/grok.rs
+++ b/crates/tokscale-cli/src/commands/usage/grok.rs
@@ -623,6 +623,7 @@ fn fetch_network_usage(credentials: &Credentials) -> Result<UsageOutput> {
     Ok(UsageOutput {
         provider: "Grok Build".into(),
         account: None,
+        credential_source: None,
         plan,
         email: credentials.email.clone(),
         metrics,
@@ -640,6 +641,7 @@ fn usage_output(
     UsageOutput {
         provider: "Grok Build".into(),
         account: None,
+        credential_source: None,
         plan,
         email,
         metrics,

--- a/crates/tokscale-cli/src/commands/usage/kimi.rs
+++ b/crates/tokscale-cli/src/commands/usage/kimi.rs
@@ -295,6 +295,7 @@ pub fn fetch() -> Result<UsageOutput> {
         Ok(UsageOutput {
             provider: "Kimi".into(),
             account: None,
+            credential_source: None,
             plan,
             email: None,
             metrics,

--- a/crates/tokscale-cli/src/commands/usage/minimax.rs
+++ b/crates/tokscale-cli/src/commands/usage/minimax.rs
@@ -247,6 +247,7 @@ pub fn fetch() -> Result<UsageOutput> {
         Ok(UsageOutput {
             provider: "MiniMax".into(),
             account: None,
+            credential_source: None,
             plan,
             email: None,
             metrics,

--- a/crates/tokscale-cli/src/commands/usage/minimax_tokenplan.rs
+++ b/crates/tokscale-cli/src/commands/usage/minimax_tokenplan.rs
@@ -202,6 +202,7 @@ pub fn fetch_all() -> Result<Vec<UsageOutput>> {
                     label: Some(site.label.to_string()),
                     is_active: true,
                 }),
+                credential_source: None,
                 plan: None,
                 email: None,
                 metrics,

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -76,6 +76,8 @@ pub struct UsageOutput {
     pub provider: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub account: Option<UsageAccount>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_source: Option<String>,
     pub plan: Option<String>,
     pub email: Option<String>,
     pub metrics: Vec<UsageMetric>,
@@ -211,7 +213,6 @@ pub struct UsageFetchReport {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UsageFetchIntent {
-    #[allow(dead_code)]
     CliReadOnly,
     TuiSurface,
 }
@@ -343,64 +344,6 @@ impl Fetch {
 
 type UsageProvider = (&'static str, fn() -> bool, Fetch);
 
-/// A provider that is active (has credentials) but whose fetch failed.
-///
-/// `name` is the human-facing provider label and `error` is the formatted
-/// error message (e.g. sakana's "refresh SAKANA_SESSION_COOKIE" guidance).
-#[derive(Debug, Clone)]
-pub struct ProviderError {
-    pub name: &'static str,
-    pub error: String,
-}
-
-/// Backwards-compatible entry point: returns only successful provider outputs.
-///
-/// Per-provider errors are silently discarded here. Callers that need to make
-/// failures visible (e.g. the CLI `run`) should use [`fetch_all_with_errors`].
-///
-/// Used by the TUI dashboard (non-test builds only); the TUI test build stubs
-/// the fetch out, so allow it to be unused there.
-#[allow(dead_code)]
-pub fn fetch_all() -> Vec<UsageOutput> {
-    fetch_all_with_errors().0
-}
-
-/// Fetch usage for every active provider in parallel, returning both the
-/// successful outputs and the per-provider errors.
-///
-/// Previously a provider whose `fetch` returned `Err` (notably a stale/expired
-/// session-cookie auth error) was silently dropped: `has_credentials()` reports
-/// the provider as active, yet it just vanished from the output. This collects
-/// those errors so the caller can surface them to the user instead.
-pub fn fetch_all_with_errors() -> (Vec<UsageOutput>, Vec<ProviderError>) {
-    let active: Vec<_> = usage_providers(Fetch::Multi(codex::fetch_all))
-        .into_iter()
-        .filter(|(_, has, _)| has())
-        .collect();
-
-    if active.is_empty() {
-        return (vec![], vec![]);
-    }
-
-    let results = std::thread::scope(|s| {
-        let handles: Vec<_> = active
-            .into_iter()
-            .map(|(name, _, fetch)| s.spawn(move || (name, fetch.call())))
-            .collect();
-
-        handles
-            .into_iter()
-            .filter_map(|handle| {
-                // A panicked provider thread should not take down the whole
-                // command; skip it (a join error has no message to surface).
-                handle.join().ok()
-            })
-            .collect::<Vec<_>>()
-    });
-
-    partition_results(results)
-}
-
 fn usage_providers(codex_fetch: Fetch) -> Vec<UsageProvider> {
     vec![
         (
@@ -499,27 +442,6 @@ fn fetch_all_report_with_codex(codex_fetch: fn() -> UsageFetchReport) -> UsageFe
     })
 }
 
-/// Split per-provider fetch results into (successful outputs, errors).
-///
-/// An active provider returning `Err` becomes a [`ProviderError`] rather than
-/// being silently dropped.
-fn partition_results(
-    results: Vec<(&'static str, Result<Vec<UsageOutput>>)>,
-) -> (Vec<UsageOutput>, Vec<ProviderError>) {
-    let mut outputs = Vec::new();
-    let mut errors = Vec::new();
-    for (name, result) in results {
-        match result {
-            Ok(mut provider_outputs) => outputs.append(&mut provider_outputs),
-            Err(err) => errors.push(ProviderError {
-                name,
-                error: err.to_string(),
-            }),
-        }
-    }
-    (outputs, errors)
-}
-
 // ── Light-mode rendering ──
 
 const BAR_WIDTH: usize = 12;
@@ -597,20 +519,24 @@ fn render_light(output: &UsageOutput) {
 }
 
 pub fn run(json: bool, _light: bool) -> Result<()> {
-    let (outputs, errors) = fetch_all_with_errors();
+    let report = fetch_all_report_with_intent(UsageFetchIntent::CliReadOnly);
     if json {
         // Keep stdout pure JSON: do NOT emit provider warnings here, since they
         // would corrupt downstream `--json` consumers that read stderr too.
-        println!("{}", serde_json::to_string_pretty(&outputs)?);
+        println!("{}", serde_json::to_string_pretty(&report.outputs)?);
     } else {
-        for o in &outputs {
+        for o in &report.outputs {
             render_light(o);
         }
         // Surface active-but-failed providers (e.g. an expired session cookie)
         // so they don't silently vanish from the output. One concise line per
         // failing provider, on stderr to keep stdout clean.
-        for err in &errors {
-            eprintln!("{}: {} — skipped", err.name, err.error);
+        for diagnostic in &report.diagnostics {
+            eprintln!(
+                "{}: {} — skipped",
+                diagnostic.display_name(),
+                diagnostic.message
+            );
         }
     }
     Ok(())
@@ -629,6 +555,7 @@ mod tests {
                 label: Some("work".to_string()),
                 is_active: true,
             }),
+            credential_source: None,
             plan: None,
             email: None,
             metrics: Vec::new(),
@@ -649,6 +576,7 @@ mod tests {
                 label: Some("  ".to_string()),
                 is_active: false,
             }),
+            credential_source: None,
             plan: None,
             email: Some("user@example.com".to_string()),
             metrics: Vec::new(),
@@ -669,6 +597,7 @@ mod tests {
                 label: None,
                 is_active: false,
             }),
+            credential_source: None,
             plan: None,
             email: None,
             metrics: Vec::new(),
@@ -678,65 +607,6 @@ mod tests {
         };
 
         assert_eq!(output.display_name(), "Codex (Account 123e45...4000)");
-    }
-
-    fn sample_output(provider: &str) -> UsageOutput {
-        UsageOutput {
-            provider: provider.to_string(),
-            account: None,
-            plan: None,
-            email: None,
-            metrics: Vec::new(),
-            reset_credits: None,
-            credit_status: None,
-            spend_control: None,
-        }
-    }
-
-    #[test]
-    fn partition_results_surfaces_provider_errors_instead_of_dropping_them() {
-        let results: Vec<(&'static str, Result<Vec<UsageOutput>>)> = vec![
-            ("Claude", Ok(vec![sample_output("Claude")])),
-            (
-                "Sakana",
-                Err(anyhow::anyhow!(
-                    "Sakana session expired or invalid. Refresh SAKANA_SESSION_COOKIE."
-                )),
-            ),
-            (
-                "Codex",
-                Ok(vec![sample_output("Codex"), sample_output("Codex")]),
-            ),
-        ];
-
-        let (outputs, errors) = partition_results(results);
-
-        // Successful providers are preserved (including a Multi provider's
-        // several outputs), in order.
-        assert_eq!(outputs.len(), 3);
-        assert_eq!(outputs[0].provider, "Claude");
-        assert_eq!(outputs[1].provider, "Codex");
-        assert_eq!(outputs[2].provider, "Codex");
-
-        // The failing provider's error is surfaced, not silently discarded.
-        assert_eq!(errors.len(), 1);
-        assert_eq!(errors[0].name, "Sakana");
-        assert!(
-            errors[0].error.contains("SAKANA_SESSION_COOKIE"),
-            "expected the auth-refresh guidance to be preserved, got: {}",
-            errors[0].error
-        );
-    }
-
-    #[test]
-    fn partition_results_reports_no_errors_when_all_succeed() {
-        let results: Vec<(&'static str, Result<Vec<UsageOutput>>)> =
-            vec![("Claude", Ok(vec![sample_output("Claude")]))];
-
-        let (outputs, errors) = partition_results(results);
-
-        assert_eq!(outputs.len(), 1);
-        assert!(errors.is_empty());
     }
 
     #[test]
@@ -751,7 +621,30 @@ mod tests {
         )?;
 
         assert!(output.account.is_none());
+        assert!(output.credential_source.is_none());
         assert_eq!(output.display_name(), "Codex");
+        Ok(())
+    }
+
+    #[test]
+    fn usage_output_round_trips_opencode_credential_source() -> Result<()> {
+        let output: UsageOutput = serde_json::from_str(
+            r#"{
+                "provider": "Codex",
+                "credential_source": "opencode",
+                "plan": "Plus",
+                "email": null,
+                "metrics": []
+            }"#,
+        )?;
+
+        assert_eq!(output.credential_source.as_deref(), Some("opencode"));
+        assert_eq!(
+            serde_json::to_value(output)?
+                .get("credential_source")
+                .and_then(serde_json::Value::as_str),
+            Some("opencode")
+        );
         Ok(())
     }
 }

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -647,4 +647,72 @@ mod tests {
         );
         Ok(())
     }
+
+    fn sample_output(provider: &str) -> UsageOutput {
+        UsageOutput {
+            provider: provider.to_string(),
+            account: None,
+            credential_source: None,
+            plan: None,
+            email: None,
+            metrics: Vec::new(),
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
+        }
+    }
+
+    /// A provider that has credentials but whose fetch fails must stay visible.
+    ///
+    /// `has_credentials()` reports such a provider as active, so dropping its
+    /// error would make the provider silently vanish from the output instead of
+    /// telling the user their session needs refreshing.
+    #[test]
+    fn fetch_provider_report_surfaces_provider_errors_instead_of_dropping_them() {
+        let report = fetch_provider_report(
+            "Sakana",
+            Err(anyhow::anyhow!(
+                "Sakana session expired or invalid. Refresh SAKANA_SESSION_COOKIE."
+            )),
+        );
+
+        assert!(
+            report.outputs.is_empty(),
+            "a failed fetch must not produce usage outputs, got: {:?}",
+            report.outputs
+        );
+        assert_eq!(
+            report.diagnostics.len(),
+            1,
+            "expected exactly one diagnostic for the failing provider, got: {:?}",
+            report.diagnostics
+        );
+
+        let diagnostic = &report.diagnostics[0];
+        assert_eq!(diagnostic.provider, "Sakana");
+        assert_eq!(diagnostic.kind, UsageFetchDiagnosticKind::FetchFailed);
+        assert_eq!(diagnostic.severity, UsageFetchDiagnosticSeverity::Error);
+        assert!(
+            diagnostic.message.contains("SAKANA_SESSION_COOKIE"),
+            "expected the auth-refresh guidance to be preserved, got: {}",
+            diagnostic.message
+        );
+        assert_eq!(diagnostic.display_name(), "Sakana");
+    }
+
+    #[test]
+    fn fetch_provider_report_reports_no_diagnostics_when_fetch_succeeds() {
+        let report = fetch_provider_report(
+            "Codex",
+            Ok(vec![sample_output("Codex"), sample_output("Codex")]),
+        );
+
+        assert_eq!(report.outputs.len(), 2);
+        assert!(report.outputs.iter().all(|o| o.provider == "Codex"));
+        assert!(
+            report.diagnostics.is_empty(),
+            "a successful fetch must not emit diagnostics, got: {:?}",
+            report.diagnostics
+        );
+    }
 }

--- a/crates/tokscale-cli/src/commands/usage/sakana.rs
+++ b/crates/tokscale-cli/src/commands/usage/sakana.rs
@@ -470,6 +470,7 @@ fn build_output(parsed: ParsedBilling) -> UsageOutput {
     UsageOutput {
         provider: "Sakana".into(),
         account: None,
+        credential_source: None,
         plan,
         email: None,
         metrics,

--- a/crates/tokscale-cli/src/commands/usage/warp.rs
+++ b/crates/tokscale-cli/src/commands/usage/warp.rs
@@ -56,6 +56,7 @@ pub fn fetch() -> Result<UsageOutput> {
     Ok(UsageOutput {
         provider: "Warp/Oz".to_string(),
         account: None,
+        credential_source: None,
         plan: None,
         email: None,
         metrics,

--- a/crates/tokscale-cli/src/commands/usage/zai.rs
+++ b/crates/tokscale-cli/src/commands/usage/zai.rs
@@ -169,6 +169,7 @@ pub fn fetch() -> Result<UsageOutput> {
         Ok(UsageOutput {
             provider: "Z.ai".into(),
             account: None,
+            credential_source: None,
             plan,
             email: None,
             metrics,

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -2970,6 +2970,7 @@ mod tests {
         UsageOutput {
             provider: provider.to_string(),
             account,
+            credential_source: None,
             plan: Some("Pro".to_string()),
             email: None,
             metrics: vec![UsageMetric {

--- a/crates/tokscale-cli/src/tui/ui/usage.rs
+++ b/crates/tokscale-cli/src/tui/ui/usage.rs
@@ -1511,14 +1511,25 @@ fn selected_status_line(output: &UsageOutput) -> String {
     )
 }
 
+/// Name of the external tool that owns the credential, when the credential did
+/// not come from the saved store. Both the `Credential` detail row and the
+/// account actions row derive their wording from this so a single credential is
+/// never described two different ways.
+fn external_credential_manager(output: &UsageOutput) -> Option<&'static str> {
+    match output.credential_source.as_deref() {
+        Some("opencode") => Some("OpenCode"),
+        _ => None,
+    }
+}
+
 fn credential_detail(output: &UsageOutput) -> String {
     match &output.account {
         Some(account) if account.is_active => "saved store, current Codex login".to_string(),
         Some(_) => "saved store".to_string(),
-        None if output.credential_source.as_deref() == Some("opencode") => {
-            "managed by OpenCode".to_string()
-        }
-        None => "managed externally".to_string(),
+        None => match external_credential_manager(output) {
+            Some(manager) => format!("managed by {manager}"),
+            None => "managed externally".to_string(),
+        },
     }
 }
 
@@ -1554,10 +1565,11 @@ fn selected_account_actions_line(
         return Line::from(spans);
     }
 
-    Line::from(Span::styled(
-        "  Managed externally",
-        app.theme.subtle_text_style(),
-    ))
+    let label = match external_credential_manager(selected) {
+        Some(manager) => format!("  Managed by {manager}"),
+        None => "  Managed externally".to_string(),
+    };
+    Line::from(Span::styled(label, app.theme.subtle_text_style()))
 }
 
 fn account_plan_label(account: &str, plan: Option<&str>) -> String {
@@ -3007,8 +3019,35 @@ mod tests {
         let body = render_body(&mut app, 150, 28);
 
         assert!(body.contains("managed by OpenCode"), "{body}");
-        assert!(!body.contains("Use Account"), "{body}");
-        assert!(!body.contains("Remove"), "{body}");
+        assert!(body.contains("Managed by OpenCode"), "{body}");
+        assert!(!body.contains("Managed externally"), "{body}");
+    }
+
+    #[test]
+    fn selected_account_actions_appear_only_for_saved_accounts() {
+        let mut app = make_app();
+        app.subscription_usage = vec![output(
+            "Codex",
+            Some(UsageAccount {
+                id: "acct_personal".to_string(),
+                label: Some("personal".to_string()),
+                is_active: false,
+            }),
+        )];
+
+        let saved = render_body(&mut app, 150, 28);
+
+        assert!(saved.contains("Use Account"), "{saved}");
+        assert!(saved.contains("Remove"), "{saved}");
+
+        let mut managed = output("Codex", None);
+        managed.credential_source = Some("opencode".to_string());
+        app.subscription_usage = vec![managed];
+
+        let external = render_body(&mut app, 150, 28);
+
+        assert!(!external.contains("Use Account"), "{external}");
+        assert!(!external.contains("Remove"), "{external}");
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/ui/usage.rs
+++ b/crates/tokscale-cli/src/tui/ui/usage.rs
@@ -1189,29 +1189,14 @@ fn render_selected_account(
         );
     }
     if lines.len() < detail_limit {
-        if let Some(account) = &selected.account {
-            push_kv_styled(
-                &mut lines,
-                app,
-                "Credential",
-                if account.is_active {
-                    "saved store, current Codex login"
-                } else {
-                    "saved store"
-                },
-                app.theme.secondary_text_style(),
-                inner.width as usize,
-            );
-        } else {
-            push_kv_styled(
-                &mut lines,
-                app,
-                "Credential",
-                "managed externally",
-                app.theme.secondary_text_style(),
-                inner.width as usize,
-            );
-        }
+        push_kv_styled(
+            &mut lines,
+            app,
+            "Credential",
+            &credential_detail(selected),
+            app.theme.secondary_text_style(),
+            inner.width as usize,
+        );
     }
     if lines.len() < detail_limit {
         if let Some(label) = credits_status_line(selected) {
@@ -1524,6 +1509,17 @@ fn selected_status_line(output: &UsageOutput) -> String {
         plan,
         account_readiness_label(output, readiness_status(output))
     )
+}
+
+fn credential_detail(output: &UsageOutput) -> String {
+    match &output.account {
+        Some(account) if account.is_active => "saved store, current Codex login".to_string(),
+        Some(_) => "saved store".to_string(),
+        None if output.credential_source.as_deref() == Some("opencode") => {
+            "managed by OpenCode".to_string()
+        }
+        None => "managed externally".to_string(),
+    }
 }
 
 fn selected_account_actions_line(
@@ -2509,6 +2505,7 @@ mod tests {
         UsageOutput {
             provider: provider.to_string(),
             account,
+            credential_source: None,
             plan: Some("Pro".to_string()),
             email: Some("user@example.com".to_string()),
             metrics: vec![UsageMetric {
@@ -2998,6 +2995,20 @@ mod tests {
         assert!(body.contains("Codex (personal)"), "{body}");
         assert!(body.contains("Use Account"), "{body}");
         assert!(body.contains("saved store"), "{body}");
+    }
+
+    #[test]
+    fn selected_opencode_fallback_names_its_external_credential_manager() {
+        let mut app = make_app();
+        let mut managed = output("Codex", None);
+        managed.credential_source = Some("opencode".to_string());
+        app.subscription_usage = vec![managed];
+
+        let body = render_body(&mut app, 150, 28);
+
+        assert!(body.contains("managed by OpenCode"), "{body}");
+        assert!(!body.contains("Use Account"), "{body}");
+        assert!(!body.contains("Remove"), "{body}");
     }
 
     #[test]
@@ -3745,6 +3756,7 @@ mod tests {
                 label: None,
                 is_active: true,
             }),
+            credential_source: None,
             plan: Some("Pro".to_string()),
             email: Some("secret@example.com".to_string()),
             metrics: vec![UsageMetric {

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -1155,10 +1155,8 @@ fn test_invalid_subcommand() {
 #[test]
 fn test_codex_accounts_empty_json() {
     let tmp = TempDir::new().expect("failed to create temp home");
-    let mut cmd = cargo_bin_cmd!("tokscale");
-    cmd.env("HOME", tmp.path())
-        .env_remove("CODEX_HOME")
-        .args(["codex", "accounts", "--json"])
+    let mut cmd = cmd_with_home(tmp.path());
+    cmd.args(["codex", "accounts", "--json"])
         .assert()
         .success()
         .stdout(predicate::str::contains(r#""accounts": []"#));


### PR DESCRIPTION
- Use OpenCode's `openai` OAuth access token as a read-only Codex usage fallback when native sources return no successful result.
- Preserve native diagnostics without importing, refreshing, or rewriting OpenCode-managed credentials.
- Identify OpenCode-managed usage in JSON and the TUI, with setup and recovery documentation across README translations.
- Add coverage for XDG discovery, fallback precedence, API-key exclusion, rejected tokens, diagnostics, and file immutability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only OpenCode OAuth fallback for Codex usage when native sources return no result. Clearly labels OpenCode-managed credentials and preserves provider diagnostics in the CLI and TUI.

- **New Features**
  - Codex fallback: read `openai` OAuth from OpenCode’s `$XDG_DATA_HOME/opencode/auth.json` only if store/file/keychain yield no usage; OpenAI API-key entries are ignored.
  - Read-only safety: never import, refresh, or rewrite OpenCode auth. If rejected, instruct users to reconnect OpenAI in OpenCode with `/connect`. Native diagnostics are preserved.
  - JSON/TUI: added `credential_source` to `UsageOutput` (`"opencode"` when used). TUI marks “managed by OpenCode” and hides account actions. Discovery honors XDG; `has_credentials()` includes the OpenCode candidate.

- **Bug Fixes**
  - Malformed/unreadable OpenCode auth now emits a clear diagnostic with the file path; CLI surfaces active-but-failing providers as diagnostics; tests cover this in `fetch_provider_report`.
  - TUI: fixed inconsistent naming so the Actions row now also shows “Managed by OpenCode” for OpenCode-sourced credentials.

<sup>Written for commit 6dc114648bc0925dc573995564f989f09c948960. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

