### PR TITLE
feat(submit): expose reconciliation census gate inputs

### DIFF
--- a/.github/workflows/frontend_migration_ci.yml
+++ b/.github/workflows/frontend_migration_ci.yml
@@ -12,6 +12,8 @@ on:
       - "packages/frontend/drizzle.config.ts"
       - "packages/frontend/scripts/check-migrations.ts"
       - "packages/frontend/src/lib/db/**"
+      - "packages/frontend/src/lib/reconciliation/ratchetCensus.ts"
+      - "packages/frontend/__tests__/integration/ratchetCensusPostgres.test.ts"
       - ".github/workflows/frontend_migration_ci.yml"
   pull_request:
     branches: [main]
@@ -62,3 +64,8 @@ jobs:
 
       - name: Replay frontend database migrations
         run: bun run --cwd packages/frontend test:migrations
+
+      - name: Execute reconciliation census against PostgreSQL
+        env:
+          RATCHET_CENSUS_DB_INTEGRATION: "1"
+        run: bun run --cwd packages/frontend test:reconciliation:db

--- a/docs/ratchet-inflation-recovery.md
+++ b/docs/ratchet-inflation-recovery.md
@@ -910,6 +910,15 @@ rather than on "a census" generally. Do not build them against the active-time
 numbers above; those are an incidence signal on an unrepresentative slice, not a
 magnitude estimate.
 
+The admin-only `GET /api/admin/reconciliation/census` endpoint exposes the gate
+inputs without changing any served value. It counts a user as measured only when
+every month/client/origin cell visible in their guarded daily rows has a matching
+device high-water row and no durable census work remains. It also compares only
+explicitly observed Phase 4a cells; omission is never interpreted as zero. The
+endpoint reports coverage, divergence bands, client/origin/version segments and
+a bounded outlier sample. It intentionally does not choose a Phase 2 rollout
+threshold or perform a repair.
+
 **Do not size the work from the worst ratios.** The 2300x device is a
 partial-scan artifact. Four devices are cleanly artifact, eleven ambiguous.
 

