### PR TITLE
feat(prime-agent): add local session support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1413,7 +1413,7 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 | Claude Code | `~/.claude/` | `%USERPROFILE%\.claude\` | すべてのプラットフォームで同じパス |
 | OpenClaw | `~/.openclaw/` (+ レガシー: `.clawdbot`, `.moltbot`, `.moldbot`) | `%USERPROFILE%\.openclaw\` (+ レガシーパス) | すべてのプラットフォームで同じパス |
 | Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | `CODEX_HOME`環境変数で設定可能（[ソース](https://github.com/openai/codex)） |
-| Prime Agent | `~/.prime/agent/` | `%USERPROFILE%\.prime\agent\` | ルートセッションおよび RLM 子セッション。`settings.json` の `sessionDir`、`PRIME_AGENT_CODING_AGENT_DIR`、または `PRIME_AGENT_SESSION_DIR` で設定可能 |
+| Prime Agent | `~/.prime/agent/` | `%USERPROFILE%\.prime\agent\` | ルートセッションおよび RLM 子セッション。`settings.json` の `sessionDir`、`PRIME_AGENT_CODING_AGENT_DIR`、`PRIME_AGENT_SESSION_DIR`、またはレガシーの `PRIME_AGENT_CODING_AGENT_SESSION_DIR` で設定可能 |
 | Copilot CLI | `~/.copilot/otel/` | `%USERPROFILE%\.copilot\otel\` | OTELファイル書き出しが必要; `COPILOT_OTEL_FILE_EXPORTER_PATH`も自動取り込み |
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | `HERMES_HOME`環境変数で設定可能（[ソース](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)） |
 | Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | `GEMINI_CLI_HOME`環境変数で設定可能 |
@@ -1711,7 +1711,7 @@ HermesはSQLiteの`sessions`テーブルにセッションレベルの使用量�
 
 ### Prime Agent
 
-場所: ルートセッションは `~/.prime/agent/sessions/*.jsonl`、RLM 子セッションは `~/.prime/agent/session-artifacts/*/sub-*/*.jsonl` に保存されます。エージェントルートは `PRIME_AGENT_CODING_AGENT_DIR` で移動でき、`sessionDir` 設定または `PRIME_AGENT_SESSION_DIR` でセッションディレクトリだけを個別に移動できます。
+場所: ルートセッションは `~/.prime/agent/sessions/*.jsonl`、RLM 子セッションは `~/.prime/agent/session-artifacts/*/sub-*/*.jsonl` に保存されます。エージェントルートは `PRIME_AGENT_CODING_AGENT_DIR` で移動でき、`sessionDir` 設定、`PRIME_AGENT_SESSION_DIR`、またはレガシーの `PRIME_AGENT_CODING_AGENT_SESSION_DIR` でセッションディレクトリだけを個別に移動できます。
 
 Prime Agent は Pi と同じ追記専用 JSONL メッセージ形式を使用します。Tokscale はルートセッションと子セッションファイルを別々のソースとしてスキャンし、`child_usage_attributed` の会計レコードを無視するため、RLM 子セッションのトークンが親の集計と子自身のトランスクリプトで二重計上されることはありません。名前付き RLM セッションはエージェント帰属情報として扱われます。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -59,6 +59,7 @@
 | <img width="48px" src=".github/assets/client-claude.jpg" alt="Claude" /> | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/projects/` および `~/.claude/transcripts/` |
 | <img width="48px" src=".github/assets/client-openclaw.jpg" alt="OpenClaw" /> | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/agents/` (+ レガシー: `.clawdbot`, `.moltbot`, `.moldbot`) |
 | <img width="48px" src=".github/assets/client-openai.jpg" alt="Codex" /> | [Codex CLI](https://github.com/openai/codex) | `~/.codex/sessions/` |
+| <img width="48px" src="https://github.com/PrimeIntellect-ai.png" alt="Prime Agent" /> | [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) | `~/.prime/agent/sessions/` および `~/.prime/agent/session-artifacts/`（RLM 子セッション） |
 | <img width="48px" src=".github/assets/client-sakana.png" alt="Sakana Fugu" /> | [Sakana Fugu](https://sakana.ai/fugu/) | Codex 経由で追跡 — `~/.codex/sessions/*.jsonl` (`model_provider: sakana`) |
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db` および `$HERMES_HOME/profiles/*/state.db`（フォールバック: `~/.hermes/...`） |
@@ -174,7 +175,7 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
   - 設定可能なカラーテーマのGitHubスタイル貢献グラフ
   - リアルタイムフィルタリングとソート
   - ゼロフリッカーレンダリング
-- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic全体の使用量を追跡
+- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Prime Agent、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic全体の使用量を追跡
 - **リアルタイム価格** - 1時間ディスクキャッシュ付きでLiteLLMから現在の価格を取得；OpenRouter自動フォールバックと新規モデル向けCursor価格サポート
 - **詳細な内訳** - 入力、出力、キャッシュ読み書き、推論トークン追跡
 - **ネイティブRustコア** - 10倍高速な処理のため、すべての解析と集計をRustで実行
@@ -385,7 +386,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-利用可能な値: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`。
+利用可能な値: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `prime-agent`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`。
 
 > **破壊的変更 (v4.0.0)**: クライアント単位のブール型フラグ（`--opencode`、`--claude`、`--codex` など）は削除され、現在はエラーになります。代わりに正規の `--client`/`-c` フラグを使用してください — 例: `tokscale --client opencode,claude`。
 
@@ -1036,7 +1037,7 @@ tokscale sources --json
 - **インタラクティブツールチップ**: ホバーで詳細な日別内訳を表示
 - **日別内訳パネル**: クリックでソース別、モデル別の詳細を確認
 - **年別フィルタリング**: 年間を移動
-- **ソースフィルタリング**: プラットフォーム別フィルター（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic）
+- **ソースフィルタリング**: プラットフォーム別フィルター（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Prime Agent、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic）
 - **統計パネル**: 総コスト、トークン、活動日数、連続記録
 - **FOUC防止**: Reactハイドレーション前にテーマを適用（フラッシュなし）
 
@@ -1412,6 +1413,7 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 | Claude Code | `~/.claude/` | `%USERPROFILE%\.claude\` | すべてのプラットフォームで同じパス |
 | OpenClaw | `~/.openclaw/` (+ レガシー: `.clawdbot`, `.moltbot`, `.moldbot`) | `%USERPROFILE%\.openclaw\` (+ レガシーパス) | すべてのプラットフォームで同じパス |
 | Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | `CODEX_HOME`環境変数で設定可能（[ソース](https://github.com/openai/codex)） |
+| Prime Agent | `~/.prime/agent/` | `%USERPROFILE%\.prime\agent\` | ルートセッションおよび RLM 子セッション。`settings.json` の `sessionDir`、`PRIME_AGENT_CODING_AGENT_DIR`、または `PRIME_AGENT_SESSION_DIR` で設定可能 |
 | Copilot CLI | `~/.copilot/otel/` | `%USERPROFILE%\.copilot\otel\` | OTELファイル書き出しが必要; `COPILOT_OTEL_FILE_EXPORTER_PATH`も自動取り込み |
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | `HERMES_HOME`環境変数で設定可能（[ソース](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)） |
 | Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | `GEMINI_CLI_HOME`環境変数で設定可能 |
@@ -1706,6 +1708,12 @@ HermesはSQLiteの`sessions`テーブルにセッションレベルの使用量�
 {"type":"session","id":"pi_ses_001","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/tmp"}
 {"type":"message","id":"msg_001","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","model":"claude-3-5-sonnet","provider":"anthropic","usage":{"input":100,"output":50,"cacheRead":10,"cacheWrite":5,"totalTokens":165}}}
 ```
