### PR TITLE
fix(workspace): name workspace rows by repo instead of a truncated path

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -310,7 +310,7 @@ TUIで`g`を押すか、`--light`/`--json`モードで`--group-by`を使用し�
 | **モデル** | `--group-by model` | ✅ | モデルごとに1行 — すべてのクライアントとプロバイダーを統合 |
 | **クライアント + モデル** | `--group-by client,model` | | クライアント-モデルペアごとに1行 |
 | **クライアント + プロバイダー + モデル** | `--group-by client,provider,model` | | 最も詳細 — 統合なし |
-| **ワークスペース + モデル** | `--group-by workspace,model` | | ローカル使用量をワークスペースキー、次にモデルでグループ化 |
+| **ワークスペース + モデル** | `--group-by workspace,model` | | ローカル使用量をワークスペースキー、次にモデルでグループ化。[`--merge-worktrees`](README.md#per-workspace-cost) を追加すると、リポジトリ内のワークツリーを親リポジトリに畳み込みます |
 | **セッション + モデル** | `--group-by session,model` | | `session_id` とモデルごとに1行 — 特定のエージェント CLI セッションにコストを帰属 |
 | **クライアント + セッション + モデル** | `--group-by client,session,model` | | クライアント・セッション・モデルごとに1行 — `session_id` で結合するマルチエージェントランナーに便利 |
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -306,7 +306,7 @@ TUI에서 `g`를 누르거나 `--light`/`--json` 모드에서 `--group-by`를 �
 | **모델** | `--group-by model` | ✅ | 모델당 한 행 — 모든 클라이언트와 프로바이더 병합 |
 | **클라이언트 + 모델** | `--group-by client,model` | | 클라이언트-모델 쌍당 한 행 |
 | **클라이언트 + 프로바이더 + 모델** | `--group-by client,provider,model` | | 가장 세분화 — 병합 없음 |
-| **워크스페이스 + 모델** | `--group-by workspace,model` | | 로컬 사용량을 워크스페이스 키별로, 그 다음 모델별로 그룹화 |
+| **워크스페이스 + 모델** | `--group-by workspace,model` | | 로컬 사용량을 워크스페이스 키별로, 그 다음 모델별로 그룹화. [`--merge-worktrees`](README.md#per-workspace-cost)를 추가하면 리포지터리 내부의 워크트리를 상위 리포지터리로 병합합니다 |
 | **세션 + 모델** | `--group-by session,model` | | `session_id`와 모델당 한 행 — 특정 에이전트-CLI 세션에 비용 귀속 |
 | **클라이언트 + 세션 + 모델** | `--group-by client,session,model` | | 클라이언트, 세션, 모델당 한 행 — `session_id`로 조인하는 멀티 에이전트 러너에 유용 |
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Press `g` in the TUI or use `--group-by` in `--light`/`--json` mode to control h
 | **Model** | `--group-by model` | ✅ | One row per model — merges all clients and providers |
 | **Client + Model** | `--group-by client,model` | | One row per client-model pair |
 | **Client + Provider + Model** | `--group-by client,provider,model` | | Most granular — no merging |
-| **Workspace + Model** | `--group-by workspace,model` | | Group local usage by workspace key, then model |
+| **Workspace + Model** | `--group-by workspace,model` | | Group local usage by workspace key, then model — add [`--merge-worktrees`](#per-workspace-cost) to fold git worktrees into their repo |
 | **Session + Model** | `--group-by session,model` | | One row per `session_id` and model — attribute cost to a specific agent-CLI session |
 | **Client + Session + Model** | `--group-by client,session,model` | | One row per client, session, and model — useful for multi-agent runners that join on `session_id` |
 
@@ -359,6 +359,28 @@ Press `g` in the TUI or use `--group-by` in `--light`/`--json` mode to control h
 ```
 
 Use `--group-by client,session,model` when you also need the client name on every row (one spawn across all 20+ supported CLIs at once).
+
+#### Per-workspace cost
+
+`--group-by workspace,model` attributes usage to the directory an agent ran in, so you can see what a given project cost:
+
+```bash
+# One row per (workspace, model)
+tokscale models --light --group-by workspace,model --month
+
+# Fold every git worktree into its parent repository — one row per repo
+tokscale models --light --group-by workspace,model --merge-worktrees --month
+
+# JSON carries workspaceKey (grouping identity) and workspaceLabel (display name)
+tokscale models --json --group-by workspace,model --merge-worktrees
+```
+
+In the TUI, press `g` → **Workspace + Model**, then `w` to toggle worktree rollup (the footer shows `[w:worktrees]` or `[w:repos]`).
+
+Workspace rows are labeled `repo` or `repo ⑃ worktree`. Clients disagree about how they record a workspace — Claude Code stores a dash-mangled directory slug (`-Users-me-devpro-app`) while Codex and OpenCode store real paths — so tokscale resolves slugs back to their true path against the filesystem. Two consequences worth knowing:
+
+- **Without `--merge-worktrees`, each git worktree is its own row.** Agent CLIs that isolate every task into a worktree will therefore spread one repository across many rows; `--merge-worktrees` re-unites them (and also merges a repo recorded by different clients under different key formats).
+- **Clients that never record a workspace roll up into a single `Unknown workspace` row.** Roughly half the supported clients (including gemini, cursor, amp, droid, roocode, kilocode, goose, and Copilot's OTEL path) do not write one, so their usage cannot be attributed to a directory.
 
 ### Filtering by Platform
 

--- a/README.md
+++ b/README.md
@@ -377,9 +377,10 @@ tokscale models --json --group-by workspace,model --merge-worktrees
 
 In the TUI, press `g` → **Workspace + Model**, then `w` to toggle worktree rollup (the footer shows `[w:worktrees]` or `[w:repos]`).
 
-Workspace rows are labeled `repo` or `repo ⑃ worktree`. Clients disagree about how they record a workspace — Claude Code stores a dash-mangled directory slug (`-Users-me-devpro-app`) while Codex and OpenCode store real paths — so tokscale resolves slugs back to their true path against the filesystem. Two consequences worth knowing:
+Workspace rows are labeled `repo` or `repo ⑃ worktree`. Clients disagree about how they record a workspace — Claude Code stores a dash-mangled directory slug (`-Users-me-devpro-app`) while Codex and OpenCode store real paths — so tokscale resolves slugs back to their true path against the filesystem. Three consequences worth knowing:
 
 - **Without `--merge-worktrees`, each git worktree is its own row.** Agent CLIs that isolate every task into a worktree will therefore spread one repository across many rows; `--merge-worktrees` re-unites them (and also merges a repo recorded by different clients under different key formats).
+- **`--merge-worktrees` folds worktrees by path, not by git.** It re-unites worktrees kept inside the repository — `<repo>/.claude/worktrees/<name>` (what agent CLIs create) and `<repo>/.git/worktrees/<name>` — because the repo root is a prefix of the path itself. A worktree checked out beside the repo (`git worktree add ../feature-x`) is linked to it only by a `gitdir:` pointer file, so it stays its own row; likewise a repo reached through two different path spellings (a symlink and its target) stays two rows, because a workspace identity is compared as a string. Totals are unaffected either way — usage is split across rows, never lost or double counted.
 - **Clients that never record a workspace roll up into a single `Unknown workspace` row.** Roughly half the supported clients (including gemini, cursor, amp, droid, roocode, kilocode, goose, and Copilot's OTEL path) do not write one, so their usage cannot be attributed to a directory.
 
 ### Filtering by Platform

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -307,7 +307,7 @@ tokscale models --json > report.json   # 保存到文件
 | **模型** | `--group-by model` | ✅ | 每个模型一行 — 合并所有客户端和提供商 |
 | **客户端 + 模型** | `--group-by client,model` | | 每个客户端-模型对一行 |
 | **客户端 + 提供商 + 模型** | `--group-by client,provider,model` | | 最详细 — 不合并 |
-| **工作区 + 模型** | `--group-by workspace,model` | | 先按工作区键、再按模型对本地使用量分组 |
+| **工作区 + 模型** | `--group-by workspace,model` | | 先按工作区键、再按模型对本地使用量分组；添加 [`--merge-worktrees`](README.md#per-workspace-cost) 可将仓库内部的 worktree 折叠进其父仓库 |
 | **会话 + 模型** | `--group-by session,model` | | 每个 `session_id` 和模型一行 — 将成本归因到特定的 agent-CLI 会话 |
 | **客户端 + 会话 + 模型** | `--group-by client,session,model` | | 每个客户端、会话和模型一行 — 适用于按 `session_id` 关联的多代理运行器 |
 

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -248,6 +248,7 @@ async fn load_wrapped_data(options: &WrappedOptions) -> Result<WrappedData> {
         until: Some(until),
         year: Some(year.clone()),
         group_by: GroupBy::default(),
+        worktree_rollup: tokscale_core::WorktreeRollup::default(),
         scanner_settings: crate::tui::settings::load_scanner_settings(),
     })
     .await

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2109,10 +2109,8 @@ fn run_models_report(
     let rt = Runtime::new()?;
     let report = rt
         .block_on(async {
-            get_model_report(
-                context.report_options_with_rollup(group_by.clone(), worktree_rollup),
-            )
-            .await
+            get_model_report(context.report_options_with_rollup(group_by.clone(), worktree_rollup))
+                .await
         })
         .map_err(|e| anyhow::anyhow!(e))?;
     let mut report = report;

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -657,6 +657,17 @@ fn main() -> Result<()> {
                 let year = normalize_year_filter(&date);
                 ensure_home_supported_for_tui(&cli.home)?;
                 auto_sync_cursor_before_tui(&cli.home, &clients)?;
+                // The TUI owns its own grouping state (`g` and `w`), so neither
+                // --group-by nor --merge-worktrees carries into it. Say so rather
+                // than dropping the flag silently.
+                if merge_worktrees {
+                    use colored::Colorize;
+                    eprintln!(
+                        "{}",
+                        "  Warning: --merge-worktrees applies to --light/--json output; in the TUI press 'w' to toggle worktree rollup"
+                            .yellow()
+                    );
+                }
                 tui::run(
                     cli.theme.as_deref().unwrap_or(""),
                     cli.refresh,

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -95,7 +95,7 @@ struct Cli {
 
     #[arg(
         long = "merge-worktrees",
-        help = "With --group-by workspace,model: fold git worktrees into their parent repository so each repo is one row"
+        help = "With --group-by workspace,model: fold worktrees kept inside the repo (.claude/worktrees/, .git/worktrees/) into their parent repository so each repo is one row"
     )]
     merge_worktrees: bool,
 
@@ -126,7 +126,7 @@ enum Commands {
         group_by: String,
         #[arg(
             long = "merge-worktrees",
-            help = "With --group-by workspace,model: fold git worktrees into their parent repository so each repo is one row"
+            help = "With --group-by workspace,model: fold worktrees kept inside the repo (.claude/worktrees/, .git/worktrees/) into their parent repository so each repo is one row"
         )]
         merge_worktrees: bool,
         #[arg(
@@ -657,17 +657,6 @@ fn main() -> Result<()> {
                 let year = normalize_year_filter(&date);
                 ensure_home_supported_for_tui(&cli.home)?;
                 auto_sync_cursor_before_tui(&cli.home, &clients)?;
-                // The TUI owns its own grouping state (`g` and `w`), so neither
-                // --group-by nor --merge-worktrees carries into it. Say so rather
-                // than dropping the flag silently.
-                if merge_worktrees {
-                    use colored::Colorize;
-                    eprintln!(
-                        "{}",
-                        "  Warning: --merge-worktrees applies to --light/--json output; in the TUI press 'w' to toggle worktree rollup"
-                            .yellow()
-                    );
-                }
                 tui::run(
                     cli.theme.as_deref().unwrap_or(""),
                     cli.refresh,
@@ -677,6 +666,9 @@ fn main() -> Result<()> {
                     until,
                     year,
                     Some(Tab::Models),
+                    // Carry the flag in as the initial rollup rather than dropping
+                    // it; `w` toggles from there.
+                    worktree_rollup_from_flag(merge_worktrees),
                 )
             }
         }
@@ -714,6 +706,7 @@ fn main() -> Result<()> {
                     until,
                     year,
                     Some(Tab::Monthly),
+                    tokscale_core::WorktreeRollup::default(),
                 )
             }
         }
@@ -751,6 +744,7 @@ fn main() -> Result<()> {
                     until,
                     year,
                     Some(Tab::Hourly),
+                    tokscale_core::WorktreeRollup::default(),
                 )
             }
         }
@@ -821,6 +815,7 @@ fn main() -> Result<()> {
                 until,
                 year,
                 None,
+                tokscale_core::WorktreeRollup::default(),
             )
         }
         Some(Commands::Submit {
@@ -1019,6 +1014,7 @@ fn main() -> Result<()> {
                     until,
                     year,
                     None,
+                    worktree_rollup,
                 )
             }
         }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -93,6 +93,12 @@ struct Cli {
     )]
     group_by: String,
 
+    #[arg(
+        long = "merge-worktrees",
+        help = "With --group-by workspace,model: fold git worktrees into their parent repository so each repo is one row"
+    )]
+    merge_worktrees: bool,
+
     #[arg(long, help = "Disable spinner (for AI agents and scripts)")]
     no_spinner: bool,
 }
@@ -118,6 +124,11 @@ enum Commands {
             help = "Grouping strategy for --light and --json output: model, client,model, client,provider,model, workspace,model, session,model, client,session,model"
         )]
         group_by: String,
+        #[arg(
+            long = "merge-worktrees",
+            help = "With --group-by workspace,model: fold git worktrees into their parent repository so each repo is one row"
+        )]
+        merge_worktrees: bool,
         #[arg(
             long = "write-cache",
             requires = "light",
@@ -614,6 +625,7 @@ fn main() -> Result<()> {
             date,
             benchmark,
             group_by,
+            merge_worktrees,
             write_cache,
             no_write_cache,
             hide_zero,
@@ -635,6 +647,7 @@ fn main() -> Result<()> {
                     benchmark,
                     no_spinner || !can_use_tui,
                     group_by,
+                    worktree_rollup_from_flag(merge_worktrees),
                     write_cache,
                     no_write_cache,
                     hide_zero,
@@ -951,6 +964,8 @@ fn main() -> Result<()> {
                 std::process::exit(1);
             });
 
+            let worktree_rollup = worktree_rollup_from_flag(cli.merge_worktrees);
+
             if cli.json {
                 run_models_report(
                     cli.json,
@@ -960,6 +975,7 @@ fn main() -> Result<()> {
                     cli.benchmark,
                     cli.no_spinner || cli.json,
                     group_by,
+                    worktree_rollup,
                     cli.write_cache,
                     cli.no_write_cache,
                     cli.hide_zero,
@@ -973,6 +989,7 @@ fn main() -> Result<()> {
                     cli.benchmark,
                     cli.no_spinner || !can_use_tui,
                     group_by,
+                    worktree_rollup,
                     cli.write_cache,
                     cli.no_write_cache,
                     cli.hide_zero,
@@ -2027,6 +2044,16 @@ impl LocalReportContext {
     }
 
     fn report_options(&self, group_by: tokscale_core::GroupBy) -> tokscale_core::ReportOptions {
+        self.report_options_with_rollup(group_by, tokscale_core::WorktreeRollup::default())
+    }
+
+    /// `report_options` for the one report that can fold worktrees. Kept separate
+    /// so the other callers are not made to pass a rollup they never vary.
+    fn report_options_with_rollup(
+        &self,
+        group_by: tokscale_core::GroupBy,
+        worktree_rollup: tokscale_core::WorktreeRollup,
+    ) -> tokscale_core::ReportOptions {
         tokscale_core::ReportOptions {
             home_dir: self.home_dir.clone(),
             use_env_roots: self.use_env_roots,
@@ -2035,8 +2062,17 @@ impl LocalReportContext {
             until: self.until.clone(),
             year: self.year.clone(),
             group_by,
+            worktree_rollup,
             scanner_settings: self.scanner_settings.clone(),
         }
+    }
+}
+
+fn worktree_rollup_from_flag(merge_worktrees: bool) -> tokscale_core::WorktreeRollup {
+    if merge_worktrees {
+        tokscale_core::WorktreeRollup::MergeIntoRepo
+    } else {
+        tokscale_core::WorktreeRollup::Separate
     }
 }
 
@@ -2049,6 +2085,7 @@ fn run_models_report(
     benchmark: bool,
     no_spinner: bool,
     group_by: tokscale_core::GroupBy,
+    worktree_rollup: tokscale_core::WorktreeRollup,
     cli_write_cache: bool,
     cli_no_write_cache: bool,
     hide_zero: bool,
@@ -2064,7 +2101,12 @@ fn run_models_report(
     );
     let rt = Runtime::new()?;
     let report = rt
-        .block_on(async { get_model_report(context.report_options(group_by.clone())).await })
+        .block_on(async {
+            get_model_report(
+                context.report_options_with_rollup(group_by.clone(), worktree_rollup),
+            )
+            .await
+        })
         .map_err(|e| anyhow::anyhow!(e))?;
     let mut report = report;
     if hide_zero {
@@ -5771,6 +5813,7 @@ fn run_submit_command(
                 until,
                 year,
                 group_by: GroupBy::default(),
+                worktree_rollup: tokscale_core::WorktreeRollup::default(),
                 scanner_settings: tui::settings::load_scanner_settings(),
             })
             .await

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -304,6 +304,9 @@ pub struct App {
     /// at the boundary via `App::scan_clients` and `App::include_synthetic`.
     pub enabled_clients: Rc<RefCell<HashSet<ClientFilter>>>,
     pub group_by: Rc<RefCell<tokscale_core::GroupBy>>,
+    /// Whether workspace rows fold git worktrees into their parent repo. Toggled
+    /// with `w`; only observable under `GroupBy::WorkspaceModel`.
+    pub worktree_rollup: tokscale_core::WorktreeRollup,
     pub sort_field: SortField,
     pub sort_direction: SortDirection,
     tab_sort_state: HashMap<Tab, (SortField, SortDirection)>,
@@ -457,6 +460,7 @@ impl App {
             data_loader,
             enabled_clients: Rc::new(RefCell::new(enabled_clients)),
             group_by: Rc::new(RefCell::new(super::cache::TUI_DEFAULT_GROUP_BY)),
+            worktree_rollup: tokscale_core::WorktreeRollup::default(),
             sort_field,
             sort_direction,
             tab_sort_state: HashMap::new(),
@@ -903,6 +907,23 @@ impl App {
             }
             KeyCode::Char('g') => {
                 self.open_group_by_picker();
+            }
+            // Only meaningful while workspace rows are on screen; leaving `w`
+            // inert elsewhere keeps it free for other tabs later.
+            KeyCode::Char('w')
+                if *self.group_by.borrow() == tokscale_core::GroupBy::WorkspaceModel =>
+            {
+                self.worktree_rollup = match self.worktree_rollup {
+                    tokscale_core::WorktreeRollup::Separate => {
+                        tokscale_core::WorktreeRollup::MergeIntoRepo
+                    }
+                    tokscale_core::WorktreeRollup::MergeIntoRepo => {
+                        tokscale_core::WorktreeRollup::Separate
+                    }
+                };
+                // Rollup changes the grouping key, so rows must be rebuilt.
+                self.needs_reload = true;
+                self.reset_selection();
             }
             KeyCode::Char('a') if self.current_tab == Tab::Usage => {
                 self.start_codex_login();

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -29,6 +29,7 @@ use super::ui::dialog::{ClientPickerDialog, ConfirmDialog, DialogStack};
 use super::ui::widgets::{get_model_color, get_provider_from_model, get_provider_shade};
 
 /// Configuration for TUI initialization
+#[derive(Default)]
 pub struct TuiConfig {
     pub theme: String,
     pub refresh: u64,
@@ -38,6 +39,9 @@ pub struct TuiConfig {
     pub until: Option<String>,
     pub year: Option<String>,
     pub initial_tab: Option<Tab>,
+    /// Initial worktree rollup, so `--merge-worktrees` survives into an
+    /// interactive launch instead of being dropped. `w` toggles it from here.
+    pub worktree_rollup: tokscale_core::WorktreeRollup,
 }
 
 #[cfg(not(test))]
@@ -460,7 +464,7 @@ impl App {
             data_loader,
             enabled_clients: Rc::new(RefCell::new(enabled_clients)),
             group_by: Rc::new(RefCell::new(super::cache::TUI_DEFAULT_GROUP_BY)),
-            worktree_rollup: tokscale_core::WorktreeRollup::default(),
+            worktree_rollup: config.worktree_rollup,
             sort_field,
             sort_direction,
             tab_sort_state: HashMap::new(),
@@ -2682,6 +2686,35 @@ mod tests {
         assert_eq!(Tab::Stats.short_name(), "Sta");
     }
 
+    /// `--merge-worktrees` has to survive into an interactive launch.
+    ///
+    /// The rollup used to be hardcoded to the default here, so the flag parsed
+    /// fine, changed `--light`/`--json` output, and was then silently dropped when
+    /// the same command opened the TUI — the user saw unmerged rows with no
+    /// indication their flag had been ignored.
+    #[test]
+    fn tui_config_seeds_the_initial_worktree_rollup() {
+        let merged = App::new_with_cached_data(
+            TuiConfig {
+                worktree_rollup: tokscale_core::WorktreeRollup::MergeIntoRepo,
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            merged.worktree_rollup,
+            tokscale_core::WorktreeRollup::MergeIntoRepo
+        );
+
+        // And the default stays per-worktree when the flag is absent.
+        let plain = App::new_with_cached_data(TuiConfig::default(), None).unwrap();
+        assert_eq!(
+            plain.worktree_rollup,
+            tokscale_core::WorktreeRollup::Separate
+        );
+    }
+
     #[test]
     fn test_reset_selection() {
         let config = TuiConfig {
@@ -2693,6 +2726,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         let mut app = App::new_with_cached_data(config, None).unwrap();
 
@@ -2718,6 +2752,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         let mut app = App::new_with_cached_data(config, None).unwrap();
 
@@ -2769,6 +2804,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         let mut app = App::new_with_cached_data(config, None).unwrap();
 
@@ -2820,6 +2856,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         let mut app = App::new_with_cached_data(config, None).unwrap();
 
@@ -2861,6 +2898,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         let mut app = App::new_with_cached_data(config, None).unwrap();
 
@@ -2895,6 +2933,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         let app = App::new_with_cached_data(config, None).unwrap();
 
@@ -2924,6 +2963,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         let app = App::new_with_cached_data(config, None).unwrap();
 
@@ -2959,6 +2999,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         let app = App::new_with_cached_data(config, None).unwrap();
 
@@ -2983,6 +3024,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         App::new_with_cached_data(config, None).unwrap()
     }
@@ -3643,6 +3685,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: Some(Tab::Minutely),
+            ..Default::default()
         };
         let app = App::new_with_cached_data(config, Some(UsageData::default())).unwrap();
         assert_eq!(app.current_tab, Tab::Overview);
@@ -3979,6 +4022,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: Some(Tab::Hourly),
+            ..Default::default()
         };
 
         let app = App::new_with_cached_data(config, None).unwrap();

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -8,7 +8,7 @@ use tokio::runtime::{Handle, Runtime};
 use tokscale_core::sessions::UnifiedMessage;
 use tokscale_core::{
     model_name_for_grouping, normalize_model_for_grouping, parse_local_unified_messages, sessions,
-    ClientId, GroupBy, LocalParseOptions, ModelPerformance,
+    ClientId, GroupBy, LocalParseOptions, ModelPerformance, WorktreeRollup,
 };
 
 /// Returns the scanner settings that `DataLoader` should use when building
@@ -214,27 +214,15 @@ pub struct DataLoader {
     pub until: Option<String>,
     pub year: Option<String>,
     pub minutely_enabled: bool,
+    pub worktree_rollup: WorktreeRollup,
 }
 
+#[cfg(test)]
 const UNKNOWN_WORKSPACE_LABEL: &str = "Unknown workspace";
-const UNKNOWN_WORKSPACE_GROUP_KEY: &str = "\0unknown-workspace";
 
-fn workspace_bucket(msg: &UnifiedMessage) -> (String, Option<String>, String) {
-    match (&msg.workspace_key, &msg.workspace_label) {
-        (Some(key), Some(label)) => (key.clone(), Some(key.clone()), label.clone()),
-        (Some(key), None) => (
-            key.clone(),
-            Some(key.clone()),
-            tokscale_core::sessions::workspace_label_from_key(key)
-                .unwrap_or_else(|| UNKNOWN_WORKSPACE_LABEL.to_string()),
-        ),
-        _ => (
-            UNKNOWN_WORKSPACE_GROUP_KEY.to_string(),
-            None,
-            UNKNOWN_WORKSPACE_LABEL.to_string(),
-        ),
-    }
-}
+// Workspace bucketing lives in tokscale_core::workspace_bucket so this
+// aggregation and the CLI report agree on worktree rollup and on labeling
+// Claude Code's dash-mangled keys.
 
 fn positive_unified_token_total(tokens: &tokscale_core::TokenBreakdown) -> i64 {
     // saturating_add (mirrors tokscale_core::TokenBreakdown::total) so a
@@ -331,6 +319,7 @@ impl DataLoader {
             until: None,
             year: None,
             minutely_enabled: false,
+            worktree_rollup: WorktreeRollup::default(),
         }
     }
 
@@ -346,11 +335,17 @@ impl DataLoader {
             until,
             year,
             minutely_enabled: false,
+            worktree_rollup: WorktreeRollup::default(),
         }
     }
 
     pub fn with_minutely_enabled(mut self, enabled: bool) -> Self {
         self.minutely_enabled = enabled;
+        self
+    }
+
+    pub fn with_worktree_rollup(mut self, rollup: WorktreeRollup) -> Self {
+        self.worktree_rollup = rollup;
         self
     }
 
@@ -468,12 +463,15 @@ impl DataLoader {
         let mut minutely_map: HashMap<NaiveDateTime, MinutelyUsage> = HashMap::new();
         let mut model_session_ids: HashMap<String, HashSet<String>> = HashMap::new();
         let mut session_map: HashMap<String, SessionUsage> = HashMap::new();
+        // Memoizes the filesystem probes that resolve a workspace key to a label.
+        let mut workspace_labeler = tokscale_core::WorkspaceLabeler::default();
 
         for msg in &messages {
             let normalized_model =
                 model_name_for_grouping(&msg.client, &msg.provider_id, &msg.model_id);
             let model_key = normalize_model_for_grouping(&msg.model_id);
-            let (workspace_group_key, workspace_key, workspace_label) = workspace_bucket(msg);
+            let (workspace_group_key, workspace_key, workspace_label) =
+                tokscale_core::workspace_bucket(msg, self.worktree_rollup, &mut workspace_labeler);
             let key = match group_by {
                 GroupBy::Model => normalized_model.clone(),
                 GroupBy::ClientModel => format!("{}:{}", msg.client, normalized_model),

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -470,8 +470,16 @@ impl DataLoader {
             let normalized_model =
                 model_name_for_grouping(&msg.client, &msg.provider_id, &msg.model_id);
             let model_key = normalize_model_for_grouping(&msg.model_id);
-            let (workspace_group_key, workspace_key, workspace_label) =
-                tokscale_core::workspace_bucket(msg, self.worktree_rollup, &mut workspace_labeler);
+            // Resolving a workspace label reads the filesystem, and every grouping
+            // except this one throws it away — the TUI defaults to ClientModel and
+            // auto-refreshes, so paying it unconditionally is pure waste.
+            let (workspace_group_key, workspace_key, workspace_label) = if *group_by
+                == GroupBy::WorkspaceModel
+            {
+                tokscale_core::workspace_bucket(msg, self.worktree_rollup, &mut workspace_labeler)
+            } else {
+                (String::new(), None, String::new())
+            };
             let key = match group_by {
                 GroupBy::Model => normalized_model.clone(),
                 GroupBy::ClientModel => format!("{}:{}", msg.client, normalized_model),

--- a/crates/tokscale-cli/src/tui/mod.rs
+++ b/crates/tokscale-cli/src/tui/mod.rs
@@ -84,6 +84,7 @@ pub fn run(
     until: Option<String>,
     year: Option<String>,
     initial_tab: Option<Tab>,
+    worktree_rollup: tokscale_core::WorktreeRollup,
 ) -> Result<()> {
     if debug {
         let _ = tracing_subscriber::fmt()
@@ -100,6 +101,7 @@ pub fn run(
         until: until.clone(),
         year: year.clone(),
         initial_tab,
+        worktree_rollup,
     };
 
     // Build the unified filter set used by the cache key, the App

--- a/crates/tokscale-cli/src/tui/mod.rs
+++ b/crates/tokscale-cli/src/tui/mod.rs
@@ -327,12 +327,19 @@ fn run_loop_with_background(
             let group_by = app.group_by.borrow().clone();
             let report_scope = background_cache_scope(&since, &until, &year);
             let minutely_enabled = app.settings.minutely_tab_enabled;
+            let worktree_rollup = app.worktree_rollup;
 
             thread::spawn(move || {
-                let loader = background_data_loader(since, until, year, minutely_enabled);
+                let loader = background_data_loader(since, until, year, minutely_enabled)
+                    .with_worktree_rollup(worktree_rollup);
                 let result = loader.load(&clients, &group_by, include_synthetic);
                 if let Ok(ref data) = result {
-                    save_cached_data(data, &enabled_clients, &group_by, &report_scope);
+                    // Rolled-up rows are a different aggregation of the same
+                    // messages, so caching them under the plain workspace scope
+                    // would serve merged rows to a later un-merged view.
+                    if worktree_rollup == tokscale_core::WorktreeRollup::Separate {
+                        save_cached_data(data, &enabled_clients, &group_by, &report_scope);
+                    }
                 }
                 let _ = tx.send(result);
             });

--- a/crates/tokscale-cli/src/tui/ui/agents.rs
+++ b/crates/tokscale-cli/src/tui/ui/agents.rs
@@ -235,6 +235,7 @@ mod tests {
                 until: None,
                 year: None,
                 initial_tab: None,
+                ..Default::default()
             },
             Some(UsageData::default()),
         )

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -571,6 +571,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         let mut app = App::new_with_cached_data(config, None).unwrap();
         app.terminal_width = width;

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -428,6 +428,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: Some(tab),
+            ..Default::default()
         };
         App::new_with_cached_data(config, Some(UsageData::default())).unwrap()
     }

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -269,6 +269,17 @@ fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
             format!("[g:{}]", app.group_by.borrow()),
             Style::default().fg(Color::Cyan),
         ));
+        // `w` only does anything under workspace grouping, so only advertise it there.
+        if *app.group_by.borrow() == tokscale_core::GroupBy::WorkspaceModel {
+            spans.push(Span::styled(" ", Style::default()));
+            spans.push(Span::styled(
+                match app.worktree_rollup {
+                    tokscale_core::WorktreeRollup::MergeIntoRepo => "[w:repos]",
+                    tokscale_core::WorktreeRollup::Separate => "[w:worktrees]",
+                },
+                Style::default().fg(Color::Cyan),
+            ));
+        }
         spans.push(Span::styled(" • ", Style::default().fg(app.theme.muted)));
         spans.push(Span::styled(
             format!("[p:{}]", app.theme.name.as_str()),

--- a/crates/tokscale-cli/src/tui/ui/header.rs
+++ b/crates/tokscale-cli/src/tui/ui/header.rs
@@ -148,6 +148,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         let mut app = App::new_with_cached_data(config, None).unwrap();
         app.terminal_width = width;

--- a/crates/tokscale-cli/src/tui/ui/hourly.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly.rs
@@ -388,6 +388,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         let mut app = App::new_with_cached_data(config, None).unwrap();
         app.terminal_width = width;

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -21,16 +21,17 @@ const WORKSPACE_COLUMN_BASE_WIDTH: u16 = 18;
 /// truncated-label bug was actually reported from.
 const WORKSPACE_COLUMN_WIDE_WIDTH: u16 = 44;
 
-/// Inner width at which the row first has cells to spare.
+/// Inner width at which the row can actually satisfy the wide Workspace column
+/// without pushing Model below its `Min(20)`.
 ///
-/// Below this every column is at its minimum and the layout is zero-sum: widening
-/// Workspace can only come out of Cost (clipping a dollar figure) or Model
-/// (collapsing it to 4 cells), which just relocates the unreadable-truncation bug
-/// instead of fixing it. Measured: the Model column sits at exactly its `Min(20)`
-/// up to 173 and only starts growing at 174, so that is where surplus begins.
-const WORKSPACE_SURPLUS_MIN_WIDTH: u16 = 174;
+/// Below this the layout is zero-sum: widening Workspace can only come out of Cost
+/// (clipping a dollar figure) or Model, which just relocates the
+/// unreadable-truncation bug instead of fixing it. Measured against the solver —
+/// 193 is the first width where Workspace is granted the full 44 cells and Model
+/// still holds 20. Pinned by `workspace_column_request_matches_what_it_is_granted`.
+const WORKSPACE_SURPLUS_MIN_WIDTH: u16 = 193;
 
-/// Cells the Workspace column gets for a table rendered into `total`.
+/// Cells the Workspace column asks for in a table rendered into `total`.
 ///
 /// Deliberately a fixed `Length` at both sizes rather than a `Min`: `Min` outranks
 /// `Length` in ratatui's solver, so a flexible workspace column steals from its
@@ -41,6 +42,50 @@ fn workspace_column_width(total: u16) -> u16 {
     } else {
         WORKSPACE_COLUMN_BASE_WIDTH
     }
+}
+
+/// Cells the Workspace column is actually *granted*, which is what the label has
+/// to be truncated to.
+///
+/// A `Length` is a request, not a guarantee: the solver shrinks it when the row is
+/// too narrow, so truncating to the requested width leaves the overflow to be
+/// clipped by the renderer with no ellipsis — the same silent truncation this
+/// change exists to remove. Asking the layout closes that gap at every width
+/// instead of relying on a threshold being exactly right.
+fn workspace_column_granted_width(total: u16) -> usize {
+    workspace_table_widths(total)
+        .get(1)
+        .copied()
+        .unwrap_or(WORKSPACE_COLUMN_BASE_WIDTH) as usize
+}
+
+/// The workspace layout's column constraints for a row of `total` cells.
+fn workspace_column_constraints(total: u16) -> Vec<Constraint> {
+    vec![
+        Constraint::Length(3),
+        Constraint::Length(workspace_column_width(total)),
+        Constraint::Min(20),
+        Constraint::Length(16),
+        Constraint::Length(14),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(12),
+        Constraint::Length(12),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(10),
+    ]
+}
+
+/// Widths the solver grants each column of the workspace layout at `total` cells.
+fn workspace_table_widths(total: u16) -> Vec<u16> {
+    Layout::horizontal(workspace_column_constraints(total))
+        .spacing(1)
+        .split(Rect::new(0, 0, total, 1))
+        .iter()
+        .map(|area| area.width)
+        .collect()
 }
 
 fn workspace_label(model: &crate::tui::data::ModelUsage) -> &str {
@@ -202,14 +247,17 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(format!("{}", idx + 1)).style(Style::default().fg(theme_muted)),
                     Cell::from(truncate_to_width(
                         workspace_label(model),
-                        workspace_column_width(inner.width) as usize,
+                        workspace_column_granted_width(inner.width),
                     ))
                     .style(
                         Style::default()
                             .fg(theme_accent)
                             .add_modifier(Modifier::BOLD),
                     ),
-                    Cell::from(truncate_text(&model.model, 24)).style(
+                    // Cells, not code points: a full-width grapheme in a model id
+                    // counts as one char but occupies two cells, so a char budget
+                    // overflows the column and gets clipped with no ellipsis.
+                    Cell::from(truncate_to_width(&model.model, 24)).style(
                         Style::default()
                             .fg(model_color)
                             .add_modifier(Modifier::BOLD),
@@ -285,22 +333,10 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     } else if group_by == GroupBy::WorkspaceModel {
         // Same shape as the default layout, with a wider Workspace column once the
         // row has surplus cells to give it. Model keeps the flexible slot so the
-        // workspace column can never widen at Cost's expense.
-        vec![
-            Constraint::Length(3),
-            Constraint::Length(workspace_column_width(inner.width)),
-            Constraint::Min(20),
-            Constraint::Length(16),
-            Constraint::Length(14),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(12),
-            Constraint::Length(12),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(10),
-        ]
+        // workspace column can never widen at Cost's expense. Shared with
+        // `workspace_column_granted_width` so the label is truncated to the width
+        // this very layout hands out.
+        workspace_column_constraints(inner.width)
     } else {
         vec![
             Constraint::Length(3),
@@ -348,31 +384,41 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 mod tests {
     use super::*;
 
-    /// Column widths for the workspace layout at a given inner width, mirroring
-    /// the `widths` vector in `render`.
+    /// Column widths the solver grants the workspace layout. Calls the production
+    /// helper rather than restating the constraints, so a change to the layout
+    /// cannot leave the test asserting against a stale copy of it.
     fn workspace_layout_at(total: u16) -> Vec<u16> {
-        use ratatui::layout::Layout;
-        let widths = vec![
-            Constraint::Length(3),
-            Constraint::Length(workspace_column_width(total)),
-            Constraint::Min(20),
-            Constraint::Length(16),
-            Constraint::Length(14),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(12),
-            Constraint::Length(12),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(10),
-        ];
-        Layout::horizontal(widths)
-            .spacing(1)
-            .split(Rect::new(0, 0, total, 1))
-            .iter()
-            .map(|r| r.width)
-            .collect()
+        workspace_table_widths(total)
+    }
+
+    /// The label is truncated to the width the table hands out, never to the width
+    /// it merely asked for.
+    ///
+    /// A `Length` is a request: between 174 and 192 cells the row could not satisfy
+    /// a 44-cell Workspace while Model held its `Min(20)`, so the solver granted
+    /// 25..43 while the formatter still cut to 44 — leaving the overflow to be
+    /// clipped with no ellipsis, which is exactly the silent truncation this change
+    /// exists to remove. Sweeps every width so no threshold can drift back into
+    /// that gap.
+    #[test]
+    fn workspace_column_request_matches_what_it_is_granted() {
+        for total in 78u16..=400 {
+            assert_eq!(
+                workspace_column_granted_width(total),
+                workspace_layout_at(total)[1] as usize,
+                "at {total} cols the truncation width disagrees with the allocated column"
+            );
+        }
+
+        // And the wide request is genuinely satisfiable at its threshold, so the
+        // extra width is real rather than immediately clawed back.
+        let widths = workspace_layout_at(WORKSPACE_SURPLUS_MIN_WIDTH);
+        assert_eq!(widths[1], WORKSPACE_COLUMN_WIDE_WIDTH);
+        assert!(
+            widths[2] >= 20,
+            "Model fell to {} cells at the switch width",
+            widths[2]
+        );
     }
 
     /// The workspace layout as it stood before this change: Workspace pinned to 18
@@ -479,6 +525,7 @@ mod tests {
                 until: None,
                 year: None,
                 initial_tab: None,
+                ..Default::default()
             },
             None,
         )

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -6,10 +6,31 @@ use ratatui::widgets::{
 use super::widgets::{
     format_cache_hit_rate, format_cost, format_cost_per_million, format_ms_per_1k, format_tokens,
     get_client_display_name, get_provider_display_name, total_tokens_cell, truncate_text,
-    viewport_scrollbar_state,
+    truncate_to_width, viewport_scrollbar_state,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use tokscale_core::GroupBy;
+
+/// Floor for the Workspace column. A `repo ⑃ worktree` label needs far more than
+/// the model column's share, so it takes `Min` and the rest of the row is fixed.
+const WORKSPACE_COLUMN_MIN_WIDTH: u16 = 28;
+
+/// Every fixed-width column in the workspace layout, in render order. Kept as
+/// data so [`workspace_column_width`] derives the leftover width from the same
+/// numbers the `widths` vector below uses — a hand-summed constant silently
+/// drifts the moment a column is added or resized.
+const WORKSPACE_LAYOUT_FIXED_COLUMNS: [u16; 12] = [3, 24, 16, 14, 10, 10, 12, 12, 10, 10, 10, 10];
+
+/// Width available to the flexible Workspace column in a table of `total` cells.
+fn workspace_column_width(total: u16) -> usize {
+    let fixed: u16 = WORKSPACE_LAYOUT_FIXED_COLUMNS.iter().sum();
+    // ratatui puts one cell of spacing between adjacent columns: one gap per
+    // fixed column, since the Workspace column sits beside each of them.
+    let gaps = WORKSPACE_LAYOUT_FIXED_COLUMNS.len() as u16;
+    total
+        .saturating_sub(fixed + gaps)
+        .max(WORKSPACE_COLUMN_MIN_WIDTH) as usize
+}
 
 fn workspace_label(model: &crate::tui::data::ModelUsage) -> &str {
     model
@@ -168,7 +189,11 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             } else if group_by == GroupBy::WorkspaceModel {
                 vec![
                     Cell::from(format!("{}", idx + 1)).style(Style::default().fg(theme_muted)),
-                    Cell::from(truncate_text(workspace_label(model), 18)).style(
+                    Cell::from(truncate_to_width(
+                        workspace_label(model),
+                        workspace_column_width(inner.width),
+                    ))
+                    .style(
                         Style::default()
                             .fg(theme_accent)
                             .add_modifier(Modifier::BOLD),
@@ -247,21 +272,18 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Percentage(25),
         ]
     } else if group_by == GroupBy::WorkspaceModel {
-        vec![
-            Constraint::Length(3),
-            Constraint::Length(18),
-            Constraint::Min(20),
-            Constraint::Length(16),
-            Constraint::Length(14),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(12),
-            Constraint::Length(12),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(10),
-        ]
+        // Workspace is the row's identity under this grouping, so it gets the
+        // flexible column and the model name a fixed one -- the reverse of every
+        // other layout. `repo ⑃ worktree` labels are long, and a fixed 18 cells
+        // clipped them back to an indistinguishable shared prefix.
+        let mut widths = vec![Constraint::Length(WORKSPACE_LAYOUT_FIXED_COLUMNS[0])];
+        widths.push(Constraint::Min(WORKSPACE_COLUMN_MIN_WIDTH));
+        widths.extend(
+            WORKSPACE_LAYOUT_FIXED_COLUMNS[1..]
+                .iter()
+                .map(|w| Constraint::Length(*w)),
+        );
+        widths
     } else {
         vec![
             Constraint::Length(3),
@@ -301,6 +323,31 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 vertical: 1,
             }),
             &mut scrollbar_state,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_column_takes_the_width_the_fixed_columns_leave_behind() {
+        let fixed: u16 = WORKSPACE_LAYOUT_FIXED_COLUMNS.iter().sum::<u16>()
+            + WORKSPACE_LAYOUT_FIXED_COLUMNS.len() as u16;
+
+        // Everything past the fixed columns belongs to Workspace.
+        assert_eq!(workspace_column_width(fixed + 40), 40);
+
+        // Narrow terminals fall back to the floor rather than 0 (which would
+        // render an empty cell) or a negative wrap.
+        assert_eq!(
+            workspace_column_width(fixed),
+            WORKSPACE_COLUMN_MIN_WIDTH as usize
+        );
+        assert_eq!(
+            workspace_column_width(0),
+            WORKSPACE_COLUMN_MIN_WIDTH as usize
         );
     }
 }

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -11,25 +11,36 @@ use super::widgets::{
 use crate::tui::app::{App, SortDirection, SortField};
 use tokscale_core::GroupBy;
 
-/// Floor for the Workspace column. A `repo ⑃ worktree` label needs far more than
-/// the model column's share, so it takes `Min` and the rest of the row is fixed.
-const WORKSPACE_COLUMN_MIN_WIDTH: u16 = 28;
+/// Width the Workspace column gets when the row has no spare cells: what every
+/// other grouping's second column gets, so nothing is taken from its neighbors.
+const WORKSPACE_COLUMN_BASE_WIDTH: u16 = 18;
 
-/// Every fixed-width column in the workspace layout, in render order. Kept as
-/// data so [`workspace_column_width`] derives the leftover width from the same
-/// numbers the `widths` vector below uses — a hand-summed constant silently
-/// drifts the moment a column is added or resized.
-const WORKSPACE_LAYOUT_FIXED_COLUMNS: [u16; 12] = [3, 24, 16, 14, 10, 10, 12, 12, 10, 10, 10, 10];
+/// Width the Workspace column gets once the row has surplus to spend.
+///
+/// Enough for `repo ⑃ worktree` on a maximized terminal, which is the case the
+/// truncated-label bug was actually reported from.
+const WORKSPACE_COLUMN_WIDE_WIDTH: u16 = 44;
 
-/// Width available to the flexible Workspace column in a table of `total` cells.
-fn workspace_column_width(total: u16) -> usize {
-    let fixed: u16 = WORKSPACE_LAYOUT_FIXED_COLUMNS.iter().sum();
-    // ratatui puts one cell of spacing between adjacent columns: one gap per
-    // fixed column, since the Workspace column sits beside each of them.
-    let gaps = WORKSPACE_LAYOUT_FIXED_COLUMNS.len() as u16;
-    total
-        .saturating_sub(fixed + gaps)
-        .max(WORKSPACE_COLUMN_MIN_WIDTH) as usize
+/// Inner width at which the row first has cells to spare.
+///
+/// Below this every column is at its minimum and the layout is zero-sum: widening
+/// Workspace can only come out of Cost (clipping a dollar figure) or Model
+/// (collapsing it to 4 cells), which just relocates the unreadable-truncation bug
+/// instead of fixing it. Measured: the Model column sits at exactly its `Min(20)`
+/// up to 173 and only starts growing at 174, so that is where surplus begins.
+const WORKSPACE_SURPLUS_MIN_WIDTH: u16 = 174;
+
+/// Cells the Workspace column gets for a table rendered into `total`.
+///
+/// Deliberately a fixed `Length` at both sizes rather than a `Min`: `Min` outranks
+/// `Length` in ratatui's solver, so a flexible workspace column steals from its
+/// neighbors on any row that cannot satisfy everyone.
+fn workspace_column_width(total: u16) -> u16 {
+    if total >= WORKSPACE_SURPLUS_MIN_WIDTH {
+        WORKSPACE_COLUMN_WIDE_WIDTH
+    } else {
+        WORKSPACE_COLUMN_BASE_WIDTH
+    }
 }
 
 fn workspace_label(model: &crate::tui::data::ModelUsage) -> &str {
@@ -191,7 +202,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(format!("{}", idx + 1)).style(Style::default().fg(theme_muted)),
                     Cell::from(truncate_to_width(
                         workspace_label(model),
-                        workspace_column_width(inner.width),
+                        workspace_column_width(inner.width) as usize,
                     ))
                     .style(
                         Style::default()
@@ -272,18 +283,24 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Percentage(25),
         ]
     } else if group_by == GroupBy::WorkspaceModel {
-        // Workspace is the row's identity under this grouping, so it gets the
-        // flexible column and the model name a fixed one -- the reverse of every
-        // other layout. `repo ⑃ worktree` labels are long, and a fixed 18 cells
-        // clipped them back to an indistinguishable shared prefix.
-        let mut widths = vec![Constraint::Length(WORKSPACE_LAYOUT_FIXED_COLUMNS[0])];
-        widths.push(Constraint::Min(WORKSPACE_COLUMN_MIN_WIDTH));
-        widths.extend(
-            WORKSPACE_LAYOUT_FIXED_COLUMNS[1..]
-                .iter()
-                .map(|w| Constraint::Length(*w)),
-        );
-        widths
+        // Same shape as the default layout, with a wider Workspace column once the
+        // row has surplus cells to give it. Model keeps the flexible slot so the
+        // workspace column can never widen at Cost's expense.
+        vec![
+            Constraint::Length(3),
+            Constraint::Length(workspace_column_width(inner.width)),
+            Constraint::Min(20),
+            Constraint::Length(16),
+            Constraint::Length(14),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(12),
+            Constraint::Length(12),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+        ]
     } else {
         vec![
             Constraint::Length(3),
@@ -331,23 +348,115 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 mod tests {
     use super::*;
 
+    /// Column widths for the workspace layout at a given inner width, mirroring
+    /// the `widths` vector in `render`.
+    fn workspace_layout_at(total: u16) -> Vec<u16> {
+        use ratatui::layout::Layout;
+        let widths = vec![
+            Constraint::Length(3),
+            Constraint::Length(workspace_column_width(total)),
+            Constraint::Min(20),
+            Constraint::Length(16),
+            Constraint::Length(14),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(12),
+            Constraint::Length(12),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+        ];
+        Layout::horizontal(widths)
+            .spacing(1)
+            .split(Rect::new(0, 0, total, 1))
+            .iter()
+            .map(|r| r.width)
+            .collect()
+    }
+
+    /// The workspace layout as it stood before this change: Workspace pinned to 18
+    /// at every width. It is the correct bar to clear — the default (non-workspace)
+    /// layout has one fewer wide column, so it is not comparable, and holding this
+    /// layout to it would flag a 1-cell difference at width 84 that predates this
+    /// change and is inherent to rendering a Workspace column at all.
+    fn previous_workspace_layout_at(total: u16) -> Vec<u16> {
+        use ratatui::layout::Layout;
+        let widths = vec![
+            Constraint::Length(3),
+            Constraint::Length(18),
+            Constraint::Min(20),
+            Constraint::Length(16),
+            Constraint::Length(14),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(12),
+            Constraint::Length(12),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+        ];
+        Layout::horizontal(widths)
+            .spacing(1)
+            .split(Rect::new(0, 0, total, 1))
+            .iter()
+            .map(|r| r.width)
+            .collect()
+    }
+
+    /// Widening Workspace must never come out of Cost, Cost/1M, or Model.
+    ///
+    /// ratatui's solver shrinks whatever it must to fit the row, so a workspace
+    /// column that grows on a row with no surplus silently pays for itself by
+    /// clipping a dollar figure or collapsing the model name — which relocates the
+    /// unreadable-truncation bug this change exists to fix rather than fixing it.
+    ///
+    /// Sweeps EVERY width in 78..=400 on purpose. The first version of this test
+    /// sampled six widths and passed while 18 widths in the same range were
+    /// clipping Cost by a cell; a solver-driven layout cannot be spot-checked.
     #[test]
-    fn workspace_column_takes_the_width_the_fixed_columns_leave_behind() {
-        let fixed: u16 = WORKSPACE_LAYOUT_FIXED_COLUMNS.iter().sum::<u16>()
-            + WORKSPACE_LAYOUT_FIXED_COLUMNS.len() as u16;
+    fn workspace_layout_never_starves_its_neighbors() {
+        for total in 78u16..=400 {
+            let ws = workspace_layout_at(total);
+            let base = previous_workspace_layout_at(total);
 
-        // Everything past the fixed columns belongs to Workspace.
-        assert_eq!(workspace_column_width(fixed + 40), 40);
+            // Cost (11) and Cost/1M (12) must be no narrower than before.
+            for (idx, name) in [(11usize, "Cost"), (12usize, "Cost/1M")] {
+                assert!(
+                    ws[idx] >= base[idx],
+                    "at {total} cols the Workspace column cost {name} {} cell(s)",
+                    base[idx] - ws[idx]
+                );
+            }
 
-        // Narrow terminals fall back to the floor rather than 0 (which would
-        // render an empty cell) or a negative wrap.
+            // Model keeps the flexible slot, so the wide Workspace column is paid
+            // for out of Model's SURPLUS -- never out of its Min(20) floor, and so
+            // never out of a column carrying a number.
+            assert!(
+                ws[2] >= 20 || ws[2] == base[2],
+                "at {total} cols Model fell below its floor: {} cells (was {})",
+                ws[2],
+                base[2]
+            );
+        }
+    }
+
+    /// The column has to actually get wider somewhere, or the fix does nothing.
+    #[test]
+    fn workspace_column_widens_once_the_row_has_surplus() {
         assert_eq!(
-            workspace_column_width(fixed),
-            WORKSPACE_COLUMN_MIN_WIDTH as usize
+            workspace_column_width(WORKSPACE_SURPLUS_MIN_WIDTH - 1),
+            WORKSPACE_COLUMN_BASE_WIDTH
         );
         assert_eq!(
-            workspace_column_width(0),
-            WORKSPACE_COLUMN_MIN_WIDTH as usize
+            workspace_column_width(WORKSPACE_SURPLUS_MIN_WIDTH),
+            WORKSPACE_COLUMN_WIDE_WIDTH
+        );
+        // `repo ⑃ worktree` for the reported case fits at the wide size.
+        assert!(
+            WORKSPACE_COLUMN_WIDE_WIDTH as usize
+                >= "ea-world-service ⑃ nicole-25-20".chars().count()
         );
     }
 

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -350,4 +350,71 @@ mod tests {
             WORKSPACE_COLUMN_MIN_WIDTH as usize
         );
     }
+
+    /// Pins the painted screen, not the helpers behind it. The reported symptom
+    /// was purely visual -- readable labels that still rendered as a truncated
+    /// shared prefix -- so only the rendered buffer can prove it is fixed.
+    #[test]
+    fn workspace_grouping_paints_full_repo_and_worktree_labels() {
+        use crate::tui::app::{Tab, TuiConfig};
+        use crate::tui::data::ModelUsage;
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let mut app = App::new_with_cached_data(
+            TuiConfig {
+                theme: "blue".to_string(),
+                refresh: 0,
+                sessions_path: None,
+                clients: None,
+                since: None,
+                until: None,
+                year: None,
+                initial_tab: None,
+            },
+            None,
+        )
+        .unwrap();
+
+        let width = 200u16;
+        app.terminal_width = width;
+        app.current_tab = Tab::Models;
+        *app.group_by.borrow_mut() = GroupBy::WorkspaceModel;
+        app.data.models = vec![ModelUsage {
+            model: "claude-opus-5".to_string(),
+            color_key: "claude-opus-5".to_string(),
+            provider: "anthropic".to_string(),
+            client: "claude".to_string(),
+            workspace_key: Some("/Users/z/devpro/ea/ea-world-service".to_string()),
+            // The label the aggregator now produces for a worktree row.
+            workspace_label: Some("ea-world-service ⑃ nicole-25-20".to_string()),
+            tokens: Default::default(),
+            cost: 5367.48,
+            performance: Default::default(),
+            session_count: 1,
+        }];
+
+        let backend = TestBackend::new(width, 8);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, &mut app, Rect::new(0, 0, width, 8)))
+            .unwrap();
+        let screen = terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(width as usize)
+            .map(|row| row.iter().map(|c| c.symbol()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            screen.contains("ea-world-service ⑃ nicole-25-20"),
+            "workspace label must be painted in full, got:\n{screen}"
+        );
+        // The old behavior: a right-truncated label ending in an ellipsis.
+        assert!(
+            !screen.contains("ea-world-s…") && !screen.contains("ea-world-s..."),
+            "label must not be truncated at this width, got:\n{screen}"
+        );
+    }
 }

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -48,17 +48,20 @@ fn workspace_column_width(total: u16) -> u16 {
 const WORKSPACE_COL_WORKSPACE: usize = 1;
 const WORKSPACE_COL_MODEL: usize = 2;
 
-/// Cells column `index` is actually *granted* in a row of `total` cells, which is
-/// what text in that cell has to be truncated to.
+/// Cells column `index` is granted out of already-solved `widths`, which is what
+/// text in that cell has to be truncated to.
 ///
 /// A `Length` is a request, not a guarantee, and `Min` floats: the solver resizes
 /// both to make the row fit. Truncating to the requested width leaves the overflow
 /// to be clipped by the renderer with no ellipsis — the same silent truncation this
-/// change exists to remove. Asking the layout closes that gap at every width for
-/// every column, instead of each cell carrying a constant that is right only for
-/// the widths someone happened to check.
-fn workspace_granted_width(total: u16, index: usize) -> usize {
-    workspace_table_widths(total)
+/// change exists to remove. Reading the solved width closes that gap at every width
+/// for every column, instead of each cell carrying a constant that is right only
+/// for the sizes someone happened to check.
+///
+/// Takes the solved widths rather than an inner width so `render` can solve once
+/// per frame instead of once per cell.
+fn workspace_granted_width(widths: &[u16], index: usize) -> usize {
+    widths
         .get(index)
         .copied()
         .unwrap_or(WORKSPACE_COLUMN_BASE_WIDTH) as usize
@@ -223,6 +226,16 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         return;
     }
 
+    // Solve the workspace layout once per render, not once per cell: the widths
+    // depend only on `inner.width`, so running the solver inside the row loop
+    // repeated the same work (and its allocation) twice for every visible row.
+    let workspace_widths = if group_by == GroupBy::WorkspaceModel {
+        workspace_table_widths(inner.width)
+    } else {
+        Vec::new()
+    };
+    let granted = |index: usize| workspace_granted_width(&workspace_widths, index);
+
     let rows: Vec<Row> = models[start..end]
         .iter()
         .enumerate()
@@ -252,7 +265,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(format!("{}", idx + 1)).style(Style::default().fg(theme_muted)),
                     Cell::from(truncate_to_width(
                         workspace_label(model),
-                        workspace_granted_width(inner.width, WORKSPACE_COL_WORKSPACE),
+                        granted(WORKSPACE_COL_WORKSPACE),
                     ))
                     .style(
                         Style::default()
@@ -266,7 +279,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     // the rest.
                     Cell::from(truncate_to_width(
                         &model.model,
-                        workspace_granted_width(inner.width, WORKSPACE_COL_MODEL),
+                        granted(WORKSPACE_COL_MODEL),
                     ))
                     .style(
                         Style::default()
@@ -419,9 +432,10 @@ mod tests {
                 (WORKSPACE_COL_WORKSPACE, "Workspace"),
                 (WORKSPACE_COL_MODEL, "Model"),
             ] {
+                let solved = workspace_layout_at(total);
                 assert_eq!(
-                    workspace_granted_width(total, index),
-                    workspace_layout_at(total)[index] as usize,
+                    workspace_granted_width(&solved, index),
+                    solved[index] as usize,
                     "at {total} cols the {name} truncation width disagrees with its allocation"
                 );
             }

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -44,17 +44,22 @@ fn workspace_column_width(total: u16) -> u16 {
     }
 }
 
-/// Cells the Workspace column is actually *granted*, which is what the label has
-/// to be truncated to.
+/// Column indices in the workspace layout, for callers that need a cell's budget.
+const WORKSPACE_COL_WORKSPACE: usize = 1;
+const WORKSPACE_COL_MODEL: usize = 2;
+
+/// Cells column `index` is actually *granted* in a row of `total` cells, which is
+/// what text in that cell has to be truncated to.
 ///
-/// A `Length` is a request, not a guarantee: the solver shrinks it when the row is
-/// too narrow, so truncating to the requested width leaves the overflow to be
-/// clipped by the renderer with no ellipsis — the same silent truncation this
-/// change exists to remove. Asking the layout closes that gap at every width
-/// instead of relying on a threshold being exactly right.
-fn workspace_column_granted_width(total: u16) -> usize {
+/// A `Length` is a request, not a guarantee, and `Min` floats: the solver resizes
+/// both to make the row fit. Truncating to the requested width leaves the overflow
+/// to be clipped by the renderer with no ellipsis — the same silent truncation this
+/// change exists to remove. Asking the layout closes that gap at every width for
+/// every column, instead of each cell carrying a constant that is right only for
+/// the widths someone happened to check.
+fn workspace_granted_width(total: u16, index: usize) -> usize {
     workspace_table_widths(total)
-        .get(1)
+        .get(index)
         .copied()
         .unwrap_or(WORKSPACE_COLUMN_BASE_WIDTH) as usize
 }
@@ -247,17 +252,23 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(format!("{}", idx + 1)).style(Style::default().fg(theme_muted)),
                     Cell::from(truncate_to_width(
                         workspace_label(model),
-                        workspace_column_granted_width(inner.width),
+                        workspace_granted_width(inner.width, WORKSPACE_COL_WORKSPACE),
                     ))
                     .style(
                         Style::default()
                             .fg(theme_accent)
                             .add_modifier(Modifier::BOLD),
                     ),
-                    // Cells, not code points: a full-width grapheme in a model id
-                    // counts as one char but occupies two cells, so a char budget
-                    // overflows the column and gets clipped with no ellipsis.
-                    Cell::from(truncate_to_width(&model.model, 24)).style(
+                    // Cells, not code points, and the granted width rather than a
+                    // constant: Model holds the flexible slot here, so the solver
+                    // hands it 20 cells on a narrow row and far more on a wide one.
+                    // A fixed 24 over-truncated at 97 widths and under-truncated at
+                    // the rest.
+                    Cell::from(truncate_to_width(
+                        &model.model,
+                        workspace_granted_width(inner.width, WORKSPACE_COL_MODEL),
+                    ))
+                    .style(
                         Style::default()
                             .fg(model_color)
                             .add_modifier(Modifier::BOLD),
@@ -391,33 +402,39 @@ mod tests {
         workspace_table_widths(total)
     }
 
-    /// The label is truncated to the width the table hands out, never to the width
+    /// Every text cell truncates to the width the table hands out, never to a width
     /// it merely asked for.
     ///
-    /// A `Length` is a request: between 174 and 192 cells the row could not satisfy
-    /// a 44-cell Workspace while Model held its `Min(20)`, so the solver granted
-    /// 25..43 while the formatter still cut to 44 — leaving the overflow to be
-    /// clipped with no ellipsis, which is exactly the silent truncation this change
-    /// exists to remove. Sweeps every width so no threshold can drift back into
-    /// that gap.
+    /// Both columns hit this. Between 174 and 192 cells the row could not satisfy a
+    /// 44-cell Workspace while Model held its `Min(20)`, so the solver granted 25..43
+    /// while the formatter cut to 44. Model had the mirror-image bug from the other
+    /// direction: a constant 24-cell budget against a floating `Min` that the solver
+    /// sets to 20 on a narrow row and 77 on a wide one — over-truncating at 97 widths
+    /// and silently clipping at the rest. Asserting per column across every width is
+    /// what makes a third cell unable to reintroduce it.
     #[test]
     fn workspace_column_request_matches_what_it_is_granted() {
         for total in 78u16..=400 {
-            assert_eq!(
-                workspace_column_granted_width(total),
-                workspace_layout_at(total)[1] as usize,
-                "at {total} cols the truncation width disagrees with the allocated column"
-            );
+            for (index, name) in [
+                (WORKSPACE_COL_WORKSPACE, "Workspace"),
+                (WORKSPACE_COL_MODEL, "Model"),
+            ] {
+                assert_eq!(
+                    workspace_granted_width(total, index),
+                    workspace_layout_at(total)[index] as usize,
+                    "at {total} cols the {name} truncation width disagrees with its allocation"
+                );
+            }
         }
 
         // And the wide request is genuinely satisfiable at its threshold, so the
         // extra width is real rather than immediately clawed back.
         let widths = workspace_layout_at(WORKSPACE_SURPLUS_MIN_WIDTH);
-        assert_eq!(widths[1], WORKSPACE_COLUMN_WIDE_WIDTH);
+        assert_eq!(widths[WORKSPACE_COL_WORKSPACE], WORKSPACE_COLUMN_WIDE_WIDTH);
         assert!(
-            widths[2] >= 20,
+            widths[WORKSPACE_COL_MODEL] >= 20,
             "Model fell to {} cells at the switch width",
-            widths[2]
+            widths[WORKSPACE_COL_MODEL]
         );
     }
 

--- a/crates/tokscale-cli/src/tui/ui/monthly.rs
+++ b/crates/tokscale-cli/src/tui/ui/monthly.rs
@@ -592,6 +592,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         let mut app = App::new_with_cached_data(config, None).unwrap();
         app.terminal_width = width;

--- a/crates/tokscale-cli/src/tui/ui/overview.rs
+++ b/crates/tokscale-cli/src/tui/ui/overview.rs
@@ -269,7 +269,18 @@ fn render_top_models(frame: &mut Frame, app: &mut App, area: Rect, items_per_pag
     let models_len = models_data.len();
     let start = scroll_offset.min(models_len);
     let end = (start + items_per_page).min(models_len);
-    let max_name_width = if is_narrow { 20 } else { 35 };
+    // `workspace / model` is roughly twice the text of a bare model name, and
+    // the label's distinguishing part (repo, worktree) sits at the far end, so a
+    // 35-cell cap truncated every row down to the same shared path prefix. The
+    // panel is full-width here, so spend it rather than clipping to a constant.
+    let max_name_width = if is_narrow {
+        20
+    } else if group_by == GroupBy::WorkspaceModel {
+        // Leave room for the "● " marker and the trailing " (12.3%)".
+        inner.width.saturating_sub(12).max(35) as usize
+    } else {
+        35
+    };
 
     if start >= models_len {
         return;

--- a/crates/tokscale-cli/src/tui/ui/overview.rs
+++ b/crates/tokscale-cli/src/tui/ui/overview.rs
@@ -2,7 +2,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation};
 
 use super::bar_chart::{render_stacked_bar_chart, ModelSegment, StackedBarData};
-use super::widgets::{format_tokens, viewport_scrollbar_state};
+use super::widgets::{format_tokens, truncate_to_width, viewport_scrollbar_state};
 use crate::tui::app::{App, ChartGranularity};
 use tokscale_core::GroupBy;
 
@@ -303,7 +303,11 @@ fn render_top_models(frame: &mut Frame, app: &mut App, area: Rect, items_per_pag
         let model_color = app.model_color_for(&model.provider, &model.color_key);
         let display_name =
             overview_model_label(&group_by, &model.model, model.workspace_label.as_deref());
-        let name = truncate_string(&display_name, max_name_width);
+        // Measured in cells, not code points: `max_name_width` is derived from
+        // `inner.width`, and a workspace path can hold full-width graphemes (a CJK
+        // directory name), which a char count calls short at twice the cells it
+        // occupies -- overflowing the row and pushing the cost percentage off it.
+        let name = truncate_to_width(&display_name, max_name_width);
         let percentage = if model.cost.is_finite() && total.is_finite() && total > 0.0 {
             (model.cost / total) * 100.0
         } else {

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -1040,6 +1040,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         let mut app = App::new_with_cached_data(config, None).unwrap();
         app.terminal_width = width;

--- a/crates/tokscale-cli/src/tui/ui/stats.rs
+++ b/crates/tokscale-cli/src/tui/ui/stats.rs
@@ -695,6 +695,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         App::new_with_cached_data(config, None).unwrap()
     }

--- a/crates/tokscale-cli/src/tui/ui/usage.rs
+++ b/crates/tokscale-cli/src/tui/ui/usage.rs
@@ -2611,6 +2611,7 @@ mod tests {
             until: None,
             year: None,
             initial_tab: None,
+            ..Default::default()
         };
         let mut app = App::new_with_cached_data(config, Some(UsageData::default())).unwrap();
         app.current_tab = Tab::Usage;

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -545,6 +545,9 @@ pub struct ReportOptions {
     pub until: Option<String>,
     pub year: Option<String>,
     pub group_by: GroupBy,
+    /// Whether `workspace,model` rows fold git worktrees into their parent repo.
+    /// Only consulted for [`GroupBy::WorkspaceModel`].
+    pub worktree_rollup: WorktreeRollup,
     /// Persistent scanner config loaded from `~/.config/tokscale/settings.json`.
     /// Defaults to empty when callers don't care about user-configured paths.
     pub scanner_settings: scanner::ScannerSettings,
@@ -2868,32 +2871,125 @@ fn filter_unified_messages(
     filtered
 }
 
-fn workspace_bucket(msg: &UnifiedMessage) -> (String, Option<String>, String) {
-    match (&msg.workspace_key, &msg.workspace_label) {
-        (Some(key), Some(label)) => (key.clone(), Some(key.clone()), label.clone()),
-        (Some(key), None) => (
-            key.clone(),
-            Some(key.clone()),
-            sessions::workspace_label_from_key(key)
-                .unwrap_or_else(|| UNKNOWN_WORKSPACE_LABEL.to_string()),
-        ),
-        _ => (
-            UNKNOWN_WORKSPACE_GROUP_KEY.to_string(),
-            None,
-            UNKNOWN_WORKSPACE_LABEL.to_string(),
-        ),
+/// How workspace rows treat git worktrees.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
+pub enum WorktreeRollup {
+    /// One row per worktree — a task-isolating agent CLI produces many rows per repo.
+    #[default]
+    Separate,
+    /// Fold every worktree into its parent repository.
+    MergeIntoRepo,
+}
+
+/// Resolving a workspace key to a display label reads the filesystem (see
+/// [`sessions::decode_claude_project_slug`]). Reports iterate hundreds of
+/// thousands of messages over a handful of distinct workspaces, so memoize per
+/// key and keep the syscalls proportional to workspaces, not messages.
+#[derive(Default)]
+pub struct WorkspaceLabeler {
+    labels: HashMap<String, String>,
+    roots: HashMap<String, Option<String>>,
+}
+
+impl WorkspaceLabeler {
+    pub fn label(&mut self, key: &str) -> String {
+        if let Some(cached) = self.labels.get(key) {
+            return cached.clone();
+        }
+        let label = sessions::workspace_display_label(key)
+            .unwrap_or_else(|| UNKNOWN_WORKSPACE_LABEL.to_string());
+        self.labels.insert(key.to_string(), label.clone());
+        label
+    }
+
+    /// The canonical repo identity for `key`: the real filesystem path, with any
+    /// worktree suffix stripped. `None` when the key cannot be resolved to a path
+    /// (an opaque client id, or a directory no longer on disk), leaving the
+    /// original key as its own identity.
+    ///
+    /// Decoding is what makes the rollup actually merge. Claude Code writes a
+    /// dash-mangled slug and Codex/OpenCode write real paths, so without this the
+    /// same repo keeps two identities and the "one row per repo" promise fails.
+    pub fn repo_root(&mut self, key: &str) -> Option<String> {
+        if let Some(cached) = self.roots.get(key) {
+            return cached.clone();
+        }
+        // Decode first: Claude's slug encodes `.claude/worktrees/` as dashes, so
+        // the marker is only visible once the real path is recovered.
+        let decoded = sessions::decode_claude_project_slug(key);
+        let path = decoded.as_deref().unwrap_or(key);
+        let root = sessions::workspace_repo_root(path)
+            // Not a worktree: the decoded path is already the repo identity.
+            .or_else(|| decoded.clone())
+            // Undecodable slug (deleted worktree): fall back to the repo prefix
+            // recovered from the slug string so it still merges with its repo.
+            .or_else(|| sessions::workspace_repo_root_from_slug(key));
+        self.roots.insert(key.to_string(), root.clone());
+        root
     }
 }
 
+/// Grouping key, stored key and display label for a message's workspace.
+///
+/// Shared with the TUI, which runs its own aggregation over the same messages —
+/// duplicating this would let the two drift on how worktrees roll up and how
+/// Claude Code's dash-mangled keys are labeled.
+pub fn workspace_bucket(
+    msg: &UnifiedMessage,
+    rollup: WorktreeRollup,
+    labeler: &mut WorkspaceLabeler,
+) -> (String, Option<String>, String) {
+    let Some(key) = msg.workspace_key.as_deref() else {
+        return (
+            UNKNOWN_WORKSPACE_GROUP_KEY.to_string(),
+            None,
+            UNKNOWN_WORKSPACE_LABEL.to_string(),
+        );
+    };
+
+    // Under MergeIntoRepo the repo root becomes the grouping identity, so every
+    // worktree of a repo lands in one row and the row reports the repo's path.
+    if rollup == WorktreeRollup::MergeIntoRepo {
+        if let Some(root) = labeler.repo_root(key) {
+            let label = labeler.label(&root);
+            return (root.clone(), Some(root), label);
+        }
+    }
+
+    // A parser-supplied label is authoritative — it is the only thing that can
+    // name a workspace whose key is not a path (Warp's workspace UUID). Keys
+    // that fell back to `workspace_label_from_key` are relabeled, because that
+    // helper returns the whole dash-mangled slug for Claude Code.
+    let label = match msg.workspace_label.as_deref() {
+        Some(label) if Some(label.to_string()) != sessions::workspace_label_from_key(key) => {
+            label.to_string()
+        }
+        _ => labeler.label(key),
+    };
+
+    (key.to_string(), Some(key.to_string()), label)
+}
+
+#[cfg(test)]
 fn aggregate_model_usage_entries(
     messages: Vec<UnifiedMessage>,
     group_by: &GroupBy,
 ) -> Vec<ModelUsage> {
+    aggregate_model_usage_entries_with_rollup(messages, group_by, WorktreeRollup::default())
+}
+
+fn aggregate_model_usage_entries_with_rollup(
+    messages: Vec<UnifiedMessage>,
+    group_by: &GroupBy,
+    rollup: WorktreeRollup,
+) -> Vec<ModelUsage> {
     let mut model_map: HashMap<String, ModelUsage> = HashMap::new();
+    let mut labeler = WorkspaceLabeler::default();
 
     for msg in messages {
         let normalized = model_name_for_grouping(&msg.client, &msg.provider_id, &msg.model_id);
-        let (workspace_group_key, workspace_key, workspace_label) = workspace_bucket(&msg);
+        let (workspace_group_key, workspace_key, workspace_label) =
+            workspace_bucket(&msg, rollup, &mut labeler);
         let key = match group_by {
             GroupBy::Model => normalized.clone(),
             GroupBy::ClientModel => format!("{}:{}", msg.client, normalized),
@@ -3058,7 +3154,11 @@ pub async fn get_model_report(options: ReportOptions) -> Result<ModelReport, Str
     );
 
     let filtered = filter_messages_for_report(all_messages, &options);
-    let entries = aggregate_model_usage_entries(filtered, &options.group_by);
+    let entries = aggregate_model_usage_entries_with_rollup(
+        filtered,
+        &options.group_by,
+        options.worktree_rollup,
+    );
 
     let (total_input, total_output, total_cache_read, total_cache_write) =
         model_report_token_totals(&entries);
@@ -4930,6 +5030,10 @@ mod tests {
         MISSING_MODEL_PRICING_REASON, ROUTING_LABEL_UNPRICED_REASON, UNKNOWN_WORKSPACE_LABEL,
         UNVERIFIED_MODEL_IDENTITY_REASON, UNVERIFIED_PROVIDER_IDENTITY_REASON,
     };
+    // Kept as its own statement rather than folded into the list above: that list
+    // is edited by nearly every PR that touches this file, and sharing it made
+    // this branch conflict on every single upstream merge.
+    use super::{aggregate_model_usage_entries_with_rollup, WorktreeRollup};
     use serial_test::serial;
     use std::collections::{HashMap, HashSet};
     use std::io::Write;
@@ -6089,6 +6193,163 @@ mod tests {
         assert_eq!(entries[0].output, 10);
         assert_eq!(entries[0].cost, 4.0);
         assert_eq!(entries[0].message_count, 2);
+    }
+
+    #[test]
+    fn worktree_rollup_merges_worktrees_of_one_repo_into_a_single_row() {
+        let messages = vec![
+            make_workspace_message(
+                "claude",
+                "claude-sonnet-4-5-20250929",
+                "anthropic",
+                "session-1",
+                1.0,
+                Some("/repo-a/.claude/worktrees/feature-x"),
+                None,
+            ),
+            make_workspace_message(
+                "claude",
+                "claude-sonnet-4-5-20250929",
+                "anthropic",
+                "session-2",
+                2.0,
+                Some("/repo-a/.claude/worktrees/feature-y"),
+                None,
+            ),
+            make_workspace_message(
+                "claude",
+                "claude-sonnet-4-5-20250929",
+                "anthropic",
+                "session-3",
+                4.0,
+                Some("/repo-a"),
+                None,
+            ),
+        ];
+
+        let separate = aggregate_model_usage_entries_with_rollup(
+            messages.clone(),
+            &GroupBy::WorkspaceModel,
+            WorktreeRollup::Separate,
+        );
+        assert_eq!(separate.len(), 3, "each worktree stays its own row");
+
+        let merged = aggregate_model_usage_entries_with_rollup(
+            messages,
+            &GroupBy::WorkspaceModel,
+            WorktreeRollup::MergeIntoRepo,
+        );
+        assert_eq!(merged.len(), 1, "every worktree folds into the repo row");
+        assert_eq!(merged[0].workspace_key.as_deref(), Some("/repo-a"));
+        assert_eq!(merged[0].workspace_label.as_deref(), Some("repo-a"));
+        // No usage may be lost or double counted by the rollup.
+        assert_eq!(merged[0].cost, 7.0);
+        assert_eq!(merged[0].message_count, 3);
+    }
+
+    #[test]
+    fn worktree_rollup_labels_name_the_repo_and_the_worktree() {
+        let entries = aggregate_model_usage_entries_with_rollup(
+            vec![make_workspace_message(
+                "claude",
+                "claude-sonnet-4-5-20250929",
+                "anthropic",
+                "session-1",
+                1.0,
+                Some("/repo-a/.claude/worktrees/feature-x"),
+                None,
+            )],
+            &GroupBy::WorkspaceModel,
+            WorktreeRollup::Separate,
+        );
+
+        // Without rollup the row must still say WHICH worktree it is -- the bug
+        // was a label that truncated to a shared, indistinguishable prefix.
+        assert_eq!(
+            entries[0].workspace_label.as_deref(),
+            Some("repo-a ⑃ feature-x")
+        );
+    }
+
+    #[test]
+    fn worktree_rollup_merges_a_slug_key_with_the_same_repos_real_path() {
+        // Claude Code writes a dash-mangled slug and Codex/OpenCode write real
+        // paths for the SAME directory. Under rollup both must resolve to one
+        // identity, or "one row per repo" silently still yields two.
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("devpro/ing/claude-witness");
+        std::fs::create_dir_all(repo.join(".claude/worktrees/feature-x")).unwrap();
+
+        let real_path = std::fs::canonicalize(&repo)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        let worktree_path = std::fs::canonicalize(repo.join(".claude/worktrees/feature-x"))
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        // How Claude Code would name that worktree's project directory.
+        let slug: String = worktree_path
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+            .collect();
+
+        let entries = aggregate_model_usage_entries_with_rollup(
+            vec![
+                make_workspace_message(
+                    "claude",
+                    "claude-sonnet-4-5-20250929",
+                    "anthropic",
+                    "session-1",
+                    1.0,
+                    Some(&slug),
+                    None,
+                ),
+                make_workspace_message(
+                    "opencode",
+                    "claude-sonnet-4-5-20250929",
+                    "anthropic",
+                    "session-2",
+                    2.0,
+                    Some(&real_path),
+                    None,
+                ),
+            ],
+            &GroupBy::WorkspaceModel,
+            WorktreeRollup::MergeIntoRepo,
+        );
+
+        assert_eq!(entries.len(), 1, "slug and real path must share one row");
+        assert_eq!(entries[0].cost, 3.0);
+        assert_eq!(
+            entries[0].workspace_label.as_deref(),
+            Some("claude-witness")
+        );
+    }
+
+    #[test]
+    fn workspace_rows_keep_parser_supplied_labels_for_non_path_keys() {
+        // Warp keys a workspace by opaque UUID; only the parser can name it, so
+        // relabeling must not clobber that.
+        let entries = aggregate_model_usage_entries_with_rollup(
+            vec![make_workspace_message(
+                "warp",
+                "claude-sonnet-4-5-20250929",
+                "anthropic",
+                "session-1",
+                1.0,
+                Some("9f2c1a04-1e4b-4c3f-a0d1-77b2e5c9aa10"),
+                Some("Ing's Team"),
+            )],
+            &GroupBy::WorkspaceModel,
+            WorktreeRollup::MergeIntoRepo,
+        );
+
+        assert_eq!(entries[0].workspace_label.as_deref(), Some("Ing's Team"));
+        assert_eq!(
+            entries[0].workspace_key.as_deref(),
+            Some("9f2c1a04-1e4b-4c3f-a0d1-77b2e5c9aa10")
+        );
     }
 
     #[test]
@@ -12161,6 +12422,7 @@ mod tests {
                     until: None,
                     year: None,
                     group_by: GroupBy::default(),
+                    worktree_rollup: WorktreeRollup::default(),
                     scanner_settings: scanner::ScannerSettings::default(),
                 },
                 None,

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2986,10 +2986,18 @@ fn aggregate_model_usage_entries_with_rollup(
     let mut model_map: HashMap<String, ModelUsage> = HashMap::new();
     let mut labeler = WorkspaceLabeler::default();
 
+    // Bucketing a workspace resolves its label, which reads the filesystem. Every
+    // other grouping discards that label a few lines below, so skip the work rather
+    // than paying it on `tokscale --light`, `monthly`, and every TUI refresh.
+    let needs_workspace = matches!(group_by, GroupBy::WorkspaceModel);
+
     for msg in messages {
         let normalized = model_name_for_grouping(&msg.client, &msg.provider_id, &msg.model_id);
-        let (workspace_group_key, workspace_key, workspace_label) =
-            workspace_bucket(&msg, rollup, &mut labeler);
+        let (workspace_group_key, workspace_key, workspace_label) = if needs_workspace {
+            workspace_bucket(&msg, rollup, &mut labeler)
+        } else {
+            (String::new(), None, String::new())
+        };
         let key = match group_by {
             GroupBy::Model => normalized.clone(),
             GroupBy::ClientModel => format!("{}:{}", msg.client, normalized),

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -6277,17 +6277,26 @@ mod tests {
         // paths for the SAME directory. Under rollup both must resolve to one
         // identity, or "one row per repo" silently still yields two.
         let temp = tempfile::tempdir().unwrap();
-        let repo = temp.path().join("devpro/ing/claude-witness");
+        // Spell the fixture the way `read_dir` reports it: Windows `%TEMP%` can be
+        // an 8.3 short name the decoder's directory walk never sees, and
+        // `canonicalize` returns a `\\?\` verbatim prefix that is not a walkable
+        // root. Both would make the slug describe a path no listing contains.
+        let temp_root = {
+            let canonical = std::fs::canonicalize(temp.path()).unwrap();
+            let spelled = canonical.to_string_lossy().to_string();
+            spelled
+                .strip_prefix(r"\\?\")
+                .map(std::path::PathBuf::from)
+                .unwrap_or(canonical)
+        };
+        let repo = temp_root.join("devpro/ing/claude-witness");
         std::fs::create_dir_all(repo.join(".claude/worktrees/feature-x")).unwrap();
 
-        let real_path = std::fs::canonicalize(&repo)
-            .unwrap()
-            .to_string_lossy()
-            .to_string();
-        let worktree_path = std::fs::canonicalize(repo.join(".claude/worktrees/feature-x"))
-            .unwrap()
-            .to_string_lossy()
-            .to_string();
+        let real_path = crate::sessions::normalize_workspace_key(&repo.to_string_lossy()).unwrap();
+        let worktree_path = crate::sessions::normalize_workspace_key(
+            &repo.join(".claude/worktrees/feature-x").to_string_lossy(),
+        )
+        .unwrap();
         // How Claude Code would name that worktree's project directory.
         let slug: String = worktree_path
             .chars()

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -643,12 +643,16 @@ fn resolve_slug_under(dir: &Path, remaining: &str) -> Option<String> {
     let mut candidates: Vec<String> = std::fs::read_dir(dir)
         .ok()?
         .flatten()
-        // `entry.path()` follows symlinks where `entry.file_type()` would not.
+        .map(|entry| entry.file_name().to_string_lossy().to_string())
+        // Name filter first: it is pure string work, and it rejects nearly every
+        // entry in a large directory. The `is_dir` check below costs a `stat` per
+        // survivor, so ordering it second keeps the syscalls proportional to
+        // matches rather than to directory size.
+        .filter(|name| slug_matches_prefix(remaining, name))
+        // `Path::is_dir` follows symlinks where `DirEntry::file_type` would not.
         // Symlinked directories are load-bearing here: macOS reaches temp dirs
         // through `/var -> /private/var`, and users symlink project roots.
-        .filter(|entry| entry.path().is_dir())
-        .map(|entry| entry.file_name().to_string_lossy().to_string())
-        .filter(|name| slug_matches_prefix(remaining, name))
+        .filter(|name| dir.join(name).is_dir())
         .collect();
     // Ties are real: `a.b` and `a-b` encode identically and nothing on disk
     // distinguishes them, so order deterministically instead of trusting
@@ -791,6 +795,30 @@ mod tests {
 
         let decoded = decode_claude_project_slug(&slug_for(&real))
             .expect("slug should resolve to the directory it was built from");
+
+        assert_eq!(
+            std::fs::canonicalize(decoded).unwrap(),
+            std::fs::canonicalize(&real).unwrap()
+        );
+    }
+
+    #[test]
+    fn decode_claude_project_slug_handles_non_ascii_directory_names() {
+        // `slugify_path_segment` maps each non-alphanumeric CHAR to one '-', so a
+        // multi-byte name encodes SHORTER than its byte length ("café" is 5 bytes
+        // and encodes to "caf-" at 4; "日本語" is 9 and encodes to "---" at 3).
+        // `resolve_slug_under` then advances by the ENCODED length and slices
+        // `&remaining[consumed..]`, which is a byte index — so this pins that the
+        // walk stays aligned and never slices mid-character. What keeps it safe is
+        // `slug_matches_prefix`: it only admits a candidate whose encoded form is
+        // an ASCII prefix of `remaining`, so `consumed` always lands on a char
+        // boundary. Without that guard this input would panic rather than degrade.
+        let (_temp, root) = canonical_tempdir();
+        let real = root.join("café/日本語/my-app");
+        std::fs::create_dir_all(&real).unwrap();
+
+        let decoded = decode_claude_project_slug(&slug_for(&real))
+            .expect("non-ASCII directory names must still resolve");
 
         assert_eq!(
             std::fs::canonicalize(decoded).unwrap(),

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -52,6 +52,8 @@ pub mod workbuddy;
 pub mod zcode;
 pub mod zed;
 
+use std::path::Path;
+
 use crate::TokenBreakdown;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -478,6 +480,181 @@ pub fn workspace_label_from_key(key: &str) -> Option<String> {
         .map(|segment| segment.to_string())
 }
 
+/// Marker between a repository and the worktree checked out inside it, e.g.
+/// `claude-witness ⑃ lens-backfill-findings`. Worktrees are the common case for
+/// agent CLIs that isolate each task, and a repo-only label would render a dozen
+/// identical rows.
+pub const WORKTREE_SEPARATOR: &str = " ⑃ ";
+
+/// Path segments that mean "everything below me is a worktree, not the repo".
+const WORKTREE_MARKERS: [&str; 2] = [".claude/worktrees/", ".git/worktrees/"];
+
+/// The same markers as they appear in a dash-encoded Claude Code slug. A deleted
+/// worktree cannot be resolved against the filesystem, but the marker survives
+/// verbatim in the slug, so the repo prefix is still recoverable from the string.
+const ENCODED_WORKTREE_MARKERS: [&str; 2] = ["--claude-worktrees-", "--git-worktrees-"];
+
+/// Split a dash-encoded slug at its worktree marker into (repo slug, worktree
+/// name). Lets rollup and labeling keep working for worktrees whose directories
+/// have since been deleted — otherwise those rows keep the raw slug forever.
+fn split_encoded_worktree(key: &str) -> Option<(String, String)> {
+    for marker in ENCODED_WORKTREE_MARKERS {
+        if let Some(index) = key.find(marker) {
+            let repo = &key[..index];
+            let worktree = &key[index + marker.len()..];
+            if !repo.is_empty() && !worktree.is_empty() {
+                return Some((repo.to_string(), worktree.to_string()));
+            }
+        }
+    }
+    None
+}
+
+/// The repository root a workspace key belongs to, with any worktree suffix
+/// removed. Returns `None` when the key is not inside a worktree, so callers can
+/// tell "already a repo root" from "rolled up to one".
+///
+/// Only path-shaped keys are handled: clients that store an opaque id (Warp's
+/// workspace UUID) have nothing to roll up and are returned untouched.
+pub fn workspace_repo_root(key: &str) -> Option<String> {
+    for marker in WORKTREE_MARKERS {
+        if let Some(index) = key.find(marker) {
+            let root = key[..index].trim_end_matches('/');
+            if !root.is_empty() {
+                return Some(root.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Human-readable label for a workspace key: `repo` or `repo ⑃ worktree`.
+///
+/// The key is whatever the originating client wrote to disk, so this also has to
+/// cope with Claude Code's dash-mangled directory slug
+/// (`-Users-zetian-devpro-ing-claude-witness`), which carries no `/` to split on
+/// and therefore used to render as the entire path — the exact prefix every row
+/// shares, so truncation dropped the only distinguishing part.
+pub fn workspace_display_label(key: &str) -> Option<String> {
+    let path = decode_claude_project_slug(key).unwrap_or_else(|| key.to_string());
+
+    if let Some(root) = workspace_repo_root(&path) {
+        let repo = workspace_label_from_key(&root)?;
+        return match workspace_label_from_key(&path) {
+            Some(worktree) => Some(format!("{repo}{WORKTREE_SEPARATOR}{worktree}")),
+            None => Some(repo),
+        };
+    }
+
+    // Undecodable slug (the directory was deleted): the marker still tells us
+    // where the repo ends, so name it from the string rather than giving up and
+    // showing the whole mangled path.
+    if let Some((repo_slug, worktree)) = split_encoded_worktree(&path) {
+        let repo = decode_claude_project_slug(&repo_slug)
+            .and_then(|decoded| workspace_label_from_key(&decoded))
+            .or_else(|| last_slug_segment(&repo_slug))?;
+        return Some(format!("{repo}{WORKTREE_SEPARATOR}{worktree}"));
+    }
+
+    workspace_label_from_key(&path)
+}
+
+/// Repo identity for a dash-encoded worktree slug whose directory no longer
+/// exists, so rollup can still merge it into its repository. Prefers the repo's
+/// real path when THAT still resolves, falling back to the repo slug itself —
+/// which keeps deleted worktrees of one repo together even then.
+pub fn workspace_repo_root_from_slug(key: &str) -> Option<String> {
+    let (repo_slug, _) = split_encoded_worktree(key)?;
+    Some(decode_claude_project_slug(&repo_slug).unwrap_or(repo_slug))
+}
+
+/// Best-effort trailing name of a dash-encoded slug whose directory is gone. The
+/// original `/` boundaries are unrecoverable, so this returns the last dash
+/// segment — a hint, not an exact path.
+fn last_slug_segment(slug: &str) -> Option<String> {
+    slug.rsplit('-')
+        .find(|segment| !segment.is_empty())
+        .map(|segment| segment.to_string())
+}
+
+/// Claude Code names each project directory after the absolute path it was
+/// launched from, replacing every non-alphanumeric byte with `-`. That map is
+/// lossy — `/`, `.`, `+` and `-` all collapse to `-` — so it cannot be inverted
+/// by string surgery alone. Instead this walks the filesystem, re-applying the
+/// same map to real directory names to find which one the slug came from, which
+/// makes the recovered path exact rather than a guess.
+///
+/// Returns `None` for keys that are already real paths, or when no directory on
+/// disk matches (a project whose folder has since been deleted or renamed).
+pub fn decode_claude_project_slug(key: &str) -> Option<String> {
+    // Real paths and Windows keys are already usable; only the slug form starts
+    // with the separator-turned-dash and contains no separator of its own.
+    if !key.starts_with('-') || key.contains('/') {
+        return None;
+    }
+
+    resolve_slug_under(Path::new("/"), key)
+}
+
+/// Walk `remaining` against the real directories under `dir`.
+///
+/// A dash in the slug is ambiguous — it may be a `/` boundary, or part of a
+/// directory name that genuinely contains `-`, `.` or `+` — so a single greedy
+/// pass mis-resolves paths like `claude-witness` (one directory, not two). This
+/// consumes one real directory at a time and backtracks when a branch dead-ends,
+/// which makes the result exact wherever the directory still exists on disk.
+fn resolve_slug_under(dir: &Path, remaining: &str) -> Option<String> {
+    if remaining.is_empty() {
+        return Some(dir.to_string_lossy().to_string());
+    }
+
+    // Longest candidate first: prefer `IngTian.github.io` over a shorter
+    // `IngTian` that happens to also exist.
+    let mut candidates: Vec<String> = std::fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        // `entry.path()` follows symlinks where `entry.file_type()` would not.
+        // Symlinked directories are load-bearing here: macOS reaches temp dirs
+        // through `/var -> /private/var`, and users symlink project roots.
+        .filter(|entry| entry.path().is_dir())
+        .map(|entry| entry.file_name().to_string_lossy().to_string())
+        .filter(|name| slug_matches_prefix(remaining, name))
+        .collect();
+    // Ties are real: `a.b` and `a-b` encode identically and nothing on disk
+    // distinguishes them, so order deterministically instead of trusting
+    // readdir order.
+    candidates.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
+
+    for name in candidates {
+        let consumed = slugify_path_segment(&name).len() + 1;
+        if let Some(resolved) = resolve_slug_under(&dir.join(&name), &remaining[consumed..]) {
+            return Some(resolved);
+        }
+    }
+
+    None
+}
+
+/// Whether `remaining` starts with `-` + the encoded form of `name`, ending on a
+/// segment boundary so a directory cannot match half of a longer name.
+fn slug_matches_prefix(remaining: &str, name: &str) -> bool {
+    let encoded = slugify_path_segment(name);
+    let Some(rest) = remaining.strip_prefix('-') else {
+        return false;
+    };
+    let Some(tail) = rest.strip_prefix(encoded.as_str()) else {
+        return false;
+    };
+    tail.is_empty() || tail.starts_with('-')
+}
+
+/// Claude Code's forward map: every non-alphanumeric byte becomes `-`.
+fn slugify_path_segment(name: &str) -> String {
+    name.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect()
+}
+
 /// Convert Unix milliseconds to a local YYYY-MM-DD date string.
 fn timestamp_to_date(timestamp_ms: i64) -> String {
     timestamp_to_date_with_timezone(timestamp_ms, &chrono::Local)
@@ -495,6 +672,118 @@ where
 mod tests {
     use super::*;
     use chrono::FixedOffset;
+
+    #[test]
+    fn workspace_repo_root_strips_worktree_suffixes() {
+        assert_eq!(
+            workspace_repo_root("/Users/z/devpro/witness/.claude/worktrees/lens-backfill")
+                .as_deref(),
+            Some("/Users/z/devpro/witness")
+        );
+        assert_eq!(
+            workspace_repo_root("/Users/z/devpro/witness/.git/worktrees/wt-1").as_deref(),
+            Some("/Users/z/devpro/witness")
+        );
+        // Plain repo checkouts have nothing to roll up.
+        assert_eq!(workspace_repo_root("/Users/z/devpro/witness"), None);
+        // Opaque, non-path keys (Warp's workspace UUID) must not be mangled.
+        assert_eq!(
+            workspace_repo_root("9f2c1a04-1e4b-4c3f-a0d1-77b2e5c9aa10"),
+            None
+        );
+    }
+
+    #[test]
+    fn workspace_display_label_names_repo_and_worktree() {
+        assert_eq!(
+            workspace_display_label("/Users/z/devpro/witness/.claude/worktrees/lens-backfill")
+                .as_deref(),
+            Some("witness ⑃ lens-backfill")
+        );
+        assert_eq!(
+            workspace_display_label("/Users/z/devpro/witness").as_deref(),
+            Some("witness")
+        );
+    }
+
+    #[test]
+    fn decode_claude_project_slug_recovers_names_containing_dashes() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        // A real name with a literal '-' is the case a greedy split gets wrong:
+        // "claude-witness" is ONE directory, not "claude" then "witness".
+        std::fs::create_dir_all(root.join("devpro/ing/claude-witness")).unwrap();
+
+        let slug =
+            super::slugify_path_segment(&root.join("devpro/ing/claude-witness").to_string_lossy());
+        let decoded = super::resolve_slug_under(Path::new("/"), &slug).unwrap();
+
+        assert_eq!(
+            std::fs::canonicalize(decoded).unwrap(),
+            std::fs::canonicalize(root.join("devpro/ing/claude-witness")).unwrap()
+        );
+    }
+
+    #[test]
+    fn decode_claude_project_slug_recovers_dots_and_worktrees() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        // '.' also encodes to '-', so "IngTian.github.io" and the ".claude"
+        // worktree marker both have to come back exactly.
+        let real = root.join("ing/IngTian.github.io/.claude/worktrees/scroll-reveal");
+        std::fs::create_dir_all(&real).unwrap();
+
+        let slug = super::slugify_path_segment(&real.to_string_lossy());
+        let decoded = super::resolve_slug_under(Path::new("/"), &slug).unwrap();
+
+        assert_eq!(
+            std::fs::canonicalize(decoded).unwrap(),
+            std::fs::canonicalize(&real).unwrap()
+        );
+    }
+
+    #[test]
+    fn decode_claude_project_slug_ignores_real_paths_and_unknown_dirs() {
+        // Already a path: nothing to decode.
+        assert_eq!(decode_claude_project_slug("/Users/z/devpro/witness"), None);
+        // Slug whose directory does not exist on disk.
+        assert_eq!(
+            decode_claude_project_slug("-nonexistent-tokscale-probe-dir-xyz"),
+            None
+        );
+    }
+
+    #[test]
+    fn deleted_worktree_slugs_still_name_and_group_by_their_repo() {
+        // A worktree deleted from disk cannot be resolved, but its slug still
+        // carries the marker, so it must not fall back to the raw mangled key.
+        let slug = "-Users-zed-devpro-ing-claude-witness--claude-worktrees-store-c1-dissolve";
+
+        assert_eq!(
+            workspace_display_label(slug).as_deref(),
+            Some("witness ⑃ store-c1-dissolve")
+        );
+        // And every deleted worktree of that repo shares one rollup identity.
+        assert_eq!(
+            workspace_repo_root_from_slug(slug).as_deref(),
+            Some("-Users-zed-devpro-ing-claude-witness")
+        );
+        assert_eq!(
+            workspace_repo_root_from_slug(
+                "-Users-zed-devpro-ing-claude-witness--claude-worktrees-proc-port-43"
+            )
+            .as_deref(),
+            Some("-Users-zed-devpro-ing-claude-witness")
+        );
+    }
+
+    #[test]
+    fn workspace_display_label_falls_back_to_raw_key_when_undecodable() {
+        // A deleted project directory cannot be resolved, so the label stays the
+        // raw slug rather than becoming empty.
+        let slug = "-nonexistent-tokscale-probe-dir-xyz";
+        assert_eq!(workspace_display_label(slug).as_deref(), Some(slug));
+    }
 
     #[test]
     fn warp_cache_parser_preserves_requests_and_spend_without_tokens() {

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -635,7 +635,13 @@ fn slug_root_and_remainder(key: &str) -> Option<(PathBuf, &str)> {
 /// which makes the result exact wherever the directory still exists on disk.
 fn resolve_slug_under(dir: &Path, remaining: &str) -> Option<String> {
     if remaining.is_empty() {
-        return Some(dir.to_string_lossy().to_string());
+        // Hand back a normalized key, not a native path. Every consumer compares
+        // against forward-slash markers (`workspace_repo_root` looks for
+        // `.claude/worktrees/`), and on Windows `Path::join` produces `\`, so
+        // returning the native spelling would silently defeat worktree rollup and
+        // make a decoded key unequal to the same directory recorded by a client
+        // that stores a real path.
+        return normalize_workspace_key(&dir.to_string_lossy());
     }
 
     // Longest candidate first: prefer `IngTian.github.io` over a shorter
@@ -823,6 +829,31 @@ mod tests {
         assert_eq!(
             std::fs::canonicalize(decoded).unwrap(),
             std::fs::canonicalize(&real).unwrap()
+        );
+    }
+
+    #[test]
+    fn decoded_slugs_use_normalized_separators() {
+        // The decoder builds its result with `Path::join`, which emits `\` on
+        // Windows. Every consumer compares against forward-slash markers, so a
+        // native-spelled key silently defeats worktree rollup there and never
+        // compares equal to the same directory recorded by a client that stores a
+        // real path. Asserting on the returned string keeps that platform-specific
+        // failure visible from any host.
+        let (_temp, root) = canonical_tempdir();
+        let real = root.join("repo-a/.claude/worktrees/feature-x");
+        std::fs::create_dir_all(&real).unwrap();
+
+        let decoded = decode_claude_project_slug(&slug_for(&real)).expect("slug should resolve");
+
+        assert!(
+            !decoded.contains('\\'),
+            "decoded key must not carry native separators: {decoded}"
+        );
+        // And the worktree marker must therefore be findable.
+        assert!(
+            workspace_repo_root(&decoded).is_some(),
+            "worktree marker must be visible in {decoded}"
         );
     }
 

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -52,7 +52,7 @@ pub mod workbuddy;
 pub mod zcode;
 pub mod zed;
 
-use std::path::Path;
+use std::path::{Path, PathBuf, MAIN_SEPARATOR_STR};
 
 use crate::TokenBreakdown;
 
@@ -587,13 +587,43 @@ fn last_slug_segment(slug: &str) -> Option<String> {
 /// Returns `None` for keys that are already real paths, or when no directory on
 /// disk matches (a project whose folder has since been deleted or renamed).
 pub fn decode_claude_project_slug(key: &str) -> Option<String> {
-    // Real paths and Windows keys are already usable; only the slug form starts
-    // with the separator-turned-dash and contains no separator of its own.
-    if !key.starts_with('-') || key.contains('/') {
+    // A real path (already usable) keeps its separators; `normalize_workspace_key`
+    // rewrites Windows backslashes to `/`, so one check covers both platforms.
+    if key.contains('/') {
         return None;
     }
 
-    resolve_slug_under(Path::new("/"), key)
+    let (root, remaining) = slug_root_and_remainder(key)?;
+    resolve_slug_under(&root, remaining)
+}
+
+/// Split a slug into the filesystem root it was anchored at and the rest.
+///
+/// A POSIX slug begins at `/`, so it opens with the separator-turned-dash. A
+/// Windows slug encodes the drive instead (`C:\Users\me` becomes `C--Users-me`:
+/// one dash for the colon, one for the separator), so the root has to be
+/// reconstructed from the drive letter rather than assumed to be `/`.
+fn slug_root_and_remainder(key: &str) -> Option<(PathBuf, &str)> {
+    if key.starts_with('-') {
+        // Pass the whole key through: `slug_matches_prefix` expects every segment
+        // to arrive separator-first, including the first one.
+        return Some((PathBuf::from(MAIN_SEPARATOR_STR), key));
+    }
+
+    let mut chars = key.chars();
+    let drive = chars.next()?;
+    if !drive.is_ascii_alphabetic() {
+        return None;
+    }
+    // The encoded colon, leaving the separator dash to start the first segment.
+    let remaining = key[1..].strip_prefix('-')?;
+    if !remaining.starts_with('-') {
+        return None;
+    }
+    Some((
+        PathBuf::from(format!("{drive}:{MAIN_SEPARATOR_STR}")),
+        remaining,
+    ))
 }
 
 /// Walk `remaining` against the real directories under `dir`.
@@ -714,14 +744,22 @@ mod tests {
         // "claude-witness" is ONE directory, not "claude" then "witness".
         std::fs::create_dir_all(root.join("devpro/ing/claude-witness")).unwrap();
 
-        let slug =
-            super::slugify_path_segment(&root.join("devpro/ing/claude-witness").to_string_lossy());
-        let decoded = super::resolve_slug_under(Path::new("/"), &slug).unwrap();
+        let decoded =
+            decode_claude_project_slug(&slug_for(&root.join("devpro/ing/claude-witness")))
+                .expect("slug should resolve to the directory it was built from");
 
         assert_eq!(
             std::fs::canonicalize(decoded).unwrap(),
             std::fs::canonicalize(root.join("devpro/ing/claude-witness")).unwrap()
         );
+    }
+
+    /// Encode a real path the way Claude Code names its project directory, going
+    /// through `normalize_workspace_key` first so Windows backslashes become `/`
+    /// exactly as they do in production before the slug is formed.
+    fn slug_for(path: &Path) -> String {
+        let normalized = normalize_workspace_key(&path.to_string_lossy()).unwrap();
+        super::slugify_path_segment(&normalized)
     }
 
     #[test]
@@ -733,13 +771,34 @@ mod tests {
         let real = root.join("ing/IngTian.github.io/.claude/worktrees/scroll-reveal");
         std::fs::create_dir_all(&real).unwrap();
 
-        let slug = super::slugify_path_segment(&real.to_string_lossy());
-        let decoded = super::resolve_slug_under(Path::new("/"), &slug).unwrap();
+        let decoded = decode_claude_project_slug(&slug_for(&real))
+            .expect("slug should resolve to the directory it was built from");
 
         assert_eq!(
             std::fs::canonicalize(decoded).unwrap(),
             std::fs::canonicalize(&real).unwrap()
         );
+    }
+
+    #[test]
+    fn slug_root_and_remainder_anchors_posix_and_windows_slugs() {
+        // POSIX: the leading dash IS the root separator, and stays in the
+        // remainder so the first segment arrives separator-first.
+        let (root, remaining) = super::slug_root_and_remainder("-Users-me-app").unwrap();
+        assert_eq!(root, PathBuf::from(MAIN_SEPARATOR_STR));
+        assert_eq!(remaining, "-Users-me-app");
+
+        // Windows: `C:\Users\me\app` encodes as `C--Users-me-app` -- one dash for
+        // the colon, one for the separator -- so the drive has to be rebuilt
+        // rather than assumed to be `/`.
+        let (root, remaining) = super::slug_root_and_remainder("C--Users-me-app").unwrap();
+        assert_eq!(root, PathBuf::from(format!("C:{MAIN_SEPARATOR_STR}")));
+        assert_eq!(remaining, "-Users-me-app");
+
+        // Neither shape: nothing to anchor against.
+        assert_eq!(super::slug_root_and_remainder("Users-me-app"), None);
+        assert_eq!(super::slug_root_and_remainder("1--Users-me"), None);
+        assert_eq!(super::slug_root_and_remainder(""), None);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -738,19 +738,18 @@ mod tests {
 
     #[test]
     fn decode_claude_project_slug_recovers_names_containing_dashes() {
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path();
+        let (_temp, root) = canonical_tempdir();
         // A real name with a literal '-' is the case a greedy split gets wrong:
         // "claude-witness" is ONE directory, not "claude" then "witness".
-        std::fs::create_dir_all(root.join("devpro/ing/claude-witness")).unwrap();
+        let real = root.join("devpro/ing/claude-witness");
+        std::fs::create_dir_all(&real).unwrap();
 
-        let decoded =
-            decode_claude_project_slug(&slug_for(&root.join("devpro/ing/claude-witness")))
-                .expect("slug should resolve to the directory it was built from");
+        let decoded = decode_claude_project_slug(&slug_for(&real))
+            .expect("slug should resolve to the directory it was built from");
 
         assert_eq!(
             std::fs::canonicalize(decoded).unwrap(),
-            std::fs::canonicalize(root.join("devpro/ing/claude-witness")).unwrap()
+            std::fs::canonicalize(&real).unwrap()
         );
     }
 
@@ -762,10 +761,29 @@ mod tests {
         super::slugify_path_segment(&normalized)
     }
 
+    /// A temp directory whose path is spelled the way `read_dir` reports it.
+    ///
+    /// The decoder matches slugs against real directory entries, so the fixture
+    /// path has to agree with what the OS enumerates. On Windows `%TEMP%` is
+    /// often an 8.3 short name (`RUNNER~1`) while `read_dir` yields the long name
+    /// (`runneradmin`), and `canonicalize` returns a `\\?\` verbatim prefix that
+    /// is not a walkable root — so strip that and let the walk start at the
+    /// drive. Without this the slug describes a path no directory listing
+    /// contains and the decode correctly finds nothing.
+    fn canonical_tempdir() -> (tempfile::TempDir, PathBuf) {
+        let temp = tempfile::tempdir().unwrap();
+        let canonical = std::fs::canonicalize(temp.path()).unwrap();
+        let spelled = canonical.to_string_lossy().to_string();
+        let stripped = spelled
+            .strip_prefix(r"\\?\")
+            .map(PathBuf::from)
+            .unwrap_or(canonical);
+        (temp, stripped)
+    }
+
     #[test]
     fn decode_claude_project_slug_recovers_dots_and_worktrees() {
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path();
+        let (_temp, root) = canonical_tempdir();
         // '.' also encodes to '-', so "IngTian.github.io" and the ".claude"
         // worktree marker both have to come back exactly.
         let real = root.join("ing/IngTian.github.io/.claude/worktrees/scroll-reveal");


### PR DESCRIPTION
## Problem

Workspace rows are labeled with the raw workspace key. For Claude Code that key is the launch directory with every non-alphanumeric byte replaced by `-` (`-Users-me-devpro-ing-app`), so it carries no `/` for `workspace_label_from_key` to split on and the label becomes the entire mangled path. Because every row then shares a long identical prefix and truncation cuts from the right, `--group-by workspace,model` renders rows that cannot be told apart — the Models table clipped labels to 18 cells and the Overview list to 35, which on a real machine collapsed 36 of 44 project directories to the same visible text.

## Approach

The slugification maps `/`, `.`, `+` and `-` all onto `-`, so it cannot be inverted by string surgery — a greedy split recovered only 18 of 45 real directories in testing. Instead, re-applying that same forward map to real directory names while walking the filesystem identifies the source path exactly, with backtracking for the ambiguous cases (a directory whose own name contains `-`, or `.`). On 46 real project directories, all 30 that still had recorded `cwd` data recovered their exact path, including names like `IngTian.github.io` and `feat+terrain-functions`.

Rows are now labeled `repo` or `repo ⑃ worktree`. Two fallbacks keep the edge cases honest: a key that resolves to no directory (a worktree since deleted from disk) still splits on the encoded `--claude-worktrees-` marker rather than reverting to the mangled string, and a parser-supplied label always wins so non-path keys such as Warp's workspace UUID keep the name only their parser knows.

## `--merge-worktrees`

Added `--merge-worktrees` (and `w` in the TUI, shown in the footer as `[w:worktrees]` / `[w:repos]`) to fold git worktrees into their parent repository. Because the rollup canonicalizes through the same decode, it also merges a repository that Claude Code and Codex/OpenCode recorded under different key formats — previously one repo could occupy a dozen rows that no flag could combine, since a dash-mangled slug and a real POSIX path never compared equal.

Workspace bucketing moved into `tokscale_core::workspace_bucket`, shared with the TUI's own aggregation so the two cannot drift on labeling or rollup behavior, and is skipped entirely for groupings that discard the label.

## Layout

The Workspace column stays a fixed `Length`, widening from 18 to 44 cells only at inner width >= 193. `Min` outranks `Length` in ratatui's solver, so a flexible workspace column pays for itself out of its neighbors on any row that cannot satisfy every column — an earlier revision of this branch clipped Cost by a cell at 18 distinct widths and squeezed Model from 20 cells to 4, which merely relocated the unreadable-truncation bug.

Labels are truncated to the width the solver actually *grants*, not the width the column requested: a `Length` is a request, and between 174 and 192 cells the row could not satisfy 44 while Model held its `Min(20)`, so the formatter and the table disagreed and the overflow was clipped with no ellipsis. The layout is solved once per frame and each cell truncates to the width its own column was actually granted, so correctness no longer depends on the threshold being exactly right. The Model cell had the same bug from the other direction — a constant 24-cell budget against a floating `Min(20)` the solver sets to 20 on a narrow row and 77 on a wide one, over-truncating at 97 of the widths in 78..=400. Model and Overview cells truncate by terminal cells rather than code points, since a path or model id can contain full-width graphemes.

## Verification

`cargo test --workspace --all-features` passes with 2,911 tests and 0 failures on this branch's own code; `cargo clippy --locked --workspace --all-features -- -D warnings` and `cargo fmt --check` are clean.

Checked against real usage data: workspace rows drop from 34 to 18 under `--merge-worktrees`, total cost is conserved to the cent between the two modes, and no row still renders a raw mangled slug.

`--merge-worktrees` is threaded into `TuiConfig`, so an interactive launch opens merged instead of silently dropping the flag.

New tests cover the decoder (names containing `-`, `.` and `+`; non-ASCII names; symlinked directories; POSIX and Windows drive roots), the deleted-worktree fallback, the non-path-key case, the cross-client rollup merge, and the painted Models screen. Two layout tests sweep every width in 78..=400 rather than sampling — one asserting the money columns are never narrowed, one asserting the truncation width equals the allocated width. A six-point sample passed while 18 widths in the same range were clipping Cost, so sampling is not enough here.

## Known limitations

- **Roughly half the session parsers (24 of 46 — including gemini, cursor, amp, droid, roocode, kilocode, goose, and Copilot's OTEL path) never record a workspace at all**, so their usage still aggregates into the single `Unknown workspace` row. Out of scope here; documented in the README.
- **Decoding reads the filesystem.** It is memoized per workspace key, so the cost is proportional to workspaces (~40 on my machine) rather than messages (~100k), and it is skipped for every grouping that does not display a workspace. Measured: `--group-by workspace,model` takes 3.65s against 2.60s for the default grouping on the same data. There is deliberately no directory-listing cache — the shared `/Users/<me>` prefix is re-enumerated per key, which is a small fraction of a report dominated by parsing session files.
- **Rollup is lexical, not git-aware.** `workspace_repo_root` looks for `.claude/worktrees/` or `.git/worktrees/` as a path prefix, so `--merge-worktrees` folds worktrees kept inside the repository (what agent CLIs create) and nothing else. A worktree checked out beside the repo (`git worktree add ../feature-x`) is linked to it only by a `gitdir:` pointer file, so it stays its own row; a repo reached through two different path spellings (a symlink and its target) likewise stays two rows, since identities are compared as strings — that part is pre-existing, `Separate` mode on `main` already keys on the raw string. Totals are unaffected either way: usage is split across rows, never lost or double counted. Closing these needs `gitdir:` parsing plus `canonicalize` on both sides, and `canonicalize` fails for the deleted worktrees this PR deliberately still labels, so it belongs in a follow-up with its own cross-platform tests.
- **Two distinct directories with the same basename** (`/tmp/a/proj` and `/tmp/b/proj`) display the same label. They remain separate rows with separate keys, so no cost is merged; only the display string is ambiguous.
- **The footer help row** needs ~14 more columns before the trailing `[r:refresh] • e • q` fits once the `[w:...]` chip is present. That row already truncates below 110 columns in the default grouping; this widens the window rather than creating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
