### PR TITLE
docs(test): show the native separator on the emitted side of the scan-path contrast

### DIFF
--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -791,7 +791,7 @@ fn settings_json_path(base: &Path) -> std::path::PathBuf {
 /// forward slash survives from the `/`-joined client-table literal. An
 /// expectation built with `Path::join` would disagree on the relative half's
 /// separators (`...\.codex/sessions` against the emitted
-/// `...\.codex/sessions`), because `join` only normalizes the junction.
+/// `...\.codex\sessions`), because `join` only normalizes the junction.
 /// Changing the emitter means changing this helper in the same commit (#1048).
 fn client_scan_path(home: &Path, relative: &str) -> String {
     let mut path = home.to_path_buf();


### PR DESCRIPTION
Follow-up to #1075, addressing an unresolved review thread from that PR after it merged.

The doc comment on `client_scan_path` exists to explain why the helper pushes components rather than calling `Path::join`. It contrasts the two spellings — but printed `...\.codex/sessions` on **both** sides, so the sentence compared a string with itself and the contrast it claims to draw was invisible.

The join-based expectation keeps the forward slash from the `/`-joined client-table literal, because `join` only normalizes the junction between the two halves. The emitted value is pushed component-by-component, so on Windows it is `...\.codex\sessions`. Correcting the emitted half makes the sentence describe what the helper actually does.

Comment-only, one character changed. No test or behaviour change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix doc comment in `client_scan_path` test helper to show the native separator on the emitted path, clarifying the contrast with a `Path::join` expectation on Windows (`...\.codex\sessions` vs `...\.codex/sessions`).
Comment-only; no behavior or test changes.

<sup>Written for commit dd0c0b92a14d24d495e4768b7d6c72a953ccdd71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