+
+### Prime Agent
+
+場所: ルートセッションは `~/.prime/agent/sessions/*.jsonl`、RLM 子セッションは `~/.prime/agent/session-artifacts/*/sub-*/*.jsonl` に保存されます。エージェントルートは `PRIME_AGENT_CODING_AGENT_DIR` で移動でき、`sessionDir` 設定または `PRIME_AGENT_SESSION_DIR` でセッションディレクトリだけを個別に移動できます。
+
+Prime Agent は Pi と同じ追記専用 JSONL メッセージ形式を使用します。Tokscale はルートセッションと子セッションファイルを別々のソースとしてスキャンし、`child_usage_attributed` の会計レコードを無視するため、RLM 子セッションのトークンが親の集計と子自身のトランスクリプトで二重計上されることはありません。名前付き RLM セッションはエージェント帰属情報として扱われます。
 
 ### Kimi CLI
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1414,7 +1414,7 @@ AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장�
 | Claude Code | `~/.claude/` | `%USERPROFILE%\.claude\` | 모든 플랫폼에서 동일한 경로 |
 | OpenClaw | `~/.openclaw/` (+ 레거시: `.clawdbot`, `.moltbot`, `.moldbot`) | `%USERPROFILE%\.openclaw\` (+ 레거시 경로) | 모든 플랫폼에서 동일한 경로 |
 | Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | `CODEX_HOME` 환경변수로 설정 가능 ([소스](https://github.com/openai/codex)) |
-| Prime Agent | `~/.prime/agent/` | `%USERPROFILE%\.prime\agent\` | 루트 세션 및 RLM 하위 세션; `settings.json`의 `sessionDir`, `PRIME_AGENT_CODING_AGENT_DIR` 또는 `PRIME_AGENT_SESSION_DIR`로 설정 가능 |
+| Prime Agent | `~/.prime/agent/` | `%USERPROFILE%\.prime\agent\` | 루트 세션 및 RLM 하위 세션; `settings.json`의 `sessionDir`, `PRIME_AGENT_CODING_AGENT_DIR`, `PRIME_AGENT_SESSION_DIR` 또는 레거시 `PRIME_AGENT_CODING_AGENT_SESSION_DIR`로 설정 가능 |
 | Copilot CLI | `~/.copilot/otel/ ` | `%USERPROFILE%\.copilot\otel\` | OTEL 파일 내보내기 필요; `COPILOT_OTEL_FILE_EXPORTER_PATH`도 자동 수집 |
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | `HERMES_HOME` 환경변수로 설정 가능 ([소스](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)) |
 | Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | `GEMINI_CLI_HOME` 환경변수로 설정 가능 |
@@ -1750,7 +1750,7 @@ Hermes는 세션 수준 사용량을 SQLite `sessions` 테이블에 저장합니
 
 ### Prime Agent
 
-위치: 루트 세션은 `~/.prime/agent/sessions/*.jsonl`, RLM 하위 세션은 `~/.prime/agent/session-artifacts/*/sub-*/*.jsonl`에 저장됩니다. 에이전트 루트는 `PRIME_AGENT_CODING_AGENT_DIR`로 이동할 수 있으며, `sessionDir` 설정 또는 `PRIME_AGENT_SESSION_DIR`로 세션 디렉터리를 별도로 이동할 수 있습니다.
+위치: 루트 세션은 `~/.prime/agent/sessions/*.jsonl`, RLM 하위 세션은 `~/.prime/agent/session-artifacts/*/sub-*/*.jsonl`에 저장됩니다. 에이전트 루트는 `PRIME_AGENT_CODING_AGENT_DIR`로 이동할 수 있으며, `sessionDir` 설정, `PRIME_AGENT_SESSION_DIR` 또는 레거시 `PRIME_AGENT_CODING_AGENT_SESSION_DIR`로 세션 디렉터리를 별도로 이동할 수 있습니다.
 
 Prime Agent는 Pi와 동일한 추가 전용 JSONL 메시지 형식을 사용합니다. Tokscale은 루트 세션과 하위 세션 파일을 별도 소스로 스캔하고 `child_usage_attributed` 장부 기록을 무시하여 RLM 하위 세션 토큰이 상위 집계와 하위 세션 자체 트랜스크립트에서 중복 계산되지 않도록 합니다. 이름이 지정된 RLM 세션은 에이전트 귀속 정보로 노출됩니다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -59,6 +59,7 @@
 | <img width="48px" src=".github/assets/client-claude.jpg" alt="Claude" /> | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/projects/` 및 `~/.claude/transcripts/` |
 | <img width="48px" src=".github/assets/client-openclaw.jpg" alt="OpenClaw" /> | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/agents/` (+ 레거시: `.clawdbot`, `.moltbot`, `.moldbot`) |
 | <img width="48px" src=".github/assets/client-openai.jpg" alt="Codex" /> | [Codex CLI](https://github.com/openai/codex) | `~/.codex/sessions/` |
+| <img width="48px" src="https://github.com/PrimeIntellect-ai.png" alt="Prime Agent" /> | [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) | `~/.prime/agent/sessions/` 및 `~/.prime/agent/session-artifacts/` (RLM 하위 세션) |
 | <img width="48px" src=".github/assets/client-sakana.png" alt="Sakana Fugu" /> | [Sakana Fugu](https://sakana.ai/fugu/) | Codex를 통해 추적 — `~/.codex/sessions/*.jsonl` (`model_provider: sakana`) |
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db` 및 `$HERMES_HOME/profiles/*/state.db` (폴백: `~/.hermes/...`) |
@@ -172,7 +173,7 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
   - 설정 가능한 색상 테마의 GitHub 스타일 기여 그래프
   - 실시간 필터링 및 정렬
   - 깜빡임 없는 렌더링
-- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic 사용량 통합 추적
+- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Prime Agent, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic 사용량 통합 추적
 - **실시간 가격 반영** - LiteLLM에서 최신 가격을 가져와(디스크 캐시 1시간) 비용 계산; OpenRouter 자동 폴백 및 신규 모델용 Cursor 가격 지원
 - **상세 분석** - 입력, 출력, 캐시 읽기/쓰기, 추론 토큰까지 추적
 - **네이티브 Rust 코어** - 모든 파싱과 집계를 Rust로 처리해 최대 10배 빠른 성능
@@ -381,7 +382,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-가능한 값: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`.
+가능한 값: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `prime-agent`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`.
 
 > **Breaking change (v4.0.0):** 클라이언트별 boolean 플래그(`--opencode`, `--claude`, `--codex` 등)는 제거되었으며 이제 오류를 발생시킵니다. 대신 정식 `--client`/`-c` 플래그를 사용하세요 — 예: `tokscale --client opencode,claude`.
 
@@ -1035,7 +1036,7 @@ tokscale sources --json
 - **인터랙티브 툴팁**: 호버 시 상세 일별 분석 표시
 - **일별 분석 패널**: 클릭하여 소스별, 모델별 세부사항 확인
 - **연도 필터링**: 연도 간 탐색
-- **소스 필터링**: 플랫폼별 필터 (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic)
+- **소스 필터링**: 플랫폼별 필터 (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Prime Agent, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic)
 - **통계 패널**: 총 비용, 토큰, 활동 일수, 연속 기록
 - **FOUC 방지**: React 하이드레이션 전 테마 적용 (깜빡임 없음)
 
@@ -1413,6 +1414,7 @@ AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장�
 | Claude Code | `~/.claude/` | `%USERPROFILE%\.claude\` | 모든 플랫폼에서 동일한 경로 |
 | OpenClaw | `~/.openclaw/` (+ 레거시: `.clawdbot`, `.moltbot`, `.moldbot`) | `%USERPROFILE%\.openclaw\` (+ 레거시 경로) | 모든 플랫폼에서 동일한 경로 |
 | Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | `CODEX_HOME` 환경변수로 설정 가능 ([소스](https://github.com/openai/codex)) |
+| Prime Agent | `~/.prime/agent/` | `%USERPROFILE%\.prime\agent\` | 루트 세션 및 RLM 하위 세션; `settings.json`의 `sessionDir`, `PRIME_AGENT_CODING_AGENT_DIR` 또는 `PRIME_AGENT_SESSION_DIR`로 설정 가능 |
 | Copilot CLI | `~/.copilot/otel/ ` | `%USERPROFILE%\.copilot\otel\` | OTEL 파일 내보내기 필요; `COPILOT_OTEL_FILE_EXPORTER_PATH`도 자동 수집 |
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | `HERMES_HOME` 환경변수로 설정 가능 ([소스](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)) |
 | Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | `GEMINI_CLI_HOME` 환경변수로 설정 가능 |
@@ -1745,6 +1747,12 @@ Hermes는 세션 수준 사용량을 SQLite `sessions` 테이블에 저장합니
 {"type":"session","id":"pi_ses_001","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/tmp"}
 {"type":"message","id":"msg_001","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","model":"claude-3-5-sonnet","provider":"anthropic","usage":{"input":100,"output":50,"cacheRead":10,"cacheWrite":5,"totalTokens":165}}}
 ```
+
+### Prime Agent
+
+위치: 루트 세션은 `~/.prime/agent/sessions/*.jsonl`, RLM 하위 세션은 `~/.prime/agent/session-artifacts/*/sub-*/*.jsonl`에 저장됩니다. 에이전트 루트는 `PRIME_AGENT_CODING_AGENT_DIR`로 이동할 수 있으며, `sessionDir` 설정 또는 `PRIME_AGENT_SESSION_DIR`로 세션 디렉터리를 별도로 이동할 수 있습니다.
+
+Prime Agent는 Pi와 동일한 추가 전용 JSONL 메시지 형식을 사용합니다. Tokscale은 루트 세션과 하위 세션 파일을 별도 소스로 스캔하고 `child_usage_attributed` 장부 기록을 무시하여 RLM 하위 세션 토큰이 상위 집계와 하위 세션 자체 트랜스크립트에서 중복 계산되지 않도록 합니다. 이름이 지정된 RLM 세션은 에이전트 귀속 정보로 노출됩니다.
 
 ### Kimi CLI
 

