### PR TITLE
fix(prime-agent): correct fork accounting and session roots

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -11329,6 +11329,66 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
+    fn test_prime_agent_contested_child_is_attributed_to_the_nearest_model() {
+        // Two parent responses on different models each persist an aggregate that
+        // contains one 50-token child, and only the second parent's child
+        // transcript survives. Both attributions are inside the tolerance window,
+        // so a maximum-cardinality match could reduce either aggregate and leave
+        // the global total intact -- but pricing is applied per model after
+        // reconciliation, so the wrong choice moves cost between models.
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let sessions = source_home.path().join(".prime/agent/sessions");
+        let child_dir = source_home
+            .path()
+            .join(".prime/agent/session-artifacts/parent/sub-child");
+        std::fs::create_dir_all(&sessions).unwrap();
+        std::fs::create_dir_all(&child_dir).unwrap();
+
+        let parent_path = sessions.join("parent.jsonl");
+        std::fs::write(
+            &parent_path,
+            r#"{"type":"session","version":3,"id":"parent","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent-a","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"model-a","responseId":"parent-response-a","usage":{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150}}}
+{"type":"child_usage_attributed","id":"00000000","parentId":"parent-a","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent-a","childUsage":{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50},"aggregateUsage":{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150},"origin":"spawn_task"}
+{"type":"message","id":"parent-b","parentId":"00000000","timestamp":"2026-08-08T00:00:01.500Z","message":{"role":"assistant","provider":"anthropic","model":"model-b","responseId":"parent-response-b","usage":{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150}}}
+{"type":"child_usage_attributed","id":"ffffffff","parentId":"parent-b","timestamp":"2026-08-08T00:00:02.002Z","targetId":"parent-b","childUsage":{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50},"aggregateUsage":{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150},"origin":"spawn_task"}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            child_dir.join("child.jsonl"),
+            format!(
+                r#"{{"type":"session","version":3,"id":"child","timestamp":"2026-08-08T00:00:01.600Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child-message","parentId":null,"timestamp":"2026-08-08T00:00:02.002Z","message":{{"role":"assistant","provider":"anthropic","model":"child-model","responseId":"child-response","usage":{{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50}}}}}}
+"#,
+                paths::json_path_literal(&parent_path)
+            ),
+        )
+        .unwrap();
+
+        let clients = ["prime-agent".to_string()];
+        for messages in [
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None),
+            // The warm source-cache lane must produce the same per-model rows,
+            // not just the same total.
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None),
+        ] {
+            let mut per_model: std::collections::HashMap<String, i64> =
+                std::collections::HashMap::new();
+            for message in &messages {
+                *per_model.entry(message.model_id.clone()).or_default() += message.tokens.input;
+            }
+            assert_eq!(per_model.get("model-a").copied(), Some(150));
+            assert_eq!(per_model.get("model-b").copied(), Some(100));
+            assert_eq!(per_model.get("child-model").copied(), Some(50));
+            assert_eq!(per_model.values().sum::<i64>(), 300);
+        }
+    }
+
+    #[test]
     fn test_parse_local_clients_reasonix_counts_reported_requests() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         // Where the scan will actually look, rather than the Unix spelling of

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -11164,6 +11164,87 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn test_prime_agent_concurrent_equal_children_are_counted_once() {
+        // Two children of the same parent spent identical tokens and finished in
+        // the same millisecond, so no timestamp separates one child's response
+        // from the other's attribution. Both must still be paired off: keeping
+        // the aggregate parent while also counting both transcripts would report
+        // their usage twice.
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let sessions = source_home.path().join(".prime/agent/sessions");
+        std::fs::create_dir_all(&sessions).unwrap();
+
+        let root_path = sessions.join("a-root.jsonl");
+        std::fs::write(
+            &root_path,
+            r#"{"type":"session","version":3,"id":"root","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":300,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":300}}}
+{"type":"child_usage_attributed","id":"usage-a","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":100,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":100},"aggregateUsage":{"input":200,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":200},"origin":"spawn_task"}
+{"type":"child_usage_attributed","id":"usage-b","parentId":"usage-a","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":100,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":100},"aggregateUsage":{"input":300,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":300},"origin":"spawn_task"}
+"#,
+        )
+        .unwrap();
+        for child in ["sub-a", "sub-b"] {
+            let child_dir = source_home
+                .path()
+                .join(".prime/agent/session-artifacts/a-root")
+                .join(child);
+            std::fs::create_dir_all(&child_dir).unwrap();
+            std::fs::write(
+                child_dir.join("child.jsonl"),
+                format!(
+                    r#"{{"type":"session","version":3,"id":"{child}","timestamp":"2026-08-08T00:00:01.500Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child-message","parentId":null,"timestamp":"2026-08-08T00:00:02.000Z","message":{{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"{child}-response","usage":{{"input":100,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":100}}}}}}
+"#,
+                    paths::json_path_literal(&root_path)
+                ),
+            )
+            .unwrap();
+        }
+
+        let clients = ["prime-agent".to_string()];
+        for messages in [
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None),
+            // Warm source-cache lane must agree with the cold parse exactly.
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None),
+        ] {
+            assert_eq!(messages.len(), 3);
+            // 100 own parent usage plus the two 100-token children, each counted
+            // once from its own transcript.
+            assert_eq!(
+                messages
+                    .iter()
+                    .map(|message| message.tokens.input)
+                    .sum::<i64>(),
+                300
+            );
+        }
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(source_home.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(clients.to_vec()),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+        assert_eq!(parsed.messages.len(), 3);
+        assert_eq!(
+            parsed
+                .messages
+                .iter()
+                .map(|message| message.input)
+                .sum::<i64>(),
+            300
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn test_prime_agent_colliding_attribution_ids_do_not_cross_lineages() {
         // Prime mints attribution ids as `randomUUID().slice(0, 8)` and only
         // checks them against the session it is writing, so two unrelated

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1669,31 +1669,40 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
-    let prime_agent_outcomes: Vec<CachedParseOutcome> = scan_result
+    let prime_agent_outcomes: Vec<(PathBuf, CachedParseOutcome)> = scan_result
         .get(ClientId::PrimeAgent)
         .par_iter()
         .map(|path| {
-            load_or_parse_source(
-                message_cache::CacheIdentity::for_client(ClientId::PrimeAgent),
-                path,
-                &source_cache,
-                pricing,
-                sessions::prime_agent::parse_prime_agent_file,
+            (
+                path.clone(),
+                load_or_parse_source(
+                    message_cache::CacheIdentity::for_client(ClientId::PrimeAgent),
+                    path,
+                    &source_cache,
+                    pricing,
+                    sessions::prime_agent::parse_prime_agent_file,
+                ),
             )
         })
         .collect();
-    let mut prime_agent_seen: HashSet<String> = HashSet::new();
-    for outcome in prime_agent_outcomes {
-        all_messages.extend(
-            outcome
-                .messages
-                .into_iter()
-                .filter(|message| should_keep_deduped_message(&mut prime_agent_seen, message)),
-        );
+    let mut prime_agent_messages = Vec::new();
+    let mut prime_agent_accounting = Vec::new();
+    for (path, outcome) in prime_agent_outcomes {
+        prime_agent_accounting.push(sessions::prime_agent::analyze_prime_agent_accounting(
+            &path,
+            &outcome.messages,
+        ));
+        prime_agent_messages.extend(outcome.messages);
         if let Some(entry) = outcome.cache_entry {
             source_cache.insert(entry);
         }
     }
+    let mut prime_agent_messages = sessions::prime_agent::reconcile_prime_agent_messages(
+        prime_agent_messages,
+        &prime_agent_accounting,
+    );
+    apply_pricing_to_messages(&mut prime_agent_messages, pricing);
+    all_messages.extend(prime_agent_messages);
 
     let kimchi_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Kimchi)
@@ -3734,15 +3743,30 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::Pi, pi_count);
     messages.extend(pi_msgs);
 
-    let prime_agent_msgs_raw: Vec<UnifiedMessage> = scan_result
+    let prime_agent_files: Vec<(
+        Vec<UnifiedMessage>,
+        sessions::prime_agent::PrimeFileAccounting,
+    )> = scan_result
         .get(ClientId::PrimeAgent)
         .par_iter()
-        .flat_map(|path| sessions::prime_agent::parse_prime_agent_file(path))
+        .map(|path| {
+            let messages = sessions::prime_agent::parse_prime_agent_file(path);
+            let accounting = sessions::prime_agent::analyze_prime_agent_accounting(path, &messages);
+            (messages, accounting)
+        })
         .collect();
-    let mut prime_agent_seen: HashSet<String> = HashSet::new();
-    let prime_agent_msgs: Vec<ParsedMessage> = prime_agent_msgs_raw
+    let mut prime_agent_msgs_raw = Vec::new();
+    let mut prime_agent_accounting = Vec::new();
+    for (file_messages, file_accounting) in prime_agent_files {
+        prime_agent_msgs_raw.extend(file_messages);
+        prime_agent_accounting.push(file_accounting);
+    }
+    let prime_agent_msgs: Vec<ParsedMessage> =
+        sessions::prime_agent::reconcile_prime_agent_messages(
+            prime_agent_msgs_raw,
+            &prime_agent_accounting,
+        )
         .into_iter()
-        .filter(|message| should_keep_deduped_message(&mut prime_agent_seen, message))
         .map(|message| unified_to_parsed(&message))
         .collect();
     let prime_agent_count = prime_agent_msgs.len() as i32;
@@ -11036,6 +11060,106 @@ mod tests {
         };
         assert!(dates.contains(&local_date(thread_created + 2000)));
         assert!(dates.contains(&local_date(ledger_timestamp)));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_prime_agent_forked_parent_and_rlm_child_are_counted_once() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let sessions = source_home.path().join(".prime/agent/sessions");
+        let child_dir = source_home
+            .path()
+            .join(".prime/agent/session-artifacts/z-original/sub-child");
+        std::fs::create_dir_all(&sessions).unwrap();
+        std::fs::create_dir_all(&child_dir).unwrap();
+
+        let original_path = sessions.join("z-original.jsonl");
+        std::fs::write(
+            sessions.join("a-fork.jsonl"),
+            format!(
+                r#"{{"type":"session","version":3,"id":"fork","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":0}}
+{{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{{"input":150,"output":70,"cacheRead":20,"cacheWrite":10,"totalTokens":250}}}}}}
+{{"type":"child_usage_attributed","id":"usage-1","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{{"input":30,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":40}},"aggregateUsage":{{"input":130,"output":60,"cacheRead":20,"cacheWrite":10,"totalTokens":220}},"origin":"spawn_task"}}
+{{"type":"child_usage_attributed","id":"usage-2","parentId":"usage-1","timestamp":"2026-08-08T00:00:03.000Z","targetId":"parent","childUsage":{{"input":20,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":30}},"aggregateUsage":{{"input":150,"output":70,"cacheRead":20,"cacheWrite":10,"totalTokens":250}},"origin":"spawn_task"}}
+"#,
+                paths::json_path_literal(&original_path)
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            &original_path,
+            r#"{"type":"session","version":3,"id":"original","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":100,"output":50,"cacheRead":20,"cacheWrite":10,"totalTokens":180}}}
+{"type":"child_usage_attributed","id":"usage-1","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":30,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":40},"aggregateUsage":{"input":130,"output":60,"cacheRead":20,"cacheWrite":10,"totalTokens":220},"origin":"spawn_task"}
+{"type":"child_usage_attributed","id":"usage-2","parentId":"usage-1","timestamp":"2026-08-08T00:00:03.000Z","targetId":"parent","childUsage":{"input":20,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":30},"aggregateUsage":{"input":150,"output":70,"cacheRead":20,"cacheWrite":10,"totalTokens":250},"origin":"spawn_task"}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            child_dir.join("child.jsonl"),
+            format!(
+                r#"{{"type":"session","version":3,"id":"child","timestamp":"2026-08-08T00:00:01.000Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child-message-1","parentId":null,"timestamp":"2026-08-08T00:00:02.000Z","message":{{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"child-response-1","usage":{{"input":30,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":40}}}}}}
+{{"type":"message","id":"child-message-2","parentId":"child-message-1","timestamp":"2026-08-08T00:00:03.000Z","message":{{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"child-response-2","usage":{{"input":20,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":30}}}}}}
+"#,
+                paths::json_path_literal(&original_path)
+            ),
+        )
+        .unwrap();
+
+        let clients = ["prime-agent".to_string()];
+        for messages in [
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None),
+            // Exercise the warm source-cache lane as well as the initial parse.
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None),
+        ] {
+            assert_eq!(messages.len(), 3);
+            assert_eq!(
+                messages
+                    .iter()
+                    .map(|message| message.tokens.input)
+                    .sum::<i64>(),
+                150
+            );
+            assert_eq!(
+                messages
+                    .iter()
+                    .map(|message| message.tokens.output)
+                    .sum::<i64>(),
+                70
+            );
+        }
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(source_home.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(clients.to_vec()),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+        assert_eq!(parsed.messages.len(), 3);
+        assert_eq!(parsed.counts.get(ClientId::PrimeAgent), 3);
+        assert_eq!(
+            parsed
+                .messages
+                .iter()
+                .map(|message| message.input)
+                .sum::<i64>(),
+            150
+        );
+        assert_eq!(
+            parsed
+                .messages
+                .iter()
+                .map(|message| message.output)
+                .sum::<i64>(),
+            70
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -11163,6 +11163,91 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
+    fn test_prime_agent_colliding_attribution_ids_do_not_cross_lineages() {
+        // Prime mints attribution ids as `randomUUID().slice(0, 8)` and only
+        // checks them against the session it is writing, so two unrelated
+        // sessions can carry the same id. Resolving one lineage's child must
+        // not mark the other lineage's attribution as accounted for.
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let sessions = source_home.path().join(".prime/agent/sessions");
+        let child_dir = source_home
+            .path()
+            .join(".prime/agent/session-artifacts/a-lineage/sub-a");
+        std::fs::create_dir_all(&sessions).unwrap();
+        std::fs::create_dir_all(&child_dir).unwrap();
+
+        let lineage_a = sessions.join("a-lineage.jsonl");
+        std::fs::write(
+            &lineage_a,
+            r#"{"type":"session","version":3,"id":"parent-a","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-a-response","usage":{"input":120,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":120}}}
+{"type":"child_usage_attributed","id":"deadbeef","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":20,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":20},"aggregateUsage":{"input":120,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":120},"origin":"spawn_task"}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            child_dir.join("child.jsonl"),
+            format!(
+                r#"{{"type":"session","version":3,"id":"child-a","timestamp":"2026-08-08T00:00:01.500Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child-message","parentId":null,"timestamp":"2026-08-08T00:00:02.001Z","message":{{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"child-a-response","usage":{{"input":20,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":20}}}}}}
+"#,
+                paths::json_path_literal(&lineage_a)
+            ),
+        )
+        .unwrap();
+        // Same 8-hex id, unrelated session, and its child transcript is gone.
+        std::fs::write(
+            sessions.join("b-lineage.jsonl"),
+            r#"{"type":"session","version":3,"id":"parent-b","timestamp":"2026-08-09T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-09T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-b-response","usage":{"input":130,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":130}}}
+{"type":"child_usage_attributed","id":"deadbeef","parentId":"parent","timestamp":"2026-08-09T00:00:02.000Z","targetId":"parent","childUsage":{"input":30,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":30},"aggregateUsage":{"input":130,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":130},"origin":"spawn_task"}
+"#,
+        )
+        .unwrap();
+
+        let clients = ["prime-agent".to_string()];
+        for messages in [
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None),
+            // Warm source-cache lane must agree with the cold parse exactly.
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None),
+        ] {
+            assert_eq!(messages.len(), 3);
+            // 100 reconciled parent + 20 parsed child + 130 aggregate parent
+            // whose own child was pruned.
+            assert_eq!(
+                messages
+                    .iter()
+                    .map(|message| message.tokens.input)
+                    .sum::<i64>(),
+                250
+            );
+        }
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(source_home.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(clients.to_vec()),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+        assert_eq!(parsed.messages.len(), 3);
+        assert_eq!(
+            parsed
+                .messages
+                .iter()
+                .map(|message| message.input)
+                .sum::<i64>(),
+            250
+        );
+    }
+
+    #[test]
     fn test_parse_local_clients_reasonix_counts_reported_requests() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         // Where the scan will actually look, rather than the Unix spelling of

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -1698,11 +1698,12 @@ fn scan_all_clients_with_env_strategy_inner(
         // the effective session directory (`dirname(sessions)/session-artifacts`).
         let [sessions, artifacts] =
             prime_agent_session_roots_with_env_strategy(home_dir, use_env_roots);
-        push_unique_scan_task(
+        push_unique_scan_task_with_pattern(
             &mut tasks,
             &mut seen_scan_roots,
             ClientId::PrimeAgent,
             sessions,
+            "prime-agent-session",
         );
         push_unique_scan_task_with_pattern(
             &mut tasks,
@@ -2167,6 +2168,22 @@ mod tests {
 
     fn restore_current_dir(previous: &Path) {
         std::env::set_current_dir(previous).unwrap();
+    }
+
+    struct CurrentDirGuard(PathBuf);
+
+    impl CurrentDirGuard {
+        fn set(path: &Path) -> Self {
+            let previous = std::env::current_dir().unwrap();
+            std::env::set_current_dir(path).unwrap();
+            Self(previous)
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.0).unwrap();
+        }
     }
 
     fn setup_mock_copilot_dir(home: &Path) {
@@ -4147,6 +4164,12 @@ mod tests {
 ",
         )
         .unwrap();
+        fs::write(
+            project.join("session-artifacts/root/rlm-subagents.jsonl"),
+            "{}
+",
+        )
+        .unwrap();
 
         let mut env = EnvGuard::capture(&[
             "PRIME_AGENT_SESSION_DIR",
@@ -4156,11 +4179,9 @@ mod tests {
         env.remove("PRIME_AGENT_SESSION_DIR");
         env.remove("PRIME_AGENT_CODING_AGENT_SESSION_DIR");
         env.remove("PRIME_AGENT_CODING_AGENT_DIR");
-        let previous_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&project).unwrap();
+        let _current_dir = CurrentDirGuard::set(&project);
         let roots = prime_agent_session_roots_with_env_strategy(home.to_str().unwrap(), true);
         let result = scan_all_clients(home.to_str().unwrap(), &["prime-agent".to_string()]);
-        restore_current_dir(&previous_dir);
 
         let canonical_project = project.canonicalize().unwrap();
         assert_eq!(roots[0].canonicalize().unwrap(), canonical_project);

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -228,33 +228,60 @@ fn expand_tilde_path_with_home(value: &str, home_dir: &str) -> PathBuf {
     if value == "~" {
         return PathBuf::from(home_dir);
     }
-    if let Some(relative) = value
-        .strip_prefix("~/")
-        .or_else(|| value.strip_prefix("~\\"))
-    {
+    if let Some(relative) = value.strip_prefix("~/") {
         return PathBuf::from(home_dir).join(relative);
     }
     PathBuf::from(value)
 }
 
-fn prime_agent_session_dir_from_settings(agent_dir: &Path, home_dir: &str) -> Option<PathBuf> {
-    fn read_session_dir(path: &Path) -> Option<String> {
+#[derive(Debug, PartialEq, Eq)]
+enum PrimeSessionDirSetting {
+    Default,
+    Path(PathBuf),
+    CurrentDirectory(PathBuf),
+}
+
+fn prime_agent_session_dir_from_settings_files(
+    global_settings: &Path,
+    project_settings: Option<&Path>,
+    home_dir: &str,
+    current_dir: Option<&Path>,
+) -> Option<PrimeSessionDirSetting> {
+    fn read_session_dir(path: &Path) -> Option<Option<String>> {
         let content = std::fs::read_to_string(path).ok()?;
         let settings: Value = serde_json::from_str(&content).ok()?;
-        settings
-            .as_object()?
-            .get("sessionDir")?
-            .as_str()
-            .map(str::to_owned)
+        match settings.as_object()?.get("sessionDir")? {
+            Value::Null => Some(None),
+            Value::String(path) => Some(Some(path.clone())),
+            _ => None,
+        }
     }
 
-    let global = read_session_dir(&agent_dir.join("settings.json"));
-    let project = std::env::current_dir()
-        .ok()
-        .and_then(|cwd| read_session_dir(&cwd.join(".prime/agent/settings.json")));
-    project
-        .or(global)
-        .map(|path| expand_tilde_path_with_home(&path, home_dir))
+    let global = read_session_dir(global_settings);
+    let project = project_settings.and_then(read_session_dir);
+    project.or(global).map(|setting| match setting {
+        None => PrimeSessionDirSetting::Default,
+        Some(path) if path.is_empty() => PrimeSessionDirSetting::CurrentDirectory(
+            current_dir.unwrap_or_else(|| Path::new("")).to_path_buf(),
+        ),
+        Some(path) => PrimeSessionDirSetting::Path(expand_tilde_path_with_home(&path, home_dir)),
+    })
+}
+
+fn prime_agent_session_dir_from_settings(
+    agent_dir: &Path,
+    home_dir: &str,
+) -> Option<PrimeSessionDirSetting> {
+    let current_dir = std::env::current_dir().ok();
+    let project_settings = current_dir
+        .as_ref()
+        .map(|cwd| cwd.join(".prime/agent/settings.json"));
+    prime_agent_session_dir_from_settings_files(
+        &agent_dir.join("settings.json"),
+        project_settings.as_deref(),
+        home_dir,
+        current_dir.as_deref(),
+    )
 }
 
 /// Resolve Prime Agent's root-session and RLM-artifact scan roots using the
@@ -263,29 +290,44 @@ pub fn prime_agent_session_roots_with_env_strategy(
     home_dir: &str,
     use_env_roots: bool,
 ) -> [PathBuf; 2] {
-    let sessions = if use_env_roots {
-        let session_override = std::env::var("PRIME_AGENT_SESSION_DIR")
-            .ok()
-            .or_else(|| std::env::var("PRIME_AGENT_CODING_AGENT_SESSION_DIR").ok());
-        if let Some(path) = session_override.filter(|value| !value.is_empty()) {
-            expand_tilde_path_with_home(&path, home_dir)
-        } else {
-            let agent_dir = std::env::var("PRIME_AGENT_CODING_AGENT_DIR")
-                .ok()
-                .filter(|value| !value.is_empty())
-                .map(|path| expand_tilde_path_with_home(&path, home_dir))
-                .unwrap_or_else(|| PathBuf::from(home_dir).join(".prime/agent"));
-            prime_agent_session_dir_from_settings(&agent_dir, home_dir)
-                .unwrap_or_else(|| agent_dir.join("sessions"))
+    fn sessions_with_sibling_artifacts(sessions: PathBuf) -> [PathBuf; 2] {
+        let artifacts = sessions
+            .parent()
+            .unwrap_or_else(|| Path::new(""))
+            .join("session-artifacts");
+        [sessions, artifacts]
+    }
+
+    if !use_env_roots {
+        let agent_dir = PathBuf::from(home_dir).join(".prime/agent");
+        return [
+            agent_dir.join("sessions"),
+            agent_dir.join("session-artifacts"),
+        ];
+    }
+
+    let session_override = std::env::var("PRIME_AGENT_SESSION_DIR")
+        .ok()
+        .or_else(|| std::env::var("PRIME_AGENT_CODING_AGENT_SESSION_DIR").ok());
+    if let Some(path) = session_override.filter(|value| !value.is_empty()) {
+        return sessions_with_sibling_artifacts(expand_tilde_path_with_home(&path, home_dir));
+    }
+
+    let agent_dir = std::env::var("PRIME_AGENT_CODING_AGENT_DIR")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .map(|path| expand_tilde_path_with_home(&path, home_dir))
+        .unwrap_or_else(|| PathBuf::from(home_dir).join(".prime/agent"));
+    match prime_agent_session_dir_from_settings(&agent_dir, home_dir) {
+        Some(PrimeSessionDirSetting::Path(sessions)) => sessions_with_sibling_artifacts(sessions),
+        Some(PrimeSessionDirSetting::CurrentDirectory(current_dir)) => {
+            [current_dir.clone(), current_dir.join("session-artifacts")]
         }
-    } else {
-        PathBuf::from(home_dir).join(".prime/agent/sessions")
-    };
-    let artifacts = sessions
-        .parent()
-        .unwrap_or_else(|| Path::new(""))
-        .join("session-artifacts");
-    [sessions, artifacts]
+        Some(PrimeSessionDirSetting::Default) | None => [
+            agent_dir.join("sessions"),
+            agent_dir.join("session-artifacts"),
+        ],
+    }
 }
 
 pub fn headless_roots_with_env_strategy(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
@@ -4015,6 +4057,118 @@ mod tests {
         let roots = prime_agent_session_roots_with_env_strategy(home.to_str().unwrap(), true);
         assert_eq!(roots[0], home.join("custom-agent/sessions"));
         assert_eq!(roots[1], home.join("custom-agent/session-artifacts"));
+    }
+
+    #[test]
+    fn test_prime_agent_tilde_expansion_matches_upstream_forward_slash_only() {
+        let home = if cfg!(windows) {
+            r"C:\Users\test"
+        } else {
+            "/tmp/home"
+        };
+        assert_eq!(
+            expand_tilde_path_with_home("~/sessions", home),
+            PathBuf::from(home).join("sessions")
+        );
+        assert_eq!(
+            expand_tilde_path_with_home(r"~\sessions", home),
+            PathBuf::from(r"~\sessions")
+        );
+    }
+
+    #[test]
+    fn test_prime_agent_project_null_session_dir_resets_global_setting() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let global = home.join("global-settings.json");
+        let project = home.join("project-settings.json");
+        fs::write(&global, r#"{"sessionDir":"~/global-sessions"}"#).unwrap();
+        fs::write(&project, r#"{"sessionDir":null}"#).unwrap();
+
+        let setting = prime_agent_session_dir_from_settings_files(
+            &global,
+            Some(&project),
+            home.to_str().unwrap(),
+            Some(home),
+        );
+        assert_eq!(setting, Some(PrimeSessionDirSetting::Default));
+        let sessions = match setting {
+            Some(PrimeSessionDirSetting::Path(path))
+            | Some(PrimeSessionDirSetting::CurrentDirectory(path)) => path,
+            Some(PrimeSessionDirSetting::Default) | None => home.join("custom-agent/sessions"),
+        };
+        assert_eq!(sessions, home.join("custom-agent/sessions"));
+    }
+
+    #[test]
+    fn test_prime_agent_empty_project_session_dir_resolves_to_current_directory() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let current_dir = home.join("project");
+        let global = home.join("global-settings.json");
+        let project = home.join("project-settings.json");
+        fs::write(&global, r#"{"sessionDir":"~/global-sessions"}"#).unwrap();
+        fs::write(&project, r#"{"sessionDir":""}"#).unwrap();
+
+        let setting = prime_agent_session_dir_from_settings_files(
+            &global,
+            Some(&project),
+            home.to_str().unwrap(),
+            Some(&current_dir),
+        );
+        assert_eq!(
+            setting,
+            Some(PrimeSessionDirSetting::CurrentDirectory(current_dir))
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_prime_agent_empty_session_dir_scans_cwd_root_and_artifacts() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let project = home.join("work/project");
+        fs::create_dir_all(project.join(".prime/agent")).unwrap();
+        fs::write(
+            project.join(".prime/agent/settings.json"),
+            r#"{"sessionDir":""}"#,
+        )
+        .unwrap();
+        let root = project.join("root.jsonl");
+        let child = project.join("session-artifacts/root/sub-child/child.jsonl");
+        fs::create_dir_all(child.parent().unwrap()).unwrap();
+        fs::write(
+            &root, "{}
+",
+        )
+        .unwrap();
+        fs::write(
+            &child, "{}
+",
+        )
+        .unwrap();
+
+        let mut env = EnvGuard::capture(&[
+            "PRIME_AGENT_SESSION_DIR",
+            "PRIME_AGENT_CODING_AGENT_SESSION_DIR",
+            "PRIME_AGENT_CODING_AGENT_DIR",
+        ]);
+        env.remove("PRIME_AGENT_SESSION_DIR");
+        env.remove("PRIME_AGENT_CODING_AGENT_SESSION_DIR");
+        env.remove("PRIME_AGENT_CODING_AGENT_DIR");
+        let previous_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&project).unwrap();
+        let roots = prime_agent_session_roots_with_env_strategy(home.to_str().unwrap(), true);
+        let result = scan_all_clients(home.to_str().unwrap(), &["prime-agent".to_string()]);
+        restore_current_dir(&previous_dir);
+
+        let canonical_project = project.canonicalize().unwrap();
+        assert_eq!(roots[0], canonical_project);
+        assert_eq!(roots[1], canonical_project.join("session-artifacts"));
+        let files = result.get(ClientId::PrimeAgent);
+        assert_eq!(files.len(), 2);
+        assert!(files.contains(&root.canonicalize().unwrap()));
+        assert!(files.contains(&child.canonicalize().unwrap()));
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -4163,12 +4163,19 @@ mod tests {
         restore_current_dir(&previous_dir);
 
         let canonical_project = project.canonicalize().unwrap();
-        assert_eq!(roots[0], canonical_project);
-        assert_eq!(roots[1], canonical_project.join("session-artifacts"));
+        assert_eq!(roots[0].canonicalize().unwrap(), canonical_project);
+        assert_eq!(
+            roots[1].canonicalize().unwrap(),
+            project.join("session-artifacts").canonicalize().unwrap()
+        );
         let files = result.get(ClientId::PrimeAgent);
         assert_eq!(files.len(), 2);
-        assert!(files.contains(&root.canonicalize().unwrap()));
-        assert!(files.contains(&child.canonicalize().unwrap()));
+        let canonical_files: Vec<PathBuf> = files
+            .iter()
+            .map(|path| path.canonicalize().unwrap())
+            .collect();
+        assert!(canonical_files.contains(&root.canonicalize().unwrap()));
+        assert!(canonical_files.contains(&child.canonicalize().unwrap()));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -26,6 +26,8 @@ pub struct PiSessionHeader {
     pub timestamp: Option<String>,
     #[allow(dead_code)]
     pub cwd: Option<String>,
+    #[serde(rename = "parentSession")]
+    pub parent_session: Option<String>,
     #[serde(rename = "rlmDepth")]
     pub rlm_depth: Option<u32>,
 }
@@ -57,6 +59,12 @@ pub struct PiSessionEntry {
     pub timestamp: Option<String>,
     pub message: Option<PiMessage>,
     pub name: Option<String>,
+    #[serde(rename = "targetId")]
+    pub target_id: Option<String>,
+    #[serde(rename = "childUsage")]
+    pub child_usage: Option<PiUsage>,
+    #[serde(rename = "aggregateUsage")]
+    pub aggregate_usage: Option<PiUsage>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -69,7 +77,7 @@ pub struct PiMessage {
     pub response_id: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PiUsage {
     pub input: Option<i64>,

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -3,16 +3,368 @@
 //! Prime Agent stores root sessions in `~/.prime/agent/sessions/*.jsonl` and
 //! RLM child sessions below the sibling `session-artifacts` tree. Both use the
 //! Pi append-only JSONL record format, so token extraction is shared with the
-//! Pi parser. `child_usage_attributed` records are intentionally ignored: they
-//! are accounting metadata that folds a child's usage into a parent message at
-//! runtime, while tokscale scans the child's own session file directly.
+//! Pi parser. `child_usage_attributed` records are never emitted as messages:
+//! tokscale scans each child's own transcript directly. Their usage metadata is
+//! used only to reverse aggregate parent usage that Prime may persist while
+//! serializing a fork, before the copied parent is deduplicated across files.
 
-use super::pi::parse_pi_format_rlm_file;
+use super::pi::{parse_pi_format_rlm_file, PiSessionEntry, PiSessionHeader, PiUsage};
 use super::UnifiedMessage;
-use std::path::Path;
+use crate::TokenBreakdown;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
 
 pub fn parse_prime_agent_file(path: &Path) -> Vec<UnifiedMessage> {
     parse_pi_format_rlm_file(path, "prime-agent", "prime-agent")
+}
+
+#[derive(Debug, Clone)]
+struct PrimeAttribution {
+    id: String,
+    child_usage: TokenBreakdown,
+    aggregate_usage: TokenBreakdown,
+}
+
+#[derive(Debug, Clone)]
+struct PrimeUsageAdjustment {
+    dedup_key: String,
+    persisted_usage: TokenBreakdown,
+    attributions: Vec<PrimeAttribution>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct PrimeFileAccounting {
+    source_path: PathBuf,
+    attributions: Vec<PrimeAttribution>,
+    adjustments: Vec<PrimeUsageAdjustment>,
+    child_message_usages: Vec<TokenBreakdown>,
+    child_parent_path: Option<PathBuf>,
+    fork_parent_path: Option<PathBuf>,
+}
+
+fn usage_breakdown(usage: &PiUsage) -> TokenBreakdown {
+    TokenBreakdown {
+        input: usage.input.unwrap_or(0).max(0),
+        output: usage.output.unwrap_or(0).max(0),
+        cache_read: usage.cache_read.unwrap_or(0).max(0),
+        cache_write: usage.cache_write.unwrap_or(0).max(0),
+        reasoning: 0,
+    }
+}
+
+fn add_usage(total: &mut TokenBreakdown, usage: &TokenBreakdown) {
+    total.input = total.input.saturating_add(usage.input);
+    total.output = total.output.saturating_add(usage.output);
+    total.cache_read = total.cache_read.saturating_add(usage.cache_read);
+    total.cache_write = total.cache_write.saturating_add(usage.cache_write);
+}
+
+fn subtract_usage(total: &mut TokenBreakdown, usage: &TokenBreakdown) {
+    total.input = total.input.saturating_sub(usage.input).max(0);
+    total.output = total.output.saturating_sub(usage.output).max(0);
+    total.cache_read = total.cache_read.saturating_sub(usage.cache_read).max(0);
+    total.cache_write = total.cache_write.saturating_sub(usage.cache_write).max(0);
+}
+
+type UsageKey = (i64, i64, i64, i64);
+type LineageUsageKey = (PathBuf, UsageKey);
+
+fn usage_key(usage: &TokenBreakdown) -> UsageKey {
+    (
+        usage.input,
+        usage.output,
+        usage.cache_read,
+        usage.cache_write,
+    )
+}
+
+fn lineage_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn referenced_lineage_path(source_file: &Path, referenced: &Path) -> PathBuf {
+    if referenced.is_absolute() {
+        lineage_path(referenced)
+    } else {
+        lineage_path(
+            &source_file
+                .parent()
+                .unwrap_or_else(|| Path::new(""))
+                .join(referenced),
+        )
+    }
+}
+
+/// Read Prime-only accounting records that are intentionally absent from the
+/// shared Pi message representation. `messages` may come from the source cache;
+/// their stable order is used to associate target entry ids with emitted rows.
+pub(crate) fn analyze_prime_agent_accounting(
+    path: &Path,
+    messages: &[UnifiedMessage],
+) -> PrimeFileAccounting {
+    let Ok(file) = std::fs::File::open(path) else {
+        return PrimeFileAccounting::default();
+    };
+
+    let source_path = lineage_path(path);
+    let mut found_header = false;
+    let mut is_rlm_child = false;
+    let mut child_parent_path = None;
+    let mut fork_parent_path = None;
+    let mut message_index = 0usize;
+    let mut targets: HashMap<String, (String, TokenBreakdown)> = HashMap::new();
+    let mut attributions: HashMap<String, Vec<PrimeAttribution>> = HashMap::new();
+
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if !found_header {
+            if let Ok(header) = serde_json::from_str::<PiSessionHeader>(trimmed) {
+                if header.entry_type == "session" {
+                    found_header = true;
+                    is_rlm_child = header.rlm_depth.unwrap_or(0) > 0;
+                    let parent_path = header
+                        .parent_session
+                        .as_deref()
+                        .map(Path::new)
+                        .map(|parent| referenced_lineage_path(path, parent));
+                    if is_rlm_child {
+                        child_parent_path = parent_path;
+                    } else {
+                        fork_parent_path = parent_path;
+                    }
+                    continue;
+                }
+            }
+            let is_pre_session_title = serde_json::from_str::<serde_json::Value>(trimmed)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("type")
+                        .and_then(|kind| kind.as_str())
+                        .map(str::to_owned)
+                })
+                .is_some_and(|kind| kind == "title");
+            if is_pre_session_title {
+                continue;
+            }
+            return PrimeFileAccounting::default();
+        }
+
+        let Ok(entry) = serde_json::from_str::<PiSessionEntry>(trimmed) else {
+            continue;
+        };
+        if entry.entry_type == "child_usage_attributed" {
+            if let (Some(id), Some(target_id), Some(child_usage), Some(aggregate_usage)) = (
+                entry.id,
+                entry.target_id,
+                entry.child_usage,
+                entry.aggregate_usage,
+            ) {
+                attributions
+                    .entry(target_id)
+                    .or_default()
+                    .push(PrimeAttribution {
+                        id,
+                        child_usage: usage_breakdown(&child_usage),
+                        aggregate_usage: usage_breakdown(&aggregate_usage),
+                    });
+            }
+            continue;
+        }
+        if entry.entry_type != "message" {
+            continue;
+        }
+        let Some(message) = entry.message else {
+            continue;
+        };
+        if message.role.as_deref() != Some("assistant") || message.usage.is_none() {
+            continue;
+        }
+        let Some(model) = message.model.filter(|model| !model.is_empty()) else {
+            continue;
+        };
+        drop(model);
+
+        let Some(parsed) = messages.get(message_index) else {
+            break;
+        };
+        message_index += 1;
+        if let (Some(id), Some(dedup_key)) = (entry.id, parsed.dedup_key.clone()) {
+            targets.insert(id, (dedup_key, parsed.tokens.clone()));
+        }
+    }
+
+    let all_attributions = attributions
+        .values()
+        .flat_map(|entries| entries.iter().cloned())
+        .collect();
+    let mut adjustments = Vec::new();
+    for (target_id, entries) in attributions {
+        let Some((dedup_key, persisted_usage)) = targets.get(&target_id) else {
+            continue;
+        };
+        let mut matching_prefix = None;
+        for (index, entry) in entries.iter().enumerate() {
+            if entry.aggregate_usage == *persisted_usage {
+                matching_prefix = Some(entries[..=index].to_vec());
+            }
+        }
+        if let Some(prefix) = matching_prefix {
+            adjustments.push(PrimeUsageAdjustment {
+                dedup_key: dedup_key.clone(),
+                persisted_usage: persisted_usage.clone(),
+                attributions: prefix,
+            });
+        }
+    }
+
+    let child_message_usages = if is_rlm_child {
+        messages
+            .iter()
+            .map(|message| message.tokens.clone())
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    PrimeFileAccounting {
+        source_path,
+        attributions: all_attributions,
+        adjustments,
+        child_message_usages,
+        child_parent_path,
+        fork_parent_path,
+    }
+}
+
+fn fallback_key_base(key: &str) -> Option<&str> {
+    if !key.starts_with("prime-agent:message:") {
+        return None;
+    }
+    let mut parts = key.rsplitn(5, ':');
+    parts.next()?;
+    parts.next()?;
+    parts.next()?;
+    parts.next()?;
+    parts.next()
+}
+
+fn rewrite_fallback_usage(key: &str, usage: &TokenBreakdown) -> String {
+    fallback_key_base(key).map_or_else(
+        || key.to_string(),
+        |base| {
+            format!(
+                "{base}:{}:{}:{}:{}",
+                usage.input, usage.output, usage.cache_read, usage.cache_write
+            )
+        },
+    )
+}
+
+/// Subtract child usage only when a matching RLM transcript was actually
+/// parsed, then collapse fork copies. Missing/pruned children remain represented
+/// by Prime's aggregate parent usage instead of disappearing from the total.
+pub(crate) fn reconcile_prime_agent_messages(
+    mut messages: Vec<UnifiedMessage>,
+    accounting: &[PrimeFileAccounting],
+) -> Vec<UnifiedMessage> {
+    let mut available_children: HashMap<LineageUsageKey, usize> = HashMap::new();
+    for file in accounting {
+        if let Some(parent_path) = &file.child_parent_path {
+            for usage in &file.child_message_usages {
+                *available_children
+                    .entry((parent_path.clone(), usage_key(usage)))
+                    .or_default() += 1;
+            }
+        }
+    }
+
+    // Attribution ids survive fork serialization. Record every file that owns
+    // a copy, but only match against children whose header points back to that
+    // exact parent session file. A same-sized child from another lineage must
+    // never authorize subtraction.
+    let mut unique_attributions: BTreeMap<String, (TokenBreakdown, BTreeSet<PathBuf>)> =
+        BTreeMap::new();
+    for file in accounting {
+        for attribution in &file.attributions {
+            let (_, owners) = unique_attributions
+                .entry(attribution.id.clone())
+                .or_insert_with(|| (attribution.child_usage.clone(), BTreeSet::new()));
+            owners.insert(file.source_path.clone());
+            if let Some(parent) = &file.fork_parent_path {
+                owners.insert(parent.clone());
+            }
+        }
+    }
+    let mut represented_attributions = HashSet::new();
+    for (id, (usage, owners)) in unique_attributions {
+        for owner in owners {
+            let key = (owner, usage_key(&usage));
+            let Some(count) = available_children.get_mut(&key) else {
+                continue;
+            };
+            if *count > 0 {
+                *count -= 1;
+                represented_attributions.insert(id);
+                break;
+            }
+        }
+    }
+
+    let mut attribution_fallback_bases = HashSet::new();
+    for adjustment in accounting.iter().flat_map(|file| &file.adjustments) {
+        if let Some(base) = fallback_key_base(&adjustment.dedup_key) {
+            attribution_fallback_bases.insert(base.to_string());
+        }
+        let mut represented_usage = TokenBreakdown::default();
+        for attribution in &adjustment.attributions {
+            if represented_attributions.contains(&attribution.id) {
+                add_usage(&mut represented_usage, &attribution.child_usage);
+            }
+        }
+        if represented_usage == TokenBreakdown::default() {
+            continue;
+        }
+        for message in &mut messages {
+            if message.dedup_key.as_deref() == Some(&adjustment.dedup_key)
+                && message.tokens == adjustment.persisted_usage
+            {
+                subtract_usage(&mut message.tokens, &represented_usage);
+                if let Some(key) = message.dedup_key.as_deref() {
+                    message.dedup_key = Some(rewrite_fallback_usage(key, &message.tokens));
+                }
+            }
+        }
+    }
+
+    let mut deduped = Vec::<UnifiedMessage>::new();
+    let mut seen = HashMap::<String, usize>::new();
+    for message in messages {
+        let Some(key) = message.dedup_key.as_deref() else {
+            deduped.push(message);
+            continue;
+        };
+        let identity = fallback_key_base(key)
+            .filter(|base| attribution_fallback_bases.contains(*base))
+            .unwrap_or(key)
+            .to_string();
+        if let Some(index) = seen.get(&identity).copied() {
+            let existing = &mut deduped[index];
+            existing.tokens.input = existing.tokens.input.max(message.tokens.input);
+            existing.tokens.output = existing.tokens.output.max(message.tokens.output);
+            existing.tokens.cache_read = existing.tokens.cache_read.max(message.tokens.cache_read);
+            existing.tokens.cache_write =
+                existing.tokens.cache_write.max(message.tokens.cache_write);
+        } else {
+            seen.insert(identity, deduped.len());
+            deduped.push(message);
+        }
+    }
+    deduped
 }
 
 #[cfg(test)]
@@ -69,6 +421,78 @@ mod tests {
         assert_eq!(messages[0].agent.as_deref(), Some("api-reviewer"));
         assert_eq!(messages[0].provider_id, "openai");
         assert_eq!(messages[0].model_id, "gpt-5.4");
+    }
+
+    #[test]
+    fn keeps_aggregate_parent_when_the_attributed_child_is_unavailable() {
+        let file = session_file(
+            r#"{"type":"session","version":3,"id":"fork-1","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":150,"output":70,"cacheRead":20,"cacheWrite":10,"totalTokens":250}}}
+{"type":"child_usage_attributed","id":"usage-1","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":50,"output":20,"cacheRead":0,"cacheWrite":0,"totalTokens":70},"aggregateUsage":{"input":150,"output":70,"cacheRead":20,"cacheWrite":10,"totalTokens":250},"origin":"spawn_task"}"#,
+        );
+
+        let messages = parse_prime_agent_file(file.path());
+        let accounting = analyze_prime_agent_accounting(file.path(), &messages);
+        let messages = reconcile_prime_agent_messages(messages, &[accounting]);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 150);
+        assert_eq!(messages[0].tokens.output, 70);
+        assert_eq!(messages[0].tokens.cache_read, 20);
+        assert_eq!(messages[0].tokens.cache_write, 10);
+    }
+
+    #[test]
+    fn same_sized_child_from_another_parent_does_not_authorize_subtraction() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let parent_path = dir.path().join("parent-a.jsonl");
+        let child_path = dir.path().join("child-b.jsonl");
+        let unrelated_parent = dir.path().join("parent-b.jsonl");
+        std::fs::write(
+            &parent_path,
+            r#"{"type":"session","version":3,"id":"parent-a","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":150,"output":70,"cacheRead":20,"cacheWrite":10,"totalTokens":250}}}
+{"type":"child_usage_attributed","id":"usage-a","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":50,"output":20,"cacheRead":0,"cacheWrite":0,"totalTokens":70},"aggregateUsage":{"input":150,"output":70,"cacheRead":20,"cacheWrite":10,"totalTokens":250},"origin":"spawn_task"}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            &child_path,
+            format!(
+                r#"{{"type":"session","version":3,"id":"child-b","timestamp":"2026-08-08T00:00:01.000Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child","parentId":null,"timestamp":"2026-08-08T00:00:02.000Z","message":{{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"child-response","usage":{{"input":50,"output":20,"cacheRead":0,"cacheWrite":0,"totalTokens":70}}}}}}
+"#,
+                serde_json::to_string(&unrelated_parent.to_string_lossy()).unwrap()
+            ),
+        )
+        .unwrap();
+
+        let parent_messages = parse_prime_agent_file(&parent_path);
+        let child_messages = parse_prime_agent_file(&child_path);
+        let accounting = [
+            analyze_prime_agent_accounting(&parent_path, &parent_messages),
+            analyze_prime_agent_accounting(&child_path, &child_messages),
+        ];
+        let messages = reconcile_prime_agent_messages(
+            parent_messages.into_iter().chain(child_messages).collect(),
+            &accounting,
+        );
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.tokens.input)
+                .sum::<i64>(),
+            200
+        );
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.tokens.output)
+                .sum::<i64>(),
+            90
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -84,6 +84,12 @@ fn subtract_usage(total: &mut TokenBreakdown, usage: &TokenBreakdown) {
 
 type UsageKey = (i64, i64, i64, i64);
 type LineageUsageKey = (PathBuf, UsageKey);
+/// Attribution ids are only unique within one session: Prime mints them with
+/// `randomUUID().slice(0, 8)` and collision-checks against that session's own id
+/// map alone. Pairing an id with its resolved lineage root keeps fork copies of
+/// one attribution collapsed while keeping a colliding id in an unrelated
+/// lineage independent.
+type AttributionKey = (PathBuf, String);
 
 fn usage_key(usage: &TokenBreakdown) -> UsageKey {
     (
@@ -92,6 +98,37 @@ fn usage_key(usage: &TokenBreakdown) -> UsageKey {
         usage.cache_read,
         usage.cache_write,
     )
+}
+
+/// Resolve every file to the head of its fork chain. Serializing a fork copies
+/// the parent's `child_usage_attributed` records verbatim, so all copies within
+/// one chain describe the same invocation and must share an attribution
+/// identity. Files in different chains never do.
+fn lineage_roots(accounting: &[PrimeFileAccounting]) -> HashMap<PathBuf, PathBuf> {
+    let forked_from: HashMap<&PathBuf, &PathBuf> = accounting
+        .iter()
+        .filter_map(|file| Some((&file.source_path, file.fork_parent_path.as_ref()?)))
+        .collect();
+    let mut roots = HashMap::new();
+    for file in accounting {
+        let mut root = &file.source_path;
+        let mut visited = HashSet::new();
+        while visited.insert(root.clone()) {
+            let Some(parent) = forked_from.get(root) else {
+                break;
+            };
+            root = parent;
+        }
+        roots.insert(file.source_path.clone(), root.clone());
+    }
+    roots
+}
+
+fn lineage_root(roots: &HashMap<PathBuf, PathBuf>, file: &PrimeFileAccounting) -> PathBuf {
+    roots
+        .get(&file.source_path)
+        .cloned()
+        .unwrap_or_else(|| file.source_path.clone())
 }
 
 fn lineage_path(path: &Path) -> PathBuf {
@@ -306,14 +343,19 @@ pub(crate) fn reconcile_prime_agent_messages(
     // parent session and whose completion timestamp is the same event (Prime
     // writes the two records within milliseconds). This disambiguates equal
     // token buckets produced by separate children in one parent.
+    // Attribution ids are unique only inside one session, so they are keyed by
+    // their lineage root as well: fork copies of one attribution still collapse,
+    // while a colliding id minted in an unrelated lineage stays separate.
+    let roots = lineage_roots(accounting);
     let mut unique_attributions: BTreeMap<
-        String,
+        AttributionKey,
         (TokenBreakdown, Option<i64>, BTreeSet<PathBuf>),
     > = BTreeMap::new();
     for file in accounting {
+        let lineage = lineage_root(&roots, file);
         for attribution in &file.attributions {
             let (_, _, owners) = unique_attributions
-                .entry(attribution.id.clone())
+                .entry((lineage.clone(), attribution.id.clone()))
                 .or_insert_with(|| {
                     (
                         attribution.child_usage.clone(),
@@ -322,14 +364,15 @@ pub(crate) fn reconcile_prime_agent_messages(
                     )
                 });
             owners.insert(file.source_path.clone());
+            owners.insert(lineage.clone());
             if let Some(parent) = &file.fork_parent_path {
                 owners.insert(parent.clone());
             }
         }
     }
 
-    let mut represented_attributions = HashSet::new();
-    for (id, (usage, attribution_timestamp, owners)) in unique_attributions {
+    let mut represented_attributions: HashSet<AttributionKey> = HashSet::new();
+    for (attribution_key, (usage, attribution_timestamp, owners)) in unique_attributions {
         let mut timed_candidates = Vec::new();
         let mut untimed_candidates = Vec::new();
         for owner in owners {
@@ -362,24 +405,28 @@ pub(crate) fn reconcile_prime_agent_messages(
         if let Some((key, index)) = selected {
             if let Some(children) = available_children.get_mut(&key) {
                 children.swap_remove(index);
-                represented_attributions.insert(id);
+                represented_attributions.insert(attribution_key);
             }
         }
     }
 
-    let mut adjustment_groups: HashMap<String, Vec<&PrimeUsageAdjustment>> = HashMap::new();
+    let mut adjustment_groups: HashMap<String, Vec<(PathBuf, &PrimeUsageAdjustment)>> =
+        HashMap::new();
     let mut attribution_fallback_bases = HashSet::new();
-    for adjustment in accounting.iter().flat_map(|file| &file.adjustments) {
-        let identity = fallback_key_base(&adjustment.dedup_key)
-            .inspect(|base| {
-                attribution_fallback_bases.insert((*base).to_string());
-            })
-            .unwrap_or(&adjustment.dedup_key)
-            .to_string();
-        adjustment_groups
-            .entry(identity)
-            .or_default()
-            .push(adjustment);
+    for file in accounting {
+        let lineage = lineage_root(&roots, file);
+        for adjustment in &file.adjustments {
+            let identity = fallback_key_base(&adjustment.dedup_key)
+                .inspect(|base| {
+                    attribution_fallback_bases.insert((*base).to_string());
+                })
+                .unwrap_or(&adjustment.dedup_key)
+                .to_string();
+            adjustment_groups
+                .entry(identity)
+                .or_default()
+                .push((lineage.clone(), adjustment));
+        }
     }
 
     let mut grouped: HashMap<String, Vec<UnifiedMessage>> = HashMap::new();
@@ -416,20 +463,20 @@ pub(crate) fn reconcile_prime_agent_messages(
 
         let mut base_usage = TokenBreakdown::default();
         let mut found_base = false;
-        let mut all_attributions: BTreeMap<String, TokenBreakdown> = BTreeMap::new();
-        for adjustment in adjustments {
+        let mut all_attributions: BTreeMap<AttributionKey, TokenBreakdown> = BTreeMap::new();
+        for (lineage, adjustment) in adjustments {
             let mut own_usage = adjustment.persisted_usage.clone();
             for attribution in &adjustment.attributions {
                 subtract_usage(&mut own_usage, &attribution.child_usage);
                 all_attributions
-                    .entry(attribution.id.clone())
+                    .entry((lineage.clone(), attribution.id.clone()))
                     .or_insert_with(|| attribution.child_usage.clone());
             }
             maximize_usage(&mut base_usage, &own_usage);
             found_base = true;
         }
         for message in &group {
-            let is_aggregate_copy = adjustments.iter().any(|adjustment| {
+            let is_aggregate_copy = adjustments.iter().any(|(_, adjustment)| {
                 message.dedup_key.as_deref() == Some(&adjustment.dedup_key)
                     && message.tokens == adjustment.persisted_usage
             });
@@ -443,8 +490,8 @@ pub(crate) fn reconcile_prime_agent_messages(
                 maximize_usage(&mut base_usage, &message.tokens);
             }
         }
-        for (id, usage) in all_attributions {
-            if !represented_attributions.contains(&id) {
+        for (attribution_key, usage) in all_attributions {
+            if !represented_attributions.contains(&attribution_key) {
                 add_usage(&mut base_usage, &usage);
             }
         }
@@ -751,6 +798,131 @@ mod tests {
 
         assert_ne!(original[0].timestamp, fork[0].timestamp);
         assert_eq!(original[0].dedup_key, fork[0].dedup_key);
+    }
+
+    /// Prime allocates attribution ids with `randomUUID().slice(0, 8)` and only
+    /// collision-checks them against the current session's own id map, so the
+    /// same 32-bit id can appear in two unrelated sessions. A collision must not
+    /// let one lineage's parsed child authorize a subtraction in the other.
+    #[test]
+    fn colliding_attribution_ids_in_separate_lineages_stay_independent() {
+        fn totals(reverse: bool) -> (i64, i64) {
+            let dir = tempfile::TempDir::new().unwrap();
+            let parent_a = dir.path().join("parent-a.jsonl");
+            let child_a = dir.path().join("child-a.jsonl");
+            let parent_b = dir.path().join("parent-b.jsonl");
+            std::fs::write(
+                &parent_a,
+                r#"{"type":"session","version":3,"id":"parent-a","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-a-response","usage":{"input":120,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":120}}}
+{"type":"child_usage_attributed","id":"deadbeef","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":20,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":20},"aggregateUsage":{"input":120,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":120},"origin":"spawn_task"}
+"#,
+            )
+            .unwrap();
+            std::fs::write(
+                &child_a,
+                format!(
+                    r#"{{"type":"session","version":3,"id":"child-a","timestamp":"2026-08-08T00:00:01.500Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child","parentId":null,"timestamp":"2026-08-08T00:00:02.001Z","message":{{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"child-a-response","usage":{{"input":20,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":20}}}}}}
+"#,
+                    serde_json::to_string(&parent_a.to_string_lossy()).unwrap()
+                ),
+            )
+            .unwrap();
+            // Unrelated lineage reusing the same 8-hex attribution id. Its own
+            // child transcript was pruned, so the aggregate parent must stand.
+            std::fs::write(
+                &parent_b,
+                r#"{"type":"session","version":3,"id":"parent-b","timestamp":"2026-08-09T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-09T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-b-response","usage":{"input":130,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":130}}}
+{"type":"child_usage_attributed","id":"deadbeef","parentId":"parent","timestamp":"2026-08-09T00:00:02.000Z","targetId":"parent","childUsage":{"input":30,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":30},"aggregateUsage":{"input":130,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":130},"origin":"spawn_task"}
+"#,
+            )
+            .unwrap();
+
+            let mut paths = vec![parent_a, child_a, parent_b];
+            if reverse {
+                paths.reverse();
+            }
+            let parsed: Vec<(PathBuf, Vec<UnifiedMessage>)> = paths
+                .into_iter()
+                .map(|path| {
+                    let messages = parse_prime_agent_file(&path);
+                    (path, messages)
+                })
+                .collect();
+            let accounting: Vec<PrimeFileAccounting> = parsed
+                .iter()
+                .map(|(path, messages)| analyze_prime_agent_accounting(path, messages))
+                .collect();
+            let messages: Vec<UnifiedMessage> = parsed
+                .into_iter()
+                .flat_map(|(_, messages)| messages)
+                .collect();
+            let messages = reconcile_prime_agent_messages(messages, &accounting);
+
+            let parent_b_input = messages
+                .iter()
+                .find(|message| {
+                    message.dedup_key.as_deref() == Some("prime-agent:response:parent-b-response")
+                })
+                .map_or(0, |message| message.tokens.input);
+            (
+                messages.iter().map(|message| message.tokens.input).sum(),
+                parent_b_input,
+            )
+        }
+
+        // parent-a reconciles to 100, its parsed child contributes 20, and the
+        // pruned lineage keeps its full aggregate 130.
+        assert_eq!(totals(false), (250, 130));
+        assert_eq!(totals(true), (250, 130));
+    }
+
+    #[test]
+    fn attributed_child_larger_than_the_parent_aggregate_clamps_at_zero() {
+        fn tokens(input: i64, output: i64) -> TokenBreakdown {
+            TokenBreakdown {
+                input,
+                output,
+                ..TokenBreakdown::default()
+            }
+        }
+
+        let mut message = UnifiedMessage::new(
+            "prime-agent",
+            "claude-opus-5",
+            "anthropic",
+            "partial",
+            1,
+            tokens(40, 10),
+            0.0,
+        );
+        message.dedup_key = Some("prime-agent:response:partial".to_string());
+        let attribution = PrimeAttribution {
+            id: "deadbeef".to_string(),
+            timestamp: Some(1),
+            child_usage: tokens(90, 25),
+            aggregate_usage: tokens(40, 10),
+        };
+        let accounting = [PrimeFileAccounting {
+            source_path: PathBuf::from("partial.jsonl"),
+            attributions: vec![attribution.clone()],
+            adjustments: vec![PrimeUsageAdjustment {
+                dedup_key: "prime-agent:response:partial".to_string(),
+                persisted_usage: tokens(40, 10),
+                attributions: vec![attribution],
+            }],
+            ..PrimeFileAccounting::default()
+        }];
+
+        let messages = reconcile_prime_agent_messages(vec![message], &accounting);
+
+        assert_eq!(messages.len(), 1);
+        // 40 - 90 clamps to 0 instead of wrapping, then the unavailable child is
+        // restored, so the row never reports a negative or absurd bucket.
+        assert_eq!(messages[0].tokens.input, 90);
+        assert_eq!(messages[0].tokens.output, 25);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -9,6 +9,7 @@
 //! serializing a fork, before the copied parent is deduplicated across files.
 
 use super::pi::{parse_pi_format_rlm_file, PiSessionEntry, PiSessionHeader, PiUsage};
+use super::utils::parse_timestamp_str;
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -22,8 +23,15 @@ pub fn parse_prime_agent_file(path: &Path) -> Vec<UnifiedMessage> {
 #[derive(Debug, Clone)]
 struct PrimeAttribution {
     id: String,
+    timestamp: Option<i64>,
     child_usage: TokenBreakdown,
     aggregate_usage: TokenBreakdown,
+}
+
+#[derive(Debug, Clone)]
+struct ChildMessageUsage {
+    timestamp: Option<i64>,
+    usage: TokenBreakdown,
 }
 
 #[derive(Debug, Clone)]
@@ -38,7 +46,7 @@ pub(crate) struct PrimeFileAccounting {
     source_path: PathBuf,
     attributions: Vec<PrimeAttribution>,
     adjustments: Vec<PrimeUsageAdjustment>,
-    child_message_usages: Vec<TokenBreakdown>,
+    child_message_usages: Vec<ChildMessageUsage>,
     child_parent_path: Option<PathBuf>,
     fork_parent_path: Option<PathBuf>,
 }
@@ -58,6 +66,13 @@ fn add_usage(total: &mut TokenBreakdown, usage: &TokenBreakdown) {
     total.output = total.output.saturating_add(usage.output);
     total.cache_read = total.cache_read.saturating_add(usage.cache_read);
     total.cache_write = total.cache_write.saturating_add(usage.cache_write);
+}
+
+fn maximize_usage(total: &mut TokenBreakdown, usage: &TokenBreakdown) {
+    total.input = total.input.max(usage.input);
+    total.output = total.output.max(usage.output);
+    total.cache_read = total.cache_read.max(usage.cache_read);
+    total.cache_write = total.cache_write.max(usage.cache_write);
 }
 
 fn subtract_usage(total: &mut TokenBreakdown, usage: &TokenBreakdown) {
@@ -115,6 +130,7 @@ pub(crate) fn analyze_prime_agent_accounting(
     let mut message_index = 0usize;
     let mut targets: HashMap<String, (String, TokenBreakdown)> = HashMap::new();
     let mut attributions: HashMap<String, Vec<PrimeAttribution>> = HashMap::new();
+    let mut child_message_usages = Vec::new();
 
     for line in BufReader::new(file).lines().map_while(Result::ok) {
         let trimmed = line.trim();
@@ -157,6 +173,7 @@ pub(crate) fn analyze_prime_agent_accounting(
         let Ok(entry) = serde_json::from_str::<PiSessionEntry>(trimmed) else {
             continue;
         };
+        let entry_timestamp = entry.timestamp.as_deref().and_then(parse_timestamp_str);
         if entry.entry_type == "child_usage_attributed" {
             if let (Some(id), Some(target_id), Some(child_usage), Some(aggregate_usage)) = (
                 entry.id,
@@ -169,6 +186,7 @@ pub(crate) fn analyze_prime_agent_accounting(
                     .or_default()
                     .push(PrimeAttribution {
                         id,
+                        timestamp: entry_timestamp,
                         child_usage: usage_breakdown(&child_usage),
                         aggregate_usage: usage_breakdown(&aggregate_usage),
                     });
@@ -181,18 +199,24 @@ pub(crate) fn analyze_prime_agent_accounting(
         let Some(message) = entry.message else {
             continue;
         };
-        if message.role.as_deref() != Some("assistant") || message.usage.is_none() {
+        if message.role.as_deref() != Some("assistant")
+            || message.usage.is_none()
+            || message.model.is_none()
+        {
             continue;
         }
-        let Some(model) = message.model.filter(|model| !model.is_empty()) else {
+
+        let parsed = messages.get(message_index);
+        message_index += 1;
+        let Some(parsed) = parsed else {
             continue;
         };
-        drop(model);
-
-        let Some(parsed) = messages.get(message_index) else {
-            break;
-        };
-        message_index += 1;
+        if is_rlm_child {
+            child_message_usages.push(ChildMessageUsage {
+                timestamp: entry_timestamp,
+                usage: parsed.tokens.clone(),
+            });
+        }
         if let (Some(id), Some(dedup_key)) = (entry.id, parsed.dedup_key.clone()) {
             targets.insert(id, (dedup_key, parsed.tokens.clone()));
         }
@@ -221,15 +245,6 @@ pub(crate) fn analyze_prime_agent_accounting(
             });
         }
     }
-
-    let child_message_usages = if is_rlm_child {
-        messages
-            .iter()
-            .map(|message| message.tokens.clone())
-            .collect()
-    } else {
-        Vec::new()
-    };
 
     PrimeFileAccounting {
         source_path,
@@ -269,100 +284,177 @@ fn rewrite_fallback_usage(key: &str, usage: &TokenBreakdown) -> String {
 /// parsed, then collapse fork copies. Missing/pruned children remain represented
 /// by Prime's aggregate parent usage instead of disappearing from the total.
 pub(crate) fn reconcile_prime_agent_messages(
-    mut messages: Vec<UnifiedMessage>,
+    messages: Vec<UnifiedMessage>,
     accounting: &[PrimeFileAccounting],
 ) -> Vec<UnifiedMessage> {
-    let mut available_children: HashMap<LineageUsageKey, usize> = HashMap::new();
+    const ATTRIBUTION_TIMESTAMP_TOLERANCE_MS: i64 = 1_000;
+
+    let mut available_children: HashMap<LineageUsageKey, Vec<Option<i64>>> = HashMap::new();
     for file in accounting {
         if let Some(parent_path) = &file.child_parent_path {
-            for usage in &file.child_message_usages {
-                *available_children
-                    .entry((parent_path.clone(), usage_key(usage)))
-                    .or_default() += 1;
+            for child in &file.child_message_usages {
+                available_children
+                    .entry((parent_path.clone(), usage_key(&child.usage)))
+                    .or_default()
+                    .push(child.timestamp);
             }
         }
     }
 
     // Attribution ids survive fork serialization. Record every file that owns
-    // a copy, but only match against children whose header points back to that
-    // exact parent session file. A same-sized child from another lineage must
-    // never authorize subtraction.
-    let mut unique_attributions: BTreeMap<String, (TokenBreakdown, BTreeSet<PathBuf>)> =
-        BTreeMap::new();
+    // a copy, but match only a child response whose header points back to that
+    // parent session and whose completion timestamp is the same event (Prime
+    // writes the two records within milliseconds). This disambiguates equal
+    // token buckets produced by separate children in one parent.
+    let mut unique_attributions: BTreeMap<
+        String,
+        (TokenBreakdown, Option<i64>, BTreeSet<PathBuf>),
+    > = BTreeMap::new();
     for file in accounting {
         for attribution in &file.attributions {
-            let (_, owners) = unique_attributions
+            let (_, _, owners) = unique_attributions
                 .entry(attribution.id.clone())
-                .or_insert_with(|| (attribution.child_usage.clone(), BTreeSet::new()));
+                .or_insert_with(|| {
+                    (
+                        attribution.child_usage.clone(),
+                        attribution.timestamp,
+                        BTreeSet::new(),
+                    )
+                });
             owners.insert(file.source_path.clone());
             if let Some(parent) = &file.fork_parent_path {
                 owners.insert(parent.clone());
             }
         }
     }
+
     let mut represented_attributions = HashSet::new();
-    for (id, (usage, owners)) in unique_attributions {
+    for (id, (usage, attribution_timestamp, owners)) in unique_attributions {
+        let mut timed_candidates = Vec::new();
+        let mut untimed_candidates = Vec::new();
         for owner in owners {
             let key = (owner, usage_key(&usage));
-            let Some(count) = available_children.get_mut(&key) else {
+            let Some(children) = available_children.get(&key) else {
                 continue;
             };
-            if *count > 0 {
-                *count -= 1;
-                represented_attributions.insert(id);
-                break;
-            }
-        }
-    }
-
-    let mut attribution_fallback_bases = HashSet::new();
-    for adjustment in accounting.iter().flat_map(|file| &file.adjustments) {
-        if let Some(base) = fallback_key_base(&adjustment.dedup_key) {
-            attribution_fallback_bases.insert(base.to_string());
-        }
-        let mut represented_usage = TokenBreakdown::default();
-        for attribution in &adjustment.attributions {
-            if represented_attributions.contains(&attribution.id) {
-                add_usage(&mut represented_usage, &attribution.child_usage);
-            }
-        }
-        if represented_usage == TokenBreakdown::default() {
-            continue;
-        }
-        for message in &mut messages {
-            if message.dedup_key.as_deref() == Some(&adjustment.dedup_key)
-                && message.tokens == adjustment.persisted_usage
-            {
-                subtract_usage(&mut message.tokens, &represented_usage);
-                if let Some(key) = message.dedup_key.as_deref() {
-                    message.dedup_key = Some(rewrite_fallback_usage(key, &message.tokens));
+            for (index, child_timestamp) in children.iter().enumerate() {
+                match (attribution_timestamp, *child_timestamp) {
+                    (Some(attribution), Some(child)) => {
+                        let distance = attribution.abs_diff(child) as i64;
+                        if distance <= ATTRIBUTION_TIMESTAMP_TOLERANCE_MS {
+                            timed_candidates.push((distance, key.clone(), index));
+                        }
+                    }
+                    _ => untimed_candidates.push((key.clone(), index)),
                 }
             }
         }
+
+        timed_candidates.sort_by_key(|candidate| candidate.0);
+        let selected = timed_candidates.first().and_then(|best| {
+            let tied = timed_candidates.get(1).is_some_and(|next| next.0 == best.0);
+            (!tied).then(|| (best.1.clone(), best.2))
+        });
+        let selected = selected.or_else(|| {
+            (timed_candidates.is_empty() && untimed_candidates.len() == 1)
+                .then(|| untimed_candidates.remove(0))
+        });
+        if let Some((key, index)) = selected {
+            if let Some(children) = available_children.get_mut(&key) {
+                children.swap_remove(index);
+                represented_attributions.insert(id);
+            }
+        }
     }
 
-    let mut deduped = Vec::<UnifiedMessage>::new();
-    let mut seen = HashMap::<String, usize>::new();
-    for message in messages {
-        let Some(key) = message.dedup_key.as_deref() else {
-            deduped.push(message);
+    let mut adjustment_groups: HashMap<String, Vec<&PrimeUsageAdjustment>> = HashMap::new();
+    let mut attribution_fallback_bases = HashSet::new();
+    for adjustment in accounting.iter().flat_map(|file| &file.adjustments) {
+        let identity = fallback_key_base(&adjustment.dedup_key)
+            .inspect(|base| {
+                attribution_fallback_bases.insert((*base).to_string());
+            })
+            .unwrap_or(&adjustment.dedup_key)
+            .to_string();
+        adjustment_groups
+            .entry(identity)
+            .or_default()
+            .push(adjustment);
+    }
+
+    let mut grouped: HashMap<String, Vec<UnifiedMessage>> = HashMap::new();
+    let mut group_order = Vec::new();
+    for (ordinal, message) in messages.into_iter().enumerate() {
+        let identity = message.dedup_key.as_deref().map_or_else(
+            || format!("prime-agent:unkeyed:{ordinal}"),
+            |key| {
+                fallback_key_base(key)
+                    .filter(|base| attribution_fallback_bases.contains(*base))
+                    .unwrap_or(key)
+                    .to_string()
+            },
+        );
+        if !grouped.contains_key(&identity) {
+            group_order.push(identity.clone());
+        }
+        grouped.entry(identity).or_default().push(message);
+    }
+
+    let mut deduped = Vec::with_capacity(group_order.len());
+    for identity in group_order {
+        let mut group = grouped.remove(&identity).unwrap_or_default();
+        let Some(mut representative) = group.first().cloned() else {
             continue;
         };
-        let identity = fallback_key_base(key)
-            .filter(|base| attribution_fallback_bases.contains(*base))
-            .unwrap_or(key)
-            .to_string();
-        if let Some(index) = seen.get(&identity).copied() {
-            let existing = &mut deduped[index];
-            existing.tokens.input = existing.tokens.input.max(message.tokens.input);
-            existing.tokens.output = existing.tokens.output.max(message.tokens.output);
-            existing.tokens.cache_read = existing.tokens.cache_read.max(message.tokens.cache_read);
-            existing.tokens.cache_write =
-                existing.tokens.cache_write.max(message.tokens.cache_write);
-        } else {
-            seen.insert(identity, deduped.len());
-            deduped.push(message);
+        let Some(adjustments) = adjustment_groups.get(&identity) else {
+            for duplicate in group.iter().skip(1) {
+                maximize_usage(&mut representative.tokens, &duplicate.tokens);
+            }
+            deduped.push(representative);
+            continue;
+        };
+
+        let mut base_usage = TokenBreakdown::default();
+        let mut found_base = false;
+        let mut all_attributions: BTreeMap<String, TokenBreakdown> = BTreeMap::new();
+        for adjustment in adjustments {
+            let mut own_usage = adjustment.persisted_usage.clone();
+            for attribution in &adjustment.attributions {
+                subtract_usage(&mut own_usage, &attribution.child_usage);
+                all_attributions
+                    .entry(attribution.id.clone())
+                    .or_insert_with(|| attribution.child_usage.clone());
+            }
+            maximize_usage(&mut base_usage, &own_usage);
+            found_base = true;
         }
+        for message in &group {
+            let is_aggregate_copy = adjustments.iter().any(|adjustment| {
+                message.dedup_key.as_deref() == Some(&adjustment.dedup_key)
+                    && message.tokens == adjustment.persisted_usage
+            });
+            if !is_aggregate_copy {
+                maximize_usage(&mut base_usage, &message.tokens);
+                found_base = true;
+            }
+        }
+        if !found_base {
+            for message in &group {
+                maximize_usage(&mut base_usage, &message.tokens);
+            }
+        }
+        for (id, usage) in all_attributions {
+            if !represented_attributions.contains(&id) {
+                add_usage(&mut base_usage, &usage);
+            }
+        }
+
+        representative.tokens = base_usage;
+        if let Some(key) = representative.dedup_key.as_deref() {
+            representative.dedup_key = Some(rewrite_fallback_usage(key, &representative.tokens));
+        }
+        group.clear();
+        deduped.push(representative);
     }
     deduped
 }
@@ -440,6 +532,134 @@ mod tests {
         assert_eq!(messages[0].tokens.output, 70);
         assert_eq!(messages[0].tokens.cache_read, 20);
         assert_eq!(messages[0].tokens.cache_write, 10);
+    }
+
+    #[test]
+    fn blank_model_message_does_not_shift_accounting_alignment() {
+        let file = session_file(
+            r#"{"type":"session","version":3,"id":"root","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"blank","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"","responseId":"blank-response","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2}}}
+{"type":"message","id":"parent","parentId":"blank","timestamp":"2026-08-08T00:00:02.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":150,"output":70,"cacheRead":20,"cacheWrite":10,"totalTokens":250}}}
+{"type":"child_usage_attributed","id":"usage-1","parentId":"parent","timestamp":"2026-08-08T00:00:03.000Z","targetId":"parent","childUsage":{"input":50,"output":20,"cacheRead":0,"cacheWrite":0,"totalTokens":70},"aggregateUsage":{"input":150,"output":70,"cacheRead":20,"cacheWrite":10,"totalTokens":250},"origin":"spawn_task"}"#,
+        );
+
+        let messages = parse_prime_agent_file(file.path());
+        let accounting = analyze_prime_agent_accounting(file.path(), &messages);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(accounting.adjustments.len(), 1);
+        assert_eq!(
+            accounting.adjustments[0].dedup_key,
+            "prime-agent:response:parent-response"
+        );
+    }
+
+    #[test]
+    fn sibling_forks_preserve_each_distinct_unavailable_child_delta() {
+        fn tokens(input: i64) -> TokenBreakdown {
+            TokenBreakdown {
+                input,
+                ..TokenBreakdown::default()
+            }
+        }
+        fn parent_message(input: i64, session: &str) -> UnifiedMessage {
+            let mut message = UnifiedMessage::new(
+                "prime-agent",
+                "claude-opus-5",
+                "anthropic",
+                session,
+                1,
+                tokens(input),
+                0.0,
+            );
+            message.dedup_key = Some("prime-agent:response:shared-parent".to_string());
+            message
+        }
+        fn fork_accounting(
+            source: &str,
+            attribution_id: &str,
+            child_input: i64,
+        ) -> PrimeFileAccounting {
+            let attribution = PrimeAttribution {
+                id: attribution_id.to_string(),
+                timestamp: Some(1),
+                child_usage: tokens(child_input),
+                aggregate_usage: tokens(100 + child_input),
+            };
+            PrimeFileAccounting {
+                source_path: PathBuf::from(source),
+                attributions: vec![attribution.clone()],
+                adjustments: vec![PrimeUsageAdjustment {
+                    dedup_key: "prime-agent:response:shared-parent".to_string(),
+                    persisted_usage: tokens(100 + child_input),
+                    attributions: vec![attribution],
+                }],
+                ..PrimeFileAccounting::default()
+            }
+        }
+
+        let messages = vec![parent_message(150, "fork-a"), parent_message(130, "fork-b")];
+        let accounting = [
+            fork_accounting("fork-a.jsonl", "child-a", 50),
+            fork_accounting("fork-b.jsonl", "child-b", 30),
+        ];
+        let messages = reconcile_prime_agent_messages(messages, &accounting);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 180);
+    }
+
+    #[test]
+    fn equal_child_usage_is_matched_by_parent_lineage_and_completion_time() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let parent_path = dir.path().join("parent.jsonl");
+        let child_path = dir.path().join("child.jsonl");
+        std::fs::write(
+            &parent_path,
+            r#"{"type":"session","version":3,"id":"parent","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent-a","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"model-a","responseId":"parent-response-a","usage":{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150}}}
+{"type":"child_usage_attributed","id":"usage-a","parentId":"parent-a","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent-a","childUsage":{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50},"aggregateUsage":{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150},"origin":"spawn_task"}
+{"type":"message","id":"parent-b","parentId":"usage-a","timestamp":"2026-08-08T00:00:10.000Z","message":{"role":"assistant","provider":"anthropic","model":"model-b","responseId":"parent-response-b","usage":{"input":250,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":250}}}
+{"type":"child_usage_attributed","id":"usage-b","parentId":"parent-b","timestamp":"2026-08-08T00:00:11.000Z","targetId":"parent-b","childUsage":{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50},"aggregateUsage":{"input":250,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":250},"origin":"spawn_task"}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            &child_path,
+            format!(
+                r#"{{"type":"session","version":3,"id":"child","timestamp":"2026-08-08T00:00:10.000Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child-message","parentId":null,"timestamp":"2026-08-08T00:00:11.001Z","message":{{"role":"assistant","provider":"anthropic","model":"child-model","responseId":"child-response","usage":{{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50}}}}}}
+"#,
+                serde_json::to_string(&parent_path.to_string_lossy()).unwrap()
+            ),
+        )
+        .unwrap();
+
+        let parent_messages = parse_prime_agent_file(&parent_path);
+        let child_messages = parse_prime_agent_file(&child_path);
+        let accounting = [
+            analyze_prime_agent_accounting(&parent_path, &parent_messages),
+            analyze_prime_agent_accounting(&child_path, &child_messages),
+        ];
+        let messages = reconcile_prime_agent_messages(
+            parent_messages.into_iter().chain(child_messages).collect(),
+            &accounting,
+        );
+
+        let parent_a = messages
+            .iter()
+            .find(|message| {
+                message.dedup_key.as_deref() == Some("prime-agent:response:parent-response-a")
+            })
+            .unwrap();
+        let parent_b = messages
+            .iter()
+            .find(|message| {
+                message.dedup_key.as_deref() == Some("prime-agent:response:parent-response-b")
+            })
+            .unwrap();
+        assert_eq!(parent_a.tokens.input, 150);
+        assert_eq!(parent_b.tokens.input, 200);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -108,22 +108,50 @@ fn usage_key(usage: &TokenBreakdown) -> UsageKey {
 /// the parent's `child_usage_attributed` records verbatim, so all copies within
 /// one chain describe the same invocation and must share an attribution
 /// identity. Files in different chains never do.
+///
+/// A chain can loop: two files can name each other as fork parent, and a rewritten
+/// or relocated session can close a longer loop. Stopping the walk on a repeat is
+/// not enough, because each member would then stop at itself and the copies would
+/// be accounted for as unrelated attributions, restoring the same child delta once
+/// per member. Every member of a loop therefore resolves to a single deterministic
+/// representative instead.
 fn lineage_roots(accounting: &[PrimeFileAccounting]) -> HashMap<PathBuf, PathBuf> {
     let forked_from: HashMap<&PathBuf, &PathBuf> = accounting
         .iter()
         .filter_map(|file| Some((&file.source_path, file.fork_parent_path.as_ref()?)))
         .collect();
-    let mut roots = HashMap::new();
+    let mut roots: HashMap<PathBuf, PathBuf> = HashMap::new();
     for file in accounting {
-        let mut root = &file.source_path;
-        let mut visited = HashSet::new();
-        while visited.insert(root.clone()) {
-            let Some(parent) = forked_from.get(root) else {
-                break;
-            };
-            root = parent;
+        // Walk the fork chain, remembering the order the files were seen so a
+        // cycle can be recognized by where it closes rather than merely stopped.
+        let mut chain: Vec<PathBuf> = Vec::new();
+        let mut position: HashMap<PathBuf, usize> = HashMap::new();
+        let mut node = file.source_path.clone();
+        let root = loop {
+            if let Some(resolved) = roots.get(&node) {
+                break resolved.clone();
+            }
+            if let Some(entered) = position.get(&node).copied() {
+                // A fork chain that loops back on itself: every file in the loop
+                // is a copy of the same fork history, so they must collapse onto
+                // one representative instead of each becoming its own root. Take
+                // the smallest path in the loop, which no scan order can change.
+                break chain[entered..].iter().min().cloned().unwrap_or(node);
+            }
+            position.insert(node.clone(), chain.len());
+            chain.push(node.clone());
+            match forked_from.get(&node) {
+                Some(parent) => node = (*parent).clone(),
+                // The head of an acyclic chain is its own root.
+                None => break node,
+            }
+        };
+        // Memoized for the whole walk: every file on a chain shares its root, and
+        // a chain that runs into a loop adopts the loop's representative.
+        for member in chain {
+            roots.insert(member, root.clone());
         }
-        roots.insert(file.source_path.clone(), root.clone());
+        roots.entry(file.source_path.clone()).or_insert(root);
     }
     roots
 }
@@ -321,30 +349,195 @@ fn rewrite_fallback_usage(key: &str, usage: &TokenBreakdown) -> String {
     )
 }
 
-/// Claim one eligible child response for `attribution`, re-seating an already
-/// matched attribution along an augmenting path when that frees a response.
-/// Returns whether `attribution` ended up matched. This is Kuhn's algorithm; it
-/// recurses only through attributions that contend for the same equal-usage
-/// child responses inside one lineage, which is a handful even in long threads.
-fn match_child_response(
-    attribution: usize,
-    eligible: &[Vec<ChildResponseRef>],
-    matched_children: &mut HashMap<ChildResponseRef, usize>,
-    visited: &mut HashSet<ChildResponseRef>,
-) -> bool {
-    for candidate in &eligible[attribution] {
-        if !visited.insert(candidate.clone()) {
-            continue;
-        }
-        let holder = matched_children.get(candidate).copied();
-        if holder
-            .is_none_or(|holder| match_child_response(holder, eligible, matched_children, visited))
-        {
-            matched_children.insert(candidate.clone(), attribution);
-            return true;
+/// Timestamp distance in milliseconds between an attribution and a parsed child
+/// response. A lower cost is a better explanation of one completion event.
+type MatchCost = i64;
+
+/// One independent contention group, in dense local indices: the attributions
+/// that reach a shared set of child responses, directly or transitively.
+/// Separate components never influence each other, so each is matched alone.
+struct MatchingComponent {
+    /// Local attribution index -> index into the global attribution key list.
+    attributions: Vec<usize>,
+    /// Local attribution index -> its eligible (local child index, cost) pairs.
+    edges: Vec<Vec<(usize, MatchCost)>>,
+    children: usize,
+}
+
+fn disjoint_set_root(parents: &mut [usize], node: usize) -> usize {
+    let mut root = node;
+    while parents[root] != root {
+        root = parents[root];
+    }
+    let mut walk = node;
+    while parents[walk] != root {
+        let next = parents[walk];
+        parents[walk] = root;
+        walk = next;
+    }
+    root
+}
+
+/// Split the attribution/child graph into connected components, so the
+/// attributions that genuinely contend for the same child responses are matched
+/// together while unrelated sessions stay out of each other's cost accounting.
+fn matching_components(eligible: &[Vec<(MatchCost, ChildResponseRef)>]) -> Vec<MatchingComponent> {
+    let mut child_indices: BTreeMap<ChildResponseRef, usize> = BTreeMap::new();
+    for candidates in eligible {
+        for (_, candidate) in candidates {
+            let next = child_indices.len();
+            child_indices.entry(candidate.clone()).or_insert(next);
         }
     }
-    false
+    let mut parents: Vec<usize> = (0..eligible.len() + child_indices.len()).collect();
+    for (attribution, candidates) in eligible.iter().enumerate() {
+        for (_, candidate) in candidates {
+            let child = eligible.len() + child_indices[candidate];
+            let left = disjoint_set_root(&mut parents, attribution);
+            let right = disjoint_set_root(&mut parents, child);
+            if left != right {
+                parents[left] = right;
+            }
+        }
+    }
+    let mut grouped: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for (attribution, candidates) in eligible.iter().enumerate() {
+        if candidates.is_empty() {
+            continue;
+        }
+        let root = disjoint_set_root(&mut parents, attribution);
+        grouped.entry(root).or_default().push(attribution);
+    }
+    grouped
+        .into_values()
+        .map(|attributions| {
+            let mut local_children: BTreeMap<ChildResponseRef, usize> = BTreeMap::new();
+            let mut edges = Vec::with_capacity(attributions.len());
+            for attribution in &attributions {
+                let mut candidates = Vec::new();
+                for (cost, candidate) in &eligible[*attribution] {
+                    let next = local_children.len();
+                    let child = *local_children.entry(candidate.clone()).or_insert(next);
+                    candidates.push((child, *cost));
+                }
+                edges.push(candidates);
+            }
+            MatchingComponent {
+                attributions,
+                edges,
+                children: local_children.len(),
+            }
+        })
+        .collect()
+}
+
+/// Minimum-cost maximum matching over one component, by successive shortest
+/// augmenting paths: every augmentation takes the cheapest path that adds one
+/// pair, so the result is a maximum matching whose total timestamp distance is
+/// the smallest of any maximum matching. Plain maximum-cardinality matching is
+/// not enough here -- it fixes how many attributions are matched but not which
+/// ones -- so this is what stops an attribution that merely lands inside the
+/// tolerance window from consuming a child response another attribution explains
+/// exactly.
+///
+/// `blocked` removes one attribution from the component, which is how the caller
+/// asks whether that attribution is dispensable at no extra cost.
+///
+/// Returns the cardinality, the total cost, and each local attribution's child.
+fn min_cost_max_matching(
+    component: &MatchingComponent,
+    blocked: Option<usize>,
+) -> (usize, MatchCost, Vec<Option<usize>>) {
+    let attributions = component.edges.len();
+    let children = component.children;
+    let source = attributions + children;
+    let sink = source + 1;
+    let mut matched_attribution: Vec<Option<usize>> = vec![None; attributions];
+    let mut matched_child: Vec<Option<usize>> = vec![None; children];
+    let mut cardinality = 0usize;
+
+    loop {
+        // Residual arcs: an unused pairing costs its distance and a used one
+        // refunds it, so the cheapest source-to-sink walk is the cheapest way
+        // to gain one pair. Refunds are negative, hence Bellman-Ford rather
+        // than Dijkstra; a component is the handful of attributions sharing one
+        // equal-usage bucket inside one lineage.
+        let mut residual: Vec<(usize, usize, MatchCost)> = Vec::new();
+        for (attribution, matched) in matched_attribution.iter().enumerate() {
+            if blocked == Some(attribution) {
+                continue;
+            }
+            if matched.is_none() {
+                residual.push((source, attribution, 0));
+            }
+            for &(child, cost) in &component.edges[attribution] {
+                if *matched == Some(child) {
+                    residual.push((attributions + child, attribution, -cost));
+                } else {
+                    residual.push((attribution, attributions + child, cost));
+                }
+            }
+        }
+        for (child, matched) in matched_child.iter().enumerate() {
+            if matched.is_none() {
+                residual.push((attributions + child, sink, 0));
+            }
+        }
+
+        let mut distance: Vec<Option<MatchCost>> = vec![None; sink + 1];
+        let mut previous: Vec<Option<usize>> = vec![None; sink + 1];
+        distance[source] = Some(0);
+        for _ in 0..=sink {
+            let mut improved = false;
+            for &(from, to, cost) in &residual {
+                let Some(reached) = distance[from] else {
+                    continue;
+                };
+                let candidate = reached + cost;
+                if distance[to].is_none_or(|current| candidate < current) {
+                    distance[to] = Some(candidate);
+                    previous[to] = Some(from);
+                    improved = true;
+                }
+            }
+            if !improved {
+                break;
+            }
+        }
+        if distance[sink].is_none() {
+            break;
+        }
+
+        // Re-seat every pairing the augmenting path crosses. A shortest path is
+        // simple, so each attribution and each child response appears at most
+        // once and the rewrites are independent of the order applied.
+        let mut node = sink;
+        let mut steps = 0;
+        while let Some(from) = previous[node] {
+            if from < attributions && (attributions..source).contains(&node) {
+                let child = node - attributions;
+                matched_attribution[from] = Some(child);
+                matched_child[child] = Some(from);
+            }
+            node = from;
+            steps += 1;
+            if steps > sink {
+                break;
+            }
+        }
+        cardinality += 1;
+    }
+
+    let mut cost = 0;
+    for (attribution, matched) in matched_attribution.iter().enumerate() {
+        if let Some(child) = matched {
+            cost += component.edges[attribution]
+                .iter()
+                .find(|(candidate, _)| candidate == child)
+                .map_or(0, |(_, cost)| *cost);
+        }
+    }
+    (cardinality, cost, matched_attribution)
 }
 
 /// Subtract child usage only when a matching RLM transcript was actually
@@ -424,14 +617,31 @@ pub(crate) fn reconcile_prime_agent_messages(
     //    discarded as ambiguous, which would count both the children and the
     //    parent aggregate that already contains them.
     //
-    // Rule 3 uses augmenting paths rather than nearest-first greed so that a
-    // contested child response cannot strand an attribution that had no other
-    // candidate. Every attribution contending for one child response carries
-    // the same `childUsage` (the pool is keyed by usage), so the reconciled
-    // total depends only on how many attributions are matched, never on which
-    // maximum matching is found.
+    // Rule 3 is settled by a minimum-cost maximum matching, the cost of a
+    // pairing being its timestamp distance. Maximum cardinality alone fixes how
+    // MANY attributions are matched but not WHICH ones, and that choice decides
+    // which parent response gets its aggregate reduced. Every attribution
+    // contending for one child response carries the same `childUsage`, so the
+    // global token total is the same for every maximum matching -- but the
+    // per-model rows are not, and pricing is applied per model after
+    // reconciliation, so an arbitrary choice silently moves cost between models.
+    // Minimum cost keeps an attribution that merely lands inside the tolerance
+    // window from consuming a child response another attribution explains
+    // exactly.
+    //
+    // Remaining ties are resolved conservatively rather than arbitrarily. An
+    // attribution is represented only when EVERY minimum-cost maximum matching
+    // contains it; if an equally cheap matching exists that leaves it out, the
+    // transcripts do not say which aggregate spent that child, so the aggregate
+    // is retained -- the same fallback used for a child that was never parsed.
+    // That rule is deterministic and independent of attribution id ordering. It
+    // cannot decide the residual case where two attributions belonging to
+    // different parent responses describe equally sized children that completed
+    // in the very same millisecond: nothing in the records distinguishes them,
+    // and proving identity there would need an upstream child or response id on
+    // the attribution record.
     let attribution_keys: Vec<AttributionKey> = unique_attributions.keys().cloned().collect();
-    let eligible: Vec<Vec<ChildResponseRef>> = unique_attributions
+    let eligible: Vec<Vec<(MatchCost, ChildResponseRef)>> = unique_attributions
         .values()
         .map(|(usage, attribution_timestamp, owners)| {
             let mut candidates: Vec<(i64, ChildResponseRef)> = Vec::new();
@@ -459,21 +669,31 @@ pub(crate) fn reconcile_prime_agent_messages(
             }
             candidates.sort();
             candidates
-                .into_iter()
-                .map(|(_, candidate)| candidate)
-                .collect()
         })
         .collect();
 
-    let mut matched_children: HashMap<ChildResponseRef, usize> = HashMap::new();
-    for attribution in 0..attribution_keys.len() {
-        let mut visited = HashSet::new();
-        match_child_response(attribution, &eligible, &mut matched_children, &mut visited);
+    let mut represented_attributions: HashSet<AttributionKey> = HashSet::new();
+    for component in matching_components(&eligible) {
+        let (cardinality, cost, assignment) = min_cost_max_matching(&component, None);
+        // When the matching already covers every attribution in the component,
+        // dropping any one of them shrinks it, so none of them is dispensable
+        // and there is nothing left to disambiguate.
+        let saturated = cardinality == component.edges.len();
+        for (local, matched) in assignment.iter().enumerate() {
+            if matched.is_none() {
+                continue;
+            }
+            if !saturated {
+                let (alternate_cardinality, alternate_cost, _) =
+                    min_cost_max_matching(&component, Some(local));
+                if alternate_cardinality == cardinality && alternate_cost == cost {
+                    continue;
+                }
+            }
+            represented_attributions
+                .insert(attribution_keys[component.attributions[local]].clone());
+        }
     }
-    let represented_attributions: HashSet<AttributionKey> = matched_children
-        .into_values()
-        .map(|attribution| attribution_keys[attribution].clone())
-        .collect();
 
     let mut adjustment_groups: HashMap<String, Vec<(PathBuf, &PrimeUsageAdjustment)>> =
         HashMap::new();
@@ -1203,6 +1423,287 @@ mod tests {
 
         assert_eq!(totals(false), (150, 100));
         assert_eq!(totals(true), (150, 100));
+    }
+
+    /// Maximum-cardinality matching alone leaves which attribution wins a
+    /// contested child response up to the order attributions happen to be
+    /// visited in, which is their random 8-hex id order. The global token total
+    /// survives that, but the per-model rows do not, and pricing is applied per
+    /// model after reconciliation -- so the cost of a pruned child lands on the
+    /// wrong model. The nearer pairing must win regardless of id order.
+    #[test]
+    fn the_nearest_attribution_wins_a_contested_child_response() {
+        fn per_model_input(reverse: bool, swap_ids: bool) -> HashMap<String, i64> {
+            let (id_a, id_b) = if swap_ids {
+                ("ffffffff", "00000000")
+            } else {
+                ("00000000", "ffffffff")
+            };
+            let dir = tempfile::TempDir::new().unwrap();
+            let parent_path = dir.path().join("parent.jsonl");
+            let child_path = dir.path().join("child.jsonl");
+            // Two parent responses, each persisting a 150 aggregate that is 100
+            // of its own plus one 50-token child. Only the second parent's child
+            // transcript survives; the first parent's child was pruned.
+            std::fs::write(
+                &parent_path,
+                format!(
+                    r#"{{"type":"session","version":3,"id":"parent","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}}
+{{"type":"message","id":"parent-a","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{{"role":"assistant","provider":"anthropic","model":"model-a","responseId":"parent-response-a","usage":{{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150}}}}}}
+{{"type":"child_usage_attributed","id":"{id_a}","parentId":"parent-a","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent-a","childUsage":{{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50}},"aggregateUsage":{{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150}},"origin":"spawn_task"}}
+{{"type":"message","id":"parent-b","parentId":"{id_a}","timestamp":"2026-08-08T00:00:01.500Z","message":{{"role":"assistant","provider":"anthropic","model":"model-b","responseId":"parent-response-b","usage":{{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150}}}}}}
+{{"type":"child_usage_attributed","id":"{id_b}","parentId":"parent-b","timestamp":"2026-08-08T00:00:02.002Z","targetId":"parent-b","childUsage":{{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50}},"aggregateUsage":{{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150}},"origin":"spawn_task"}}
+"#
+                ),
+            )
+            .unwrap();
+            // The surviving child completed in the same millisecond as the
+            // second parent's attribution, and two milliseconds from the first
+            // parent's -- inside the tolerance window for both.
+            std::fs::write(
+                &child_path,
+                format!(
+                    r#"{{"type":"session","version":3,"id":"child","timestamp":"2026-08-08T00:00:01.600Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child-message","parentId":null,"timestamp":"2026-08-08T00:00:02.002Z","message":{{"role":"assistant","provider":"anthropic","model":"child-model","responseId":"child-response","usage":{{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50}}}}}}
+"#,
+                    serde_json::to_string(&parent_path.to_string_lossy()).unwrap()
+                ),
+            )
+            .unwrap();
+
+            let mut paths = vec![parent_path, child_path];
+            if reverse {
+                paths.reverse();
+            }
+            let parsed: Vec<(PathBuf, Vec<UnifiedMessage>)> = paths
+                .into_iter()
+                .map(|path| {
+                    let messages = parse_prime_agent_file(&path);
+                    (path, messages)
+                })
+                .collect();
+            let accounting: Vec<PrimeFileAccounting> = parsed
+                .iter()
+                .map(|(path, messages)| analyze_prime_agent_accounting(path, messages))
+                .collect();
+            let messages: Vec<UnifiedMessage> = parsed
+                .into_iter()
+                .flat_map(|(_, messages)| messages)
+                .collect();
+            let messages = reconcile_prime_agent_messages(messages, &accounting);
+
+            let mut per_model: HashMap<String, i64> = HashMap::new();
+            for message in &messages {
+                *per_model.entry(message.model_id.clone()).or_default() += message.tokens.input;
+            }
+            per_model
+        }
+
+        for reverse in [false, true] {
+            for swap_ids in [false, true] {
+                let per_model = per_model_input(reverse, swap_ids);
+                assert_eq!(
+                    per_model.get("model-a").copied(),
+                    Some(150),
+                    "the parent whose child was pruned keeps its aggregate \
+                     (reverse={reverse}, swap_ids={swap_ids})"
+                );
+                assert_eq!(
+                    per_model.get("model-b").copied(),
+                    Some(100),
+                    "the parent whose child survived keeps only its own usage \
+                     (reverse={reverse}, swap_ids={swap_ids})"
+                );
+                assert_eq!(per_model.get("child-model").copied(), Some(50));
+                assert_eq!(per_model.values().sum::<i64>(), 300);
+            }
+        }
+    }
+
+    /// Two fork copies that name each other as fork parent describe one fork
+    /// history, so their copies of one attribution must collapse. Resolving each
+    /// copy to itself instead makes the pair look like two independent
+    /// attributions, and the unavailable child's delta is restored once per copy.
+    #[test]
+    fn a_fork_parent_loop_collapses_onto_one_lineage() {
+        fn totals(reverse: bool, with_child: bool) -> (i64, i64) {
+            let dir = tempfile::TempDir::new().unwrap();
+            let first_path = dir.path().join("fork-a.jsonl");
+            let second_path = dir.path().join("fork-b.jsonl");
+            let child_path = dir.path().join("child.jsonl");
+            // Each copy names the other as its fork parent, and both carry the
+            // same response, the same attribution id, and the same 150 aggregate
+            // that is 100 of their own plus one 50-token child.
+            for (path, fork_parent) in [(&first_path, &second_path), (&second_path, &first_path)] {
+                std::fs::write(
+                    path,
+                    format!(
+                        r#"{{"type":"session","version":3,"id":"fork","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":0}}
+{{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"shared-parent","usage":{{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150}}}}}}
+{{"type":"child_usage_attributed","id":"aaaa1111","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50}},"aggregateUsage":{{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150}},"origin":"spawn_task"}}
+"#,
+                        serde_json::to_string(&fork_parent.to_string_lossy()).unwrap()
+                    ),
+                )
+                .unwrap();
+            }
+            if with_child {
+                std::fs::write(
+                    &child_path,
+                    format!(
+                        r#"{{"type":"session","version":3,"id":"child","timestamp":"2026-08-08T00:00:01.500Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child-message","parentId":null,"timestamp":"2026-08-08T00:00:02.000Z","message":{{"role":"assistant","provider":"anthropic","model":"child-model","responseId":"child-response","usage":{{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50}}}}}}
+"#,
+                        serde_json::to_string(&first_path.to_string_lossy()).unwrap()
+                    ),
+                )
+                .unwrap();
+            }
+
+            let mut paths = vec![first_path, second_path];
+            if with_child {
+                paths.push(child_path);
+            }
+            if reverse {
+                paths.reverse();
+            }
+            let parsed: Vec<(PathBuf, Vec<UnifiedMessage>)> = paths
+                .into_iter()
+                .map(|path| {
+                    let messages = parse_prime_agent_file(&path);
+                    (path, messages)
+                })
+                .collect();
+            let accounting: Vec<PrimeFileAccounting> = parsed
+                .iter()
+                .map(|(path, messages)| analyze_prime_agent_accounting(path, messages))
+                .collect();
+            let messages: Vec<UnifiedMessage> = parsed
+                .into_iter()
+                .flat_map(|(_, messages)| messages)
+                .collect();
+            let messages = reconcile_prime_agent_messages(messages, &accounting);
+
+            let parent_input = messages
+                .iter()
+                .find(|message| {
+                    message.dedup_key.as_deref() == Some("prime-agent:response:shared-parent")
+                })
+                .map_or(0, |message| message.tokens.input);
+            (
+                messages.iter().map(|message| message.tokens.input).sum(),
+                parent_input,
+            )
+        }
+
+        for reverse in [false, true] {
+            // The child was never parsed, so the one aggregate is kept whole and
+            // counted once rather than once per fork copy.
+            assert_eq!(totals(reverse, false), (150, 150), "reverse={reverse}");
+            // The child transcript is available, so the collapsed parent keeps
+            // only its own 100 and the child is counted once from its own file.
+            assert_eq!(totals(reverse, true), (150, 100), "reverse={reverse}");
+        }
+    }
+
+    /// The partial case: three parent responses each claim a 50-token child
+    /// inside one timestamp window, but only two of those child transcripts
+    /// survive. Maximum cardinality fixes that two attributions are matched
+    /// without saying which two, so the surviving transcripts must go to the
+    /// attributions they are nearest to, not to whichever the scan reaches first.
+    #[test]
+    fn partial_equal_usage_matches_keep_each_attributions_identity() {
+        fn per_model_input(reverse: bool, descending_ids: bool) -> HashMap<String, i64> {
+            let mut ids = ["00000000", "88888888", "ffffffff"];
+            if descending_ids {
+                ids.reverse();
+            }
+            let dir = tempfile::TempDir::new().unwrap();
+            let parent_path = dir.path().join("parent.jsonl");
+            let mut parent = r#"{"type":"session","version":3,"id":"parent","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+"#
+            .to_string();
+            // model-a's child was pruned; model-b's and model-c's survived, each
+            // completing in the same millisecond as its own attribution.
+            for (model, id, millis) in [
+                ("model-a", ids[0], "000"),
+                ("model-b", ids[1], "003"),
+                ("model-c", ids[2], "006"),
+            ] {
+                parent.push_str(&format!(
+                    r#"{{"type":"message","id":"parent-{model}","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{{"role":"assistant","provider":"anthropic","model":"{model}","responseId":"response-{model}","usage":{{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150}}}}}}
+{{"type":"child_usage_attributed","id":"{id}","parentId":"parent-{model}","timestamp":"2026-08-08T00:00:02.{millis}Z","targetId":"parent-{model}","childUsage":{{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50}},"aggregateUsage":{{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150}},"origin":"spawn_task"}}
+"#
+                ));
+            }
+            std::fs::write(&parent_path, parent).unwrap();
+
+            let mut paths = vec![parent_path.clone()];
+            for (name, millis) in [("child-b", "003"), ("child-c", "006")] {
+                let child_path = dir.path().join(format!("{name}.jsonl"));
+                std::fs::write(
+                    &child_path,
+                    format!(
+                        r#"{{"type":"session","version":3,"id":"{name}","timestamp":"2026-08-08T00:00:01.500Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child-message","parentId":null,"timestamp":"2026-08-08T00:00:02.{millis}Z","message":{{"role":"assistant","provider":"anthropic","model":"child-model","responseId":"{name}-response","usage":{{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50}}}}}}
+"#,
+                        serde_json::to_string(&parent_path.to_string_lossy()).unwrap()
+                    ),
+                )
+                .unwrap();
+                paths.push(child_path);
+            }
+            if reverse {
+                paths.reverse();
+            }
+
+            let parsed: Vec<(PathBuf, Vec<UnifiedMessage>)> = paths
+                .into_iter()
+                .map(|path| {
+                    let messages = parse_prime_agent_file(&path);
+                    (path, messages)
+                })
+                .collect();
+            let accounting: Vec<PrimeFileAccounting> = parsed
+                .iter()
+                .map(|(path, messages)| analyze_prime_agent_accounting(path, messages))
+                .collect();
+            let messages: Vec<UnifiedMessage> = parsed
+                .into_iter()
+                .flat_map(|(_, messages)| messages)
+                .collect();
+            let messages = reconcile_prime_agent_messages(messages, &accounting);
+
+            let mut per_model: HashMap<String, i64> = HashMap::new();
+            for message in &messages {
+                *per_model.entry(message.model_id.clone()).or_default() += message.tokens.input;
+            }
+            per_model
+        }
+
+        for reverse in [false, true] {
+            for descending_ids in [false, true] {
+                let per_model = per_model_input(reverse, descending_ids);
+                let context = format!("reverse={reverse}, descending_ids={descending_ids}");
+                assert_eq!(
+                    per_model.get("model-a").copied(),
+                    Some(150),
+                    "the pruned child's aggregate is retained ({context})"
+                );
+                assert_eq!(
+                    per_model.get("model-b").copied(),
+                    Some(100),
+                    "model-b's own child authorizes its subtraction ({context})"
+                );
+                assert_eq!(
+                    per_model.get("model-c").copied(),
+                    Some(100),
+                    "model-c's own child authorizes its subtraction ({context})"
+                );
+                assert_eq!(per_model.get("child-model").copied(), Some(100));
+                assert_eq!(per_model.values().sum::<i64>(), 450);
+            }
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -440,8 +440,11 @@ fn matching_components(eligible: &[Vec<(MatchCost, ChildResponseRef)>]) -> Vec<M
 /// tolerance window from consuming a child response another attribution explains
 /// exactly.
 ///
-/// `blocked` removes one attribution from the component, which is how the caller
-/// asks whether that attribution is dispensable at no extra cost.
+/// `blocked` removes one attribution from the component, which answers whether
+/// that attribution is dispensable at no extra cost by brute force. Production
+/// code derives that from a single matching via `indispensable_attributions`;
+/// the parameter is kept so the tests can check the fast derivation against the
+/// definition it implements.
 ///
 /// Returns the cardinality, the total cost, and each local attribution's child.
 fn min_cost_max_matching(
@@ -538,6 +541,124 @@ fn min_cost_max_matching(
         }
     }
     (cardinality, cost, matched_attribution)
+}
+
+/// Which attributions appear in EVERY minimum-cost maximum matching of the
+/// component, derived from a single matching instead of re-solving the whole
+/// component once per matched attribution.
+///
+/// Read the matching as a unit-capacity min-cost flow of value `cardinality`:
+/// `source -> attribution -> child -> sink`. Any other matching of the same
+/// cardinality and the same cost is that flow plus a zero-cost circulation in
+/// the residual graph, and every such circulation splits into simple residual
+/// cycles that individually cost zero. Node potentials that make all residual
+/// arcs non-negative exist because the matching is already cost-optimal, and
+/// potentials cancel around a cycle, so a residual cycle costs zero exactly
+/// when every arc on it has zero reduced cost.
+///
+/// A matched attribution drops out of the matching precisely when such a cycle
+/// cancels its `source -> attribution` arc, i.e. when the residual arc
+/// `attribution -> source` has zero reduced cost and lies on a zero-reduced-cost
+/// cycle. Because that arc leads to `source`, the cycle exists exactly when
+/// `source` reaches the attribution over zero-reduced-cost residual arcs. So one
+/// Bellman-Ford pass for the potentials plus one traversal answers the question
+/// for every attribution at once.
+fn indispensable_attributions(
+    component: &MatchingComponent,
+    matched_attribution: &[Option<usize>],
+) -> Vec<bool> {
+    let attributions = component.edges.len();
+    let children = component.children;
+    let source = attributions + children;
+    let sink = source + 1;
+    let nodes = sink + 1;
+
+    let mut matched_child: Vec<Option<usize>> = vec![None; children];
+    for (attribution, matched) in matched_attribution.iter().enumerate() {
+        if let Some(child) = matched {
+            matched_child[*child] = Some(attribution);
+        }
+    }
+
+    // The complete residual graph, unlike the augmenting-path search, which can
+    // skip the arcs back to the source and out of the sink because a shortest
+    // path never takes them. A cycle that re-seats which child feeds the sink
+    // does take them, and that cycle can free an attribution, so they matter
+    // here.
+    let mut residual: Vec<(usize, usize, MatchCost)> = Vec::new();
+    for (attribution, matched) in matched_attribution.iter().enumerate() {
+        match matched {
+            None => residual.push((source, attribution, 0)),
+            Some(_) => residual.push((attribution, source, 0)),
+        }
+        for &(child, cost) in &component.edges[attribution] {
+            if *matched == Some(child) {
+                residual.push((attributions + child, attribution, -cost));
+            } else {
+                residual.push((attribution, attributions + child, cost));
+            }
+        }
+    }
+    for (child, matched) in matched_child.iter().enumerate() {
+        match matched {
+            None => residual.push((attributions + child, sink, 0)),
+            Some(_) => residual.push((sink, attributions + child, 0)),
+        }
+    }
+
+    // Potentials, as Bellman-Ford from a virtual node joined to every node at
+    // zero cost: `potential[v] <= potential[u] + cost(u, v)` on every residual
+    // arc is exactly the non-negative reduced cost the argument above needs.
+    // The relaxation converges because a cost-optimal flow leaves no negative
+    // residual cycle.
+    let mut potential: Vec<MatchCost> = vec![0; nodes];
+    for _ in 0..nodes {
+        let mut improved = false;
+        for &(from, to, cost) in &residual {
+            let candidate = potential[from] + cost;
+            if candidate < potential[to] {
+                potential[to] = candidate;
+                improved = true;
+            }
+        }
+        if !improved {
+            break;
+        }
+    }
+    // `<= 0` rather than `== 0`: with converged potentials the two agree, and if
+    // they ever disagreed the extra arcs would only widen the set of
+    // attributions treated as dispensable, which is the conservative direction
+    // -- an unmatched attribution keeps its parent aggregate rather than
+    // authorizing a subtraction.
+    let reduced_cost =
+        |from: usize, to: usize, cost: MatchCost| cost + potential[from] - potential[to];
+
+    let mut adjacency: Vec<Vec<usize>> = vec![Vec::new(); nodes];
+    for &(from, to, cost) in &residual {
+        if reduced_cost(from, to, cost) <= 0 {
+            adjacency[from].push(to);
+        }
+    }
+    let mut reached = vec![false; nodes];
+    reached[source] = true;
+    let mut stack = vec![source];
+    while let Some(node) = stack.pop() {
+        for &next in &adjacency[node] {
+            if !reached[next] {
+                reached[next] = true;
+                stack.push(next);
+            }
+        }
+    }
+
+    matched_attribution
+        .iter()
+        .enumerate()
+        .map(|(attribution, matched)| {
+            matched.is_some()
+                && !(reached[attribution] && reduced_cost(attribution, source, 0) <= 0)
+        })
+        .collect()
 }
 
 /// Subtract child usage only when a matching RLM transcript was actually
@@ -674,24 +795,15 @@ pub(crate) fn reconcile_prime_agent_messages(
 
     let mut represented_attributions: HashSet<AttributionKey> = HashSet::new();
     for component in matching_components(&eligible) {
-        let (cardinality, cost, assignment) = min_cost_max_matching(&component, None);
-        // When the matching already covers every attribution in the component,
-        // dropping any one of them shrinks it, so none of them is dispensable
-        // and there is nothing left to disambiguate.
-        let saturated = cardinality == component.edges.len();
-        for (local, matched) in assignment.iter().enumerate() {
-            if matched.is_none() {
-                continue;
+        let (_, _, assignment) = min_cost_max_matching(&component, None);
+        for (local, indispensable) in indispensable_attributions(&component, &assignment)
+            .into_iter()
+            .enumerate()
+        {
+            if indispensable {
+                represented_attributions
+                    .insert(attribution_keys[component.attributions[local]].clone());
             }
-            if !saturated {
-                let (alternate_cardinality, alternate_cost, _) =
-                    min_cost_max_matching(&component, Some(local));
-                if alternate_cardinality == cardinality && alternate_cost == cost {
-                    continue;
-                }
-            }
-            represented_attributions
-                .insert(attribution_keys[component.attributions[local]].clone());
         }
     }
 
@@ -1704,6 +1816,131 @@ mod tests {
                 assert_eq!(per_model.values().sum::<i64>(), 450);
             }
         }
+    }
+
+    /// The definition the fast derivation implements: re-solve the component
+    /// with one attribution removed and see whether an equally cheap maximum
+    /// matching survives without it.
+    fn indispensable_by_reprobe(component: &MatchingComponent) -> Vec<bool> {
+        let (cardinality, cost, assignment) = min_cost_max_matching(component, None);
+        let saturated = cardinality == component.edges.len();
+        assignment
+            .iter()
+            .enumerate()
+            .map(|(local, matched)| {
+                if matched.is_none() {
+                    return false;
+                }
+                if saturated {
+                    return true;
+                }
+                let (alternate_cardinality, alternate_cost, _) =
+                    min_cost_max_matching(component, Some(local));
+                !(alternate_cardinality == cardinality && alternate_cost == cost)
+            })
+            .collect()
+    }
+
+    /// Deterministic xorshift, so a failing case is reproducible from its seed
+    /// without pulling a random-number crate into the dependency tree.
+    struct Rng(u64);
+
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            self.0 ^= self.0 << 13;
+            self.0 ^= self.0 >> 7;
+            self.0 ^= self.0 << 17;
+            self.0
+        }
+
+        fn below(&mut self, bound: usize) -> usize {
+            (self.next() % bound as u64) as usize
+        }
+    }
+
+    fn random_component(rng: &mut Rng, attributions: usize, children: usize) -> MatchingComponent {
+        // Three cost shapes, because ties are what make the tie rule bite: all
+        // pairings equally close, a mix of exact and merely-in-window hits, and
+        // fully spread timestamp distances.
+        let shape = rng.below(3);
+        let edges = (0..attributions)
+            .map(|_| {
+                let mut candidates: Vec<(usize, MatchCost)> = Vec::new();
+                for child in 0..children {
+                    // Partially pruned children: not every attribution reaches
+                    // every child response.
+                    if rng.below(3) == 0 {
+                        continue;
+                    }
+                    let cost = match shape {
+                        0 => [0, 0, 1001][rng.below(3)],
+                        1 => [0, 1, 2, 1001][rng.below(4)],
+                        _ => rng.below(1001) as MatchCost,
+                    };
+                    candidates.push((child, cost));
+                }
+                candidates.sort();
+                candidates
+            })
+            .collect();
+        MatchingComponent {
+            attributions: (0..attributions).collect(),
+            edges,
+            children,
+        }
+    }
+
+    #[test]
+    fn one_matching_decides_indispensability_the_same_way_as_re_solving() {
+        let mut rng = Rng(0x9e37_79b9_7f4a_7c15);
+        let mut checked = 0usize;
+        for _ in 0..4_000 {
+            let attributions = 1 + rng.below(8);
+            let children = 1 + rng.below(8);
+            let component = random_component(&mut rng, attributions, children);
+            if component.edges.iter().all(|edges| edges.is_empty()) {
+                continue;
+            }
+            let (_, _, assignment) = min_cost_max_matching(&component, None);
+            assert_eq!(
+                indispensable_attributions(&component, &assignment),
+                indispensable_by_reprobe(&component),
+                "component {:?} with {children} children",
+                component.edges
+            );
+            checked += 1;
+        }
+        assert!(checked > 3_000, "only {checked} components were generated");
+    }
+
+    #[test]
+    fn a_large_equal_usage_component_with_pruned_children_resolves_quickly() {
+        // 60 attributions in one equal-usage bucket, all landing on the same
+        // completion timestamp, with only half the child responses still on
+        // disk: the legacy shape where the per-attribution re-probe used to run
+        // a full matching 30 times over.
+        let attributions = 60usize;
+        let children = attributions / 2;
+        let component = MatchingComponent {
+            attributions: (0..attributions).collect(),
+            edges: (0..attributions)
+                .map(|_| (0..children).map(|child| (child, 0)).collect())
+                .collect(),
+            children,
+        };
+        let start = std::time::Instant::now();
+        let (cardinality, _, assignment) = min_cost_max_matching(&component, None);
+        let indispensable = indispensable_attributions(&component, &assignment);
+        let elapsed = start.elapsed();
+
+        assert_eq!(cardinality, children);
+        // Every attribution is interchangeable, so no matching is forced and
+        // each parent aggregate is kept.
+        assert!(indispensable.iter().all(|forced| !forced));
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "matching a 60-attribution component took {elapsed:?}"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -90,6 +90,10 @@ type LineageUsageKey = (PathBuf, UsageKey);
 /// one attribution collapsed while keeping a colliding id in an unrelated
 /// lineage independent.
 type AttributionKey = (PathBuf, String);
+/// One parsed child response: the pool bucket it landed in plus its position
+/// inside that bucket. Buckets are keyed by parent lineage and usage, so this
+/// identifies a single transcript entry without depending on scan order.
+type ChildResponseRef = (LineageUsageKey, usize);
 
 fn usage_key(usage: &TokenBreakdown) -> UsageKey {
     (
@@ -317,6 +321,32 @@ fn rewrite_fallback_usage(key: &str, usage: &TokenBreakdown) -> String {
     )
 }
 
+/// Claim one eligible child response for `attribution`, re-seating an already
+/// matched attribution along an augmenting path when that frees a response.
+/// Returns whether `attribution` ended up matched. This is Kuhn's algorithm; it
+/// recurses only through attributions that contend for the same equal-usage
+/// child responses inside one lineage, which is a handful even in long threads.
+fn match_child_response(
+    attribution: usize,
+    eligible: &[Vec<ChildResponseRef>],
+    matched_children: &mut HashMap<ChildResponseRef, usize>,
+    visited: &mut HashSet<ChildResponseRef>,
+) -> bool {
+    for candidate in &eligible[attribution] {
+        if !visited.insert(candidate.clone()) {
+            continue;
+        }
+        let holder = matched_children.get(candidate).copied();
+        if holder
+            .is_none_or(|holder| match_child_response(holder, eligible, matched_children, visited))
+        {
+            matched_children.insert(candidate.clone(), attribution);
+            return true;
+        }
+    }
+    false
+}
+
 /// Subtract child usage only when a matching RLM transcript was actually
 /// parsed, then collapse fork copies. Missing/pruned children remain represented
 /// by Prime's aggregate parent usage instead of disappearing from the total.
@@ -371,44 +401,79 @@ pub(crate) fn reconcile_prime_agent_messages(
         }
     }
 
-    let mut represented_attributions: HashSet<AttributionKey> = HashSet::new();
-    for (attribution_key, (usage, attribution_timestamp, owners)) in unique_attributions {
-        let mut timed_candidates = Vec::new();
-        let mut untimed_candidates = Vec::new();
-        for owner in owners {
-            let key = (owner, usage_key(&usage));
-            let Some(children) = available_children.get(&key) else {
-                continue;
-            };
-            for (index, child_timestamp) in children.iter().enumerate() {
-                match (attribution_timestamp, *child_timestamp) {
-                    (Some(attribution), Some(child)) => {
-                        let distance = attribution.abs_diff(child) as i64;
-                        if distance <= ATTRIBUTION_TIMESTAMP_TOLERANCE_MS {
-                            timed_candidates.push((distance, key.clone(), index));
+    // The matching rule, in full. An attribution authorizes subtracting its
+    // `childUsage` from the parent aggregate only when a parsed child response
+    // is matched to it, and a child response is eligible only when all three
+    // hold:
+    //
+    // 1. Lineage and size. The child's `parentSession` header must resolve to a
+    //    file that owns the attribution, and the child's usage must equal the
+    //    recorded `childUsage` bucket exactly.
+    // 2. Provable completion identity. Either both records carry a timestamp
+    //    within ATTRIBUTION_TIMESTAMP_TOLERANCE_MS -- Prime appends the
+    //    attribution milliseconds after the child response it describes -- or
+    //    neither record carries one, which only happens in transcripts written
+    //    before Prime timestamped its entries and where lineage plus size is
+    //    the only identity that exists. A half-timed pairing proves nothing, so
+    //    an unrelated same-sized sibling can never stand in for a pruned child
+    //    and shrink the parent.
+    // 3. Exclusivity. Matching is one-to-one: every child response authorizes
+    //    at most one attribution and every attribution consumes at most one
+    //    child response. N children of equal size completing in the same
+    //    millisecond pair off with their N attributions rather than being
+    //    discarded as ambiguous, which would count both the children and the
+    //    parent aggregate that already contains them.
+    //
+    // Rule 3 uses augmenting paths rather than nearest-first greed so that a
+    // contested child response cannot strand an attribution that had no other
+    // candidate. Every attribution contending for one child response carries
+    // the same `childUsage` (the pool is keyed by usage), so the reconciled
+    // total depends only on how many attributions are matched, never on which
+    // maximum matching is found.
+    let attribution_keys: Vec<AttributionKey> = unique_attributions.keys().cloned().collect();
+    let eligible: Vec<Vec<ChildResponseRef>> = unique_attributions
+        .values()
+        .map(|(usage, attribution_timestamp, owners)| {
+            let mut candidates: Vec<(i64, ChildResponseRef)> = Vec::new();
+            for owner in owners {
+                let key = (owner.clone(), usage_key(usage));
+                let Some(children) = available_children.get(&key) else {
+                    continue;
+                };
+                for (index, child_timestamp) in children.iter().enumerate() {
+                    match (attribution_timestamp, *child_timestamp) {
+                        (Some(attribution), Some(child)) => {
+                            let distance = attribution.abs_diff(child) as i64;
+                            if distance <= ATTRIBUTION_TIMESTAMP_TOLERANCE_MS {
+                                candidates.push((distance, (key.clone(), index)));
+                            }
                         }
+                        // Untimed on both sides: legacy transcripts, matched on
+                        // lineage and size alone and ranked after every timed
+                        // pairing.
+                        (None, None) => candidates
+                            .push((ATTRIBUTION_TIMESTAMP_TOLERANCE_MS + 1, (key.clone(), index))),
+                        _ => {}
                     }
-                    _ => untimed_candidates.push((key.clone(), index)),
                 }
             }
-        }
+            candidates.sort();
+            candidates
+                .into_iter()
+                .map(|(_, candidate)| candidate)
+                .collect()
+        })
+        .collect();
 
-        timed_candidates.sort_by_key(|candidate| candidate.0);
-        let selected = timed_candidates.first().and_then(|best| {
-            let tied = timed_candidates.get(1).is_some_and(|next| next.0 == best.0);
-            (!tied).then(|| (best.1.clone(), best.2))
-        });
-        let selected = selected.or_else(|| {
-            (timed_candidates.is_empty() && untimed_candidates.len() == 1)
-                .then(|| untimed_candidates.remove(0))
-        });
-        if let Some((key, index)) = selected {
-            if let Some(children) = available_children.get_mut(&key) {
-                children.swap_remove(index);
-                represented_attributions.insert(attribution_key);
-            }
-        }
+    let mut matched_children: HashMap<ChildResponseRef, usize> = HashMap::new();
+    for attribution in 0..attribution_keys.len() {
+        let mut visited = HashSet::new();
+        match_child_response(attribution, &eligible, &mut matched_children, &mut visited);
     }
+    let represented_attributions: HashSet<AttributionKey> = matched_children
+        .into_values()
+        .map(|attribution| attribution_keys[attribution].clone())
+        .collect();
 
     let mut adjustment_groups: HashMap<String, Vec<(PathBuf, &PrimeUsageAdjustment)>> =
         HashMap::new();
@@ -923,6 +988,221 @@ mod tests {
         // restored, so the row never reports a negative or absurd bucket.
         assert_eq!(messages[0].tokens.input, 90);
         assert_eq!(messages[0].tokens.output, 25);
+    }
+
+    /// Two child responses of the same size completing inside one timestamp
+    /// millisecond used to produce two tied candidates for each attribution.
+    /// Rejecting both ties left the parent aggregate holding both children while
+    /// the two child transcripts were also counted, double counting them.
+    #[test]
+    fn concurrent_equal_sized_children_pair_off_with_their_attributions() {
+        fn totals(reverse: bool) -> (i64, i64) {
+            let dir = tempfile::TempDir::new().unwrap();
+            let parent_path = dir.path().join("parent.jsonl");
+            let child_a = dir.path().join("child-a.jsonl");
+            let child_b = dir.path().join("child-b.jsonl");
+            std::fs::write(
+                &parent_path,
+                r#"{"type":"session","version":3,"id":"parent","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":300,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":300}}}
+{"type":"child_usage_attributed","id":"usage-a","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":100,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":100},"aggregateUsage":{"input":200,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":200},"origin":"spawn_task"}
+{"type":"child_usage_attributed","id":"usage-b","parentId":"usage-a","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":100,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":100},"aggregateUsage":{"input":300,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":300},"origin":"spawn_task"}
+"#,
+            )
+            .unwrap();
+            // Both children answered the same parent in the same millisecond, so
+            // neither timestamp distinguishes them from the other's attribution.
+            for (path, response) in [
+                (&child_a, "child-a-response"),
+                (&child_b, "child-b-response"),
+            ] {
+                std::fs::write(
+                    path,
+                    format!(
+                        r#"{{"type":"session","version":3,"id":"{response}","timestamp":"2026-08-08T00:00:01.500Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child-message","parentId":null,"timestamp":"2026-08-08T00:00:02.000Z","message":{{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"{response}","usage":{{"input":100,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":100}}}}}}
+"#,
+                        serde_json::to_string(&parent_path.to_string_lossy()).unwrap()
+                    ),
+                )
+                .unwrap();
+            }
+
+            let mut paths = vec![parent_path, child_a, child_b];
+            if reverse {
+                paths.reverse();
+            }
+            let parsed: Vec<(PathBuf, Vec<UnifiedMessage>)> = paths
+                .into_iter()
+                .map(|path| {
+                    let messages = parse_prime_agent_file(&path);
+                    (path, messages)
+                })
+                .collect();
+            let accounting: Vec<PrimeFileAccounting> = parsed
+                .iter()
+                .map(|(path, messages)| analyze_prime_agent_accounting(path, messages))
+                .collect();
+            let messages: Vec<UnifiedMessage> = parsed
+                .into_iter()
+                .flat_map(|(_, messages)| messages)
+                .collect();
+            let messages = reconcile_prime_agent_messages(messages, &accounting);
+
+            let parent_input = messages
+                .iter()
+                .find(|message| {
+                    message.dedup_key.as_deref() == Some("prime-agent:response:parent-response")
+                })
+                .map_or(0, |message| message.tokens.input);
+            (
+                messages.iter().map(|message| message.tokens.input).sum(),
+                parent_input,
+            )
+        }
+
+        // The parent keeps only its own 100; each of the two 100-token children
+        // is counted once from its own transcript.
+        assert_eq!(totals(false), (300, 100));
+        assert_eq!(totals(true), (300, 100));
+    }
+
+    /// A surviving child response with no completion timestamp cannot prove it
+    /// is the child a timed attribution describes. Accepting it because it was
+    /// the only same-sized bucket let an unrelated sibling authorize the
+    /// subtraction of a pruned child, undercounting billable usage.
+    #[test]
+    fn an_untimed_sibling_child_does_not_authorize_a_pruned_child_subtraction() {
+        fn totals(reverse: bool) -> (i64, i64) {
+            let dir = tempfile::TempDir::new().unwrap();
+            let parent_path = dir.path().join("parent.jsonl");
+            let sibling_path = dir.path().join("sibling.jsonl");
+            // The attributed child transcript is gone; only the attribution
+            // records that it spent 50 input tokens inside the 150 aggregate.
+            std::fs::write(
+                &parent_path,
+                r#"{"type":"session","version":3,"id":"parent","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150}}}
+{"type":"child_usage_attributed","id":"usage-a","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50},"aggregateUsage":{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150},"origin":"spawn_task"}
+"#,
+            )
+            .unwrap();
+            // An unrelated child of the same parent that happens to have spent
+            // the same 50 input tokens, and whose entry carries no timestamp.
+            std::fs::write(
+                &sibling_path,
+                format!(
+                    r#"{{"type":"session","version":3,"id":"sibling","timestamp":"2026-08-08T00:00:20.000Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child-message","parentId":null,"message":{{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"sibling-response","usage":{{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50}}}}}}
+"#,
+                    serde_json::to_string(&parent_path.to_string_lossy()).unwrap()
+                ),
+            )
+            .unwrap();
+
+            let mut paths = vec![parent_path, sibling_path];
+            if reverse {
+                paths.reverse();
+            }
+            let parsed: Vec<(PathBuf, Vec<UnifiedMessage>)> = paths
+                .into_iter()
+                .map(|path| {
+                    let messages = parse_prime_agent_file(&path);
+                    (path, messages)
+                })
+                .collect();
+            let accounting: Vec<PrimeFileAccounting> = parsed
+                .iter()
+                .map(|(path, messages)| analyze_prime_agent_accounting(path, messages))
+                .collect();
+            let messages: Vec<UnifiedMessage> = parsed
+                .into_iter()
+                .flat_map(|(_, messages)| messages)
+                .collect();
+            let messages = reconcile_prime_agent_messages(messages, &accounting);
+
+            let parent_input = messages
+                .iter()
+                .find(|message| {
+                    message.dedup_key.as_deref() == Some("prime-agent:response:parent-response")
+                })
+                .map_or(0, |message| message.tokens.input);
+            (
+                messages.iter().map(|message| message.tokens.input).sum(),
+                parent_input,
+            )
+        }
+
+        // The aggregate parent keeps its full 150 because the child it names was
+        // never parsed, and the untimed sibling adds its own 50 on top.
+        assert_eq!(totals(false), (200, 150));
+        assert_eq!(totals(true), (200, 150));
+    }
+
+    /// Transcripts written before Prime timestamped its entries carry no timing
+    /// on either side of the pair. Lineage plus usage is then the only identity
+    /// that exists, so it must still authorize the subtraction rather than
+    /// double counting every legacy child.
+    #[test]
+    fn timestampless_transcripts_still_match_on_lineage_and_usage() {
+        fn totals(reverse: bool) -> (i64, i64) {
+            let dir = tempfile::TempDir::new().unwrap();
+            let parent_path = dir.path().join("parent.jsonl");
+            let child_path = dir.path().join("child.jsonl");
+            std::fs::write(
+                &parent_path,
+                r#"{"type":"session","version":3,"id":"parent","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150}}}
+{"type":"child_usage_attributed","id":"usage-a","parentId":"parent","targetId":"parent","childUsage":{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50},"aggregateUsage":{"input":150,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":150},"origin":"spawn_task"}
+"#,
+            )
+            .unwrap();
+            std::fs::write(
+                &child_path,
+                format!(
+                    r#"{{"type":"session","version":3,"id":"child","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child-message","parentId":null,"message":{{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"child-response","usage":{{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":50}}}}}}
+"#,
+                    serde_json::to_string(&parent_path.to_string_lossy()).unwrap()
+                ),
+            )
+            .unwrap();
+
+            let mut paths = vec![parent_path, child_path];
+            if reverse {
+                paths.reverse();
+            }
+            let parsed: Vec<(PathBuf, Vec<UnifiedMessage>)> = paths
+                .into_iter()
+                .map(|path| {
+                    let messages = parse_prime_agent_file(&path);
+                    (path, messages)
+                })
+                .collect();
+            let accounting: Vec<PrimeFileAccounting> = parsed
+                .iter()
+                .map(|(path, messages)| analyze_prime_agent_accounting(path, messages))
+                .collect();
+            let messages: Vec<UnifiedMessage> = parsed
+                .into_iter()
+                .flat_map(|(_, messages)| messages)
+                .collect();
+            let messages = reconcile_prime_agent_messages(messages, &accounting);
+
+            let parent_input = messages
+                .iter()
+                .find(|message| {
+                    message.dedup_key.as_deref() == Some("prime-agent:response:parent-response")
+                })
+                .map_or(0, |message| message.tokens.input);
+            (
+                messages.iter().map(|message| message.tokens.input).sum(),
+                parent_input,
+            )
+        }
+
+        assert_eq!(totals(false), (150, 100));
+        assert_eq!(totals(true), (150, 100));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reconcile Prime Agent fork copies with RLM child transcripts using copied attribution IDs, individual child-response usage, and exact parent-session lineage
- retain aggregate parent usage when an attributed child transcript is unavailable, avoiding undercounting pruned or external artifacts
- mirror Prime Agent settings precedence for `sessionDir: null`, empty-string CWD roots, and literal `~\` paths
- add cold-cache, warm-cache, local-parse, missing-child, lineage-collision, multi-response child, and scanner regressions

## Context

Follow-up to #1080. Prime Agent applies `child_usage_attributed` records in memory before serializing a fork. A fork can therefore persist aggregate parent usage while tokscale also discovers the individual RLM child transcript. The reconciliation step now subtracts only child responses that were actually parsed from the same resolved parent lineage; otherwise the aggregate remains the fallback source of billable usage.

## Verification

- `cargo test -p tokscale-core`
- `cargo test -p tokscale-core prime_agent --lib`
- `cargo clippy -p tokscale-core -p tokscale-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Prime Agent token accounting across forks by pairing each attribution to its nearest child response and collapsing fork loops. Also improves session root detection and scanning to prevent false matches and double-counting, and speeds up reconciliation on large sessions.

- **Bug Fixes**
  - One-to-one pairing of `child_usage_attributed` to parsed children via minimum‑cost maximum matching; choose the nearest completion time (±1s); ambiguous pairs don’t subtract; untimed↔untimed match, single‑timed don’t.
  - Key attribution identity by (lineage‑root, attribution id); collapse fork‑chain copies and resolve fork loops deterministically; dedup across files keeps the highest adjusted usage and rewrites fallback keys after reconciliation.
  - Keep aggregate parent usage when no matching child transcript exists; never subtract using untimed siblings or children from other parents.
  - Session roots and scanning: support `sessionDir: null` and `""` (CWD) and `~/` expansion (forward slash only); honor `PRIME_AGENT_SESSION_DIR`, `PRIME_AGENT_CODING_AGENT_SESSION_DIR`, `PRIME_AGENT_CODING_AGENT_DIR`; resolve sibling `session-artifacts`; skip RLM catalogs; compare scanner paths canonically.

- **Performance**
  - Derive attribution indispensability from the final min‑cost flow in one pass via zero‑reduced‑cost residual cycles, avoiding per‑attribution re-solves and preventing stalls on large tied components.

<sup>Written for commit 9117144842c1dff6c3095992f552912a97e66d5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

