### PR TITLE
fix(prime-agent): cache reconciliation accounting

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1069,7 +1069,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             );
         };
 
-        let fingerprint = match fingerprint_status {
+        let mut fingerprint = match fingerprint_status {
             message_cache::FingerprintStatus::Unchanged => cached
                 .expect("an uncached source always builds a complete fingerprint")
                 .fingerprint
@@ -1079,31 +1079,59 @@ fn parse_all_messages_with_pricing_with_env_strategy(
 
         if let Some(cached) = cached {
             if cached.fingerprint == fingerprint && !cached.messages.is_empty() {
-                let (accounting, cache_entry) = match cached.prime_accounting.as_ref() {
-                    Some(accounting) => (accounting.clone(), None),
-                    None => {
-                        // Version-4 entries already contain valid messages but
-                        // predate Prime accounting metadata. Decode just the
-                        // accounting view once, then rewrite the same identity
-                        // and fingerprint with the backfill attached.
-                        let accounting = sessions::prime_agent::analyze_prime_agent_accounting(
-                            path,
-                            &cached.messages,
+                if let Some(accounting) = cached.prime_accounting.as_ref() {
+                    return (
+                        CachedParseOutcome {
+                            messages: cached_messages(cached, pricing),
+                            cache_entry: None,
+                            invalidate_cache: false,
+                        },
+                        accounting.clone(),
+                    );
+                }
+
+                // Version-4 entries already contain valid messages but predate
+                // Prime accounting metadata. Decode just the accounting view
+                // once, but never combine it with those messages until the
+                // fingerprint is revalidated: the file can change between the
+                // first check and this second transcript read.
+                #[cfg(test)]
+                sessions::prime_agent::run_accounting_backfill_test_hook(path);
+                let accounting =
+                    sessions::prime_agent::analyze_prime_agent_accounting(path, &cached.messages);
+                match message_cache::SourceFingerprint::check_path_samples_only(
+                    path,
+                    Some(&fingerprint),
+                ) {
+                    Some(message_cache::FingerprintStatus::Unchanged) => {
+                        return (
+                            CachedParseOutcome {
+                                messages: cached_messages(cached, pricing),
+                                cache_entry: Some(
+                                    cached.clone().with_prime_accounting(accounting.clone()),
+                                ),
+                                invalidate_cache: false,
+                            },
+                            accounting,
                         );
-                        (
-                            accounting.clone(),
-                            Some(cached.clone().with_prime_accounting(accounting)),
-                        )
                     }
-                };
-                return (
-                    CachedParseOutcome {
-                        messages: cached_messages(cached, pricing),
-                        cache_entry,
-                        invalidate_cache: false,
-                    },
-                    accounting,
-                );
+                    Some(message_cache::FingerprintStatus::Changed(refreshed)) => {
+                        fingerprint = refreshed;
+                    }
+                    None => {
+                        let (mut messages, accounting) =
+                            sessions::prime_agent::parse_prime_agent_file_with_accounting(path);
+                        apply_pricing_to_messages(&mut messages, pricing);
+                        return (
+                            CachedParseOutcome {
+                                messages,
+                                cache_entry: None,
+                                invalidate_cache: false,
+                            },
+                            accounting,
+                        );
+                    }
+                }
             }
         }
 
@@ -11462,6 +11490,59 @@ mod tests {
             .unwrap()
             .prime_accounting
             .is_some());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_prime_agent_legacy_backfill_rebuilds_if_source_changes_during_read() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let sessions_dir = source_home.path().join(".prime/agent/sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let source_path = sessions_dir.join("legacy-race.jsonl");
+        let old_contents = r#"{"type":"session","version":3,"id":"legacy","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":120,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":130}}}
+{"type":"child_usage_attributed","id":"usage-1","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":20,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":20},"aggregateUsage":{"input":120,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":130},"origin":"spawn_task"}
+"#;
+        let new_contents = r#"{"type":"session","version":3,"id":"legacy","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":240,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":250}}}
+{"type":"child_usage_attributed","id":"usage-1","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":40,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":40},"aggregateUsage":{"input":240,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":250},"origin":"spawn_task"}
+"#;
+        std::fs::write(&source_path, old_contents).unwrap();
+
+        let identity = message_cache::CacheIdentity::for_client(ClientId::PrimeAgent);
+        let messages = sessions::prime_agent::parse_prime_agent_file(&source_path);
+        let mut cache = message_cache::SourceMessageCache::default();
+        cache.insert(message_cache::CachedSourceEntry::new(
+            identity,
+            &source_path,
+            message_cache::SourceFingerprint::from_path(&source_path).unwrap(),
+            messages,
+            Vec::new(),
+            None,
+        ));
+        cache.save_if_dirty();
+
+        sessions::prime_agent::schedule_accounting_backfill_test_rewrite(
+            &source_path,
+            new_contents.to_string(),
+        );
+        sessions::prime_agent::reset_transcript_decode_call_counts(source_home.path());
+        let clients = ["prime-agent".to_string()];
+        let rebuilt =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        let rebuild_calls = sessions::prime_agent::transcript_decode_call_counts();
+        assert_eq!(rebuild_calls, (1, 1));
+        assert_eq!(rebuilt[0].tokens.input, 240);
+
+        let warm =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        assert_eq!(
+            sessions::prime_agent::transcript_decode_call_counts(),
+            rebuild_calls
+        );
+        assert_eq!(warm[0].tokens.input, 240);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1042,6 +1042,83 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         )
     }
 
+    fn uncached_prime_outcome(
+        mut messages: Vec<UnifiedMessage>,
+        accounting: sessions::prime_agent::PrimeFileAccounting,
+        pricing: Option<&pricing::PricingService>,
+    ) -> (
+        CachedParseOutcome,
+        sessions::prime_agent::PrimeFileAccounting,
+    ) {
+        apply_pricing_to_messages(&mut messages, pricing);
+        (
+            CachedParseOutcome {
+                messages,
+                cache_entry: None,
+                invalidate_cache: false,
+            },
+            accounting,
+        )
+    }
+
+    fn parse_stable_prime_source(
+        path: &Path,
+        identity: message_cache::CacheIdentity,
+        mut fingerprint_before: message_cache::SourceFingerprint,
+        pricing: Option<&pricing::PricingService>,
+    ) -> (
+        CachedParseOutcome,
+        sessions::prime_agent::PrimeFileAccounting,
+    ) {
+        const MAX_STABLE_PARSE_ATTEMPTS: usize = 2;
+
+        let mut last_parse = None;
+        for _ in 0..MAX_STABLE_PARSE_ATTEMPTS {
+            #[cfg(test)]
+            sessions::prime_agent::run_stable_parse_test_hook(path);
+
+            // Both views come from this one decoded record stream. Exact hashes
+            // on either side ensure that the pair is only cached when the bytes
+            // stayed at the fingerprint under which the entry is stored.
+            let parsed = sessions::prime_agent::parse_prime_agent_file_with_accounting(path);
+            let Some(fingerprint_after) = message_cache::SourceFingerprint::from_path(path) else {
+                return uncached_prime_outcome(parsed.0, parsed.1, pricing);
+            };
+            if fingerprint_after == fingerprint_before {
+                let (mut messages, accounting) = parsed;
+                let cache_entry = (!messages.is_empty()).then(|| {
+                    message_cache::CachedSourceEntry::new(
+                        identity,
+                        path,
+                        fingerprint_after,
+                        messages.clone(),
+                        Vec::new(),
+                        None,
+                    )
+                    .with_prime_accounting(accounting.clone())
+                });
+                apply_pricing_to_messages(&mut messages, pricing);
+                return (
+                    CachedParseOutcome {
+                        messages,
+                        cache_entry,
+                        invalidate_cache: false,
+                    },
+                    accounting,
+                );
+            }
+
+            fingerprint_before = fingerprint_after;
+            last_parse = Some(parsed);
+        }
+
+        // A continuously rewritten file still yields a coherent messages +
+        // accounting pair from one pass, but no cache entry may claim that pair
+        // belongs to either exact fingerprint observed around the read.
+        let (messages, accounting) = last_parse.expect("the retry bound is non-zero");
+        uncached_prime_outcome(messages, accounting, pricing)
+    }
+
     fn load_or_parse_prime_source(
         path: &Path,
         source_cache: &message_cache::SourceMessageCache,
@@ -1056,17 +1133,9 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             path,
             cached.map(|entry| &entry.fingerprint),
         ) else {
-            let (mut messages, accounting) =
+            let (messages, accounting) =
                 sessions::prime_agent::parse_prime_agent_file_with_accounting(path);
-            apply_pricing_to_messages(&mut messages, pricing);
-            return (
-                CachedParseOutcome {
-                    messages,
-                    cache_entry: None,
-                    invalidate_cache: false,
-                },
-                accounting,
-            );
+            return uncached_prime_outcome(messages, accounting, pricing);
         };
 
         let mut fingerprint = match fingerprint_status {
@@ -1080,82 +1149,65 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         if let Some(cached) = cached {
             if cached.fingerprint == fingerprint && !cached.messages.is_empty() {
                 if let Some(accounting) = cached.prime_accounting.as_ref() {
-                    return (
-                        CachedParseOutcome {
-                            messages: cached_messages(cached, pricing),
-                            cache_entry: None,
-                            invalidate_cache: false,
-                        },
-                        accounting.clone(),
-                    );
-                }
-
-                // Version-4 entries already contain valid messages but predate
-                // Prime accounting metadata. Decode just the accounting view
-                // once, but never combine it with those messages until the
-                // fingerprint is revalidated with a full content hash: the
-                // file can change between the first bounded-sample check and
-                // this second transcript read, including outside sample windows.
-                #[cfg(test)]
-                sessions::prime_agent::run_accounting_backfill_test_hook(path);
-                let accounting =
-                    sessions::prime_agent::analyze_prime_agent_accounting(path, &cached.messages);
-                match message_cache::SourceFingerprint::from_path(path) {
-                    Some(refreshed) if refreshed == fingerprint => {
-                        return (
-                            CachedParseOutcome {
-                                messages: cached_messages(cached, pricing),
-                                cache_entry: Some(
-                                    cached.clone().with_prime_accounting(accounting.clone()),
-                                ),
-                                invalidate_cache: false,
-                            },
-                            accounting,
-                        );
+                    // Prime's accounting is byte-coupled to its messages. Warm
+                    // v5 scans therefore hash the complete transcript before a
+                    // hit, while still avoiding JSON decode and accounting walk.
+                    match message_cache::SourceFingerprint::from_path(path) {
+                        Some(refreshed) if refreshed == cached.fingerprint => {
+                            return (
+                                CachedParseOutcome {
+                                    messages: cached_messages(cached, pricing),
+                                    cache_entry: None,
+                                    invalidate_cache: false,
+                                },
+                                accounting.clone(),
+                            );
+                        }
+                        Some(refreshed) => fingerprint = refreshed,
+                        None => {
+                            let (messages, accounting) =
+                                sessions::prime_agent::parse_prime_agent_file_with_accounting(path);
+                            return uncached_prime_outcome(messages, accounting, pricing);
+                        }
                     }
-                    Some(refreshed) => fingerprint = refreshed,
-                    None => {
-                        let (mut messages, accounting) =
-                            sessions::prime_agent::parse_prime_agent_file_with_accounting(path);
-                        apply_pricing_to_messages(&mut messages, pricing);
-                        return (
-                            CachedParseOutcome {
-                                messages,
-                                cache_entry: None,
-                                invalidate_cache: false,
-                            },
-                            accounting,
-                        );
+                } else {
+                    // Version-4 entries already contain valid messages but predate
+                    // Prime accounting metadata. Decode just the accounting view
+                    // once, but never combine it with those messages until the
+                    // fingerprint is revalidated with a full content hash: the
+                    // file can change between the first bounded-sample check and
+                    // this second transcript read, including outside sample windows.
+                    #[cfg(test)]
+                    sessions::prime_agent::run_accounting_backfill_test_hook(path);
+                    let accounting = sessions::prime_agent::analyze_prime_agent_accounting(
+                        path,
+                        &cached.messages,
+                    );
+                    match message_cache::SourceFingerprint::from_path(path) {
+                        Some(refreshed) if refreshed == fingerprint => {
+                            return (
+                                CachedParseOutcome {
+                                    messages: cached_messages(cached, pricing),
+                                    cache_entry: Some(
+                                        cached.clone().with_prime_accounting(accounting.clone()),
+                                    ),
+                                    invalidate_cache: false,
+                                },
+                                accounting,
+                            );
+                        }
+                        Some(refreshed) => fingerprint = refreshed,
+                        None => {
+                            let (messages, accounting) =
+                                sessions::prime_agent::parse_prime_agent_file_with_accounting(path);
+                            return uncached_prime_outcome(messages, accounting, pricing);
+                        }
                     }
                 }
             }
         }
 
-        // A cold or changed Prime transcript produces both views from the one
-        // decoded Pi record stream. The accounting payload is persisted beside
-        // the raw messages under this exact fingerprint.
-        let (mut messages, accounting) =
-            sessions::prime_agent::parse_prime_agent_file_with_accounting(path);
-        let cache_entry = (!messages.is_empty()).then(|| {
-            message_cache::CachedSourceEntry::new(
-                identity,
-                path,
-                fingerprint,
-                messages.clone(),
-                Vec::new(),
-                None,
-            )
-            .with_prime_accounting(accounting.clone())
-        });
-        apply_pricing_to_messages(&mut messages, pricing);
-        (
-            CachedParseOutcome {
-                messages,
-                cache_entry,
-                invalidate_cache: false,
-            },
-            accounting,
-        )
+        parse_stable_prime_source(path, identity, fingerprint, pricing)
     }
 
     fn load_or_parse_sqlite_source<F>(
@@ -4669,6 +4721,39 @@ mod tests {
             false,
             &scanner::ScannerSettings::default(),
         )
+    }
+
+    fn large_prime_contents(input: i64, child_input: i64) -> String {
+        const FILE_BYTES: usize = 100_000;
+        const SEMANTIC_OFFSET: usize = 10_000;
+        let before_padding = r#"{"type":"session","version":3,"id":"legacy","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","padding":""#;
+        let before_semantic = r#"","usage":{"#;
+        let padding_bytes = SEMANTIC_OFFSET
+            .checked_sub(before_padding.len() + before_semantic.len())
+            .unwrap();
+        let mut contents = String::with_capacity(FILE_BYTES);
+        contents.push_str(before_padding);
+        contents.push_str(&"p".repeat(padding_bytes));
+        contents.push_str(before_semantic);
+        assert_eq!(contents.len(), SEMANTIC_OFFSET);
+        contents.push_str(&format!(
+            r#""input":{input},"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":{}}}}}}}
+{{"type":"child_usage_attributed","id":"usage-1","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{{"input":{child_input},"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":{child_input}}},"aggregateUsage":{{"input":{input},"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":{}}},"origin":"spawn_task"}}
+"#,
+            input + 10,
+            input + 10,
+        ));
+        let tail_prefix = r#"{"type":"ignored","padding":""#;
+        let tail_suffix = "\"}\n";
+        let tail_bytes = FILE_BYTES
+            .checked_sub(contents.len() + tail_prefix.len() + tail_suffix.len())
+            .unwrap();
+        contents.push_str(tail_prefix);
+        contents.push_str(&"t".repeat(tail_bytes));
+        contents.push_str(tail_suffix);
+        assert_eq!(contents.len(), FILE_BYTES);
+        contents
     }
 
     fn home_guard() -> crate::paths::test_env::EnvGuard {
@@ -11434,6 +11519,134 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn test_prime_agent_warm_cache_hashes_unsampled_semantic_rewrite() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let sessions_dir = source_home.path().join(".prime/agent/sessions");
+        let child_dir = source_home
+            .path()
+            .join(".prime/agent/session-artifacts/legacy/sub-child");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        std::fs::create_dir_all(&child_dir).unwrap();
+        let source_path = sessions_dir.join("legacy.jsonl");
+        let child_path = child_dir.join("child.jsonl");
+        let old_contents = large_prime_contents(120, 20);
+        let new_contents = large_prime_contents(240, 40);
+        assert_eq!(old_contents.len(), new_contents.len());
+        assert_eq!(&old_contents[..4_096], &new_contents[..4_096]);
+        assert_eq!(&old_contents[23_976..], &new_contents[23_976..]);
+        std::fs::write(&source_path, old_contents).unwrap();
+        std::fs::write(
+            &child_path,
+            format!(
+                r#"{{"type":"session","version":3,"id":"child","timestamp":"2026-08-08T00:00:01.000Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child-message","parentId":null,"timestamp":"2026-08-08T00:00:02.000Z","message":{{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"child-response","usage":{{"input":40,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":40}}}}}}
+"#,
+                paths::json_path_literal(&source_path)
+            ),
+        )
+        .unwrap();
+
+        let clients = ["prime-agent".to_string()];
+        let established =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        assert_eq!(
+            established
+                .iter()
+                .map(|message| message.tokens.input)
+                .sum::<i64>(),
+            160
+        );
+
+        let original_modified = std::fs::metadata(&source_path).unwrap().modified().unwrap();
+        std::fs::write(&source_path, new_contents).unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(&source_path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(original_modified))
+            .unwrap();
+
+        sessions::prime_agent::reset_transcript_decode_call_counts(source_home.path());
+        let warm =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        assert_eq!(
+            sessions::prime_agent::transcript_decode_call_counts(),
+            (1, 0),
+            "the rewritten root is decoded once while the unchanged child stays decode-free"
+        );
+
+        let (root_messages, root_accounting) =
+            sessions::prime_agent::parse_prime_agent_file_with_accounting(&source_path);
+        let (child_messages, child_accounting) =
+            sessions::prime_agent::parse_prime_agent_file_with_accounting(&child_path);
+        let expected_cold = sessions::prime_agent::reconcile_prime_agent_messages(
+            root_messages.into_iter().chain(child_messages).collect(),
+            &[root_accounting, child_accounting],
+        );
+        assert_eq!(warm, expected_cold);
+        assert_eq!(
+            warm.iter().map(|message| message.tokens.input).sum::<i64>(),
+            240,
+            "stale accounting would fail to subtract the rewritten 40-token child aggregate"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_prime_agent_retries_when_source_changes_before_combined_parse() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let sessions_dir = source_home.path().join(".prime/agent/sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let source_path = sessions_dir.join("parse-race.jsonl");
+        std::fs::write(&source_path, large_prime_contents(120, 20)).unwrap();
+
+        let clients = ["prime-agent".to_string()];
+        let established =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        assert_eq!(established[0].tokens.input, 120);
+
+        std::fs::write(&source_path, large_prime_contents(360, 60)).unwrap();
+        sessions::prime_agent::schedule_stable_parse_test_rewrite(
+            &source_path,
+            large_prime_contents(480, 80),
+        );
+        sessions::prime_agent::reset_transcript_decode_call_counts(source_home.path());
+        let rebuilt =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        assert_eq!(rebuilt[0].tokens.input, 480);
+        assert_eq!(
+            sessions::prime_agent::transcript_decode_call_counts(),
+            (2, 0),
+            "the first parse belongs to a different pre-parse fingerprint and must be retried"
+        );
+
+        let identity = message_cache::CacheIdentity::for_client(ClientId::PrimeAgent);
+        let cached = message_cache::SourceMessageCache::load();
+        let entry = cached.get(identity, &source_path).unwrap();
+        assert_eq!(
+            entry.fingerprint,
+            message_cache::SourceFingerprint::from_path(&source_path).unwrap()
+        );
+        assert_eq!(entry.messages[0].tokens.input, 480);
+        assert!(entry.prime_accounting.is_some());
+
+        let decode_calls = sessions::prime_agent::transcript_decode_call_counts();
+        let warm =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        assert_eq!(warm[0].tokens.input, 480);
+        assert_eq!(
+            sessions::prime_agent::transcript_decode_call_counts(),
+            decode_calls,
+            "the exact stable retry snapshot should be a decode-free warm hit"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn test_prime_agent_legacy_cache_backfills_accounting_once() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
@@ -11504,38 +11717,6 @@ mod tests {
         let sessions_dir = source_home.path().join(".prime/agent/sessions");
         std::fs::create_dir_all(&sessions_dir).unwrap();
         let source_path = sessions_dir.join("legacy-race.jsonl");
-        fn large_prime_contents(input: i64, child_input: i64) -> String {
-            const FILE_BYTES: usize = 100_000;
-            const SEMANTIC_OFFSET: usize = 10_000;
-            let before_padding = r#"{"type":"session","version":3,"id":"legacy","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
-{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","padding":""#;
-            let before_semantic = r#"","usage":{"#;
-            let padding_bytes = SEMANTIC_OFFSET
-                .checked_sub(before_padding.len() + before_semantic.len())
-                .unwrap();
-            let mut contents = String::with_capacity(FILE_BYTES);
-            contents.push_str(before_padding);
-            contents.push_str(&"p".repeat(padding_bytes));
-            contents.push_str(before_semantic);
-            assert_eq!(contents.len(), SEMANTIC_OFFSET);
-            contents.push_str(&format!(
-                r#""input":{input},"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":{}}}}}}}
-{{"type":"child_usage_attributed","id":"usage-1","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{{"input":{child_input},"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":{child_input}}},"aggregateUsage":{{"input":{input},"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":{}}},"origin":"spawn_task"}}
-"#,
-                input + 10,
-                input + 10,
-            ));
-            let tail_prefix = r#"{"type":"ignored","padding":""#;
-            let tail_suffix = "\"}\n";
-            let tail_bytes = FILE_BYTES
-                .checked_sub(contents.len() + tail_prefix.len() + tail_suffix.len())
-                .unwrap();
-            contents.push_str(tail_prefix);
-            contents.push_str(&"t".repeat(tail_bytes));
-            contents.push_str(tail_suffix);
-            assert_eq!(contents.len(), FILE_BYTES);
-            contents
-        }
 
         let old_contents = large_prime_contents(120, 20);
         let new_contents = large_prime_contents(240, 40);

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1052,7 +1052,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
     ) {
         let identity = message_cache::CacheIdentity::for_client(ClientId::PrimeAgent);
         let cached = source_cache.get(identity, path);
-        let Some(fingerprint_status) = message_cache::SourceFingerprint::check_path_samples_only(
+        let Some(fingerprint_status) = message_cache::SourceFingerprint::check_path(
             path,
             cached.map(|entry| &entry.fingerprint),
         ) else {
@@ -1093,17 +1093,15 @@ fn parse_all_messages_with_pricing_with_env_strategy(
                 // Version-4 entries already contain valid messages but predate
                 // Prime accounting metadata. Decode just the accounting view
                 // once, but never combine it with those messages until the
-                // fingerprint is revalidated: the file can change between the
-                // first check and this second transcript read.
+                // fingerprint is revalidated with a full content hash: the
+                // file can change between the first bounded-sample check and
+                // this second transcript read, including outside sample windows.
                 #[cfg(test)]
                 sessions::prime_agent::run_accounting_backfill_test_hook(path);
                 let accounting =
                     sessions::prime_agent::analyze_prime_agent_accounting(path, &cached.messages);
-                match message_cache::SourceFingerprint::check_path_samples_only(
-                    path,
-                    Some(&fingerprint),
-                ) {
-                    Some(message_cache::FingerprintStatus::Unchanged) => {
+                match message_cache::SourceFingerprint::from_path(path) {
+                    Some(refreshed) if refreshed == fingerprint => {
                         return (
                             CachedParseOutcome {
                                 messages: cached_messages(cached, pricing),
@@ -1115,9 +1113,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
                             accounting,
                         );
                     }
-                    Some(message_cache::FingerprintStatus::Changed(refreshed)) => {
-                        fingerprint = refreshed;
-                    }
+                    Some(refreshed) => fingerprint = refreshed,
                     None => {
                         let (mut messages, accounting) =
                             sessions::prime_agent::parse_prime_agent_file_with_accounting(path);
@@ -11459,11 +11455,18 @@ mod tests {
         // is absent until the next scan backfills it.
         let identity = message_cache::CacheIdentity::for_client(ClientId::PrimeAgent);
         let messages = sessions::prime_agent::parse_prime_agent_file(&source_path);
+        let legacy_fingerprint =
+            match message_cache::SourceFingerprint::check_path_samples_only(&source_path, None)
+                .unwrap()
+            {
+                message_cache::FingerprintStatus::Changed(fingerprint) => fingerprint,
+                message_cache::FingerprintStatus::Unchanged => unreachable!(),
+            };
         let mut cache = message_cache::SourceMessageCache::default();
         cache.insert(message_cache::CachedSourceEntry::new(
             identity,
             &source_path,
-            message_cache::SourceFingerprint::from_path(&source_path).unwrap(),
+            legacy_fingerprint,
             messages,
             Vec::new(),
             None,
@@ -11475,7 +11478,7 @@ mod tests {
         let first =
             parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
         let first_calls = sessions::prime_agent::transcript_decode_call_counts();
-        assert_eq!(first_calls, (0, 1));
+        assert_eq!(first_calls, (1, 1));
         assert_eq!(first[0].tokens.input, 120);
 
         let second =
@@ -11501,15 +11504,45 @@ mod tests {
         let sessions_dir = source_home.path().join(".prime/agent/sessions");
         std::fs::create_dir_all(&sessions_dir).unwrap();
         let source_path = sessions_dir.join("legacy-race.jsonl");
-        let old_contents = r#"{"type":"session","version":3,"id":"legacy","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
-{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":120,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":130}}}
-{"type":"child_usage_attributed","id":"usage-1","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":20,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":20},"aggregateUsage":{"input":120,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":130},"origin":"spawn_task"}
-"#;
-        let new_contents = r#"{"type":"session","version":3,"id":"legacy","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
-{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":240,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":250}}}
-{"type":"child_usage_attributed","id":"usage-1","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":40,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":40},"aggregateUsage":{"input":240,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":250},"origin":"spawn_task"}
-"#;
-        std::fs::write(&source_path, old_contents).unwrap();
+        fn large_prime_contents(input: i64, child_input: i64) -> String {
+            const FILE_BYTES: usize = 100_000;
+            const SEMANTIC_OFFSET: usize = 10_000;
+            let before_padding = r#"{"type":"session","version":3,"id":"legacy","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","padding":""#;
+            let before_semantic = r#"","usage":{"#;
+            let padding_bytes = SEMANTIC_OFFSET
+                .checked_sub(before_padding.len() + before_semantic.len())
+                .unwrap();
+            let mut contents = String::with_capacity(FILE_BYTES);
+            contents.push_str(before_padding);
+            contents.push_str(&"p".repeat(padding_bytes));
+            contents.push_str(before_semantic);
+            assert_eq!(contents.len(), SEMANTIC_OFFSET);
+            contents.push_str(&format!(
+                r#""input":{input},"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":{}}}}}}}
+{{"type":"child_usage_attributed","id":"usage-1","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{{"input":{child_input},"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":{child_input}}},"aggregateUsage":{{"input":{input},"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":{}}},"origin":"spawn_task"}}
+"#,
+                input + 10,
+                input + 10,
+            ));
+            let tail_prefix = r#"{"type":"ignored","padding":""#;
+            let tail_suffix = "\"}\n";
+            let tail_bytes = FILE_BYTES
+                .checked_sub(contents.len() + tail_prefix.len() + tail_suffix.len())
+                .unwrap();
+            contents.push_str(tail_prefix);
+            contents.push_str(&"t".repeat(tail_bytes));
+            contents.push_str(tail_suffix);
+            assert_eq!(contents.len(), FILE_BYTES);
+            contents
+        }
+
+        let old_contents = large_prime_contents(120, 20);
+        let new_contents = large_prime_contents(240, 40);
+        assert_eq!(old_contents.len(), new_contents.len());
+        assert_eq!(&old_contents[..4_096], &new_contents[..4_096]);
+        assert_eq!(&old_contents[23_976..], &new_contents[23_976..]);
+        std::fs::write(&source_path, &old_contents).unwrap();
 
         let identity = message_cache::CacheIdentity::for_client(ClientId::PrimeAgent);
         let messages = sessions::prime_agent::parse_prime_agent_file(&source_path);
@@ -11526,7 +11559,7 @@ mod tests {
 
         sessions::prime_agent::schedule_accounting_backfill_test_rewrite(
             &source_path,
-            new_contents.to_string(),
+            new_contents,
         );
         sessions::prime_agent::reset_transcript_decode_call_counts(source_home.path());
         let clients = ["prime-agent".to_string()];

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1042,6 +1042,98 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         )
     }
 
+    fn load_or_parse_prime_source(
+        path: &Path,
+        source_cache: &message_cache::SourceMessageCache,
+        pricing: Option<&pricing::PricingService>,
+    ) -> (
+        CachedParseOutcome,
+        sessions::prime_agent::PrimeFileAccounting,
+    ) {
+        let identity = message_cache::CacheIdentity::for_client(ClientId::PrimeAgent);
+        let cached = source_cache.get(identity, path);
+        let Some(fingerprint_status) = message_cache::SourceFingerprint::check_path_samples_only(
+            path,
+            cached.map(|entry| &entry.fingerprint),
+        ) else {
+            let (mut messages, accounting) =
+                sessions::prime_agent::parse_prime_agent_file_with_accounting(path);
+            apply_pricing_to_messages(&mut messages, pricing);
+            return (
+                CachedParseOutcome {
+                    messages,
+                    cache_entry: None,
+                    invalidate_cache: false,
+                },
+                accounting,
+            );
+        };
+
+        let fingerprint = match fingerprint_status {
+            message_cache::FingerprintStatus::Unchanged => cached
+                .expect("an uncached source always builds a complete fingerprint")
+                .fingerprint
+                .clone(),
+            message_cache::FingerprintStatus::Changed(fingerprint) => fingerprint,
+        };
+
+        if let Some(cached) = cached {
+            if cached.fingerprint == fingerprint && !cached.messages.is_empty() {
+                let (accounting, cache_entry) = match cached.prime_accounting.as_ref() {
+                    Some(accounting) => (accounting.clone(), None),
+                    None => {
+                        // Version-4 entries already contain valid messages but
+                        // predate Prime accounting metadata. Decode just the
+                        // accounting view once, then rewrite the same identity
+                        // and fingerprint with the backfill attached.
+                        let accounting = sessions::prime_agent::analyze_prime_agent_accounting(
+                            path,
+                            &cached.messages,
+                        );
+                        (
+                            accounting.clone(),
+                            Some(cached.clone().with_prime_accounting(accounting)),
+                        )
+                    }
+                };
+                return (
+                    CachedParseOutcome {
+                        messages: cached_messages(cached, pricing),
+                        cache_entry,
+                        invalidate_cache: false,
+                    },
+                    accounting,
+                );
+            }
+        }
+
+        // A cold or changed Prime transcript produces both views from the one
+        // decoded Pi record stream. The accounting payload is persisted beside
+        // the raw messages under this exact fingerprint.
+        let (mut messages, accounting) =
+            sessions::prime_agent::parse_prime_agent_file_with_accounting(path);
+        let cache_entry = (!messages.is_empty()).then(|| {
+            message_cache::CachedSourceEntry::new(
+                identity,
+                path,
+                fingerprint,
+                messages.clone(),
+                Vec::new(),
+                None,
+            )
+            .with_prime_accounting(accounting.clone())
+        });
+        apply_pricing_to_messages(&mut messages, pricing);
+        (
+            CachedParseOutcome {
+                messages,
+                cache_entry,
+                invalidate_cache: false,
+            },
+            accounting,
+        )
+    }
+
     fn load_or_parse_sqlite_source<F>(
         identity: message_cache::CacheIdentity,
         path: &Path,
@@ -1708,29 +1800,18 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
-    let prime_agent_outcomes: Vec<(PathBuf, CachedParseOutcome)> = scan_result
+    let prime_agent_outcomes: Vec<(
+        CachedParseOutcome,
+        sessions::prime_agent::PrimeFileAccounting,
+    )> = scan_result
         .get(ClientId::PrimeAgent)
         .par_iter()
-        .map(|path| {
-            (
-                path.clone(),
-                load_or_parse_source(
-                    message_cache::CacheIdentity::for_client(ClientId::PrimeAgent),
-                    path,
-                    &source_cache,
-                    pricing,
-                    sessions::prime_agent::parse_prime_agent_file,
-                ),
-            )
-        })
+        .map(|path| load_or_parse_prime_source(path, &source_cache, pricing))
         .collect();
     let mut prime_agent_messages = Vec::new();
     let mut prime_agent_accounting = Vec::new();
-    for (path, outcome) in prime_agent_outcomes {
-        prime_agent_accounting.push(sessions::prime_agent::analyze_prime_agent_accounting(
-            &path,
-            &outcome.messages,
-        ));
+    for (outcome, accounting) in prime_agent_outcomes {
+        prime_agent_accounting.push(accounting);
         prime_agent_messages.extend(outcome.messages);
         if let Some(entry) = outcome.cache_entry {
             source_cache.insert(entry);
@@ -3818,11 +3899,7 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     )> = scan_result
         .get(ClientId::PrimeAgent)
         .par_iter()
-        .map(|path| {
-            let messages = sessions::prime_agent::parse_prime_agent_file(path);
-            let accounting = sessions::prime_agent::analyze_prime_agent_accounting(path, &messages);
-            (messages, accounting)
-        })
+        .map(|path| sessions::prime_agent::parse_prime_agent_file_with_accounting(path))
         .collect();
     let mut prime_agent_msgs_raw = Vec::new();
     let mut prime_agent_accounting = Vec::new();
@@ -4545,8 +4622,8 @@ mod tests {
         message_cache, normalize_model_for_grouping,
         parse_all_messages_with_pricing_with_env_strategy, parse_local_clients, parsed_to_unified,
         paths, pricing, retain_for_requested_clients, scanner, select_local_parse_pricing,
-        unified_to_parsed, validate_priced_messages, ClientId, GraphPricingRequirement, GroupBy,
-        LocalParseOptions, ReportOptions, TokenBreakdown, UnifiedMessage,
+        sessions, unified_to_parsed, validate_priced_messages, ClientId, GraphPricingRequirement,
+        GroupBy, LocalParseOptions, ReportOptions, TokenBreakdown, UnifiedMessage,
         UnpricedSubmissionExclusion, INCOMPLETE_MODEL_PRICING_REASON, MISSING_MODEL_PRICING_REASON,
         ROUTING_LABEL_UNPRICED_REASON, UNKNOWN_WORKSPACE_LABEL,
     };
@@ -11269,11 +11346,21 @@ mod tests {
         .unwrap();
 
         let clients = ["prime-agent".to_string()];
-        for messages in [
-            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None),
-            // Exercise the warm source-cache lane as well as the initial parse.
-            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None),
-        ] {
+        sessions::prime_agent::reset_transcript_decode_call_counts(source_home.path());
+        let cold =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        let cold_decode_calls = sessions::prime_agent::transcript_decode_call_counts();
+        assert_eq!(cold_decode_calls, (3, 0));
+
+        let warm =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        assert_eq!(
+            sessions::prime_agent::transcript_decode_call_counts(),
+            cold_decode_calls,
+            "an unchanged warm scan must decode neither messages nor accounting"
+        );
+
+        for messages in [cold, warm] {
             assert_eq!(messages.len(), 3);
             assert_eq!(
                 messages
@@ -11319,6 +11406,62 @@ mod tests {
                 .sum::<i64>(),
             70
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_prime_agent_legacy_cache_backfills_accounting_once() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let sessions_dir = source_home.path().join(".prime/agent/sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let source_path = sessions_dir.join("legacy.jsonl");
+        std::fs::write(
+            &source_path,
+            r#"{"type":"session","version":3,"id":"legacy","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","parentId":null,"timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":120,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":130}}}
+{"type":"child_usage_attributed","id":"usage-1","parentId":"parent","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":20,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":20},"aggregateUsage":{"input":120,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":130},"origin":"spawn_task"}
+"#,
+        )
+        .unwrap();
+
+        // Reproduce a successfully migrated v4 entry: messages and the exact
+        // fingerprint survive, while the newly-added Prime accounting payload
+        // is absent until the next scan backfills it.
+        let identity = message_cache::CacheIdentity::for_client(ClientId::PrimeAgent);
+        let messages = sessions::prime_agent::parse_prime_agent_file(&source_path);
+        let mut cache = message_cache::SourceMessageCache::default();
+        cache.insert(message_cache::CachedSourceEntry::new(
+            identity,
+            &source_path,
+            message_cache::SourceFingerprint::from_path(&source_path).unwrap(),
+            messages,
+            Vec::new(),
+            None,
+        ));
+        cache.save_if_dirty();
+
+        let clients = ["prime-agent".to_string()];
+        sessions::prime_agent::reset_transcript_decode_call_counts(source_home.path());
+        let first =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        let first_calls = sessions::prime_agent::transcript_decode_call_counts();
+        assert_eq!(first_calls, (0, 1));
+        assert_eq!(first[0].tokens.input, 120);
+
+        let second =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        assert_eq!(
+            sessions::prime_agent::transcript_decode_call_counts(),
+            first_calls
+        );
+        assert_eq!(second[0].tokens.input, 120);
+        assert!(message_cache::SourceMessageCache::load()
+            .get(identity, &source_path)
+            .unwrap()
+            .prime_accounting
+            .is_some());
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1815,11 +1815,13 @@ fn hash_bytes(bytes: &[u8]) -> u64 {
 
 /// Whether a fingerprint carries a whole-file `content_hash`.
 ///
-/// Validation uses size + mtime + samples ([`primary_fingerprint_matches`] and
-/// [`related_fingerprint_metadata_matches`]) for every source. Only Codex reads
-/// `content_hash` for incremental resume;
-/// generic parsers and SQLite sources store a zero sentinel so changed or cold
-/// files do not pay for a second whole-file hash that cannot affect parsing.
+/// Most warm validation uses size + mtime + samples
+/// ([`primary_fingerprint_matches`] and [`related_fingerprint_metadata_matches`]).
+/// Codex reads `content_hash` for incremental resume, while Prime hashes the
+/// complete transcript on every warm hit because its cached messages and
+/// reconciliation accounting must describe one exact byte snapshot. Generic
+/// parsers and SQLite sources store a zero sentinel so their changed or cold
+/// files do not pay for a whole-file hash that cannot affect parsing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ContentHashMode {
     Full,

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -27,7 +27,7 @@ use std::time::UNIX_EPOCH;
 // payload layout. Old shards must be silently rebuilt rather than decoded.
 // 5: Prime Agent entries cache reconciliation accounting beside their messages.
 // Version-4 shards have an explicit wire migration below, so other clients stay
-// warm and Prime entries need only one accounting-only backfill.
+// warm and Prime entries need only one rebuild/backfill.
 const CACHE_FORMAT_VERSION: u32 = 5;
 const LEGACY_CACHE_FORMAT_VERSION: u32 = 4;
 // V2 intentionally starts cold and leaves source-message-cache.bin untouched:

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -25,7 +25,11 @@ use std::time::UNIX_EPOCH;
 // warning), so the format version moves with the struct.
 // 4: UnifiedMessage gained model_attribution_conflicted, changing the bincode
 // payload layout. Old shards must be silently rebuilt rather than decoded.
-const CACHE_FORMAT_VERSION: u32 = 4;
+// 5: Prime Agent entries cache reconciliation accounting beside their messages.
+// Version-4 shards have an explicit wire migration below, so other clients stay
+// warm and Prime entries need only one accounting-only backfill.
+const CACHE_FORMAT_VERSION: u32 = 5;
+const LEGACY_CACHE_FORMAT_VERSION: u32 = 4;
 // V2 intentionally starts cold and leaves source-message-cache.bin untouched:
 // the monolith did not record a trustworthy parser owner for migration.
 const CACHE_SHARD_DIRNAME: &str = "source-message-cache-v2";
@@ -1116,6 +1120,40 @@ pub(crate) struct CachedSourceEntry {
     pub messages: Vec<UnifiedMessage>,
     pub fallback_timestamp_indices: Vec<usize>,
     pub codex_incremental: Option<CodexIncrementalCache>,
+    /// Prime-only metadata used to reconcile fork aggregates with child
+    /// transcripts. It shares this entry's parser identity and fingerprint, so
+    /// a message cache hit can never pair with accounting from different bytes.
+    pub prime_accounting: Option<crate::sessions::prime_agent::PrimeFileAccounting>,
+}
+
+/// Exact version-4 entry layout. Keeping this wire type lets existing shards
+/// migrate without discarding cached messages for unrelated clients. Prime
+/// entries convert with no accounting and are backfilled once on their next
+/// unchanged scan.
+#[derive(Debug, Serialize, Deserialize)]
+struct LegacyCachedSourceEntryV4 {
+    parser_namespace: String,
+    parser_version: u32,
+    path: CachedPath,
+    fingerprint: SourceFingerprint,
+    messages: Vec<UnifiedMessage>,
+    fallback_timestamp_indices: Vec<usize>,
+    codex_incremental: Option<CodexIncrementalCache>,
+}
+
+impl From<LegacyCachedSourceEntryV4> for CachedSourceEntry {
+    fn from(entry: LegacyCachedSourceEntryV4) -> Self {
+        Self {
+            parser_namespace: entry.parser_namespace,
+            parser_version: entry.parser_version,
+            path: entry.path,
+            fingerprint: entry.fingerprint,
+            messages: entry.messages,
+            fallback_timestamp_indices: entry.fallback_timestamp_indices,
+            codex_incremental: entry.codex_incremental,
+            prime_accounting: None,
+        }
+    }
 }
 
 impl CachedSourceEntry {
@@ -1135,7 +1173,16 @@ impl CachedSourceEntry {
             messages,
             fallback_timestamp_indices,
             codex_incremental,
+            prime_accounting: None,
         }
+    }
+
+    pub(crate) fn with_prime_accounting(
+        mut self,
+        accounting: crate::sessions::prime_agent::PrimeFileAccounting,
+    ) -> Self {
+        self.prime_accounting = Some(accounting);
+        self
     }
 
     fn identity_is_current(&self) -> bool {
@@ -1290,31 +1337,13 @@ impl SourceMessageCache {
                     index,
                 };
                 let path = dir_entry.path();
-                match read_shard(&path, identity) {
-                    ShardReadStatus::Loaded(entries) => {
-                        for mut entry in entries {
-                            let key = CacheKey::from_entry(&entry);
-                            if key.shard() == shard_key && entry.identity_is_current() {
-                                if entry.parser_namespace == ClientId::Claude.as_str()
-                                    && crate::sessions::claudecode::remove_synthetic_placeholder_messages(
-                                        &mut entry.messages,
-                                    )
-                                {
-                                    // Do not bump Claude's parser version here: compacted
-                                    // transcripts rely on cached assistant history that a
-                                    // full invalidation cannot recover. Repair only the bad
-                                    // `<synthetic>` rows and persist that narrow migration.
-                                    cache.dirty_keys.insert(key.clone());
-                                }
-                                cache.entries.insert(key, entry);
-                            } else {
-                                cache.rewrite_shards.insert(shard_key.clone());
-                            }
-                        }
-                    }
-                    ShardReadStatus::Missing => {}
+                let (entries, migrated) = match read_shard(&path, identity) {
+                    ShardReadStatus::Loaded(entries) => (entries, false),
+                    ShardReadStatus::Migrated(entries) => (entries, true),
+                    ShardReadStatus::Missing => continue,
                     ShardReadStatus::Stale => {
                         cache.rewrite_shards.insert(shard_key);
+                        continue;
                     }
                     ShardReadStatus::Invalid(error) => {
                         warn_cache_failure_once(
@@ -1323,6 +1352,29 @@ impl SourceMessageCache {
                             &error,
                         );
                         cache.rewrite_shards.insert(shard_key);
+                        continue;
+                    }
+                };
+                if migrated {
+                    cache.rewrite_shards.insert(shard_key.clone());
+                }
+                for mut entry in entries {
+                    let key = CacheKey::from_entry(&entry);
+                    if key.shard() == shard_key && entry.identity_is_current() {
+                        if entry.parser_namespace == ClientId::Claude.as_str()
+                            && crate::sessions::claudecode::remove_synthetic_placeholder_messages(
+                                &mut entry.messages,
+                            )
+                        {
+                            // Do not bump Claude's parser version here: compacted
+                            // transcripts rely on cached assistant history that a
+                            // full invalidation cannot recover. Repair only the bad
+                            // `<synthetic>` rows and persist that narrow migration.
+                            cache.dirty_keys.insert(key.clone());
+                        }
+                        cache.entries.insert(key, entry);
+                    } else {
+                        cache.rewrite_shards.insert(shard_key.clone());
                     }
                 }
             }
@@ -1463,12 +1515,14 @@ impl SourceMessageCache {
 
             let mut merged_entries: HashMap<CacheKey, CachedSourceEntry> =
                 match read_shard_with_limit(&final_path, identity, max_shard_bytes) {
-                    ShardReadStatus::Loaded(entries) => entries
-                        .into_iter()
-                        .filter(|entry| entry.identity_is_current())
-                        .map(|entry| (CacheKey::from_entry(&entry), entry))
-                        .filter(|(key, _)| key.shard() == shard_key)
-                        .collect(),
+                    ShardReadStatus::Loaded(entries) | ShardReadStatus::Migrated(entries) => {
+                        entries
+                            .into_iter()
+                            .filter(|entry| entry.identity_is_current())
+                            .map(|entry| (CacheKey::from_entry(&entry), entry))
+                            .filter(|(key, _)| key.shard() == shard_key)
+                            .collect()
+                    }
                     ShardReadStatus::Missing | ShardReadStatus::Stale => HashMap::new(),
                     ShardReadStatus::Invalid(error) => {
                         warn_cache_failure_once(
@@ -1562,6 +1616,7 @@ enum ShardReadStatus {
     Stale,
     Invalid(String),
     Loaded(Vec<CachedSourceEntry>),
+    Migrated(Vec<CachedSourceEntry>),
 }
 
 fn read_shard(path: &Path, identity: CacheIdentity) -> ShardReadStatus {
@@ -1599,12 +1654,24 @@ fn read_shard_with_limit(
         Ok(envelope) => envelope,
         Err(error) => return ShardReadStatus::Invalid(error.to_string()),
     };
-    if envelope.format_version != CACHE_FORMAT_VERSION {
-        return ShardReadStatus::Stale;
-    }
     if envelope.parser_namespace != identity.namespace
         || envelope.parser_version != identity.parser_version
     {
+        return ShardReadStatus::Stale;
+    }
+
+    if envelope.format_version == LEGACY_CACHE_FORMAT_VERSION {
+        return match bincode::options()
+            .with_limit(max_shard_bytes)
+            .deserialize::<Vec<LegacyCachedSourceEntryV4>>(&envelope.payload)
+        {
+            Ok(entries) => ShardReadStatus::Migrated(
+                entries.into_iter().map(CachedSourceEntry::from).collect(),
+            ),
+            Err(error) => ShardReadStatus::Invalid(error.to_string()),
+        };
+    }
+    if envelope.format_version != CACHE_FORMAT_VERSION {
         return ShardReadStatus::Stale;
     }
 
@@ -3375,7 +3442,7 @@ mod tests {
         let stale_path = shard_path(&cache_shard_dir().unwrap(), &stale_key);
         ensure_cache_dir(stale_path.parent().unwrap()).unwrap();
         let stale_envelope = CachedShardEnvelope {
-            format_version: CACHE_FORMAT_VERSION - 1,
+            format_version: LEGACY_CACHE_FORMAT_VERSION - 1,
             parser_namespace: codex.namespace.to_string(),
             parser_version: codex.parser_version,
             payload: b"prior UnifiedMessage layout".to_vec(),
@@ -3389,6 +3456,62 @@ mod tests {
         assert!(matches!(
             read_shard(&stale_path, codex),
             ShardReadStatus::Stale
+        ));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_v4_shard_migrates_messages_and_rewrites_once() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let source = write_temp_file(b"{}\n");
+        let identity = CacheIdentity::for_client(ClientId::PrimeAgent);
+        let entry = test_entry(identity, source.path(), "legacy-prime");
+        let key = CacheKey::from_entry(&entry);
+        let shard_key = key.shard();
+        let legacy_path = shard_path(&cache_shard_dir().unwrap(), &shard_key);
+        ensure_cache_dir(legacy_path.parent().unwrap()).unwrap();
+        let legacy_entry = LegacyCachedSourceEntryV4 {
+            parser_namespace: entry.parser_namespace,
+            parser_version: entry.parser_version,
+            path: entry.path,
+            fingerprint: entry.fingerprint,
+            messages: entry.messages,
+            fallback_timestamp_indices: entry.fallback_timestamp_indices,
+            codex_incremental: entry.codex_incremental,
+        };
+        let envelope = CachedShardEnvelope {
+            format_version: LEGACY_CACHE_FORMAT_VERSION,
+            parser_namespace: identity.namespace.to_string(),
+            parser_version: identity.parser_version,
+            payload: bincode::options().serialize(&vec![legacy_entry]).unwrap(),
+        };
+        let mut writer = BufWriter::new(File::create(&legacy_path).unwrap());
+        bincode::options()
+            .serialize_into(&mut writer, &envelope)
+            .unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+
+        assert!(matches!(
+            read_shard(&legacy_path, identity),
+            ShardReadStatus::Migrated(entries)
+                if entries.len() == 1
+                    && entries[0].messages[0].session_id == "legacy-prime"
+                    && entries[0].prime_accounting.is_none()
+        ));
+
+        let mut cache = SourceMessageCache::load();
+        assert_eq!(
+            cache.get(identity, source.path()).unwrap().messages[0].session_id,
+            "legacy-prime"
+        );
+        assert!(cache.rewrite_shards.contains(&shard_key));
+        cache.save_if_dirty();
+        assert!(matches!(
+            read_shard(&legacy_path, identity),
+            ShardReadStatus::Loaded(entries)
+                if entries.len() == 1 && entries[0].prime_accounting.is_none()
         ));
     }
 

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -145,7 +145,16 @@ pub(crate) fn parse_pi_format_file(
     client: &str,
     fallback_provider: &'static str,
 ) -> Vec<UnifiedMessage> {
-    parse_pi_format_file_inner(path, client, fallback_provider, None, false, false)
+    let mut observer = NoopPiFormatObserver;
+    parse_pi_format_file_inner(
+        path,
+        client,
+        fallback_provider,
+        None,
+        false,
+        false,
+        &mut observer,
+    )
 }
 
 /// Parse a Pi-format session and retain message ids in namespaced dedup keys.
@@ -156,8 +165,32 @@ pub(crate) fn parse_pi_format_file_with_dedup(
     client: &str,
     fallback_provider: &'static str,
 ) -> Vec<UnifiedMessage> {
-    parse_pi_format_file_inner(path, client, fallback_provider, Some(client), false, false)
+    let mut observer = NoopPiFormatObserver;
+    parse_pi_format_file_inner(
+        path,
+        client,
+        fallback_provider,
+        Some(client),
+        false,
+        false,
+        &mut observer,
+    )
 }
+
+/// Receives already-decoded Pi records while the shared parser walks a file.
+///
+/// Prime Agent uses this hook to derive its fork/child accounting metadata in
+/// the same pass that emits messages. The emitted message is supplied only for
+/// an assistant record that passed the shared parser's validation.
+pub(crate) trait PiFormatObserver {
+    fn observe_header(&mut self, _header: &PiSessionHeader) {}
+
+    fn observe_entry(&mut self, _entry: &PiSessionEntry, _emitted: Option<&UnifiedMessage>) {}
+}
+
+struct NoopPiFormatObserver;
+
+impl PiFormatObserver for NoopPiFormatObserver {}
 
 /// Parse a Pi-format session whose `session_info.name` identifies an RLM
 /// subagent when the session header has `rlmDepth > 0`.
@@ -165,12 +198,21 @@ pub(crate) fn parse_pi_format_file_with_dedup(
 /// Deduplication is intentionally cross-session: Prime Agent forks copy prior
 /// message entries into a file with a new session id. Provider response ids are
 /// preferred; the message id plus immutable event fields is the fallback.
-pub(crate) fn parse_pi_format_rlm_file(
+pub(crate) fn parse_pi_format_rlm_file_with_observer(
     path: &Path,
     client: &str,
     fallback_provider: &'static str,
+    observer: &mut impl PiFormatObserver,
 ) -> Vec<UnifiedMessage> {
-    parse_pi_format_file_inner(path, client, fallback_provider, Some(client), true, true)
+    parse_pi_format_file_inner(
+        path,
+        client,
+        fallback_provider,
+        Some(client),
+        true,
+        true,
+        observer,
+    )
 }
 
 fn parse_pi_format_file_inner(
@@ -180,6 +222,7 @@ fn parse_pi_format_file_inner(
     dedup_namespace: Option<&str>,
     rlm_session_name_as_agent: bool,
     cross_session_dedup: bool,
+    observer: &mut impl PiFormatObserver,
 ) -> Vec<UnifiedMessage> {
     let file = match std::fs::File::open(path) {
         Ok(f) => f,
@@ -230,7 +273,8 @@ fn parse_pi_format_file_inner(
                 Err(_) => return Vec::new(),
             };
 
-            session_id = Some(header.id);
+            observer.observe_header(&header);
+            session_id = Some(header.id.clone());
             workspace_key = header.cwd.as_deref().and_then(normalize_workspace_key);
             workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
             is_rlm_subagent = header.rlm_depth.unwrap_or(0) > 0;
@@ -246,36 +290,41 @@ fn parse_pi_format_file_inner(
 
         if entry.entry_type == "session_info" {
             agent = if rlm_session_name_as_agent && is_rlm_subagent {
-                entry.name.filter(|name| !name.trim().is_empty())
+                entry
+                    .name
+                    .as_ref()
+                    .filter(|name| !name.trim().is_empty())
+                    .cloned()
             } else {
                 entry.name.as_deref().and_then(pi_subagent_name)
             };
+            observer.observe_entry(&entry, None);
             continue;
         }
 
         if entry.entry_type != "message" {
+            observer.observe_entry(&entry, None);
             continue;
         }
 
-        let message_id = entry.id;
-        let message = match entry.message {
-            Some(m) => m,
-            None => continue,
+        let Some(message) = entry.message.as_ref() else {
+            observer.observe_entry(&entry, None);
+            continue;
         };
 
         if message.role.as_deref() != Some("assistant") {
+            observer.observe_entry(&entry, None);
             continue;
         }
 
-        let response_id = message.response_id;
-        let usage = match message.usage {
-            Some(u) => u,
-            None => continue,
+        let Some(usage) = message.usage.as_ref() else {
+            observer.observe_entry(&entry, None);
+            continue;
         };
 
-        let model = match message.model {
-            Some(m) => m,
-            None => continue,
+        let Some(model) = message.model.as_deref() else {
+            observer.observe_entry(&entry, None);
+            continue;
         };
 
         // A missing/blank provider field is recoverable: infer it from the
@@ -283,17 +332,18 @@ fn parse_pi_format_file_inner(
         // "openai"), falling back to "pi" only when inference can't
         // identify the model, rather than dropping a message that carries
         // valid tokens.
-        let provider = match message.provider {
-            Some(p) if !p.is_empty() => p,
-            _ => inferred_provider_from_model(&model)
+        let provider = match message.provider.as_deref() {
+            Some(provider) if !provider.is_empty() => provider.to_string(),
+            _ => inferred_provider_from_model(model)
                 .unwrap_or(fallback_provider)
                 .to_string(),
         };
 
         let recorded_timestamp = entry
             .timestamp
-            .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
-            .map(|dt| dt.timestamp_millis());
+            .as_deref()
+            .and_then(|timestamp| chrono::DateTime::parse_from_rfc3339(timestamp).ok())
+            .map(|timestamp| timestamp.timestamp_millis());
         let timestamp = recorded_timestamp.unwrap_or(fallback_timestamp);
 
         // `usage.reasoning` is read but deliberately not mapped onto
@@ -303,7 +353,7 @@ fn parse_pi_format_file_inner(
         // through would double count.
         let mut unified = UnifiedMessage::new_with_agent(
             client,
-            model.as_str(),
+            model,
             provider.as_str(),
             session_id.clone().unwrap_or_else(|| "unknown".to_string()),
             timestamp,
@@ -319,12 +369,14 @@ fn parse_pi_format_file_inner(
         );
         if let Some(namespace) = dedup_namespace {
             if cross_session_dedup {
-                unified.dedup_key = response_id
+                unified.dedup_key = message
+                    .response_id
                     .as_deref()
                     .filter(|id| !id.trim().is_empty())
                     .map(|id| format!("{namespace}:response:{id}"))
                     .or_else(|| {
-                        message_id
+                        entry
+                            .id
                             .as_deref()
                             .filter(|id| !id.trim().is_empty())
                             .map(|id| {
@@ -340,14 +392,14 @@ fn parse_pi_format_file_inner(
                                 )
                             })
                     });
-            } else if let Some(message_id) =
-                message_id.as_deref().filter(|id| !id.trim().is_empty())
+            } else if let Some(message_id) = entry.id.as_deref().filter(|id| !id.trim().is_empty())
             {
                 let session_id = session_id.as_deref().unwrap_or("unknown");
                 unified.dedup_key = Some(format!("{namespace}:{session_id}:{message_id}"));
             }
         }
         unified.set_workspace(workspace_key.clone(), workspace_label.clone());
+        observer.observe_entry(&entry, Some(&unified));
         messages.push(unified);
     }
 

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -33,6 +33,32 @@ static PRIME_DECODE_COUNTER: std::sync::LazyLock<std::sync::Mutex<PrimeDecodeCou
     std::sync::LazyLock::new(|| std::sync::Mutex::new(PrimeDecodeCounter::default()));
 
 #[cfg(test)]
+static ACCOUNTING_BACKFILL_REWRITE: std::sync::LazyLock<
+    std::sync::Mutex<Option<(PathBuf, String)>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+
+#[cfg(test)]
+pub(crate) fn schedule_accounting_backfill_test_rewrite(path: &Path, contents: String) {
+    *ACCOUNTING_BACKFILL_REWRITE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some((path.to_path_buf(), contents));
+}
+
+#[cfg(test)]
+pub(crate) fn run_accounting_backfill_test_hook(path: &Path) {
+    let mut scheduled = ACCOUNTING_BACKFILL_REWRITE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if scheduled
+        .as_ref()
+        .is_some_and(|(scheduled_path, _)| scheduled_path == path)
+    {
+        let (_, contents) = scheduled.take().unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+}
+
+#[cfg(test)]
 fn record_transcript_decode(path: &Path, accounting: bool) {
     let mut counter = PRIME_DECODE_COUNTER
         .lock()

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -38,8 +38,19 @@ static ACCOUNTING_BACKFILL_REWRITE: std::sync::LazyLock<
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
 
 #[cfg(test)]
+static STABLE_PARSE_REWRITE: std::sync::LazyLock<std::sync::Mutex<Option<(PathBuf, String)>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+
+#[cfg(test)]
 pub(crate) fn schedule_accounting_backfill_test_rewrite(path: &Path, contents: String) {
     *ACCOUNTING_BACKFILL_REWRITE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some((path.to_path_buf(), contents));
+}
+
+#[cfg(test)]
+pub(crate) fn schedule_stable_parse_test_rewrite(path: &Path, contents: String) {
+    *STABLE_PARSE_REWRITE
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some((path.to_path_buf(), contents));
 }
@@ -62,6 +73,20 @@ pub(crate) fn run_accounting_backfill_test_hook(path: &Path) {
             .unwrap()
             .set_times(std::fs::FileTimes::new().set_modified(modified))
             .unwrap();
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn run_stable_parse_test_hook(path: &Path) {
+    let mut scheduled = STABLE_PARSE_REWRITE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if scheduled
+        .as_ref()
+        .is_some_and(|(scheduled_path, _)| scheduled_path == path)
+    {
+        let (_, contents) = scheduled.take().unwrap();
+        std::fs::write(path, contents).unwrap();
     }
 }
 

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -54,7 +54,14 @@ pub(crate) fn run_accounting_backfill_test_hook(path: &Path) {
         .is_some_and(|(scheduled_path, _)| scheduled_path == path)
     {
         let (_, contents) = scheduled.take().unwrap();
+        let modified = std::fs::metadata(path).unwrap().modified().unwrap();
         std::fs::write(path, contents).unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(modified))
+            .unwrap();
     }
 }
 

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -8,19 +8,53 @@
 //! used only to reverse aggregate parent usage that Prime may persist while
 //! serializing a fork, before the copied parent is deduplicated across files.
 
-use super::pi::{parse_pi_format_rlm_file, PiSessionEntry, PiSessionHeader, PiUsage};
+use super::pi::{
+    parse_pi_format_rlm_file_with_observer, PiFormatObserver, PiSessionEntry, PiSessionHeader,
+    PiUsage,
+};
 use super::utils::parse_timestamp_str;
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
-pub fn parse_prime_agent_file(path: &Path) -> Vec<UnifiedMessage> {
-    parse_pi_format_rlm_file(path, "prime-agent", "prime-agent")
+#[cfg(test)]
+#[derive(Default)]
+struct PrimeDecodeCounter {
+    root: Option<PathBuf>,
+    messages: usize,
+    accounting: usize,
 }
 
-#[derive(Debug, Clone)]
+#[cfg(test)]
+static PRIME_DECODE_COUNTER: std::sync::LazyLock<std::sync::Mutex<PrimeDecodeCounter>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(PrimeDecodeCounter::default()));
+
+#[cfg(test)]
+fn record_transcript_decode(path: &Path, accounting: bool) {
+    let mut counter = PRIME_DECODE_COUNTER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if counter
+        .root
+        .as_deref()
+        .is_some_and(|root| path.starts_with(root))
+    {
+        if accounting {
+            counter.accounting += 1;
+        } else {
+            counter.messages += 1;
+        }
+    }
+}
+
+pub fn parse_prime_agent_file(path: &Path) -> Vec<UnifiedMessage> {
+    parse_prime_agent_file_with_accounting(path).0
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct PrimeAttribution {
     id: String,
     timestamp: Option<i64>,
@@ -28,20 +62,20 @@ struct PrimeAttribution {
     aggregate_usage: TokenBreakdown,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct ChildMessageUsage {
     timestamp: Option<i64>,
     usage: TokenBreakdown,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct PrimeUsageAdjustment {
     dedup_key: String,
     persisted_usage: TokenBreakdown,
     attributions: Vec<PrimeAttribution>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct PrimeFileAccounting {
     source_path: PathBuf,
     attributions: Vec<PrimeAttribution>,
@@ -49,6 +83,157 @@ pub(crate) struct PrimeFileAccounting {
     child_message_usages: Vec<ChildMessageUsage>,
     child_parent_path: Option<PathBuf>,
     fork_parent_path: Option<PathBuf>,
+}
+
+struct PrimeAccountingBuilder<'a> {
+    path: &'a Path,
+    found_header: bool,
+    is_rlm_child: bool,
+    child_parent_path: Option<PathBuf>,
+    fork_parent_path: Option<PathBuf>,
+    targets: HashMap<String, (String, TokenBreakdown)>,
+    attributions: HashMap<String, Vec<PrimeAttribution>>,
+    child_message_usages: Vec<ChildMessageUsage>,
+}
+
+impl<'a> PrimeAccountingBuilder<'a> {
+    fn new(path: &'a Path) -> Self {
+        Self {
+            path,
+            found_header: false,
+            is_rlm_child: false,
+            child_parent_path: None,
+            fork_parent_path: None,
+            targets: HashMap::new(),
+            attributions: HashMap::new(),
+            child_message_usages: Vec::new(),
+        }
+    }
+
+    fn finish(self) -> PrimeFileAccounting {
+        if !self.found_header {
+            return PrimeFileAccounting::default();
+        }
+
+        let all_attributions = self
+            .attributions
+            .values()
+            .flat_map(|entries| entries.iter().cloned())
+            .collect();
+        let mut adjustments = Vec::new();
+        for (target_id, entries) in self.attributions {
+            let Some((dedup_key, persisted_usage)) = self.targets.get(&target_id) else {
+                continue;
+            };
+            let mut matching_prefix = None;
+            for (index, entry) in entries.iter().enumerate() {
+                if entry.aggregate_usage == *persisted_usage {
+                    matching_prefix = Some(entries[..=index].to_vec());
+                }
+            }
+            if let Some(prefix) = matching_prefix {
+                adjustments.push(PrimeUsageAdjustment {
+                    dedup_key: dedup_key.clone(),
+                    persisted_usage: persisted_usage.clone(),
+                    attributions: prefix,
+                });
+            }
+        }
+
+        PrimeFileAccounting {
+            source_path: lineage_path(self.path),
+            attributions: all_attributions,
+            adjustments,
+            child_message_usages: self.child_message_usages,
+            child_parent_path: self.child_parent_path,
+            fork_parent_path: self.fork_parent_path,
+        }
+    }
+}
+
+impl PiFormatObserver for PrimeAccountingBuilder<'_> {
+    fn observe_header(&mut self, header: &PiSessionHeader) {
+        self.found_header = true;
+        self.is_rlm_child = header.rlm_depth.unwrap_or(0) > 0;
+        let parent_path = header
+            .parent_session
+            .as_deref()
+            .map(Path::new)
+            .map(|parent| referenced_lineage_path(self.path, parent));
+        if self.is_rlm_child {
+            self.child_parent_path = parent_path;
+        } else {
+            self.fork_parent_path = parent_path;
+        }
+    }
+
+    fn observe_entry(&mut self, entry: &PiSessionEntry, emitted: Option<&UnifiedMessage>) {
+        let entry_timestamp = entry.timestamp.as_deref().and_then(parse_timestamp_str);
+        if entry.entry_type == "child_usage_attributed" {
+            if let (Some(id), Some(target_id), Some(child_usage), Some(aggregate_usage)) = (
+                entry.id.as_ref(),
+                entry.target_id.as_ref(),
+                entry.child_usage.as_ref(),
+                entry.aggregate_usage.as_ref(),
+            ) {
+                self.attributions
+                    .entry(target_id.clone())
+                    .or_default()
+                    .push(PrimeAttribution {
+                        id: id.clone(),
+                        timestamp: entry_timestamp,
+                        child_usage: usage_breakdown(child_usage),
+                        aggregate_usage: usage_breakdown(aggregate_usage),
+                    });
+            }
+            return;
+        }
+
+        let Some(parsed) = emitted else {
+            return;
+        };
+        if self.is_rlm_child {
+            self.child_message_usages.push(ChildMessageUsage {
+                timestamp: entry_timestamp,
+                usage: parsed.tokens.clone(),
+            });
+        }
+        if let (Some(id), Some(dedup_key)) = (entry.id.as_ref(), parsed.dedup_key.as_ref()) {
+            self.targets
+                .insert(id.clone(), (dedup_key.clone(), parsed.tokens.clone()));
+        }
+    }
+}
+
+pub(crate) fn parse_prime_agent_file_with_accounting(
+    path: &Path,
+) -> (Vec<UnifiedMessage>, PrimeFileAccounting) {
+    #[cfg(test)]
+    record_transcript_decode(path, false);
+
+    let mut accounting = PrimeAccountingBuilder::new(path);
+    let messages =
+        parse_pi_format_rlm_file_with_observer(path, "prime-agent", "prime-agent", &mut accounting);
+    (messages, accounting.finish())
+}
+
+#[cfg(test)]
+pub(crate) fn reset_transcript_decode_call_counts(root: &Path) {
+    *PRIME_DECODE_COUNTER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = PrimeDecodeCounter {
+        root: Some(root.to_path_buf()),
+        messages: 0,
+        accounting: 0,
+    };
+}
+
+#[cfg(test)]
+pub(crate) fn transcript_decode_call_counts() -> (usize, usize) {
+    let counter = PRIME_DECODE_COUNTER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    (counter.messages, counter.accounting)
 }
 
 fn usage_breakdown(usage: &PiUsage) -> TokenBreakdown {
@@ -187,20 +372,16 @@ pub(crate) fn analyze_prime_agent_accounting(
     path: &Path,
     messages: &[UnifiedMessage],
 ) -> PrimeFileAccounting {
+    #[cfg(test)]
+    record_transcript_decode(path, true);
+
     let Ok(file) = std::fs::File::open(path) else {
         return PrimeFileAccounting::default();
     };
 
-    let source_path = lineage_path(path);
+    let mut accounting = PrimeAccountingBuilder::new(path);
     let mut found_header = false;
-    let mut is_rlm_child = false;
-    let mut child_parent_path = None;
-    let mut fork_parent_path = None;
     let mut message_index = 0usize;
-    let mut targets: HashMap<String, (String, TokenBreakdown)> = HashMap::new();
-    let mut attributions: HashMap<String, Vec<PrimeAttribution>> = HashMap::new();
-    let mut child_message_usages = Vec::new();
-
     for line in BufReader::new(file).lines().map_while(Result::ok) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -210,17 +391,7 @@ pub(crate) fn analyze_prime_agent_accounting(
             if let Ok(header) = serde_json::from_str::<PiSessionHeader>(trimmed) {
                 if header.entry_type == "session" {
                     found_header = true;
-                    is_rlm_child = header.rlm_depth.unwrap_or(0) > 0;
-                    let parent_path = header
-                        .parent_session
-                        .as_deref()
-                        .map(Path::new)
-                        .map(|parent| referenced_lineage_path(path, parent));
-                    if is_rlm_child {
-                        child_parent_path = parent_path;
-                    } else {
-                        fork_parent_path = parent_path;
-                    }
+                    accounting.observe_header(&header);
                     continue;
                 }
             }
@@ -242,87 +413,24 @@ pub(crate) fn analyze_prime_agent_accounting(
         let Ok(entry) = serde_json::from_str::<PiSessionEntry>(trimmed) else {
             continue;
         };
-        let entry_timestamp = entry.timestamp.as_deref().and_then(parse_timestamp_str);
-        if entry.entry_type == "child_usage_attributed" {
-            if let (Some(id), Some(target_id), Some(child_usage), Some(aggregate_usage)) = (
-                entry.id,
-                entry.target_id,
-                entry.child_usage,
-                entry.aggregate_usage,
-            ) {
-                attributions
-                    .entry(target_id)
-                    .or_default()
-                    .push(PrimeAttribution {
-                        id,
-                        timestamp: entry_timestamp,
-                        child_usage: usage_breakdown(&child_usage),
-                        aggregate_usage: usage_breakdown(&aggregate_usage),
-                    });
-            }
-            continue;
-        }
-        if entry.entry_type != "message" {
-            continue;
-        }
-        let Some(message) = entry.message else {
-            continue;
-        };
-        if message.role.as_deref() != Some("assistant")
-            || message.usage.is_none()
-            || message.model.is_none()
-        {
-            continue;
-        }
-
-        let parsed = messages.get(message_index);
-        message_index += 1;
-        let Some(parsed) = parsed else {
-            continue;
-        };
-        if is_rlm_child {
-            child_message_usages.push(ChildMessageUsage {
-                timestamp: entry_timestamp,
-                usage: parsed.tokens.clone(),
+        let emitted = entry
+            .message
+            .as_ref()
+            .filter(|message| {
+                entry.entry_type == "message"
+                    && message.role.as_deref() == Some("assistant")
+                    && message.usage.is_some()
+                    && message.model.is_some()
+            })
+            .and_then(|_| {
+                let parsed = messages.get(message_index);
+                message_index += 1;
+                parsed
             });
-        }
-        if let (Some(id), Some(dedup_key)) = (entry.id, parsed.dedup_key.clone()) {
-            targets.insert(id, (dedup_key, parsed.tokens.clone()));
-        }
+        accounting.observe_entry(&entry, emitted);
     }
 
-    let all_attributions = attributions
-        .values()
-        .flat_map(|entries| entries.iter().cloned())
-        .collect();
-    let mut adjustments = Vec::new();
-    for (target_id, entries) in attributions {
-        let Some((dedup_key, persisted_usage)) = targets.get(&target_id) else {
-            continue;
-        };
-        let mut matching_prefix = None;
-        for (index, entry) in entries.iter().enumerate() {
-            if entry.aggregate_usage == *persisted_usage {
-                matching_prefix = Some(entries[..=index].to_vec());
-            }
-        }
-        if let Some(prefix) = matching_prefix {
-            adjustments.push(PrimeUsageAdjustment {
-                dedup_key: dedup_key.clone(),
-                persisted_usage: persisted_usage.clone(),
-                attributions: prefix,
-            });
-        }
-    }
-
-    PrimeFileAccounting {
-        source_path,
-        attributions: all_attributions,
-        adjustments,
-        child_message_usages,
-        child_parent_path,
-        fork_parent_path,
-    }
+    accounting.finish()
 }
 
 fn fallback_key_base(key: &str) -> Option<&str> {


### PR DESCRIPTION
## Summary

- cache serde-serializable Prime Agent reconciliation accounting beside raw messages under the same cache identity and source fingerprint
- derive messages and accounting from one decoded Pi record stream on cold and changed scans, including the non-cached local parser path
- migrate v4 cache shards without discarding other clients' messages, then backfill legacy Prime accounting exactly once
- prove unchanged warm scans run neither the Prime message decoder nor the legacy accounting decoder while preserving cold/warm global and per-model totals
- require a full-content fingerprint before attaching legacy accounting to cached messages, including same-size unsampled rewrites with restored mtimes

## Context

Follow-up to #1082 and its intentionally unresolved [warm-cache accounting thread](https://github.com/junhoyeo/tokscale/pull/1082#discussion_r3743070089).

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p tokscale-core prime_agent`
- `cargo test -p tokscale-core sessions::pi::tests`
- `cargo test -p tokscale-core message_cache::tests`
- `cargo test --workspace --all-features` (1549 core tests passed; workspace integration suites passed)