--- a/packages/frontend/__tests__/api/ratchetCensusRoute.test.ts
+++ b/packages/frontend/__tests__/api/ratchetCensusRoute.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+const { mockRequireAdminSession, mockGetRatchetCensusReport } = vi.hoisted(() => ({
+  mockRequireAdminSession: vi.fn(),
+  mockGetRatchetCensusReport: vi.fn(),
+}));
+
+vi.mock("@/lib/moderation/guard", () => ({
+  requireAdminSession: mockRequireAdminSession,
+}));
+
+vi.mock("@/lib/reconciliation/ratchetCensus", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/reconciliation/ratchetCensus")>();
+
+  return {
+    ...actual,
+    getRatchetCensusReport: mockGetRatchetCensusReport,
+  };
+});
+
+import { GET } from "@/app/api/admin/reconciliation/census/route";
+
+describe("GET /api/admin/reconciliation/census", () => {
+  beforeEach(() => {
+    mockRequireAdminSession.mockReset();
+    mockGetRatchetCensusReport.mockReset();
+  });
+
+  it("returns the concealed admin response without touching census data", async () => {
+    const concealed = NextResponse.json({ error: "Not found" }, { status: 404 });
+    mockRequireAdminSession.mockResolvedValue({ response: concealed });
+
+    const response = await GET(
+      new Request("https://tokscale.ai/api/admin/reconciliation/census")
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockGetRatchetCensusReport).not.toHaveBeenCalled();
+  });
+
+  it("returns a private non-cacheable report to an admin", async () => {
+    mockRequireAdminSession.mockResolvedValue({ session: { id: "admin" } });
+    mockGetRatchetCensusReport.mockResolvedValue({
+      generatedAt: "2026-08-08T12:00:00.000Z",
+      coverage: { totalUsers: 0 },
+    });
+
+    const response = await GET(
+      new Request(
+        "https://tokscale.ai/api/admin/reconciliation/census?candidateLimit=40"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(mockGetRatchetCensusReport).toHaveBeenCalledWith({ candidateLimit: 40 });
+  });
+
+  it.each([
+    ["missing", "", 25],
+    ["empty", "?candidateLimit=", 25],
+    ["zero", "?candidateLimit=0", 25],
+    ["negative", "?candidateLimit=-4", 25],
+    ["fractional", "?candidateLimit=1.5", 25],
+    ["non-numeric", "?candidateLimit=nope", 25],
+    ["over the cap", "?candidateLimit=10000", 100],
+  ])(
+    "normalizes a %s candidate limit before querying",
+    async (_label, query, expectedLimit) => {
+      mockRequireAdminSession.mockResolvedValue({ session: { id: "admin" } });
+      mockGetRatchetCensusReport.mockResolvedValue({
+        generatedAt: "2026-08-08T12:00:00.000Z",
+      });
+
+      const response = await GET(
+        new Request(
+          `https://tokscale.ai/api/admin/reconciliation/census${query}`
+        )
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockGetRatchetCensusReport).toHaveBeenCalledWith({
+        candidateLimit: expectedLimit,
+      });
+    }
+  );
+
+  it("does not leak database errors", async () => {
+    mockRequireAdminSession.mockResolvedValue({ session: { id: "admin" } });
+    mockGetRatchetCensusReport.mockRejectedValue(new Error("private db detail"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await GET(
+      new Request("https://tokscale.ai/api/admin/reconciliation/census")
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: "Failed to load reconciliation census",
+    });
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/frontend/__tests__/api/ratchetCensusRoute.test.ts
+++ b/packages/frontend/__tests__/api/ratchetCensusRoute.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NextResponse } from "next/server";
 
 const { mockRequireAdminSession, mockGetRatchetCensusReport } = vi.hoisted(() => ({
@@ -26,6 +26,10 @@ describe("GET /api/admin/reconciliation/census", () => {
   beforeEach(() => {
     mockRequireAdminSession.mockReset();
     mockGetRatchetCensusReport.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("returns the concealed admin response without touching census data", async () => {
@@ -90,7 +94,7 @@ describe("GET /api/admin/reconciliation/census", () => {
   it("does not leak database errors", async () => {
     mockRequireAdminSession.mockResolvedValue({ session: { id: "admin" } });
     mockGetRatchetCensusReport.mockRejectedValue(new Error("private db detail"));
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
 
     const response = await GET(
       new Request("https://tokscale.ai/api/admin/reconciliation/census")
@@ -100,6 +104,5 @@ describe("GET /api/admin/reconciliation/census", () => {
     expect(await response.json()).toEqual({
       error: "Failed to load reconciliation census",
     });
-    errorSpy.mockRestore();
   });
 });

--- a/packages/frontend/__tests__/integration/ratchetCensusPostgres.test.ts
+++ b/packages/frontend/__tests__/integration/ratchetCensusPostgres.test.ts
@@ -1,0 +1,254 @@
+import { randomUUID } from "node:crypto";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { getRatchetCensusReport } from "@/lib/reconciliation/ratchetCensus";
+
+const integrationEnabled =
+  process.env.RATCHET_CENSUS_DB_INTEGRATION === "1";
+const describeWithPostgres = integrationEnabled ? describe : describe.skip;
+
+describeWithPostgres("ratchet census PostgreSQL integration", () => {
+  const databaseUrl = process.env.DATABASE_URL;
+  const userIds = [randomUUID(), randomUUID(), randomUUID()];
+  const submissionIds = [randomUUID(), randomUUID(), randomUUID()];
+  const deviceIds = [randomUUID(), randomUUID(), randomUUID()];
+  const fixtureSuffix = randomUUID().replaceAll("-", "").slice(0, 8);
+  const usernames = {
+    severe: `census_severe_${fixtureSuffix}`,
+    warming: `census_warming_${fixtureSuffix}`,
+    pending: `census_pending_${fixtureSuffix}`,
+  };
+  const largeTokenTotal = BigInt("9007199254740993");
+  const highwaterTotal = BigInt("3000000000000000");
+  const githubIdBase =
+    -1_900_000_000 + Number.parseInt(fixtureSuffix.slice(0, 6), 16);
+
+  let fixtureDb: ReturnType<typeof postgres>;
+
+  beforeAll(async () => {
+    if (!databaseUrl) {
+      throw new Error(
+        "DATABASE_URL is required when RATCHET_CENSUS_DB_INTEGRATION=1"
+      );
+    }
+
+    fixtureDb = postgres(databaseUrl, { max: 1, prepare: false });
+
+    await fixtureDb.begin(async (sql) => {
+      await sql`
+        INSERT INTO users (id, github_id, username)
+        VALUES
+          (${userIds[0]}, ${githubIdBase}, ${usernames.severe}),
+          (${userIds[1]}, ${githubIdBase + 1}, ${usernames.warming}),
+          (${userIds[2]}, ${githubIdBase + 2}, ${usernames.pending})
+      `;
+
+      await sql`
+        INSERT INTO submissions (
+          id, user_id, total_tokens, total_cost, input_tokens, output_tokens,
+          date_start, date_end, sources_used, models_used, cli_version
+        )
+        VALUES
+          (
+            ${submissionIds[0]}, ${userIds[0]}, ${largeTokenTotal.toString()},
+            0, ${largeTokenTotal.toString()}, 0, '2026-01-01', '2026-01-05',
+            ARRAY['claude'], ARRAY['fixture-model'], '4.12.0'
+          ),
+          (
+            ${submissionIds[1]}, ${userIds[1]}, 100, 0, 100, 0,
+            '2026-01-01', '2026-01-01', ARRAY['claude'],
+            ARRAY['fixture-model'], '4.11.0'
+          ),
+          (
+            ${submissionIds[2]}, ${userIds[2]}, 90, 0, 90, 0,
+            '2026-01-01', '2026-01-01', ARRAY['codex'],
+            ARRAY['fixture-model'], '4.10.0'
+          )
+      `;
+
+      await sql`
+        INSERT INTO submitted_devices (id, user_id, device_key)
+        VALUES
+          (${deviceIds[0]}, ${userIds[0]}, 'census-severe-device'),
+          (${deviceIds[1]}, ${userIds[1]}, 'census-warming-device'),
+          (${deviceIds[2]}, ${userIds[2]}, 'census-pending-device')
+      `;
+
+      const observedRatios = [
+        { date: "2026-01-01", guardedTokens: 50, reportedTokens: 100 },
+        { date: "2026-01-02", guardedTokens: 100, reportedTokens: 100 },
+        { date: "2026-01-03", guardedTokens: 110, reportedTokens: 100 },
+        { date: "2026-01-04", guardedTokens: 150, reportedTokens: 100 },
+        { date: "2026-01-05", guardedTokens: 300, reportedTokens: 100 },
+      ];
+
+      for (const observation of observedRatios) {
+        await sql`
+          INSERT INTO daily_breakdown (
+            submission_id, submitted_device_id, date, tokens, cost,
+            input_tokens, output_tokens, source_breakdown
+          )
+          VALUES (
+            ${submissionIds[0]}, ${deviceIds[0]}, ${observation.date},
+            ${observation.guardedTokens}, 0, ${observation.guardedTokens}, 0,
+            ${sql.json({
+              claude: {
+                tokens: observation.guardedTokens,
+                provenance: { origin: "cli" },
+              },
+            })}
+          )
+        `;
+        await sql`
+          INSERT INTO daily_breakdown_reported (
+            submitted_device_id, date, client, tokens, cost, input, output, origin
+          )
+          VALUES (
+            ${deviceIds[0]}, ${observation.date}, 'claude',
+            ${observation.reportedTokens}, 0, ${observation.reportedTokens}, 0,
+            'cli'
+          )
+        `;
+      }
+
+      await sql`
+        INSERT INTO daily_breakdown (
+          submission_id, submitted_device_id, date, tokens, cost,
+          input_tokens, output_tokens, source_breakdown
+        )
+        VALUES
+          (
+            ${submissionIds[1]}, ${deviceIds[1]}, '2026-01-01', 100, 0, 100, 0,
+            ${sql.json({
+              claude: {
+                tokens: 100,
+                provenance: { origin: "backfill" },
+              },
+            })}
+          ),
+          (
+            ${submissionIds[2]}, ${deviceIds[2]}, '2026-01-01', 90, 0, 90, 0,
+            ${sql.json({
+              codex: { tokens: 90, provenance: { origin: "cli" } },
+            })}
+          )
+      `;
+
+      await sql`
+        INSERT INTO daily_breakdown_reported (
+          submitted_device_id, date, client, tokens, cost, input, output, origin
+        )
+        VALUES (${deviceIds[0]}, '2026-01-01', 'omitted-client', 100, 0, 100, 0, 'cli')
+      `;
+
+      await sql`
+        INSERT INTO submitted_device_client_totals (
+          submitted_device_id, client, origin, bucket_width, bucket_key,
+          tokens_highwater, cost_highwater
+        )
+        VALUES
+          (
+            ${deviceIds[0]}, 'claude', 'cli', 'month', '2026-01',
+            ${highwaterTotal.toString()}, 0
+          ),
+          (${deviceIds[2]}, 'codex', 'cli', 'month', '2026-01', 90, 0)
+      `;
+
+      await sql`
+        INSERT INTO ratchet_census_work (
+          submission_id, submitted_device_id, buckets
+        )
+        VALUES (${submissionIds[2]}, ${deviceIds[2]}, ${sql.json([])})
+      `;
+    });
+  });
+
+  afterAll(async () => {
+    if (!fixtureDb) return;
+
+    for (const userId of userIds) {
+      await fixtureDb`DELETE FROM users WHERE id = ${userId}`;
+    }
+    await fixtureDb.end();
+  });
+
+  it("returns typed gate inputs from the migrated schema", async () => {
+    const report = await getRatchetCensusReport({
+      candidateLimit: 10,
+      now: new Date("2026-08-09T12:00:00.000Z"),
+    });
+
+    expect(report.coverage).toEqual({
+      totalUsers: 3,
+      measuredUsers: 1,
+      totalTokens: (largeTokenTotal + BigInt(190)).toString(),
+      measuredTokens: largeTokenTotal.toString(),
+      userCoverage: 0.333333,
+      tokenCoverage: 1,
+      pendingWorkItems: 1,
+    });
+    expect(report.divergenceBands).toEqual([
+      { band: "pending", users: 1, tokens: "90" },
+      { band: "warming", users: 1, tokens: "100" },
+      {
+        band: "severe",
+        users: 1,
+        tokens: largeTokenTotal.toString(),
+      },
+    ]);
+    expect(report.observedCells).toEqual({
+      comparableCells: 5,
+      under: 1,
+      clean: 1,
+      mild: 1,
+      clear: 1,
+      severe: 1,
+      maxRatio: 3,
+    });
+    expect(report.segments.byOrigin).toEqual([
+      {
+        key: "backfill",
+        expectedCells: 1,
+        measuredCells: 0,
+        cellCoverage: 0,
+      },
+      {
+        key: "cli",
+        expectedCells: 2,
+        measuredCells: 2,
+        cellCoverage: 1,
+      },
+    ]);
+    expect(report.segments.byClient).toEqual([
+      {
+        key: "claude",
+        expectedCells: 2,
+        measuredCells: 1,
+        cellCoverage: 0.5,
+      },
+      {
+        key: "codex",
+        expectedCells: 1,
+        measuredCells: 1,
+        cellCoverage: 1,
+      },
+    ]);
+    expect(report.candidates).toHaveLength(1);
+    expect(report.candidates[0]).toMatchObject({
+      username: usernames.severe,
+      totalTokens: largeTokenTotal.toString(),
+      highwaterTokens: highwaterTotal.toString(),
+      band: "severe",
+      expectedCells: 1,
+      measuredCells: 1,
+      cliVersion: "4.12.0",
+      deviceCount: 1,
+    });
+    expect(report.candidates[0].ratio).toBeCloseTo(
+      Number(largeTokenTotal) / Number(highwaterTotal),
+      12
+    );
+    expect(report.generatedAt).toBe("2026-08-09T12:00:00.000Z");
+  });
+});

--- a/packages/frontend/__tests__/integration/ratchetCensusPostgres.test.ts
+++ b/packages/frontend/__tests__/integration/ratchetCensusPostgres.test.ts
@@ -8,19 +8,62 @@ const integrationEnabled =
   process.env.RATCHET_CENSUS_DB_INTEGRATION === "1";
 const describeWithPostgres = integrationEnabled ? describe : describe.skip;
 
+/**
+ * Executes the real census SQL against a migrated PostgreSQL instance.
+ *
+ * The unit suite mocks `db.execute`, so it can only prove the Zod contract and
+ * that certain substrings appear in the query. Everything the report actually
+ * promises — bigint-preserving `::text` casts, 6-digit coverage rounding, the
+ * user and cell band cutoffs, and the origin/bucket-key strictness of the
+ * coverage join — is only observable by running the statement. This fixture is
+ * built so that each of those properties has at least one row that changes the
+ * asserted output when the corresponding SQL is altered.
+ *
+ * The fixture assumes it owns the database (it asserts site-wide totals), which
+ * is why it runs against the throwaway CI PostgreSQL service rather than in the
+ * default `vitest run` suite.
+ */
 describeWithPostgres("ratchet census PostgreSQL integration", () => {
   const databaseUrl = process.env.DATABASE_URL;
-  const userIds = [randomUUID(), randomUUID(), randomUUID()];
-  const submissionIds = [randomUUID(), randomUUID(), randomUUID()];
-  const deviceIds = [randomUUID(), randomUUID(), randomUUID()];
   const fixtureSuffix = randomUUID().replaceAll("-", "").slice(0, 8);
-  const usernames = {
-    severe: `census_severe_${fixtureSuffix}`,
-    warming: `census_warming_${fixtureSuffix}`,
-    pending: `census_pending_${fixtureSuffix}`,
-  };
-  const largeTokenTotal = BigInt("9007199254740993");
-  const highwaterTotal = BigInt("3000000000000000");
+
+  // Personas, one user + submission + device each. `cliVersion` values are
+  // zero-padded so the `ORDER BY users DESC, cli_version` tiebreak is a plain
+  // lexicographic sort.
+  const personas = [
+    "severe",
+    "warming",
+    "pending",
+    "under",
+    "clean",
+    "clear",
+    "partial",
+  ] as const;
+  type Persona = (typeof personas)[number];
+
+  const ids = Object.fromEntries(
+    personas.map((persona) => [
+      persona,
+      {
+        userId: randomUUID(),
+        submissionId: randomUUID(),
+        deviceId: randomUUID(),
+        username: `census_${persona}_${fixtureSuffix}`,
+      },
+    ])
+  ) as Record<
+    Persona,
+    { userId: string; submissionId: string; deviceId: string; username: string }
+  >;
+
+  // Both totals are deliberately UNREPRESENTABLE as IEEE-754 doubles, so a
+  // dropped `::text` cast cannot pass by accident:
+  //   9007199254740993  = 2^53 + 1   -> nearest double is ...992
+  //   90071992547409937              -> nearest double is ...936
+  // If the SQL emits these as JSON numbers rather than text, the driver's
+  // JSON.parse silently rounds them and the assertions below fail.
+  const largeTokenTotal = BigInt("90071992547409937");
+  const highwaterTotal = BigInt("9007199254740993");
   const githubIdBase =
     -1_900_000_000 + Number.parseInt(fixtureSuffix.slice(0, 6), 16);
 
@@ -36,168 +79,219 @@ describeWithPostgres("ratchet census PostgreSQL integration", () => {
     fixtureDb = postgres(databaseUrl, { max: 1, prepare: false });
 
     await fixtureDb.begin(async (sql) => {
-      await sql`
-        INSERT INTO users (id, github_id, username)
-        VALUES
-          (${userIds[0]}, ${githubIdBase}, ${usernames.severe}),
-          (${userIds[1]}, ${githubIdBase + 1}, ${usernames.warming}),
-          (${userIds[2]}, ${githubIdBase + 2}, ${usernames.pending})
-      `;
+      const submissionTotals: Record<
+        Persona,
+        { tokens: string; cliVersion: string }
+      > = {
+        under: { tokens: "900", cliVersion: "4.01.0" },
+        clean: { tokens: "1000", cliVersion: "4.02.0" },
+        clear: { tokens: "1500", cliVersion: "4.03.0" },
+        partial: { tokens: "300", cliVersion: "4.04.0" },
+        pending: { tokens: "90", cliVersion: "4.10.0" },
+        warming: { tokens: "100", cliVersion: "4.11.0" },
+        severe: { tokens: largeTokenTotal.toString(), cliVersion: "4.12.0" },
+      };
 
-      await sql`
-        INSERT INTO submissions (
-          id, user_id, total_tokens, total_cost, input_tokens, output_tokens,
-          date_start, date_end, sources_used, models_used, cli_version
-        )
-        VALUES
-          (
-            ${submissionIds[0]}, ${userIds[0]}, ${largeTokenTotal.toString()},
-            0, ${largeTokenTotal.toString()}, 0, '2026-01-01', '2026-01-05',
-            ARRAY['claude'], ARRAY['fixture-model'], '4.12.0'
-          ),
-          (
-            ${submissionIds[1]}, ${userIds[1]}, 100, 0, 100, 0,
-            '2026-01-01', '2026-01-01', ARRAY['claude'],
-            ARRAY['fixture-model'], '4.11.0'
-          ),
-          (
-            ${submissionIds[2]}, ${userIds[2]}, 90, 0, 90, 0,
-            '2026-01-01', '2026-01-01', ARRAY['codex'],
-            ARRAY['fixture-model'], '4.10.0'
-          )
-      `;
+      for (const [index, persona] of personas.entries()) {
+        const { userId, submissionId, deviceId, username } = ids[persona];
+        const { tokens, cliVersion } = submissionTotals[persona];
 
-      await sql`
-        INSERT INTO submitted_devices (id, user_id, device_key)
-        VALUES
-          (${deviceIds[0]}, ${userIds[0]}, 'census-severe-device'),
-          (${deviceIds[1]}, ${userIds[1]}, 'census-warming-device'),
-          (${deviceIds[2]}, ${userIds[2]}, 'census-pending-device')
-      `;
-
-      const observedRatios = [
-        { date: "2026-01-01", guardedTokens: 50, reportedTokens: 100 },
-        { date: "2026-01-02", guardedTokens: 100, reportedTokens: 100 },
-        { date: "2026-01-03", guardedTokens: 110, reportedTokens: 100 },
-        { date: "2026-01-04", guardedTokens: 150, reportedTokens: 100 },
-        { date: "2026-01-05", guardedTokens: 300, reportedTokens: 100 },
-      ];
-
-      for (const observation of observedRatios) {
         await sql`
+          INSERT INTO users (id, github_id, username)
+          VALUES (${userId}, ${githubIdBase + index}, ${username})
+        `;
+        await sql`
+          INSERT INTO submissions (
+            id, user_id, total_tokens, total_cost, input_tokens, output_tokens,
+            date_start, date_end, sources_used, models_used, cli_version
+          )
+          VALUES (
+            ${submissionId}, ${userId}, ${tokens}, 0, ${tokens}, 0,
+            '2026-01-01', '2026-03-01', ARRAY['claude'],
+            ARRAY['fixture-model'], ${cliVersion}
+          )
+        `;
+        await sql`
+          INSERT INTO submitted_devices (id, user_id, device_key)
+          VALUES (${deviceId}, ${userId}, ${`census-${persona}-device`})
+        `;
+      }
+
+      /** One guarded daily row, i.e. one (device, client, origin, month) cell. */
+      const guardedDay = (
+        persona: Persona,
+        date: string,
+        client: string,
+        origin: string,
+        tokens: number
+      ) =>
+        sql`
           INSERT INTO daily_breakdown (
             submission_id, submitted_device_id, date, tokens, cost,
             input_tokens, output_tokens, source_breakdown
           )
           VALUES (
-            ${submissionIds[0]}, ${deviceIds[0]}, ${observation.date},
-            ${observation.guardedTokens}, 0, ${observation.guardedTokens}, 0,
-            ${sql.json({
-              claude: {
-                tokens: observation.guardedTokens,
-                provenance: { origin: "cli" },
-              },
-            })}
+            ${ids[persona].submissionId}, ${ids[persona].deviceId}, ${date},
+            ${tokens}, 0, ${tokens}, 0,
+            ${sql.json({ [client]: { tokens, provenance: { origin } } })}
           )
         `;
+
+      /** One per-device high-water row, i.e. one *measured* cell. */
+      const highwater = (
+        persona: Persona,
+        client: string,
+        origin: string,
+        bucketKey: string,
+        tokens: string
+      ) =>
+        sql`
+          INSERT INTO submitted_device_client_totals (
+            submitted_device_id, client, origin, bucket_width, bucket_key,
+            tokens_highwater, cost_highwater
+          )
+          VALUES (
+            ${ids[persona].deviceId}, ${client}, ${origin}, 'month',
+            ${bucketKey}, ${tokens}, 0
+          )
+        `;
+
+      // `severe`: five guarded days in one month collapse to a single expected
+      // cell, while the paired reported rows give one observation per band.
+      const observedRatios = [
+        { date: "2026-01-01", guardedTokens: 50, reportedTokens: 100 }, // 0.50 under
+        { date: "2026-01-02", guardedTokens: 100, reportedTokens: 100 }, // 1.00 clean
+        { date: "2026-01-03", guardedTokens: 110, reportedTokens: 100 }, // 1.10 mild
+        { date: "2026-01-04", guardedTokens: 150, reportedTokens: 100 }, // 1.50 clear
+        { date: "2026-01-05", guardedTokens: 300, reportedTokens: 100 }, // 3.00 severe
+      ];
+
+      for (const observation of observedRatios) {
+        await guardedDay(
+          "severe",
+          observation.date,
+          "claude",
+          "cli",
+          observation.guardedTokens
+        );
         await sql`
           INSERT INTO daily_breakdown_reported (
             submitted_device_id, date, client, tokens, cost, input, output, origin
           )
           VALUES (
-            ${deviceIds[0]}, ${observation.date}, 'claude',
+            ${ids.severe.deviceId}, ${observation.date}, 'claude',
             ${observation.reportedTokens}, 0, ${observation.reportedTokens}, 0,
             'cli'
           )
         `;
       }
 
-      await sql`
-        INSERT INTO daily_breakdown (
-          submission_id, submitted_device_id, date, tokens, cost,
-          input_tokens, output_tokens, source_breakdown
-        )
-        VALUES
-          (
-            ${submissionIds[1]}, ${deviceIds[1]}, '2026-01-01', 100, 0, 100, 0,
-            ${sql.json({
-              claude: {
-                tokens: 100,
-                provenance: { origin: "backfill" },
-              },
-            })}
-          ),
-          (
-            ${submissionIds[2]}, ${deviceIds[2]}, '2026-01-01', 90, 0, 90, 0,
-            ${sql.json({
-              codex: { tokens: 90, provenance: { origin: "cli" } },
-            })}
-          )
-      `;
-
+      // A reported client with no matching guarded entry. `source_breakdown ?
+      // r.client` must exclude it rather than read the absence as zero tokens.
       await sql`
         INSERT INTO daily_breakdown_reported (
           submitted_device_id, date, client, tokens, cost, input, output, origin
         )
-        VALUES (${deviceIds[0]}, '2026-01-01', 'omitted-client', 100, 0, 100, 0, 'cli')
-      `;
-
-      await sql`
-        INSERT INTO submitted_device_client_totals (
-          submitted_device_id, client, origin, bucket_width, bucket_key,
-          tokens_highwater, cost_highwater
+        VALUES (
+          ${ids.severe.deviceId}, '2026-01-01', 'omitted-client', 100, 0, 100, 0, 'cli'
         )
-        VALUES
-          (
-            ${deviceIds[0]}, 'claude', 'cli', 'month', '2026-01',
-            ${highwaterTotal.toString()}, 0
-          ),
-          (${deviceIds[2]}, 'codex', 'cli', 'month', '2026-01', 90, 0)
       `;
+      await highwater(
+        "severe",
+        "claude",
+        "cli",
+        "2026-01",
+        highwaterTotal.toString()
+      );
 
+      // `warming`: a backfill-origin cell with no high-water row yet.
+      await guardedDay("warming", "2026-01-01", "claude", "backfill", 100);
+
+      // `pending`: fully covered, but durable census work is outstanding.
+      await guardedDay("pending", "2026-01-01", "codex", "cli", 90);
+      await highwater("pending", "codex", "cli", "2026-01", "90");
       await sql`
         INSERT INTO ratchet_census_work (
           submission_id, submitted_device_id, buckets
         )
-        VALUES (${submissionIds[2]}, ${deviceIds[2]}, ${sql.json([])})
+        VALUES (
+          ${ids.pending.submissionId}, ${ids.pending.deviceId}, ${sql.json([])}
+        )
       `;
+
+      // Measured users, one per divergence band below `severe`.
+      await guardedDay("under", "2026-01-01", "claude", "cli", 900);
+      await highwater("under", "claude", "cli", "2026-01", "1000"); // 900/1000
+      await guardedDay("clean", "2026-01-01", "claude", "cli", 1000);
+      await highwater("clean", "claude", "cli", "2026-01", "1000"); // 1000/1000
+      await guardedDay("clear", "2026-01-01", "claude", "cli", 1500);
+      await highwater("clear", "claude", "cli", "2026-01", "1000"); // 1500/1000
+
+      // `partial`: three expected cells, only ONE of which may count as
+      // measured. The other two have a high-water row that matches on every
+      // column except one, so dropping either the origin or the bucket-key
+      // predicate from the coverage join silently inflates coverage.
+      await guardedDay("partial", "2026-01-01", "claude", "cli", 100);
+      await highwater("partial", "claude", "cli", "2026-01", "500"); // matches
+      await guardedDay("partial", "2026-02-01", "gemini", "cli", 100);
+      await highwater("partial", "gemini", "cli", "2026-07", "100"); // wrong month
+      await guardedDay("partial", "2026-03-01", "codex", "backfill", 100);
+      await highwater("partial", "codex", "cli", "2026-03", "100"); // wrong origin
     });
   });
 
   afterAll(async () => {
     if (!fixtureDb) return;
 
-    for (const userId of userIds) {
-      await fixtureDb`DELETE FROM users WHERE id = ${userId}`;
+    for (const persona of personas) {
+      await fixtureDb`DELETE FROM users WHERE id = ${ids[persona].userId}`;
     }
     await fixtureDb.end();
   });
 
-  it("returns typed gate inputs from the migrated schema", async () => {
+  it("reports site coverage with bigint-safe totals and 6-digit rounding", async () => {
     const report = await getRatchetCensusReport({
       candidateLimit: 10,
       now: new Date("2026-08-09T12:00:00.000Z"),
     });
 
     expect(report.coverage).toEqual({
-      totalUsers: 3,
-      measuredUsers: 1,
-      totalTokens: (largeTokenTotal + BigInt(190)).toString(),
-      measuredTokens: largeTokenTotal.toString(),
-      userCoverage: 0.333333,
+      totalUsers: 7,
+      // severe + under + clean + clear; warming/partial are incomplete and
+      // pending still has durable work.
+      measuredUsers: 4,
+      totalTokens: (largeTokenTotal + BigInt(3890)).toString(),
+      measuredTokens: (largeTokenTotal + BigInt(3400)).toString(),
+      // 4/7 does not terminate, so this pins ROUND(..., 6) rather than any
+      // rounding that happens to agree on a short decimal.
+      userCoverage: 0.571429,
       tokenCoverage: 1,
       pendingWorkItems: 1,
     });
+    expect(report.generatedAt).toBe("2026-08-09T12:00:00.000Z");
+  });
+
+  it("classifies every user divergence band", async () => {
+    const report = await getRatchetCensusReport({ candidateLimit: 10 });
+
     expect(report.divergenceBands).toEqual([
       { band: "pending", users: 1, tokens: "90" },
-      { band: "warming", users: 1, tokens: "100" },
-      {
-        band: "severe",
-        users: 1,
-        tokens: largeTokenTotal.toString(),
-      },
+      // `warming` collects both the user with no high-water row and the user
+      // whose cells are only partially measured.
+      { band: "warming", users: 2, tokens: "400" },
+      { band: "under", users: 1, tokens: "900" },
+      { band: "clean", users: 1, tokens: "1000" },
+      { band: "clear", users: 1, tokens: "1500" },
+      { band: "severe", users: 1, tokens: largeTokenTotal.toString() },
     ]);
+  });
+
+  it("classifies every observed cell band and ignores unmatched clients", async () => {
+    const report = await getRatchetCensusReport({ candidateLimit: 10 });
+
     expect(report.observedCells).toEqual({
+      // The `omitted-client` reported row has no guarded counterpart and is
+      // excluded instead of being compared against zero.
       comparableCells: 5,
       under: 1,
       clean: 1,
@@ -206,37 +300,58 @@ describeWithPostgres("ratchet census PostgreSQL integration", () => {
       severe: 1,
       maxRatio: 3,
     });
+  });
+
+  it("keeps segment coverage origin-, client-, and bucket-key-aware", async () => {
+    const report = await getRatchetCensusReport({ candidateLimit: 10 });
+
     expect(report.segments.byOrigin).toEqual([
-      {
-        key: "backfill",
-        expectedCells: 1,
-        measuredCells: 0,
-        cellCoverage: 0,
-      },
-      {
-        key: "cli",
-        expectedCells: 2,
-        measuredCells: 2,
-        cellCoverage: 1,
-      },
+      { key: "backfill", expectedCells: 2, measuredCells: 0, cellCoverage: 0 },
+      // 6/7 does not terminate: this pins the segment rounding too. It also
+      // drops if the coverage join stops matching on origin or bucket key,
+      // because `partial` would then measure cells it must not.
+      { key: "cli", expectedCells: 7, measuredCells: 6, cellCoverage: 0.857143 },
     ]);
     expect(report.segments.byClient).toEqual([
+      { key: "claude", expectedCells: 6, measuredCells: 5, cellCoverage: 0.833333 },
+      { key: "codex", expectedCells: 2, measuredCells: 1, cellCoverage: 0.5 },
+      { key: "gemini", expectedCells: 1, measuredCells: 0, cellCoverage: 0 },
+    ]);
+    // Ordered by `users DESC, cli_version`; every fixture user is alone on its
+    // version, so this is a lexicographic sort. Asserting the exact token
+    // strings is what pins the `::text` casts on the per-version totals.
+    expect(report.segments.byCliVersion).toEqual([
+      { cliVersion: "4.01.0", users: 1, measuredUsers: 1, totalTokens: "900", measuredTokens: "900" },
+      { cliVersion: "4.02.0", users: 1, measuredUsers: 1, totalTokens: "1000", measuredTokens: "1000" },
+      { cliVersion: "4.03.0", users: 1, measuredUsers: 1, totalTokens: "1500", measuredTokens: "1500" },
+      { cliVersion: "4.04.0", users: 1, measuredUsers: 0, totalTokens: "300", measuredTokens: "0" },
+      { cliVersion: "4.10.0", users: 1, measuredUsers: 0, totalTokens: "90", measuredTokens: "0" },
+      { cliVersion: "4.11.0", users: 1, measuredUsers: 0, totalTokens: "100", measuredTokens: "0" },
       {
-        key: "claude",
-        expectedCells: 2,
-        measuredCells: 1,
-        cellCoverage: 0.5,
-      },
-      {
-        key: "codex",
-        expectedCells: 1,
-        measuredCells: 1,
-        cellCoverage: 1,
+        cliVersion: "4.12.0",
+        users: 1,
+        measuredUsers: 1,
+        totalTokens: largeTokenTotal.toString(),
+        measuredTokens: largeTokenTotal.toString(),
       },
     ]);
-    expect(report.candidates).toHaveLength(1);
+  });
+
+  it("ranks measured candidates by divergence and preserves bigint columns", async () => {
+    const report = await getRatchetCensusReport({ candidateLimit: 10 });
+
+    // `clean` is measured but never a candidate; `warming`/`pending` are not
+    // measured at all. Ordering is `ABS(ratio - 1) DESC`.
+    expect(
+      report.candidates.map((candidate) => [candidate.username, candidate.band])
+    ).toEqual([
+      [ids.severe.username, "severe"],
+      [ids.clear.username, "clear"],
+      [ids.under.username, "under"],
+    ]);
+
     expect(report.candidates[0]).toMatchObject({
-      username: usernames.severe,
+      username: ids.severe.username,
       totalTokens: largeTokenTotal.toString(),
       highwaterTokens: highwaterTotal.toString(),
       band: "severe",
@@ -247,8 +362,26 @@ describeWithPostgres("ratchet census PostgreSQL integration", () => {
     });
     expect(report.candidates[0].ratio).toBeCloseTo(
       Number(largeTokenTotal) / Number(highwaterTotal),
-      12
+      9
     );
-    expect(report.generatedAt).toBe("2026-08-09T12:00:00.000Z");
+    expect(report.candidates[1]).toMatchObject({
+      totalTokens: "1500",
+      highwaterTokens: "1000",
+      ratio: 1.5,
+      cliVersion: "4.03.0",
+    });
+    expect(report.candidates[2]).toMatchObject({
+      totalTokens: "900",
+      highwaterTokens: "1000",
+      ratio: 0.9,
+      cliVersion: "4.01.0",
+    });
+  });
+
+  it("honours the candidate limit", async () => {
+    const report = await getRatchetCensusReport({ candidateLimit: 1 });
+
+    expect(report.candidates).toHaveLength(1);
+    expect(report.candidates[0].username).toBe(ids.severe.username);
   });
 });

--- a/packages/frontend/__tests__/integration/ratchetCensusPostgres.test.ts
+++ b/packages/frontend/__tests__/integration/ratchetCensusPostgres.test.ts
@@ -31,6 +31,7 @@ describeWithPostgres("ratchet census PostgreSQL integration", () => {
   // zero-padded so the `ORDER BY users DESC, cli_version` tiebreak is a plain
   // lexicographic sort.
   const personas = [
+    "zero",
     "severe",
     "warming",
     "pending",
@@ -83,6 +84,7 @@ describeWithPostgres("ratchet census PostgreSQL integration", () => {
         Persona,
         { tokens: string; cliVersion: string }
       > = {
+        zero: { tokens: "0", cliVersion: "4.00.0" },
         under: { tokens: "900", cliVersion: "4.01.0" },
         clean: { tokens: "1000", cliVersion: "4.02.0" },
         clear: { tokens: "1500", cliVersion: "4.03.0" },
@@ -204,6 +206,12 @@ describeWithPostgres("ratchet census PostgreSQL integration", () => {
         highwaterTotal.toString()
       );
 
+      // `zero`: a durable zero-valued high-water row is complete evidence,
+      // not a missing measurement. The 0/0 comparison is clean and has no
+      // reason to appear in the ranked repair candidates.
+      await guardedDay("zero", "2026-01-01", "claude", "cli", 0);
+      await highwater("zero", "claude", "cli", "2026-01", "0");
+
       // `warming`: a backfill-origin cell with no high-water row yet.
       await guardedDay("warming", "2026-01-01", "claude", "backfill", 100);
 
@@ -256,15 +264,14 @@ describeWithPostgres("ratchet census PostgreSQL integration", () => {
     });
 
     expect(report.coverage).toEqual({
-      totalUsers: 7,
-      // severe + under + clean + clear; warming/partial are incomplete and
-      // pending still has durable work.
-      measuredUsers: 4,
+      totalUsers: 8,
+      // zero + severe + under + clean + clear; warming/partial are incomplete
+      // and pending still has durable work.
+      measuredUsers: 5,
       totalTokens: (largeTokenTotal + BigInt(3890)).toString(),
       measuredTokens: (largeTokenTotal + BigInt(3400)).toString(),
-      // 4/7 does not terminate, so this pins ROUND(..., 6) rather than any
-      // rounding that happens to agree on a short decimal.
-      userCoverage: 0.571429,
+      // 5/8 is exact; client coverage below pins ROUND(..., 6).
+      userCoverage: 0.625,
       tokenCoverage: 1,
       pendingWorkItems: 1,
     });
@@ -280,7 +287,7 @@ describeWithPostgres("ratchet census PostgreSQL integration", () => {
       // whose cells are only partially measured.
       { band: "warming", users: 2, tokens: "400" },
       { band: "under", users: 1, tokens: "900" },
-      { band: "clean", users: 1, tokens: "1000" },
+      { band: "clean", users: 2, tokens: "1000" },
       { band: "clear", users: 1, tokens: "1500" },
       { band: "severe", users: 1, tokens: largeTokenTotal.toString() },
     ]);
@@ -307,13 +314,12 @@ describeWithPostgres("ratchet census PostgreSQL integration", () => {
 
     expect(report.segments.byOrigin).toEqual([
       { key: "backfill", expectedCells: 2, measuredCells: 0, cellCoverage: 0 },
-      // 6/7 does not terminate: this pins the segment rounding too. It also
-      // drops if the coverage join stops matching on origin or bucket key,
+      // It drops if the coverage join stops matching on origin or bucket key,
       // because `partial` would then measure cells it must not.
-      { key: "cli", expectedCells: 7, measuredCells: 6, cellCoverage: 0.857143 },
+      { key: "cli", expectedCells: 8, measuredCells: 7, cellCoverage: 0.875 },
     ]);
     expect(report.segments.byClient).toEqual([
-      { key: "claude", expectedCells: 6, measuredCells: 5, cellCoverage: 0.833333 },
+      { key: "claude", expectedCells: 7, measuredCells: 6, cellCoverage: 0.857143 },
       { key: "codex", expectedCells: 2, measuredCells: 1, cellCoverage: 0.5 },
       { key: "gemini", expectedCells: 1, measuredCells: 0, cellCoverage: 0 },
     ]);
@@ -321,6 +327,7 @@ describeWithPostgres("ratchet census PostgreSQL integration", () => {
     // version, so this is a lexicographic sort. Asserting the exact token
     // strings is what pins the `::text` casts on the per-version totals.
     expect(report.segments.byCliVersion).toEqual([
+      { cliVersion: "4.00.0", users: 1, measuredUsers: 1, totalTokens: "0", measuredTokens: "0" },
       { cliVersion: "4.01.0", users: 1, measuredUsers: 1, totalTokens: "900", measuredTokens: "900" },
       { cliVersion: "4.02.0", users: 1, measuredUsers: 1, totalTokens: "1000", measuredTokens: "1000" },
       { cliVersion: "4.03.0", users: 1, measuredUsers: 1, totalTokens: "1500", measuredTokens: "1500" },
@@ -340,8 +347,9 @@ describeWithPostgres("ratchet census PostgreSQL integration", () => {
   it("ranks measured candidates by divergence and preserves bigint columns", async () => {
     const report = await getRatchetCensusReport({ candidateLimit: 10 });
 
-    // `clean` is measured but never a candidate; `warming`/`pending` are not
-    // measured at all. Ordering is `ABS(ratio - 1) DESC`.
+    // `zero` and `clean` are measured but never candidates;
+    // `warming`/`pending` are not measured at all. Ordering is
+    // `ABS(ratio - 1) DESC`.
     expect(
       report.candidates.map((candidate) => [candidate.username, candidate.band])
     ).toEqual([

--- a/packages/frontend/__tests__/lib/ratchetCensus.test.ts
+++ b/packages/frontend/__tests__/lib/ratchetCensus.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockExecute } = vi.hoisted(() => ({ mockExecute: vi.fn() }));
+
+vi.mock("@/lib/db", () => ({
+  db: { execute: mockExecute },
+}));
+
+import {
+  getRatchetCensusReport,
+  normalizeRatchetCensusCandidateLimit,
+  RATCHET_CENSUS_DEFAULT_CANDIDATE_LIMIT,
+  RATCHET_CENSUS_MAX_CANDIDATE_LIMIT,
+} from "@/lib/reconciliation/ratchetCensus";
+
+function reportFixture() {
+  return {
+    coverage: {
+      totalUsers: 10,
+      measuredUsers: 7,
+      totalTokens: "90071992547409930",
+      measuredTokens: "80000000000000000",
+      userCoverage: 0.7,
+      tokenCoverage: 0.888889,
+      pendingWorkItems: 2,
+    },
+    divergenceBands: [
+      { band: "warming", users: 3, tokens: "100" },
+      { band: "clean", users: 6, tokens: "700" },
+      { band: "severe", users: 1, tokens: "200" },
+    ],
+    observedCells: {
+      comparableCells: 25,
+      under: 1,
+      clean: 20,
+      mild: 2,
+      clear: 1,
+      severe: 1,
+      maxRatio: 3.5,
+    },
+    segments: {
+      byOrigin: [
+        { key: "cli", expectedCells: 100, measuredCells: 90, cellCoverage: 0.9 },
+      ],
+      byClient: [
+        { key: "claude", expectedCells: 50, measuredCells: 45, cellCoverage: 0.9 },
+      ],
+      byCliVersion: [
+        {
+          cliVersion: "4.12.0",
+          users: 5,
+          measuredUsers: 4,
+          totalTokens: "600",
+          measuredTokens: "500",
+        },
+      ],
+    },
+    candidates: [
+      {
+        username: "candidate",
+        totalTokens: "200",
+        highwaterTokens: "50",
+        ratio: 4,
+        band: "severe",
+        expectedCells: 4,
+        measuredCells: 4,
+        cliVersion: "4.12.0",
+        deviceCount: 2,
+      },
+    ],
+  };
+}
+
+function flattenSqlChunks(node: unknown): unknown[] {
+  if (
+    node &&
+    typeof node === "object" &&
+    Array.isArray((node as { queryChunks?: unknown }).queryChunks)
+  ) {
+    return (node as { queryChunks: unknown[] }).queryChunks.flatMap(flattenSqlChunks);
+  }
+  if (
+    node &&
+    typeof node === "object" &&
+    Array.isArray((node as { value?: unknown }).value)
+  ) {
+    return (node as { value: unknown[] }).value;
+  }
+  return [node];
+}
+
+describe("ratchet census report", () => {
+  beforeEach(() => mockExecute.mockReset());
+
+  it("preserves bigint token totals as strings and adds the snapshot timestamp", async () => {
+    mockExecute.mockResolvedValue([{ report: reportFixture() }]);
+
+    const report = await getRatchetCensusReport({
+      candidateLimit: 12,
+      now: new Date("2026-08-08T12:00:00.000Z"),
+    });
+
+    expect(report.coverage.totalTokens).toBe("90071992547409930");
+    expect(report.candidates[0].highwaterTokens).toBe("50");
+    expect(report.generatedAt).toBe("2026-08-08T12:00:00.000Z");
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps census coverage origin-aware and never treats an omitted shadow cell as zero", async () => {
+    mockExecute.mockResolvedValue([{ report: reportFixture() }]);
+
+    await getRatchetCensusReport();
+
+    const query = flattenSqlChunks(mockExecute.mock.calls[0][0]).join(" ");
+    expect(query).toContain("source.value #>> '{provenance,origin}'");
+    expect(query).toContain("t.origin = e.origin");
+    expect(query).toContain("db.source_breakdown ? r.client");
+    expect(query).not.toMatch(/\b(?:INSERT|UPDATE|DELETE|MERGE)\b/i);
+  });
+
+  it("fails closed when the database result does not match the report contract", async () => {
+    mockExecute.mockResolvedValue([{ report: { coverage: {} } }]);
+    await expect(getRatchetCensusReport()).rejects.toThrow();
+  });
+});
+
+describe("normalizeRatchetCensusCandidateLimit", () => {
+  it.each([null, "", "0", "-4", "1.5", "nope"])(
+    "uses the default for %j",
+    (value) => {
+      expect(normalizeRatchetCensusCandidateLimit(value)).toBe(
+        RATCHET_CENSUS_DEFAULT_CANDIDATE_LIMIT
+      );
+    }
+  );
+
+  it("accepts positive integers and caps expensive requests", () => {
+    expect(normalizeRatchetCensusCandidateLimit("17")).toBe(17);
+    expect(normalizeRatchetCensusCandidateLimit("10000")).toBe(
+      RATCHET_CENSUS_MAX_CANDIDATE_LIMIT
+    );
+  });
+});

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:reconciliation:db": "vitest run __tests__/integration/ratchetCensusPostgres.test.ts",
+    "test:reconciliation:db": "RATCHET_CENSUS_DB_INTEGRATION=1 vitest run __tests__/integration/ratchetCensusPostgres.test.ts",
     "test:migrations": "drizzle-kit migrate && bun scripts/check-migrations.ts",
     "gallery": "bun scripts/gallery/build-gallery.ts",
     "db:generate": "drizzle-kit generate",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:reconciliation:db": "vitest run __tests__/integration/ratchetCensusPostgres.test.ts",
     "test:migrations": "drizzle-kit migrate && bun scripts/check-migrations.ts",
     "gallery": "bun scripts/gallery/build-gallery.ts",
     "db:generate": "drizzle-kit generate",

--- a/packages/frontend/src/app/api/admin/reconciliation/census/route.ts
+++ b/packages/frontend/src/app/api/admin/reconciliation/census/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { requireAdminSession } from "@/lib/moderation/guard";
+import {
+  getRatchetCensusReport,
+  normalizeRatchetCensusCandidateLimit,
+} from "@/lib/reconciliation/ratchetCensus";
+
+export async function GET(request: Request) {
+  try {
+    const auth = await requireAdminSession(request);
+    if ("response" in auth) {
+      return auth.response;
+    }
+
+    const url = new URL(request.url);
+    const report = await getRatchetCensusReport({
+      candidateLimit: normalizeRatchetCensusCandidateLimit(
+        url.searchParams.get("candidateLimit")
+      ),
+    });
+
+    return NextResponse.json(report, {
+      headers: { "Cache-Control": "private, no-store" },
+    });
+  } catch (error) {
+    console.error("Ratchet census report error:", error);
+    return NextResponse.json(
+      { error: "Failed to load reconciliation census" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/frontend/src/lib/reconciliation/ratchetCensus.ts
+++ b/packages/frontend/src/lib/reconciliation/ratchetCensus.ts
@@ -1,0 +1,391 @@
+import { sql } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/lib/db";
+
+export const RATCHET_CENSUS_DEFAULT_CANDIDATE_LIMIT = 25;
+export const RATCHET_CENSUS_MAX_CANDIDATE_LIMIT = 100;
+
+const divergenceBandSchema = z.enum([
+  "pending",
+  "warming",
+  "under",
+  "clean",
+  "mild",
+  "clear",
+  "severe",
+]);
+
+const tokenTextSchema = z.union([z.string(), z.number()]).transform(String);
+
+const coverageSchema = z.object({
+  totalUsers: z.number().int().nonnegative(),
+  measuredUsers: z.number().int().nonnegative(),
+  totalTokens: tokenTextSchema,
+  measuredTokens: tokenTextSchema,
+  userCoverage: z.number().min(0).max(1),
+  tokenCoverage: z.number().min(0).max(1),
+  pendingWorkItems: z.number().int().nonnegative(),
+});
+
+const segmentSchema = z.object({
+  key: z.string(),
+  expectedCells: z.number().int().nonnegative(),
+  measuredCells: z.number().int().nonnegative(),
+  cellCoverage: z.number().min(0).max(1),
+});
+
+const reportPayloadSchema = z.object({
+  coverage: coverageSchema,
+  divergenceBands: z.array(
+    z.object({
+      band: divergenceBandSchema,
+      users: z.number().int().nonnegative(),
+      tokens: tokenTextSchema,
+    })
+  ),
+  observedCells: z.object({
+    comparableCells: z.number().int().nonnegative(),
+    under: z.number().int().nonnegative(),
+    clean: z.number().int().nonnegative(),
+    mild: z.number().int().nonnegative(),
+    clear: z.number().int().nonnegative(),
+    severe: z.number().int().nonnegative(),
+    maxRatio: z.number().nullable(),
+  }),
+  segments: z.object({
+    byOrigin: z.array(segmentSchema),
+    byClient: z.array(segmentSchema),
+    byCliVersion: z.array(
+      z.object({
+        cliVersion: z.string(),
+        users: z.number().int().nonnegative(),
+        measuredUsers: z.number().int().nonnegative(),
+        totalTokens: tokenTextSchema,
+        measuredTokens: tokenTextSchema,
+      })
+    ),
+  }),
+  candidates: z.array(
+    z.object({
+      username: z.string(),
+      totalTokens: tokenTextSchema,
+      highwaterTokens: tokenTextSchema,
+      ratio: z.number().positive(),
+      band: z.enum(["under", "mild", "clear", "severe"]),
+      expectedCells: z.number().int().positive(),
+      measuredCells: z.number().int().positive(),
+      cliVersion: z.string(),
+      deviceCount: z.number().int().nonnegative(),
+    })
+  ),
+});
+
+export type RatchetCensusReport = z.infer<typeof reportPayloadSchema> & {
+  generatedAt: string;
+};
+
+interface CensusDbRow extends Record<string, unknown> {
+  report: unknown;
+}
+
+export function normalizeRatchetCensusCandidateLimit(value: unknown): number {
+  const parsed = typeof value === "string" && value.trim() !== "" ? Number(value) : NaN;
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return RATCHET_CENSUS_DEFAULT_CANDIDATE_LIMIT;
+  }
+  return Math.min(parsed, RATCHET_CENSUS_MAX_CANDIDATE_LIMIT);
+}
+
+/**
+ * Builds the Phase 1 reconciliation gate inputs from one PostgreSQL snapshot.
+ *
+ * Read-only by construction: this is a single SELECT with no writable CTEs.
+ * A user is "measured" only after every month/client/origin cell visible in
+ * their guarded daily rows has a matching per-device high-water row and no
+ * durable census work remains. Missing cells therefore mean "warming", never
+ * zero. Phase 4a comparisons likewise join only cells explicitly present in
+ * both stores; an omitted latest observation is not treated as a deletion.
+ *
+ * The report deliberately stops at gate inputs. It does not authorize Phase 2
+ * or mutate served totals; rollout thresholds remain an operator decision.
+ */
+export async function getRatchetCensusReport(params?: {
+  candidateLimit?: number;
+  now?: Date;
+}): Promise<RatchetCensusReport> {
+  const candidateLimit = Math.min(
+    Math.max(params?.candidateLimit ?? RATCHET_CENSUS_DEFAULT_CANDIDATE_LIMIT, 1),
+    RATCHET_CENSUS_MAX_CANDIDATE_LIMIT
+  );
+
+  const result = await db.execute<CensusDbRow>(sql`
+    WITH expected_cells AS (
+      SELECT DISTINCT
+        s.user_id,
+        db.submitted_device_id,
+        source.key AS client,
+        COALESCE(NULLIF(source.value #>> '{provenance,origin}', ''), 'cli') AS origin,
+        to_char(db.date, 'YYYY-MM') AS bucket_key
+      FROM daily_breakdown AS db
+      JOIN submissions AS s ON s.id = db.submission_id
+      CROSS JOIN LATERAL jsonb_each(
+        COALESCE(db.source_breakdown, '{}'::jsonb)
+      ) AS source(key, value)
+    ),
+    expected_status AS (
+      SELECT
+        e.user_id,
+        e.client,
+        e.origin,
+        COUNT(*)::int AS expected_cells,
+        COUNT(t.submitted_device_id)::int AS measured_cells
+      FROM expected_cells AS e
+      LEFT JOIN submitted_device_client_totals AS t
+        ON t.submitted_device_id = e.submitted_device_id
+       AND t.client = e.client
+       AND t.origin = e.origin
+       AND t.bucket_width = 'month'
+       AND t.bucket_key = e.bucket_key
+      GROUP BY e.user_id, e.client, e.origin
+    ),
+    coverage_by_user AS (
+      SELECT
+        user_id,
+        SUM(expected_cells)::int AS expected_cells,
+        SUM(measured_cells)::int AS measured_cells
+      FROM expected_status
+      GROUP BY user_id
+    ),
+    highwater_by_user AS (
+      SELECT
+        d.user_id,
+        COUNT(*)::int AS bucket_count,
+        COALESCE(SUM(t.tokens_highwater), 0) AS highwater_tokens
+      FROM submitted_device_client_totals AS t
+      JOIN submitted_devices AS d ON d.id = t.submitted_device_id
+      WHERE t.bucket_width = 'month'
+      GROUP BY d.user_id
+    ),
+    pending_by_user AS (
+      SELECT s.user_id, COUNT(*)::int AS pending_work
+      FROM ratchet_census_work AS w
+      JOIN submissions AS s ON s.id = w.submission_id
+      GROUP BY s.user_id
+    ),
+    devices_by_user AS (
+      SELECT user_id, COUNT(*)::int AS device_count
+      FROM submitted_devices
+      GROUP BY user_id
+    ),
+    per_user AS (
+      SELECT
+        u.username,
+        s.user_id,
+        s.total_tokens::numeric AS total_tokens,
+        COALESCE(NULLIF(s.cli_version, ''), 'unknown') AS cli_version,
+        COALESCE(c.expected_cells, 0) AS expected_cells,
+        COALESCE(c.measured_cells, 0) AS measured_cells,
+        COALESCE(h.bucket_count, 0) AS bucket_count,
+        COALESCE(h.highwater_tokens, 0)::numeric AS highwater_tokens,
+        COALESCE(p.pending_work, 0) AS pending_work,
+        COALESCE(d.device_count, 0) AS device_count,
+        (
+          COALESCE(c.expected_cells, 0) > 0
+          AND c.measured_cells = c.expected_cells
+          AND COALESCE(p.pending_work, 0) = 0
+          AND COALESCE(h.highwater_tokens, 0) > 0
+        ) AS fully_measured
+      FROM submissions AS s
+      JOIN users AS u ON u.id = s.user_id
+      LEFT JOIN coverage_by_user AS c ON c.user_id = s.user_id
+      LEFT JOIN highwater_by_user AS h ON h.user_id = s.user_id
+      LEFT JOIN pending_by_user AS p ON p.user_id = s.user_id
+      LEFT JOIN devices_by_user AS d ON d.user_id = s.user_id
+    ),
+    classified AS (
+      SELECT
+        p.*,
+        CASE
+          WHEN p.pending_work > 0 THEN 'pending'
+          WHEN NOT p.fully_measured THEN 'warming'
+          WHEN p.total_tokens / NULLIF(p.highwater_tokens, 0) < 0.95 THEN 'under'
+          WHEN p.total_tokens / NULLIF(p.highwater_tokens, 0) <= 1.05 THEN 'clean'
+          WHEN p.total_tokens / NULLIF(p.highwater_tokens, 0) <= 1.25 THEN 'mild'
+          WHEN p.total_tokens / NULLIF(p.highwater_tokens, 0) <= 2.0 THEN 'clear'
+          ELSE 'severe'
+        END AS band,
+        CASE WHEN p.fully_measured
+          THEN p.total_tokens / NULLIF(p.highwater_tokens, 0)
+          ELSE NULL
+        END AS ratio
+      FROM per_user AS p
+    ),
+    site AS (
+      SELECT
+        COUNT(*)::int AS total_users,
+        COUNT(*) FILTER (WHERE fully_measured)::int AS measured_users,
+        COALESCE(SUM(total_tokens), 0) AS total_tokens,
+        COALESCE(SUM(total_tokens) FILTER (WHERE fully_measured), 0) AS measured_tokens
+      FROM classified
+    ),
+    pending_site AS (
+      SELECT COUNT(*)::int AS pending_work_items FROM ratchet_census_work
+    ),
+    divergence AS (
+      SELECT
+        band,
+        COUNT(*)::int AS users,
+        COALESCE(SUM(total_tokens), 0) AS tokens
+      FROM classified
+      GROUP BY band
+    ),
+    observed_cell_ratios AS (
+      SELECT
+        (
+          COALESCE((db.source_breakdown -> r.client ->> 'tokens')::numeric, 0)
+          / NULLIF(r.tokens::numeric, 0)
+        ) AS ratio
+      FROM daily_breakdown_reported AS r
+      JOIN daily_breakdown AS db
+        ON db.submitted_device_id = r.submitted_device_id
+       AND db.date = r.date
+      WHERE r.tokens > 0
+        AND db.source_breakdown ? r.client
+    ),
+    observed_cells AS (
+      SELECT
+        COUNT(*)::int AS comparable_cells,
+        COUNT(*) FILTER (WHERE ratio < 0.95)::int AS under_count,
+        COUNT(*) FILTER (WHERE ratio >= 0.95 AND ratio <= 1.05)::int AS clean_count,
+        COUNT(*) FILTER (WHERE ratio > 1.05 AND ratio <= 1.25)::int AS mild_count,
+        COUNT(*) FILTER (WHERE ratio > 1.25 AND ratio <= 2.0)::int AS clear_count,
+        COUNT(*) FILTER (WHERE ratio > 2.0)::int AS severe_count,
+        MAX(ratio) AS max_ratio
+      FROM observed_cell_ratios
+      WHERE ratio IS NOT NULL
+    ),
+    origin_segments AS (
+      SELECT
+        origin AS key,
+        SUM(expected_cells)::int AS expected_cells,
+        SUM(measured_cells)::int AS measured_cells
+      FROM expected_status
+      GROUP BY origin
+    ),
+    client_segments AS (
+      SELECT
+        client AS key,
+        SUM(expected_cells)::int AS expected_cells,
+        SUM(measured_cells)::int AS measured_cells
+      FROM expected_status
+      GROUP BY client
+    ),
+    version_segments AS (
+      SELECT
+        cli_version,
+        COUNT(*)::int AS users,
+        COUNT(*) FILTER (WHERE fully_measured)::int AS measured_users,
+        COALESCE(SUM(total_tokens), 0) AS total_tokens,
+        COALESCE(SUM(total_tokens) FILTER (WHERE fully_measured), 0) AS measured_tokens
+      FROM classified
+      GROUP BY cli_version
+    ),
+    candidates AS (
+      SELECT *
+      FROM classified
+      WHERE fully_measured
+        AND band IN ('under', 'mild', 'clear', 'severe')
+      ORDER BY ABS(ratio - 1) DESC, total_tokens DESC, username
+      LIMIT ${candidateLimit}
+    )
+    SELECT jsonb_build_object(
+      'coverage', jsonb_build_object(
+        'totalUsers', site.total_users,
+        'measuredUsers', site.measured_users,
+        'totalTokens', site.total_tokens::text,
+        'measuredTokens', site.measured_tokens::text,
+        'userCoverage', COALESCE(
+          ROUND(site.measured_users::numeric / NULLIF(site.total_users, 0), 6), 0
+        ),
+        'tokenCoverage', COALESCE(
+          ROUND(site.measured_tokens / NULLIF(site.total_tokens, 0), 6), 0
+        ),
+        'pendingWorkItems', pending_site.pending_work_items
+      ),
+      'divergenceBands', COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+          'band', band,
+          'users', users,
+          'tokens', tokens::text
+        ) ORDER BY CASE band
+          WHEN 'pending' THEN 0 WHEN 'warming' THEN 1 WHEN 'under' THEN 2
+          WHEN 'clean' THEN 3 WHEN 'mild' THEN 4 WHEN 'clear' THEN 5 ELSE 6 END)
+        FROM divergence
+      ), '[]'::jsonb),
+      'observedCells', jsonb_build_object(
+        'comparableCells', observed_cells.comparable_cells,
+        'under', observed_cells.under_count,
+        'clean', observed_cells.clean_count,
+        'mild', observed_cells.mild_count,
+        'clear', observed_cells.clear_count,
+        'severe', observed_cells.severe_count,
+        'maxRatio', observed_cells.max_ratio
+      ),
+      'segments', jsonb_build_object(
+        'byOrigin', COALESCE((
+          SELECT jsonb_agg(jsonb_build_object(
+            'key', key,
+            'expectedCells', expected_cells,
+            'measuredCells', measured_cells,
+            'cellCoverage', COALESCE(
+              ROUND(measured_cells::numeric / NULLIF(expected_cells, 0), 6), 0
+            )
+          ) ORDER BY key) FROM origin_segments
+        ), '[]'::jsonb),
+        'byClient', COALESCE((
+          SELECT jsonb_agg(jsonb_build_object(
+            'key', key,
+            'expectedCells', expected_cells,
+            'measuredCells', measured_cells,
+            'cellCoverage', COALESCE(
+              ROUND(measured_cells::numeric / NULLIF(expected_cells, 0), 6), 0
+            )
+          ) ORDER BY expected_cells DESC, key) FROM client_segments
+        ), '[]'::jsonb),
+        'byCliVersion', COALESCE((
+          SELECT jsonb_agg(jsonb_build_object(
+            'cliVersion', cli_version,
+            'users', users,
+            'measuredUsers', measured_users,
+            'totalTokens', total_tokens::text,
+            'measuredTokens', measured_tokens::text
+          ) ORDER BY users DESC, cli_version) FROM version_segments
+        ), '[]'::jsonb)
+      ),
+      'candidates', COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+          'username', username,
+          'totalTokens', total_tokens::text,
+          'highwaterTokens', highwater_tokens::text,
+          'ratio', ratio,
+          'band', band,
+          'expectedCells', expected_cells,
+          'measuredCells', measured_cells,
+          'cliVersion', cli_version,
+          'deviceCount', device_count
+        ) ORDER BY ABS(ratio - 1) DESC, total_tokens DESC, username)
+        FROM candidates
+      ), '[]'::jsonb)
+    ) AS report
+    FROM site
+    CROSS JOIN pending_site
+    CROSS JOIN observed_cells
+  `);
+
+  const rows = result as unknown as CensusDbRow[];
+  const parsed = reportPayloadSchema.parse(rows[0]?.report);
+  return {
+    ...parsed,
+    generatedAt: (params?.now ?? new Date()).toISOString(),
+  };
+}

--- a/packages/frontend/src/lib/reconciliation/ratchetCensus.ts
+++ b/packages/frontend/src/lib/reconciliation/ratchetCensus.ts
@@ -193,7 +193,6 @@ export async function getRatchetCensusReport(params?: {
           COALESCE(c.expected_cells, 0) > 0
           AND c.measured_cells = c.expected_cells
           AND COALESCE(p.pending_work, 0) = 0
-          AND COALESCE(h.highwater_tokens, 0) > 0
         ) AS fully_measured
       FROM submissions AS s
       JOIN users AS u ON u.id = s.user_id
@@ -208,14 +207,18 @@ export async function getRatchetCensusReport(params?: {
         CASE
           WHEN p.pending_work > 0 THEN 'pending'
           WHEN NOT p.fully_measured THEN 'warming'
+          WHEN p.total_tokens = 0 AND p.highwater_tokens = 0 THEN 'clean'
+          WHEN p.highwater_tokens = 0 THEN 'severe'
           WHEN p.total_tokens / NULLIF(p.highwater_tokens, 0) < 0.95 THEN 'under'
           WHEN p.total_tokens / NULLIF(p.highwater_tokens, 0) <= 1.05 THEN 'clean'
           WHEN p.total_tokens / NULLIF(p.highwater_tokens, 0) <= 1.25 THEN 'mild'
           WHEN p.total_tokens / NULLIF(p.highwater_tokens, 0) <= 2.0 THEN 'clear'
           ELSE 'severe'
         END AS band,
-        CASE WHEN p.fully_measured
-          THEN p.total_tokens / NULLIF(p.highwater_tokens, 0)
+        CASE
+          WHEN p.fully_measured AND p.total_tokens = 0 AND p.highwater_tokens = 0 THEN 1
+          WHEN p.fully_measured AND p.highwater_tokens > 0
+            THEN p.total_tokens / p.highwater_tokens
           ELSE NULL
         END AS ratio
       FROM per_user AS p
@@ -295,6 +298,7 @@ export async function getRatchetCensusReport(params?: {
       FROM classified
       WHERE fully_measured
         AND band IN ('under', 'mild', 'clear', 'severe')
+        AND ratio IS NOT NULL
       ORDER BY ABS(ratio - 1) DESC, total_tokens DESC, username
       LIMIT ${candidateLimit}
     )


### PR DESCRIPTION
## Summary

- add an admin-only `GET /api/admin/reconciliation/census` endpoint that exposes reconciliation gate inputs without changing served totals
- count a user as measured only when every expected device/client/origin/month cell has a matching high-water row and no durable census work remains
- classify divergence, report explicit cell comparisons, segment coverage, and return a bounded repair-candidate sample
- execute the production census SQL against a migrated PostgreSQL 16 fixture in CI
- treat a fully covered zero-token user as a valid clean `0/0` observation, while keeping undefined zero-denominator cases out of candidate ranking

Advances the evidence-gathering path for #960. It does not enable automatic repair or change leaderboard totals.

## Why

The project already records guarded daily totals and per-device high-water buckets, but operators had no single read surface that could prove whether the population was sufficiently measured before a recovery rollout. Treating an absent measurement as zero would manufacture severe regressions during warm-up, while treating a durable zero-valued measurement as absent would keep valid zero-token users permanently warming.

This report separates those states: expected cells must be explicitly covered, pending work blocks readiness, and a fully measured `0/0` user is clean rather than missing.

## Safety model

- concealed behind the existing admin-session guard; non-admin callers receive the same `404` used by the moderation surface
- one read-only PostgreSQL snapshot with no writable CTEs, locks, scheduled work, or repair side effects
- `private, no-store` response; bigint token totals remain strings; the database payload is validated before it leaves the server
- candidate limits are normalized and capped at 100
- incomplete coverage remains `pending` or `warming`; only explicit complete evidence can enter a divergence band
- no invariant regression introduced

## Diff scope

- census report contract and SQL snapshot query
- authenticated read-only API route
- focused unit and route tests
- PostgreSQL integration fixture and CI invocation
- operator-facing recovery documentation

No schema migration, submission write path, public leaderboard path, dependency, or version manifest changed.

## Branch and commit integrity

- base: `origin/main` at `9814fa49e8ba32b19d94ef2b1545b66b17944435`
- ahead/behind against the fetched base: 4 ahead / 44 behind
- merge base: `d1d2c2d62d8095b5f287c7986fa5ed5e3addb97d`
- GitHub reports the PR mergeable; final pull-request CI is the required synthetic-merge proof against current `main`
- introduced commits:
  - `f023a440a201576173834f7e1e8772a388e8a531 feat(submit): expose reconciliation census gate inputs`
  - `c3e253aef539eb8978172a7040c8e93ff4fcbf59 test(reconciliation): verify census SQL against postgres instead of a mock`
  - `dcb49c7662b41c440bbc40b52a0a956347bba5da chore(frontend): set the census integration flag in its own test script`
  - `5625cb07314f11846b18d8c358bf162d306dad4d fix(submit): classify covered zero-token census users`
- multiple commits are intentional post-review corrections within one census change; the final PR diff contains only the intended eight files
- ledger: not applicable — not required for this change family
- version: not applicable — release tooling owns version synchronization

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: eight intended files
- `git diff --check origin/main...HEAD`: PASS, no output
- no secrets, local environment files, caches, build output, coverage artifacts, or unrelated generated files are included

## Validation mode and local proof

Validation mode: Mode 4 — the runtime change is a read-only admin query and the PR extends CI verification for its PostgreSQL contract.

- targeted census unit and route Vitest: PASS, 20 tests
- full frontend Vitest: PASS, 858 tests; the six opt-in PostgreSQL tests were collected but require the CI database flag
- frontend TypeScript typecheck: PASS
- targeted ESLint for every changed TypeScript runtime/test file: PASS
- PostgreSQL integration locally: not run — mandatory Frontend Migration Replay runs the fixture against PostgreSQL 16 on the final PR SHA

## Remote proof on final SHA

All checks passed on `5625cb07314f11846b18d8c358bf162d306dad4d`:

- Frontend Migration Replay, including the PostgreSQL 16 census fixture
- Frontend Vitest
- Frontend Container
- Actionlint
- Vercel preview
- Cubic review
- repository merge/WIP gates

## Runtime and migration notes

No migration changed. The PostgreSQL fixture runs after the existing migration replay and deletes its own users through schema cascades. Runtime code adds no write, queue, background poll, or served-total switch.

## Rollback

Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: none known.

## Known residual risk

The census performs full-site aggregates, so execution cost scales with reconciliation history. The route is admin-only and unscheduled, and the candidate payload is bounded; production latency should still be observed before using it as a frequently refreshed dashboard.