--- a/README.md
+++ b/README.md
@@ -1445,7 +1445,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Claude Code | `~/.claude/` | `%USERPROFILE%\.claude\` | Same path on all platforms |
 | OpenClaw | `~/.openclaw/` (+ legacy: `.clawdbot`, `.moltbot`, `.moldbot`) | `%USERPROFILE%\.openclaw\` (+ legacy paths) | Same path on all platforms |
 | Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | Configurable via `CODEX_HOME` env var ([source](https://github.com/openai/codex)) |
-| Prime Agent | `~/.prime/agent/` | `%USERPROFILE%\.prime\agent\` | Root sessions plus RLM child sessions; configurable via `sessionDir` in `settings.json`, `PRIME_AGENT_CODING_AGENT_DIR`, or `PRIME_AGENT_SESSION_DIR` |
+| Prime Agent | `~/.prime/agent/` | `%USERPROFILE%\.prime\agent\` | Root sessions plus RLM child sessions; configurable via `sessionDir` in `settings.json`, `PRIME_AGENT_CODING_AGENT_DIR`, `PRIME_AGENT_SESSION_DIR`, or legacy `PRIME_AGENT_CODING_AGENT_SESSION_DIR` |
 | Copilot CLI | `~/.copilot/otel/` | `%USERPROFILE%\.copilot\otel\` | Requires OTEL file export; also auto-ingests `COPILOT_OTEL_FILE_EXPORTER_PATH` |
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | Configurable via `HERMES_HOME` env var ([source](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)) |
 | Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | Configurable via `GEMINI_CLI_HOME` env var |
@@ -1781,7 +1781,7 @@ JSONL format with session header and message entries:
 
 ### Prime Agent
 
-Location: `~/.prime/agent/sessions/*.jsonl` for root sessions and `~/.prime/agent/session-artifacts/*/sub-*/*.jsonl` for RLM child sessions. The agent root can be moved with `PRIME_AGENT_CODING_AGENT_DIR`; the `sessionDir` setting or `PRIME_AGENT_SESSION_DIR` can move the session directory independently.
+Location: `~/.prime/agent/sessions/*.jsonl` for root sessions and `~/.prime/agent/session-artifacts/*/sub-*/*.jsonl` for RLM child sessions. The agent root can be moved with `PRIME_AGENT_CODING_AGENT_DIR`; the `sessionDir` setting, `PRIME_AGENT_SESSION_DIR`, or legacy `PRIME_AGENT_CODING_AGENT_SESSION_DIR` can move the session directory independently.
 
 Prime Agent uses the same append-only JSONL message format as Pi. Tokscale scans root and child session files as separate sources and ignores `child_usage_attributed` bookkeeping records, which prevents RLM child tokens from being counted both in the parent aggregate and in the child's own transcript. Named RLM sessions are exposed as agent attribution.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 | <img width="48px" src=".github/assets/client-claude.jpg" alt="Claude" /> | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/projects/` and `~/.claude/transcripts/` |
 | <img width="48px" src=".github/assets/client-openclaw.jpg" alt="OpenClaw" /> | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/agents/` (+ legacy: `.clawdbot`, `.moltbot`, `.moldbot`) |
 | <img width="48px" src=".github/assets/client-openai.jpg" alt="Codex" /> | [Codex CLI](https://github.com/openai/codex) | `~/.codex/sessions/` |
+| <img width="48px" src="https://github.com/PrimeIntellect-ai.png" alt="Prime Agent" /> | [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) | `~/.prime/agent/sessions/` and `~/.prime/agent/session-artifacts/` (RLM child sessions) |
 | <img width="48px" src=".github/assets/client-sakana.png" alt="Sakana Fugu" /> | [Sakana Fugu](https://sakana.ai/fugu/) | via Codex — `~/.codex/sessions/*.jsonl` (`model_provider: sakana`) |
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db` and `$HERMES_HOME/profiles/*/state.db` (fallback: `~/.hermes/...`) |
@@ -171,7 +172,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with configurable color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, and Synthetic
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Prime Agent, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, and Synthetic
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -382,7 +383,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`.
+Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `prime-agent`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`.
 
 > **Breaking change (v4.0.0):** The per-client boolean flags (`--opencode`, `--claude`, `--codex`, etc.) have been removed and now error. Use the canonical `--client`/`-c` flag instead — e.g. `tokscale --client opencode,claude`.
 
@@ -1064,7 +1065,7 @@ The frontend provides a GitHub-style contribution graph visualization:
 - **Interactive tooltips**: Hover for detailed daily breakdowns
 - **Day breakdown panel**: Click to see per-source and per-model details
 - **Year filtering**: Navigate between years
-- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic)
+- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Prime Agent, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic)
 - **Stats panel**: Total cost, tokens, active days, streaks
 - **FOUC prevention**: Theme applied before React hydrates (no flash)
 
@@ -1444,6 +1445,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Claude Code | `~/.claude/` | `%USERPROFILE%\.claude\` | Same path on all platforms |
 | OpenClaw | `~/.openclaw/` (+ legacy: `.clawdbot`, `.moltbot`, `.moldbot`) | `%USERPROFILE%\.openclaw\` (+ legacy paths) | Same path on all platforms |
 | Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | Configurable via `CODEX_HOME` env var ([source](https://github.com/openai/codex)) |
+| Prime Agent | `~/.prime/agent/` | `%USERPROFILE%\.prime\agent\` | Root sessions plus RLM child sessions; configurable via `sessionDir` in `settings.json`, `PRIME_AGENT_CODING_AGENT_DIR`, or `PRIME_AGENT_SESSION_DIR` |
 | Copilot CLI | `~/.copilot/otel/` | `%USERPROFILE%\.copilot\otel\` | Requires OTEL file export; also auto-ingests `COPILOT_OTEL_FILE_EXPORTER_PATH` |
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | Configurable via `HERMES_HOME` env var ([source](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)) |
 | Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | Configurable via `GEMINI_CLI_HOME` env var |
@@ -1776,6 +1778,12 @@ JSONL format with session header and message entries:
 {"type":"session","id":"pi_ses_001","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/tmp"}
 {"type":"message","id":"msg_001","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","model":"claude-3-5-sonnet","provider":"anthropic","usage":{"input":100,"output":50,"cacheRead":10,"cacheWrite":5,"totalTokens":165}}}
 ```
+
+### Prime Agent
+
+Location: `~/.prime/agent/sessions/*.jsonl` for root sessions and `~/.prime/agent/session-artifacts/*/sub-*/*.jsonl` for RLM child sessions. The agent root can be moved with `PRIME_AGENT_CODING_AGENT_DIR`; the `sessionDir` setting or `PRIME_AGENT_SESSION_DIR` can move the session directory independently.
+
+Prime Agent uses the same append-only JSONL message format as Pi. Tokscale scans root and child session files as separate sources and ignores `child_usage_attributed` bookkeeping records, which prevents RLM child tokens from being counted both in the parent aggregate and in the child's own transcript. Named RLM sessions are exposed as agent attribution.
 
 ### Kimi CLI
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -60,6 +60,7 @@
 | <img width="48px" src=".github/assets/client-claude.jpg" alt="Claude" /> | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/projects/` 和 `~/.claude/transcripts/` |
 | <img width="48px" src=".github/assets/client-openclaw.jpg" alt="OpenClaw" /> | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/agents/` (+ 旧版: `.clawdbot`, `.moltbot`, `.moldbot`) |
 | <img width="48px" src=".github/assets/client-openai.jpg" alt="Codex" /> | [Codex CLI](https://github.com/openai/codex) | `~/.codex/sessions/` |
+| <img width="48px" src="https://github.com/PrimeIntellect-ai.png" alt="Prime Agent" /> | [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) | `~/.prime/agent/sessions/` 和 `~/.prime/agent/session-artifacts/`（RLM 子会话） |
 | <img width="48px" src=".github/assets/client-sakana.png" alt="Sakana Fugu" /> | [Sakana Fugu](https://sakana.ai/fugu/) | 通过 Codex 追踪 — `~/.codex/sessions/*.jsonl` (`model_provider: sakana`) |
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db` 和 `$HERMES_HOME/profiles/*/state.db`（回退：`~/.hermes/...`） |
@@ -172,7 +173,7 @@
   - 支持可配置颜色主题的 GitHub 风格贡献图
   - 实时筛选和排序
   - 零闪烁渲染
-- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code 和 Synthetic 的使用情况
+- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Prime Agent、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code 和 Synthetic 的使用情况
 - **实时定价** - 从 LiteLLM 获取当前价格，带 1 小时磁盘缓存；OpenRouter 自动回退和新模型的 Cursor 定价支持
 - **详细分解** - 输入、输出、缓存读写和推理 Token 跟踪
 - **原生 Rust 核心** - 所有解析和聚合在 Rust 中完成，处理速度提升 10 倍
@@ -382,7 +383,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-可用值：`opencode`、`claude`、`codex`、`copilot`、`gemini`、`cursor`、`amp`、`codebuff`、`droid`、`openclaw`、`hermes`、`pi`、`kimchi`、`kimi`、`qwen`、`roocode`、`kilocode`、`kilo`、`mux`、`crush`、`goose`、`antigravity`、`antigravity-cli`、`zed`、`kiro`、`trae`、`warp`、`cline`、`gjc`、`grok`、`jcode`、`micode`、`commandcode`、`junie`、`zcode`、`opencodereview`、`codebuddy`、`augment`、`synthetic`。
+可用值：`opencode`、`claude`、`codex`、`copilot`、`gemini`、`cursor`、`amp`、`codebuff`、`droid`、`openclaw`、`hermes`、`pi`、`prime-agent`、`kimchi`、`kimi`、`qwen`、`roocode`、`kilocode`、`kilo`、`mux`、`crush`、`goose`、`antigravity`、`antigravity-cli`、`zed`、`kiro`、`trae`、`warp`、`cline`、`gjc`、`grok`、`jcode`、`micode`、`commandcode`、`junie`、`zcode`、`opencodereview`、`codebuddy`、`augment`、`synthetic`。
 
 > **破坏性变更（v4.0.0）**：单客户端布尔选项（`--opencode`、`--claude`、`--codex` 等）已被移除，现在会直接报错。请改用规范的 `--client`/`-c` 选项——例如 `tokscale --client opencode,claude`。
 
@@ -1038,7 +1039,7 @@ tokscale sources --json
 - **交互式提示**：悬停查看详细的每日分解
 - **每日分解面板**：点击查看每个来源和模型的详情
 - **年份筛选**：在年份之间导航
-- **来源筛选**：按平台筛选（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic）
+- **来源筛选**：按平台筛选（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Prime Agent、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic）
 - **统计面板**：总成本、Token、活跃天数、连续记录
 - **FOUC 防护**：在 React 水合前应用主题（无闪烁）
 
@@ -1412,6 +1413,7 @@ AI 编程工具将会话数据存储在跨平台位置。大多数工具在所�
 | Claude Code | `~/.claude/` | `%USERPROFILE%\.claude\` | 所有平台使用相同路径 |
 | OpenClaw | `~/.openclaw/` (+ 旧版: `.clawdbot`, `.moltbot`, `.moldbot`) | `%USERPROFILE%\.openclaw\` (+ 旧版路径) | 所有平台使用相同路径 |
 | Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | 可通过 `CODEX_HOME` 环境变量配置（[源码](https://github.com/openai/codex)） |
+| Prime Agent | `~/.prime/agent/` | `%USERPROFILE%\.prime\agent\` | 根会话和 RLM 子会话；可通过 `settings.json` 中的 `sessionDir`、`PRIME_AGENT_CODING_AGENT_DIR` 或 `PRIME_AGENT_SESSION_DIR` 配置 |
 | Copilot CLI | `~/.copilot/otel/` | `%USERPROFILE%\.copilot\otel\` | 需要 OTEL 文件导出；同时自动采集 `COPILOT_OTEL_FILE_EXPORTER_PATH` |
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | 可通过 `HERMES_HOME` 环境变量配置（[源码](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)） |
 | Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | 可通过 `GEMINI_CLI_HOME` 环境变量配置 |
@@ -1744,6 +1746,12 @@ Hermes 将会话级使用量存储在 SQLite `sessions` 表中。Tokscale 导入
 {"type":"session","id":"pi_ses_001","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/tmp"}
 {"type":"message","id":"msg_001","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","model":"claude-3-5-sonnet","provider":"anthropic","usage":{"input":100,"output":50,"cacheRead":10,"cacheWrite":5,"totalTokens":165}}}
 ```
+
+### Prime Agent
+
+位置：根会话位于 `~/.prime/agent/sessions/*.jsonl`，RLM 子会话位于 `~/.prime/agent/session-artifacts/*/sub-*/*.jsonl`。可通过 `PRIME_AGENT_CODING_AGENT_DIR` 移动代理根目录，也可通过 `sessionDir` 设置或 `PRIME_AGENT_SESSION_DIR` 单独移动会话目录。
+
+Prime Agent 使用与 Pi 相同的追加式 JSONL 消息格式。Tokscale 将根会话和子会话文件作为独立来源扫描，并忽略 `child_usage_attributed` 记账记录，从而避免 RLM 子会话的 Token 在父级汇总和子会话自身的会话记录中被重复计算。具名 RLM 会话的名称会作为 agent 归因信息展示。
 
 ### Kimi CLI
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1413,7 +1413,7 @@ AI 编程工具将会话数据存储在跨平台位置。大多数工具在所�
 | Claude Code | `~/.claude/` | `%USERPROFILE%\.claude\` | 所有平台使用相同路径 |
 | OpenClaw | `~/.openclaw/` (+ 旧版: `.clawdbot`, `.moltbot`, `.moldbot`) | `%USERPROFILE%\.openclaw\` (+ 旧版路径) | 所有平台使用相同路径 |
 | Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | 可通过 `CODEX_HOME` 环境变量配置（[源码](https://github.com/openai/codex)） |
-| Prime Agent | `~/.prime/agent/` | `%USERPROFILE%\.prime\agent\` | 根会话和 RLM 子会话；可通过 `settings.json` 中的 `sessionDir`、`PRIME_AGENT_CODING_AGENT_DIR` 或 `PRIME_AGENT_SESSION_DIR` 配置 |
+| Prime Agent | `~/.prime/agent/` | `%USERPROFILE%\.prime\agent\` | 根会话和 RLM 子会话；可通过 `settings.json` 中的 `sessionDir`、`PRIME_AGENT_CODING_AGENT_DIR`、`PRIME_AGENT_SESSION_DIR` 或旧版 `PRIME_AGENT_CODING_AGENT_SESSION_DIR` 配置 |
 | Copilot CLI | `~/.copilot/otel/` | `%USERPROFILE%\.copilot\otel\` | 需要 OTEL 文件导出；同时自动采集 `COPILOT_OTEL_FILE_EXPORTER_PATH` |
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | 可通过 `HERMES_HOME` 环境变量配置（[源码](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)） |
 | Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | 可通过 `GEMINI_CLI_HOME` 环境变量配置 |
@@ -1749,7 +1749,7 @@ Hermes 将会话级使用量存储在 SQLite `sessions` 表中。Tokscale 导入
 
 ### Prime Agent
 
-位置：根会话位于 `~/.prime/agent/sessions/*.jsonl`，RLM 子会话位于 `~/.prime/agent/session-artifacts/*/sub-*/*.jsonl`。可通过 `PRIME_AGENT_CODING_AGENT_DIR` 移动代理根目录，也可通过 `sessionDir` 设置或 `PRIME_AGENT_SESSION_DIR` 单独移动会话目录。
+位置：根会话位于 `~/.prime/agent/sessions/*.jsonl`，RLM 子会话位于 `~/.prime/agent/session-artifacts/*/sub-*/*.jsonl`。可通过 `PRIME_AGENT_CODING_AGENT_DIR` 移动代理根目录，也可通过 `sessionDir` 设置、`PRIME_AGENT_SESSION_DIR` 或旧版 `PRIME_AGENT_CODING_AGENT_SESSION_DIR` 单独移动会话目录。
 
 Prime Agent 使用与 Pi 相同的追加式 JSONL 消息格式。Tokscale 将根会话和子会话文件作为独立来源扫描，并忽略 `child_usage_attributed` 记账记录，从而避免 RLM 子会话的 Token 在父级汇总和子会话自身的会话记录中被重复计算。具名 RLM 会话的名称会作为 agent 归因信息展示。
 

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -2446,6 +2446,11 @@ mod tests {
     }
 
     #[test]
+    fn test_client_display_name_prime_agent() {
+        assert_eq!(client_display_name("prime-agent"), Some("Prime Agent"));
+    }
+
+    #[test]
     fn test_client_display_name_kilo() {
         assert_eq!(client_display_name("kilo"), Some("Kilo CLI"));
     }
@@ -2604,6 +2609,14 @@ mod tests {
         assert_eq!(
             client_logo_url("Pi"),
             Some("https://tokscale.ai/assets/logos/pi.png")
+        );
+    }
+
+    #[test]
+    fn test_client_logo_url_prime_agent() {
+        assert_eq!(
+            client_logo_url("Prime Agent"),
+            Some("https://github.com/PrimeIntellect-ai.png")
         );
     }
 

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -1472,6 +1472,7 @@ fn client_display_name(client: &str) -> Option<&'static str> {
         "junie" => Some("Junie"),
         "augment" => Some("Augment Code"),
         "kimchi" => Some("Kimchi"),
+        "prime-agent" => Some("Prime Agent"),
         "synthetic" => Some("Synthetic"),
         _ => None,
     }
@@ -1495,6 +1496,7 @@ fn client_logo_url(client_name: &str) -> Option<&'static str> {
         "OpenClaw" => Some("https://tokscale.ai/assets/logos/openclaw.png"),
         "Hermes Agent" => Some("https://tokscale.ai/assets/logos/hermes.png"),
         "Pi" => Some("https://tokscale.ai/assets/logos/pi.png"),
+        "Prime Agent" => Some("https://github.com/PrimeIntellect-ai.png"),
         "Kimi CLI" => Some("https://tokscale.ai/assets/logos/kimi.png"),
         "Qwen CLI" => Some("https://tokscale.ai/assets/logos/qwen.png"),
         "Roo Code" => Some("https://tokscale.ai/assets/logos/roocode.png"),

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1077,6 +1077,8 @@ pub enum ClientFilter {
     Augment,
     Kimchi,
     Reasonix,
+    #[value(name = "prime-agent")]
+    PrimeAgent,
     Synthetic,
 }
 
@@ -1130,6 +1132,7 @@ impl ClientFilter {
             Self::Augment => "augment",
             Self::Kimchi => "kimchi",
             Self::Reasonix => "reasonix",
+            Self::PrimeAgent => "prime-agent",
             Self::Synthetic => "synthetic",
         }
     }
@@ -1186,6 +1189,7 @@ impl ClientFilter {
             Self::Augment => Some(ClientId::Augment),
             Self::Kimchi => Some(ClientId::Kimchi),
             Self::Reasonix => Some(ClientId::Reasonix),
+            Self::PrimeAgent => Some(ClientId::PrimeAgent),
             Self::Synthetic => None,
         }
     }
@@ -1238,6 +1242,7 @@ impl ClientFilter {
             ClientId::Augment => Self::Augment,
             ClientId::Kimchi => Self::Kimchi,
             ClientId::Reasonix => Self::Reasonix,
+            ClientId::PrimeAgent => Self::PrimeAgent,
         }
     }
 
@@ -3915,6 +3920,7 @@ fn capitalize_client(client: &str) -> String {
         "senpi" => "Senpi (OmO Native)".to_string(),
         "augment" => "Augment Code".to_string(),
         "kimchi" => "Kimchi".to_string(),
+        "prime-agent" => "Prime Agent".to_string(),
         other => other.to_string(),
     }
 }
@@ -4026,9 +4032,20 @@ fn run_clients_command(json: bool, home_dir: Option<String>) -> Result<()> {
     let clients: Vec<ClientRow> =
         ClientId::iter()
             .map(|client| {
-                let sessions_path = client
-                    .data()
-                    .resolve_path_with_env_strategy(&home_dir_str, use_env_roots);
+                let prime_agent_roots = (client == ClientId::PrimeAgent).then(|| {
+                    tokscale_core::scanner::prime_agent_session_roots_with_env_strategy(
+                        &home_dir_str,
+                        use_env_roots,
+                    )
+                });
+                let sessions_path = prime_agent_roots
+                    .as_ref()
+                    .map(|roots| roots[0].to_string_lossy().into_owned())
+                    .unwrap_or_else(|| {
+                        client
+                            .data()
+                            .resolve_path_with_env_strategy(&home_dir_str, use_env_roots)
+                    });
                 let sessions_path_exists = Path::new(&sessions_path).exists();
                 let mut additional_paths: Vec<AdditionalPath> = built_in_extra_paths
                     .iter()
@@ -4038,6 +4055,12 @@ fn run_clients_command(json: bool, home_dir: Option<String>) -> Result<()> {
                         exists: path.exists(),
                     })
                     .collect();
+                if let Some(roots) = &prime_agent_roots {
+                    additional_paths.push(AdditionalPath {
+                        path: roots[1].to_string_lossy().into_owned(),
+                        exists: roots[1].exists(),
+                    });
+                }
                 if client == ClientId::Zcode {
                     let path = home_dir.join(".zcode/cli/db/db.sqlite");
                     additional_paths.push(AdditionalPath {

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -184,6 +184,10 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
         display_name: "Reasonix",
         hotkey: 'R',
     },
+    ClientUi {
+        display_name: "Prime Agent",
+        hotkey: 'P',
+    },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1614,6 +1614,8 @@ mod tests {
         assert_eq!(clients[39], ClientId::Senpi);
         assert_eq!(clients[40], ClientId::Augment);
         assert_eq!(clients[41], ClientId::Kimchi);
+        assert_eq!(clients[42], ClientId::Reasonix);
+        assert_eq!(clients[43], ClientId::PrimeAgent);
     }
 
     #[test]
@@ -1725,6 +1727,10 @@ mod tests {
             crate::tui::client_ui::display_name(ClientId::Kimchi),
             "Kimchi"
         );
+        assert_eq!(
+            crate::tui::client_ui::display_name(ClientId::PrimeAgent),
+            "Prime Agent"
+        );
     }
 
     #[test]
@@ -1762,6 +1768,7 @@ mod tests {
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::WorkBuddy), 'B');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Augment), 'A');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Kimchi), 'K');
+        assert_eq!(crate::tui::client_ui::hotkey(ClientId::PrimeAgent), 'P');
     }
 
     #[test]
@@ -1877,6 +1884,10 @@ mod tests {
         assert_eq!(
             crate::tui::client_ui::from_hotkey('K'),
             Some(ClientId::Kimchi)
+        );
+        assert_eq!(
+            crate::tui::client_ui::from_hotkey('P'),
+            Some(ClientId::PrimeAgent)
         );
     }
 

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -492,6 +492,7 @@ pub fn get_client_color(client: &str) -> Color {
         "gjc" => Color::Rgb(220, 38, 38),          // #DC2626 gajae-code red-claw
         "jcode" => Color::Rgb(245, 158, 11),       // #F59E0B Jcode amber
         "junie" => Color::Rgb(123, 97, 255),       // #7B61FF Junie violet
+        "prime-agent" => Color::Rgb(108, 99, 255), // #6C63FF Prime violet
         _ => Color::Rgb(136, 136, 136),            // #888888
     }
 }

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -553,7 +553,10 @@ fn cmd_with_home(tmp: &Path) -> Command {
         .env_remove("GOOSE_PATH_ROOT")
         .env_remove("CODEBUFF_DATA_DIR")
         .env_remove("GEMINI_CLI_HOME")
-        .env_remove("HERMES_HOME");
+        .env_remove("HERMES_HOME")
+        .env_remove("PRIME_AGENT_CODING_AGENT_DIR")
+        .env_remove("PRIME_AGENT_SESSION_DIR")
+        .env_remove("PRIME_AGENT_CODING_AGENT_SESSION_DIR");
     cmd
 }
 
@@ -589,7 +592,10 @@ fn offline_cmd_with_home(tmp: &Path) -> Command {
         .env_remove("GOOSE_PATH_ROOT")
         .env_remove("CODEBUFF_DATA_DIR")
         .env_remove("GEMINI_CLI_HOME")
-        .env_remove("HERMES_HOME");
+        .env_remove("HERMES_HOME")
+        .env_remove("PRIME_AGENT_CODING_AGENT_DIR")
+        .env_remove("PRIME_AGENT_SESSION_DIR")
+        .env_remove("PRIME_AGENT_CODING_AGENT_SESSION_DIR");
     cmd
 }
 

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -725,6 +725,21 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    // Prime Agent uses the Pi append-only JSONL session format. Root sessions
+    // live in `<agent dir>/sessions`; RLM child sessions are discovered from
+    // the sibling `session-artifacts` tree by the scanner.
+    PrimeAgent = 43 => {
+        id: "prime-agent",
+        root: PathRoot::EnvVar {
+            var: "PRIME_AGENT_CODING_AGENT_DIR",
+            fallback_relative: ".prime/agent",
+        },
+        relative: "sessions",
+        pattern: "*.jsonl",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -808,13 +823,29 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 43);
+        assert_eq!(ClientId::COUNT, 44);
     }
 
     #[test]
     fn test_senpi_client_registered_as_local_session_source() {
         let client = ClientId::from_str("senpi").expect("senpi client should be registered");
         assert_eq!(client.data().relative_path, "sessions");
+        assert_eq!(client.data().pattern, "*.jsonl");
+        assert!(client.data().parse_local);
+        assert!(client.data().submit_default);
+        assert!(!client.data().headless);
+    }
+
+    #[test]
+    fn test_prime_agent_client_registered_as_local_session_source() {
+        let client =
+            ClientId::from_str("prime-agent").expect("prime-agent client should be registered");
+        assert_eq!(
+            client
+                .data()
+                .resolve_path_with_env_strategy("/tmp/home", false),
+            native_join(std::path::Path::new("/tmp/home"), ".prime/agent/sessions")
+        );
         assert_eq!(client.data().pattern, "*.jsonl");
         assert!(client.data().parse_local);
         assert!(client.data().submit_default);

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1669,6 +1669,32 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
+    let prime_agent_outcomes: Vec<CachedParseOutcome> = scan_result
+        .get(ClientId::PrimeAgent)
+        .par_iter()
+        .map(|path| {
+            load_or_parse_source(
+                message_cache::CacheIdentity::for_client(ClientId::PrimeAgent),
+                path,
+                &source_cache,
+                pricing,
+                sessions::prime_agent::parse_prime_agent_file,
+            )
+        })
+        .collect();
+    let mut prime_agent_seen: HashSet<String> = HashSet::new();
+    for outcome in prime_agent_outcomes {
+        all_messages.extend(
+            outcome
+                .messages
+                .into_iter()
+                .filter(|message| should_keep_deduped_message(&mut prime_agent_seen, message)),
+        );
+        if let Some(entry) = outcome.cache_entry {
+            source_cache.insert(entry);
+        }
+    }
+
     let kimchi_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Kimchi)
         .par_iter()
@@ -3683,6 +3709,21 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let pi_count = pi_msgs.len() as i32;
     counts.set(ClientId::Pi, pi_count);
     messages.extend(pi_msgs);
+
+    let prime_agent_msgs_raw: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::PrimeAgent)
+        .par_iter()
+        .flat_map(|path| sessions::prime_agent::parse_prime_agent_file(path))
+        .collect();
+    let mut prime_agent_seen: HashSet<String> = HashSet::new();
+    let prime_agent_msgs: Vec<ParsedMessage> = prime_agent_msgs_raw
+        .into_iter()
+        .filter(|message| should_keep_deduped_message(&mut prime_agent_seen, message))
+        .map(|message| unified_to_parsed(&message))
+        .collect();
+    let prime_agent_count = prime_agent_msgs.len() as i32;
+    counts.set(ClientId::PrimeAgent, prime_agent_count);
+    messages.extend(prime_agent_msgs);
 
     let kimchi_msgs_raw: Vec<UnifiedMessage> = scan_result
         .get(ClientId::Kimchi)

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -4007,6 +4007,14 @@ mod tests {
         let roots = prime_agent_session_roots_with_env_strategy(home.to_str().unwrap(), true);
         assert_eq!(roots[0], legacy_sessions);
         assert_eq!(roots[1], home.join("legacy/session-artifacts"));
+
+        // Match Prime Agent's `primary ?? legacy` environment lookup exactly:
+        // an explicitly empty primary value suppresses the legacy variable,
+        // then falls through to settings/default resolution.
+        env.set("PRIME_AGENT_SESSION_DIR", "");
+        let roots = prime_agent_session_roots_with_env_strategy(home.to_str().unwrap(), true);
+        assert_eq!(roots[0], home.join("custom-agent/sessions"));
+        assert_eq!(roots[1], home.join("custom-agent/session-artifacts"));
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -224,6 +224,70 @@ impl ScanResult {
     }
 }
 
+fn expand_tilde_path_with_home(value: &str, home_dir: &str) -> PathBuf {
+    if value == "~" {
+        return PathBuf::from(home_dir);
+    }
+    if let Some(relative) = value
+        .strip_prefix("~/")
+        .or_else(|| value.strip_prefix("~\\"))
+    {
+        return PathBuf::from(home_dir).join(relative);
+    }
+    PathBuf::from(value)
+}
+
+fn prime_agent_session_dir_from_settings(agent_dir: &Path, home_dir: &str) -> Option<PathBuf> {
+    fn read_session_dir(path: &Path) -> Option<String> {
+        let content = std::fs::read_to_string(path).ok()?;
+        let settings: Value = serde_json::from_str(&content).ok()?;
+        settings
+            .as_object()?
+            .get("sessionDir")?
+            .as_str()
+            .map(str::to_owned)
+    }
+
+    let global = read_session_dir(&agent_dir.join("settings.json"));
+    let project = std::env::current_dir()
+        .ok()
+        .and_then(|cwd| read_session_dir(&cwd.join(".prime/agent/settings.json")));
+    project
+        .or(global)
+        .map(|path| expand_tilde_path_with_home(&path, home_dir))
+}
+
+/// Resolve Prime Agent's root-session and RLM-artifact scan roots using the
+/// same environment precedence and tilde expansion as Prime Agent itself.
+pub fn prime_agent_session_roots_with_env_strategy(
+    home_dir: &str,
+    use_env_roots: bool,
+) -> [PathBuf; 2] {
+    let sessions = if use_env_roots {
+        let session_override = std::env::var("PRIME_AGENT_SESSION_DIR")
+            .ok()
+            .or_else(|| std::env::var("PRIME_AGENT_CODING_AGENT_SESSION_DIR").ok());
+        if let Some(path) = session_override.filter(|value| !value.is_empty()) {
+            expand_tilde_path_with_home(&path, home_dir)
+        } else {
+            let agent_dir = std::env::var("PRIME_AGENT_CODING_AGENT_DIR")
+                .ok()
+                .filter(|value| !value.is_empty())
+                .map(|path| expand_tilde_path_with_home(&path, home_dir))
+                .unwrap_or_else(|| PathBuf::from(home_dir).join(".prime/agent"));
+            prime_agent_session_dir_from_settings(&agent_dir, home_dir)
+                .unwrap_or_else(|| agent_dir.join("sessions"))
+        }
+    } else {
+        PathBuf::from(home_dir).join(".prime/agent/sessions")
+    };
+    let artifacts = sessions
+        .parent()
+        .unwrap_or_else(|| Path::new(""))
+        .join("session-artifacts");
+    [sessions, artifacts]
+}
+
 pub fn headless_roots_with_env_strategy(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
     if use_env_roots {
         if let Ok(path) = std::env::var("TOKSCALE_HEADLESS_DIR") {
@@ -302,6 +366,9 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 "*.json" => file_name.ends_with(".json"),
                 "*.json|*.jsonl" => file_name.ends_with(".json") || file_name.ends_with(".jsonl"),
                 "*.jsonl" => file_name.ends_with(".jsonl"),
+                "prime-agent-session" => {
+                    file_name.ends_with(".jsonl") && file_name != "rlm-subagents.jsonl"
+                }
                 "*.ndjson" => file_name.ends_with(".ndjson"),
                 "*.log" => file_name.ends_with(".log"),
                 "codebuddy-extension-log" => {
@@ -1264,6 +1331,7 @@ fn scan_all_clients_with_env_strategy_inner(
                 | ClientId::MiMoCode
                 | ClientId::DevinCli
                 | ClientId::Grok
+                | ClientId::PrimeAgent
         ) {
             continue;
         }
@@ -1580,6 +1648,27 @@ fn scan_all_clients_with_env_strategy_inner(
     if enabled.contains(&ClientId::Pi) {
         let omp_path = join_native(home_dir, ".omp/agent/sessions");
         push_unique_scan_task(&mut tasks, &mut seen_scan_roots, ClientId::Pi, omp_path);
+    }
+
+    if enabled.contains(&ClientId::PrimeAgent) {
+        // Prime Agent lets the session directory move independently from its
+        // agent directory. Its RLM child session tree is always a sibling of
+        // the effective session directory (`dirname(sessions)/session-artifacts`).
+        let [sessions, artifacts] =
+            prime_agent_session_roots_with_env_strategy(home_dir, use_env_roots);
+        push_unique_scan_task(
+            &mut tasks,
+            &mut seen_scan_roots,
+            ClientId::PrimeAgent,
+            sessions,
+        );
+        push_unique_scan_task_with_pattern(
+            &mut tasks,
+            &mut seen_scan_roots,
+            ClientId::PrimeAgent,
+            artifacts,
+            "prime-agent-session",
+        );
     }
 
     if include_synthetic {
@@ -3827,6 +3916,124 @@ mod tests {
         assert_eq!(result.get(ClientId::Pi).len(), 1);
         assert!(result.get(ClientId::OpenCode).is_empty());
         assert!(result.get(ClientId::Claude).is_empty());
+    }
+
+    #[test]
+    fn test_scan_all_clients_prime_agent_includes_root_and_rlm_child_sessions() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let root_dir = home.join(".prime/agent/sessions");
+        let child_dir = home.join(".prime/agent/session-artifacts/root/sub-deadbeef");
+        fs::create_dir_all(&root_dir).unwrap();
+        fs::create_dir_all(&child_dir).unwrap();
+        File::create(root_dir.join("root.jsonl")).unwrap();
+        File::create(child_dir.join("child.jsonl")).unwrap();
+        File::create(home.join(".prime/agent/session-artifacts/root/rlm-subagents.jsonl")).unwrap();
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["prime-agent".to_string()],
+            false,
+        );
+
+        assert_eq!(result.get(ClientId::PrimeAgent).len(), 2);
+        assert!(result
+            .get(ClientId::PrimeAgent)
+            .iter()
+            .any(|path| path.ends_with("root.jsonl")));
+        assert!(result
+            .get(ClientId::PrimeAgent)
+            .iter()
+            .any(|path| path.ends_with("child.jsonl")));
+        assert!(result.get(ClientId::Pi).is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_prime_agent_honors_session_dir_override() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let custom_root = home.join("custom/sessions");
+        let child_dir = home.join("custom/session-artifacts/root/sub-deadbeef");
+        fs::create_dir_all(&custom_root).unwrap();
+        fs::create_dir_all(&child_dir).unwrap();
+        File::create(custom_root.join("root.jsonl")).unwrap();
+        File::create(child_dir.join("child.jsonl")).unwrap();
+
+        let mut env = EnvGuard::capture(&[
+            "PRIME_AGENT_SESSION_DIR",
+            "PRIME_AGENT_CODING_AGENT_SESSION_DIR",
+            "PRIME_AGENT_CODING_AGENT_DIR",
+        ]);
+        env.set("PRIME_AGENT_SESSION_DIR", "~/custom/sessions");
+        env.remove("PRIME_AGENT_CODING_AGENT_SESSION_DIR");
+        env.set(
+            "PRIME_AGENT_CODING_AGENT_DIR",
+            home.join("unused-agent-dir"),
+        );
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["prime-agent".to_string()],
+            true,
+        );
+
+        assert_eq!(result.get(ClientId::PrimeAgent).len(), 2);
+        assert!(result
+            .get(ClientId::PrimeAgent)
+            .iter()
+            .all(|path| path.starts_with(home.join("custom"))));
+    }
+
+    #[test]
+    #[serial]
+    fn test_prime_agent_roots_honor_agent_dir_and_legacy_session_override() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let mut env = EnvGuard::capture(&[
+            "PRIME_AGENT_SESSION_DIR",
+            "PRIME_AGENT_CODING_AGENT_SESSION_DIR",
+            "PRIME_AGENT_CODING_AGENT_DIR",
+        ]);
+        env.remove("PRIME_AGENT_SESSION_DIR");
+        env.remove("PRIME_AGENT_CODING_AGENT_SESSION_DIR");
+        env.set("PRIME_AGENT_CODING_AGENT_DIR", "~/custom-agent");
+
+        let roots = prime_agent_session_roots_with_env_strategy(home.to_str().unwrap(), true);
+        assert_eq!(roots[0], home.join("custom-agent/sessions"));
+        assert_eq!(roots[1], home.join("custom-agent/session-artifacts"));
+
+        let legacy_sessions = home.join("legacy/sessions");
+        env.set("PRIME_AGENT_CODING_AGENT_SESSION_DIR", &legacy_sessions);
+        let roots = prime_agent_session_roots_with_env_strategy(home.to_str().unwrap(), true);
+        assert_eq!(roots[0], legacy_sessions);
+        assert_eq!(roots[1], home.join("legacy/session-artifacts"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_prime_agent_roots_honor_settings_session_dir() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let agent_dir = home.join("custom-agent");
+        fs::create_dir_all(&agent_dir).unwrap();
+        fs::write(
+            agent_dir.join("settings.json"),
+            r#"{"sessionDir":"~/settings-sessions"}"#,
+        )
+        .unwrap();
+
+        let mut env = EnvGuard::capture(&[
+            "PRIME_AGENT_SESSION_DIR",
+            "PRIME_AGENT_CODING_AGENT_SESSION_DIR",
+            "PRIME_AGENT_CODING_AGENT_DIR",
+        ]);
+        env.remove("PRIME_AGENT_SESSION_DIR");
+        env.remove("PRIME_AGENT_CODING_AGENT_SESSION_DIR");
+        env.set("PRIME_AGENT_CODING_AGENT_DIR", &agent_dir);
+
+        let roots = prime_agent_session_roots_with_env_strategy(home.to_str().unwrap(), true);
+        assert_eq!(roots[0], home.join("settings-sessions"));
+        assert_eq!(roots[1], home.join("session-artifacts"));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -37,6 +37,7 @@ pub mod openclaw;
 pub mod opencode;
 pub mod opencodereview;
 pub mod pi;
+pub mod prime_agent;
 pub mod qwen;
 pub mod reasonix;
 pub mod roocode;

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -26,6 +26,8 @@ pub struct PiSessionHeader {
     pub timestamp: Option<String>,
     #[allow(dead_code)]
     pub cwd: Option<String>,
+    #[serde(rename = "rlmDepth")]
+    pub rlm_depth: Option<u32>,
 }
 
 /// Loose type-only probe for a JSONL line, used to identify pre-session
@@ -63,6 +65,8 @@ pub struct PiMessage {
     pub usage: Option<PiUsage>,
     pub model: Option<String>,
     pub provider: Option<String>,
+    #[serde(rename = "responseId")]
+    pub response_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -133,7 +137,7 @@ pub(crate) fn parse_pi_format_file(
     client: &str,
     fallback_provider: &'static str,
 ) -> Vec<UnifiedMessage> {
-    parse_pi_format_file_inner(path, client, fallback_provider, None)
+    parse_pi_format_file_inner(path, client, fallback_provider, None, false, false)
 }
 
 /// Parse a Pi-format session and retain message ids in namespaced dedup keys.
@@ -144,7 +148,21 @@ pub(crate) fn parse_pi_format_file_with_dedup(
     client: &str,
     fallback_provider: &'static str,
 ) -> Vec<UnifiedMessage> {
-    parse_pi_format_file_inner(path, client, fallback_provider, Some(client))
+    parse_pi_format_file_inner(path, client, fallback_provider, Some(client), false, false)
+}
+
+/// Parse a Pi-format session whose `session_info.name` identifies an RLM
+/// subagent when the session header has `rlmDepth > 0`.
+///
+/// Deduplication is intentionally cross-session: Prime Agent forks copy prior
+/// message entries into a file with a new session id. Provider response ids are
+/// preferred; the message id plus immutable event fields is the fallback.
+pub(crate) fn parse_pi_format_rlm_file(
+    path: &Path,
+    client: &str,
+    fallback_provider: &'static str,
+) -> Vec<UnifiedMessage> {
+    parse_pi_format_file_inner(path, client, fallback_provider, Some(client), true, true)
 }
 
 fn parse_pi_format_file_inner(
@@ -152,6 +170,8 @@ fn parse_pi_format_file_inner(
     client: &str,
     fallback_provider: &'static str,
     dedup_namespace: Option<&str>,
+    rlm_session_name_as_agent: bool,
+    cross_session_dedup: bool,
 ) -> Vec<UnifiedMessage> {
     let file = match std::fs::File::open(path) {
         Ok(f) => f,
@@ -168,6 +188,7 @@ fn parse_pi_format_file_inner(
     let mut workspace_key: Option<String> = None;
     let mut workspace_label: Option<String> = None;
     let mut agent: Option<String> = None;
+    let mut is_rlm_subagent = false;
     for line in reader.lines() {
         let line = match line {
             Ok(l) => l,
@@ -204,6 +225,7 @@ fn parse_pi_format_file_inner(
             session_id = Some(header.id);
             workspace_key = header.cwd.as_deref().and_then(normalize_workspace_key);
             workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
+            is_rlm_subagent = header.rlm_depth.unwrap_or(0) > 0;
             continue;
         }
 
@@ -215,7 +237,11 @@ fn parse_pi_format_file_inner(
         };
 
         if entry.entry_type == "session_info" {
-            agent = entry.name.as_deref().and_then(pi_subagent_name);
+            agent = if rlm_session_name_as_agent && is_rlm_subagent {
+                entry.name.filter(|name| !name.trim().is_empty())
+            } else {
+                entry.name.as_deref().and_then(pi_subagent_name)
+            };
             continue;
         }
 
@@ -233,6 +259,7 @@ fn parse_pi_format_file_inner(
             continue;
         }
 
+        let response_id = message.response_id;
         let usage = match message.usage {
             Some(u) => u,
             None => continue,
@@ -268,8 +295,8 @@ fn parse_pi_format_file_inner(
         // through would double count.
         let mut unified = UnifiedMessage::new_with_agent(
             client,
-            model,
-            provider,
+            model.as_str(),
+            provider.as_str(),
             session_id.clone().unwrap_or_else(|| "unknown".to_string()),
             timestamp,
             TokenBreakdown {
@@ -283,7 +310,28 @@ fn parse_pi_format_file_inner(
             agent.clone(),
         );
         if let Some(namespace) = dedup_namespace {
-            if let Some(message_id) = message_id.as_deref().filter(|id| !id.trim().is_empty()) {
+            if cross_session_dedup {
+                unified.dedup_key = response_id
+                    .as_deref()
+                    .filter(|id| !id.trim().is_empty())
+                    .map(|id| format!("{namespace}:response:{id}"))
+                    .or_else(|| {
+                        message_id
+                            .as_deref()
+                            .filter(|id| !id.trim().is_empty())
+                            .map(|id| {
+                                format!(
+                                    "{namespace}:message:{id}:{timestamp}:{provider}:{model}:{}:{}:{}:{}",
+                                    unified.tokens.input,
+                                    unified.tokens.output,
+                                    unified.tokens.cache_read,
+                                    unified.tokens.cache_write,
+                                )
+                            })
+                    });
+            } else if let Some(message_id) =
+                message_id.as_deref().filter(|id| !id.trim().is_empty())
+            {
                 let session_id = session_id.as_deref().unwrap_or("unknown");
                 unified.dedup_key = Some(format!("{namespace}:{session_id}:{message_id}"));
             }

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -282,11 +282,11 @@ fn parse_pi_format_file_inner(
                 .to_string(),
         };
 
-        let timestamp = entry
+        let recorded_timestamp = entry
             .timestamp
             .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
-            .map(|dt| dt.timestamp_millis())
-            .unwrap_or(fallback_timestamp);
+            .map(|dt| dt.timestamp_millis());
+        let timestamp = recorded_timestamp.unwrap_or(fallback_timestamp);
 
         // `usage.reasoning` is read but deliberately not mapped onto
         // `TokenBreakdown::reasoning`. In the Pi format reasoning tokens are a
@@ -320,8 +320,11 @@ fn parse_pi_format_file_inner(
                             .as_deref()
                             .filter(|id| !id.trim().is_empty())
                             .map(|id| {
+                                let stable_timestamp = recorded_timestamp
+                                    .map(|timestamp| timestamp.to_string())
+                                    .unwrap_or_else(|| "missing".to_string());
                                 format!(
-                                    "{namespace}:message:{id}:{timestamp}:{provider}:{model}:{}:{}:{}:{}",
+                                    "{namespace}:message:{id}:{stable_timestamp}:{provider}:{model}:{}:{}:{}:{}",
                                     unified.tokens.input,
                                     unified.tokens.output,
                                     unified.tokens.cache_read,

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -91,6 +91,25 @@ mod tests {
     }
 
     #[test]
+    fn copied_fork_history_without_response_or_event_timestamp_still_deduplicates() {
+        let original = session_file(
+            r#"{"type":"session","version":3,"id":"root-1","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"assistant-1","parentId":null,"message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","usage":{"input":100,"output":50,"cacheRead":20,"cacheWrite":10,"totalTokens":180}}}"#,
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let fork = session_file(
+            r#"{"type":"session","version":3,"id":"fork-2","timestamp":"2026-08-08T01:00:00.000Z","cwd":"/tmp/project","parentSession":"/tmp/root.jsonl","rlmDepth":0}
+{"type":"message","id":"assistant-1","parentId":null,"message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","usage":{"input":100,"output":50,"cacheRead":20,"cacheWrite":10,"totalTokens":180}}}"#,
+        );
+
+        let original = parse_prime_agent_file(original.path());
+        let fork = parse_prime_agent_file(fork.path());
+
+        assert_ne!(original[0].timestamp, fork[0].timestamp);
+        assert_eq!(original[0].dedup_key, fork[0].dedup_key);
+    }
+
+    #[test]
     fn rejects_the_rlm_subagent_catalog_as_a_session() {
         let file = session_file(
             r#"{"type":"rlm_subagent","childId":"sub-deadbeef","sessionName":"worker","sessionFile":"/tmp/child.jsonl"}"#,

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -1,0 +1,101 @@
+//! Prime Agent session parser.
+//!
+//! Prime Agent stores root sessions in `~/.prime/agent/sessions/*.jsonl` and
+//! RLM child sessions below the sibling `session-artifacts` tree. Both use the
+//! Pi append-only JSONL record format, so token extraction is shared with the
+//! Pi parser. `child_usage_attributed` records are intentionally ignored: they
+//! are accounting metadata that folds a child's usage into a parent message at
+//! runtime, while tokscale scans the child's own session file directly.
+
+use super::pi::parse_pi_format_rlm_file;
+use super::UnifiedMessage;
+use std::path::Path;
+
+pub fn parse_prime_agent_file(path: &Path) -> Vec<UnifiedMessage> {
+    parse_pi_format_rlm_file(path, "prime-agent", "prime-agent")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn session_file(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    #[test]
+    fn parses_root_session_without_counting_child_attribution_records() {
+        let file = session_file(
+            r#"{"type":"session","version":3,"id":"root-1","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"session_info","id":"info","parentId":null,"timestamp":"2026-08-08T00:00:00.500Z","name":"My renamed thread"}
+{"type":"message","id":"assistant-1","parentId":"info","timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"msg_provider_001","usage":{"input":100,"output":50,"cacheRead":20,"cacheWrite":10,"totalTokens":180}}}
+{"type":"child_usage_attributed","id":"usage-1","parentId":"assistant-1","timestamp":"2026-08-08T00:00:02.000Z","targetId":"assistant-1","childUsage":{"input":500,"output":200,"cacheRead":0,"cacheWrite":0,"totalTokens":700},"aggregateUsage":{"input":600,"output":250,"cacheRead":20,"cacheWrite":10,"totalTokens":880},"origin":"spawn_task"}"#,
+        );
+
+        let messages = parse_prime_agent_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        let message = &messages[0];
+        assert_eq!(message.client, "prime-agent");
+        assert_eq!(message.session_id, "root-1");
+        assert_eq!(message.workspace_key.as_deref(), Some("/tmp/project"));
+        assert_eq!(message.tokens.input, 100);
+        assert_eq!(message.tokens.output, 50);
+        assert_eq!(message.tokens.cache_read, 20);
+        assert_eq!(message.tokens.cache_write, 10);
+        assert_eq!(message.agent, None, "a root thread name is not an agent");
+        assert_eq!(
+            message.dedup_key.as_deref(),
+            Some("prime-agent:response:msg_provider_001")
+        );
+    }
+
+    #[test]
+    fn attributes_rlm_child_messages_to_the_session_name() {
+        let file = session_file(
+            r#"{"type":"session","version":3,"id":"child-1","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","parentSession":"/tmp/root.jsonl","rlmDepth":1}
+{"type":"session_info","id":"info","parentId":null,"timestamp":"2026-08-08T00:00:00.500Z","name":"api-reviewer"}
+{"type":"message","id":"assistant-1","parentId":"info","timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"openai","model":"gpt-5.4","usage":{"input":40,"output":12,"cacheRead":8,"cacheWrite":0,"totalTokens":60}}}"#,
+        );
+
+        let messages = parse_prime_agent_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].agent.as_deref(), Some("api-reviewer"));
+        assert_eq!(messages[0].provider_id, "openai");
+        assert_eq!(messages[0].model_id, "gpt-5.4");
+    }
+
+    #[test]
+    fn copied_fork_history_keeps_a_cross_session_dedup_key() {
+        let original = session_file(
+            r#"{"type":"session","version":3,"id":"root-1","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"assistant-1","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"msg_provider_001","usage":{"input":100,"output":50,"cacheRead":20,"cacheWrite":10,"totalTokens":180}}}"#,
+        );
+        let fork = session_file(
+            r#"{"type":"session","version":3,"id":"fork-2","timestamp":"2026-08-08T01:00:00.000Z","cwd":"/tmp/project","parentSession":"/tmp/root.jsonl","rlmDepth":0}
+{"type":"message","id":"assistant-1","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"msg_provider_001","usage":{"input":100,"output":50,"cacheRead":20,"cacheWrite":10,"totalTokens":180}}}"#,
+        );
+
+        let original = parse_prime_agent_file(original.path());
+        let fork = parse_prime_agent_file(fork.path());
+
+        assert_eq!(original.len(), 1);
+        assert_eq!(fork.len(), 1);
+        assert_eq!(original[0].dedup_key, fork[0].dedup_key);
+    }
+
+    #[test]
+    fn rejects_the_rlm_subagent_catalog_as_a_session() {
+        let file = session_file(
+            r#"{"type":"rlm_subagent","childId":"sub-deadbeef","sessionName":"worker","sessionFile":"/tmp/child.jsonl"}"#,
+        );
+
+        assert!(parse_prime_agent_file(file.path()).is_empty());
+    }
+}

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -72,6 +72,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   augment: "Augment Code",
   kimchi: "Kimchi",
   reasonix: "Reasonix",
+  "prime-agent": "Prime Agent",
 };
 
 // Client logos from GitHub CDN (public repo)
@@ -127,6 +128,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
   augment: "https://github.com/augmentcode.png",
   kimchi: "https://github.com/getkimchi.png",
   reasonix: `${GITHUB_CDN_BASE}/client-synthetic.png`,
+  "prime-agent": "https://github.com/PrimeIntellect-ai.png",
 };
 
 export const SOURCE_COLORS: Record<ClientType, string> = {
@@ -175,6 +177,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   augment: "#9333EA",
   kimchi: "#14B8A6",
   reasonix: "#6366F1",
+  "prime-agent": "#6C63FF",
 };
 
 // Derived values

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -44,6 +44,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "augment",
   "kimchi",
   "reasonix",
+  "prime-agent",
 ] as const;
 
 export type CcMirrorClientType = `cc-mirror/${string}`;


### PR DESCRIPTION
## Summary

- register Prime Agent as a local, submit-enabled client across the Rust core, CLI filters, TUI, Wrapped, and frontend submission/display registries
- scan root sessions and RLM child sessions from the effective Prime Agent session directory, honoring `PRIME_AGENT_CODING_AGENT_DIR`, `PRIME_AGENT_SESSION_DIR`, the legacy session-dir variable, and `settings.json` `sessionDir`
- reuse the Pi-compatible JSONL parser while attributing named RLM children, ignoring parent-side child usage bookkeeping, and deduplicating history copied by session forks
- document Prime Agent immediately after Codex using the Prime Intellect GitHub logo, with matching path and accounting details in the English, Korean, Japanese, and Simplified Chinese READMEs

## Local proof of concept

Ran the built CLI against a frozen copy of the local `~/.prime/agent/sessions/` and `~/.prime/agent/session-artifacts/` trees with `--client prime-agent --json`. Its 1,157-message result matched an independent JSONL summation exactly for message count and all four token buckets (`input`, `output`, `cacheRead`, and `cacheWrite`). `tokscale clients --json` also reported the root session directory plus the RLM artifact directory separately.

## Verification

- `cargo test -p tokscale-core`
- `cargo test -p tokscale-core prime_agent`
- `cargo check -p tokscale-core -p tokscale-cli`
- `cargo clippy -p tokscale-core -p tokscale-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bun run typecheck` in `packages/frontend`
- `bun run test __tests__/lib/clientRegistry.test.ts __tests__/components/sourceLogo.test.tsx` in `packages/frontend`
