### PR TITLE
fix(droid): attribute session usage to the replies that spent it

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1068,7 +1068,11 @@ fn parser_version(client: ClientId) -> u32 {
         // token it ever spent against the day it was started. A session that
         // has since ended never changes its bytes again, so its fingerprint
         // stays valid forever and only this bump discards the v1 anchor.
-        ClientId::Droid => 2,
+        // v2->v3: a session's cumulative total is no longer one record at one
+        // instant. It is now apportioned across the assistant replies in the
+        // sibling transcript, weighted by the context each reply read, so a
+        // multi-day session reports against the days it actually ran.
+        ClientId::Droid => 3,
         _ => 1,
     }
 }
@@ -2601,7 +2605,7 @@ mod tests {
         // A finished Droid session's settings.json is never rewritten again, so
         // its fingerprint keeps matching and only the version bump discards the
         // v1 lock-timestamp anchor.
-        assert_eq!(parser_version(ClientId::Droid), 2);
+        assert_eq!(parser_version(ClientId::Droid), 3);
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1072,7 +1072,12 @@ fn parser_version(client: ClientId) -> u32 {
         // instant. It is now apportioned across the assistant replies in the
         // sibling transcript, weighted by the context each reply read, so a
         // multi-day session reports against the days it actually ran.
-        ClientId::Droid => 3,
+        // v3->v4: a reply is weighted by the context standing before it rather
+        // than including its own bytes, so a long answer no longer charges
+        // itself for its own output. Versions 2 and 3 only ever existed in
+        // pre-release builds of this change; the bump past them keeps anyone
+        // who ran one from holding the superseded weighting.
+        ClientId::Droid => 4,
         _ => 1,
     }
 }
@@ -2605,7 +2610,7 @@ mod tests {
         // A finished Droid session's settings.json is never rewritten again, so
         // its fingerprint keeps matching and only the version bump discards the
         // v1 lock-timestamp anchor.
-        assert_eq!(parser_version(ClientId::Droid), 3);
+        assert_eq!(parser_version(ClientId::Droid), 4);
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1062,6 +1062,13 @@ fn parser_version(client: ClientId) -> u32 {
         // v2->v3: duplicate merging now upgrades the retained row when a later
         // copy carries an explicit cost, including zero.
         ClientId::MiMoCode => 3,
+        // Droid's cumulative session totals now anchor on the settings file's
+        // mtime (floored at providerLockTimestamp) instead of the lock
+        // timestamp alone, so a long-running session stops reporting every
+        // token it ever spent against the day it was started. A session that
+        // has since ended never changes its bytes again, so its fingerprint
+        // stays valid forever and only this bump discards the v1 anchor.
+        ClientId::Droid => 2,
         _ => 1,
     }
 }
@@ -2587,6 +2594,14 @@ mod tests {
         // fingerprint forever, so only the version bump discards the truncated
         // v6 parse and forces a cold reparse.
         assert_eq!(parser_version(ClientId::Grok), 7);
+    }
+
+    #[test]
+    fn test_droid_usage_anchor_parser_version_invalidates_v1_entries() {
+        // A finished Droid session's settings.json is never rewritten again, so
+        // its fingerprint keeps matching and only the version bump discards the
+        // v1 lock-timestamp anchor.
+        assert_eq!(parser_version(ClientId::Droid), 2);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/droid.rs
+++ b/crates/tokscale-core/src/sessions/droid.rs
@@ -165,6 +165,22 @@ pub(crate) fn droid_jsonl_path(path: &Path) -> Option<PathBuf> {
 /// When the filesystem reports no mtime at all, fall back to the lock
 /// timestamp, then to now() — a record with real token usage is never dropped
 /// just because its timestamp could not be resolved.
+/// Parse `providerLockTimestamp` into epoch milliseconds, rejecting values that
+/// cannot describe a real provider lock.
+///
+/// Zero is Droid's unset sentinel, and a negative value is a clock or
+/// corruption artifact — neither is a usable anchor. Both collapse to `None` so
+/// the resolver treats them as absent, which keeps this anchor's validity rule
+/// symmetric with the mtime one: `file_modified_timestamp_ms_opt` already
+/// reports `None` for a pre-epoch mtime. Without that symmetry a negative lock
+/// would survive as the resolved anchor whenever mtime was unavailable, and the
+/// record would land in a 1969 bucket that no date filter can reach.
+fn parse_lock_timestamp(raw: Option<&str>) -> Option<i64> {
+    raw.and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
+        .map(|dt| dt.timestamp_millis())
+        .filter(|&ts| ts > 0)
+}
+
 fn resolve_usage_timestamp(lock_timestamp: Option<i64>, modified: Option<i64>) -> i64 {
     match (modified, lock_timestamp) {
         (Some(modified), Some(lock)) => modified.max(lock),
@@ -230,12 +246,7 @@ pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
         }
     };
 
-    let lock_timestamp = settings
-        .provider_lock_timestamp
-        .as_deref()
-        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
-        .map(|dt| dt.timestamp_millis())
-        .filter(|&ts| ts != 0);
+    let lock_timestamp = parse_lock_timestamp(settings.provider_lock_timestamp.as_deref());
 
     let timestamp = resolve_usage_timestamp(lock_timestamp, file_modified_timestamp_ms_opt(path));
 
@@ -308,6 +319,33 @@ mod tests {
         assert_eq!(get_default_model_from_provider("google"), "gemini-unknown");
         assert_eq!(get_default_model_from_provider("xai"), "grok-unknown");
         assert_eq!(get_default_model_from_provider("custom"), "custom-unknown");
+    }
+
+    #[test]
+    fn test_parse_lock_timestamp_rejects_unusable_anchors() {
+        // Zero is Droid's unset sentinel.
+        assert_eq!(parse_lock_timestamp(Some("1970-01-01T00:00:00Z")), None);
+        // A pre-epoch lock is a clock/corruption artifact. Keeping it would
+        // outlive the mtime fallback and bucket the record in 1969, where no
+        // date filter can reach it.
+        assert_eq!(parse_lock_timestamp(Some("1969-07-20T20:17:00Z")), None);
+        assert_eq!(parse_lock_timestamp(Some("not-a-timestamp")), None);
+        assert_eq!(parse_lock_timestamp(None), None);
+
+        assert_eq!(
+            parse_lock_timestamp(Some("2026-08-07T03:32:46.663Z")),
+            Some(1_786_073_566_663)
+        );
+    }
+
+    #[test]
+    fn test_pre_epoch_lock_falls_through_to_now_without_mtime() {
+        // The resolver only reaches its now() fallback if the rejected lock
+        // arrives as None, so this pins the two halves together: an unusable
+        // lock plus an unavailable mtime must not yield a pre-epoch anchor.
+        let lock = parse_lock_timestamp(Some("1969-07-20T20:17:00Z"));
+
+        assert!(resolve_usage_timestamp(lock, None) > 1_700_000_000_000);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/droid.rs
+++ b/crates/tokscale-core/src/sessions/droid.rs
@@ -208,9 +208,11 @@ struct TranscriptTurn {
 /// another, which is all the apportioning below needs.
 ///
 /// Only assistant replies are counted, since one reply corresponds to one API
-/// call; user and tool records ride along inside the call that reads them.
-/// Compaction resets the running context because it discards the transcript
-/// the following calls would otherwise re-read.
+/// call; user and tool records ride along inside the call that reads them. Each
+/// reply is weighted by the context standing *before* it, since its own bytes
+/// are output rather than something it paid to read. Compaction resets the
+/// running context because it discards the transcript the following calls would
+/// otherwise re-read.
 fn transcript_turns(jsonl: &Path) -> Vec<TranscriptTurn> {
     let Ok(file) = std::fs::File::open(jsonl) else {
         return Vec::new();
@@ -232,6 +234,12 @@ fn transcript_turns(jsonl: &Path) -> Vec<TranscriptTurn> {
             context_bytes = line_bytes;
             continue;
         }
+
+        // What the call read is the conversation as it stood *before* this
+        // record. A reply's own bytes are its output; charging them back to the
+        // same reply would let a long answer inflate its own share of the
+        // input and cache-read totals. They join the context for later calls.
+        let context_read = context_bytes;
         context_bytes = context_bytes.saturating_add(line_bytes);
 
         if record_type != Some("message") {
@@ -252,7 +260,9 @@ fn transcript_turns(jsonl: &Path) -> Vec<TranscriptTurn> {
 
         turns.push(TranscriptTurn {
             timestamp,
-            weight: context_bytes.max(1),
+            // The first reply in a session reads a context of zero bytes but
+            // still cost something, so every turn carries at least one unit.
+            weight: context_read.max(1),
         });
     }
 
@@ -470,6 +480,13 @@ mod tests {
         )
     }
 
+    fn user(timestamp: &str, filler: usize) -> String {
+        format!(
+            r#"{{"type":"message","timestamp":"{timestamp}","message":{{"role":"user","content":"{}"}}}}"#,
+            "x".repeat(filler)
+        )
+    }
+
     #[test]
     fn test_apportion_parts_sum_to_the_original_total() {
         // Truncation must never lose or invent tokens: the daily figures have to
@@ -518,6 +535,38 @@ mod tests {
     }
 
     #[test]
+    fn test_a_long_reply_does_not_charge_itself_for_its_own_output() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        // Two replies on an identical context, one of them enormously long.
+        // What each call *read* is the same, so the split must be even: the
+        // long answer's own bytes are output, not context it paid to read.
+        let settings = write_session(
+            temp_dir.path(),
+            "44444444-4444-4444-4444-444444444444",
+            r#"{"inputTokens":1000}"#,
+            &[
+                r#"{"type":"message","timestamp":"2026-08-07T11:00:00Z","message":{"role":"user","content":"seed"}}"#,
+                &assistant("2026-08-07T12:00:00Z", 50_000),
+                &assistant("2026-08-07T13:00:00Z", 10),
+            ],
+        );
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 1000);
+        // The first reply read only the short seed; the second read that plus a
+        // 50KB answer, so it should carry overwhelmingly more. Charging a reply
+        // for its own output would instead hand the first one that same 50KB
+        // and leave the two nearly equal, so the ratio is what discriminates.
+        assert!(
+            messages[1].tokens.input > messages[0].tokens.input * 10,
+            "a long reply inflated its own share: {:?}",
+            messages.iter().map(|m| m.tokens.input).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn test_compaction_resets_the_context_weighting() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         // A big conversation, compacted, then one short reply afterwards. The
@@ -527,7 +576,11 @@ mod tests {
             "11111111-1111-1111-1111-111111111111",
             r#"{"inputTokens":1000}"#,
             &[
-                &assistant("2026-08-07T12:00:00Z", 2000),
+                // A long conversation the first reply had to read...
+                &user("2026-08-07T11:00:00Z", 4000),
+                &assistant("2026-08-07T12:00:00Z", 10),
+                // ...then compaction discards it, so the reply after it reads
+                // only the compacted summary.
                 r#"{"type":"compaction_state","timestamp":"2026-08-08T12:00:00Z"}"#,
                 &assistant("2026-08-09T12:00:00Z", 10),
             ],
@@ -539,7 +592,8 @@ mod tests {
         assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 1000);
         assert!(
             messages[0].tokens.input > messages[1].tokens.input,
-            "the compacted-away context should not keep charging later replies"
+            "the compacted-away context should not keep charging later replies: {:?}",
+            messages.iter().map(|m| m.tokens.input).collect::<Vec<_>>()
         );
     }
 

--- a/crates/tokscale-core/src/sessions/droid.rs
+++ b/crates/tokscale-core/src/sessions/droid.rs
@@ -2,7 +2,7 @@
 //!
 //! Parses JSON files from ~/.factory/sessions/
 
-use super::utils::{file_modified_timestamp_ms, read_file_or_none};
+use super::utils::{file_modified_timestamp_ms_opt, read_file_or_none};
 use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
@@ -142,6 +142,38 @@ pub(crate) fn droid_jsonl_path(path: &Path) -> Option<PathBuf> {
     Some(path.with_file_name(format!("{stem}.jsonl")))
 }
 
+/// Pick the instant a Droid session's cumulative `tokenUsage` is attributed to.
+///
+/// A Droid `*.settings.json` holds one running total for the whole session and
+/// is rewritten every time the agent spends tokens, so the parser emits a
+/// single record and has to anchor it somewhere.
+///
+/// `providerLockTimestamp` is the wrong anchor: it records when the provider
+/// was *selected*, not when the tokens were spent. Droid rewrites the totals
+/// in place without touching that field, so a session left running across days
+/// (a `/loop`, a long autonomous run) keeps reporting its very first instant
+/// while the totals climb. Every token it has ever spent lands in the bucket
+/// for the day it started, and the session reads as silent in `--today` and
+/// `--yesterday` even while it is actively burning tokens.
+///
+/// The file's mtime is when the totals being read were written, which is the
+/// closest available marker for when they were last accrued, so it wins. The
+/// lock timestamp becomes a floor rather than the answer: usage cannot predate
+/// provider selection, so a stale mtime (a restore or copy that rewound it)
+/// cannot drag the record earlier than the session could possibly have run.
+///
+/// When the filesystem reports no mtime at all, fall back to the lock
+/// timestamp, then to now() — a record with real token usage is never dropped
+/// just because its timestamp could not be resolved.
+fn resolve_usage_timestamp(lock_timestamp: Option<i64>, modified: Option<i64>) -> i64 {
+    match (modified, lock_timestamp) {
+        (Some(modified), Some(lock)) => modified.max(lock),
+        (Some(modified), None) => modified,
+        (None, Some(lock)) => lock,
+        (None, None) => chrono::Utc::now().timestamp_millis(),
+    }
+}
+
 /// Parse a Droid settings.json file
 pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
     let Some(data) = read_file_or_none(path) else {
@@ -198,15 +230,14 @@ pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
         }
     };
 
-    // Get timestamp from providerLockTimestamp, falling back to file mtime
-    // (which itself falls back to now()). Never drop a record with real token
-    // usage just because the timestamp could not be resolved.
-    let timestamp = settings
+    let lock_timestamp = settings
         .provider_lock_timestamp
-        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
+        .as_deref()
+        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
         .map(|dt| dt.timestamp_millis())
-        .filter(|&ts| ts != 0)
-        .unwrap_or_else(|| file_modified_timestamp_ms(path));
+        .filter(|&ts| ts != 0);
+
+    let timestamp = resolve_usage_timestamp(lock_timestamp, file_modified_timestamp_ms_opt(path));
 
     vec![UnifiedMessage::new(
         "droid",
@@ -277,6 +308,84 @@ mod tests {
         assert_eq!(get_default_model_from_provider("google"), "gemini-unknown");
         assert_eq!(get_default_model_from_provider("xai"), "grok-unknown");
         assert_eq!(get_default_model_from_provider("custom"), "custom-unknown");
+    }
+
+    #[test]
+    fn test_resolve_usage_timestamp_prefers_mtime_over_stale_lock() {
+        // The regression: a session locked its provider on day 1 and was still
+        // spending tokens on day 4. Anchoring on the lock timestamp reported
+        // all of it against day 1 and left the session invisible in --today.
+        let lock = 1_700_000_000_000;
+        let modified = lock + 3 * 86_400_000;
+
+        assert_eq!(
+            resolve_usage_timestamp(Some(lock), Some(modified)),
+            modified
+        );
+    }
+
+    #[test]
+    fn test_resolve_usage_timestamp_floors_stale_mtime_at_lock() {
+        // A copy or restore can rewind mtime below the instant the provider was
+        // locked. Usage cannot predate provider selection, so the lock wins.
+        let lock = 1_700_000_000_000;
+        let modified = lock - 86_400_000;
+
+        assert_eq!(resolve_usage_timestamp(Some(lock), Some(modified)), lock);
+    }
+
+    #[test]
+    fn test_resolve_usage_timestamp_falls_back_across_missing_inputs() {
+        let lock = 1_700_000_000_000;
+        let modified = 1_700_000_500_000;
+
+        // Droid omits providerLockTimestamp on plenty of sessions.
+        assert_eq!(resolve_usage_timestamp(None, Some(modified)), modified);
+        // Filesystem reported no mtime: the lock is still better than now().
+        assert_eq!(resolve_usage_timestamp(Some(lock), None), lock);
+    }
+
+    #[test]
+    fn test_resolve_usage_timestamp_without_any_anchor_is_not_pre_epoch() {
+        // Neither anchor available: the record still carries real token usage,
+        // so it must land in a present-day bucket rather than at the epoch.
+        assert!(resolve_usage_timestamp(None, None) > 1_700_000_000_000);
+    }
+
+    #[test]
+    fn test_parse_droid_file_anchors_long_running_session_at_last_write() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir
+            .path()
+            .join("11111111-2222-3333-4444-555555555555.settings.json");
+
+        // providerLockTimestamp far in the past, totals written just now —
+        // the shape of a session that has been looping for days.
+        let lock_ms = chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+            .unwrap()
+            .timestamp_millis();
+        std::fs::write(
+            &path,
+            r#"{
+                "model": "custom:Kimi-K3-(free)-0",
+                "providerLockTimestamp": "2024-01-01T00:00:00Z",
+                "tokenUsage": { "inputTokens": 1000, "outputTokens": 200 }
+            }"#,
+        )
+        .unwrap();
+
+        let messages = parse_droid_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].session_id,
+            "11111111-2222-3333-4444-555555555555"
+        );
+        assert!(
+            messages[0].timestamp > lock_ms,
+            "cumulative usage anchored on the stale lock timestamp ({lock_ms}), \
+             got {}",
+            messages[0].timestamp
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/droid.rs
+++ b/crates/tokscale-core/src/sessions/droid.rs
@@ -2,10 +2,13 @@
 //!
 //! Parses JSON files from ~/.factory/sessions/
 
-use super::utils::{file_modified_timestamp_ms_opt, read_file_or_none};
+use super::utils::{
+    file_modified_timestamp_ms_opt, lossy_lines, parse_timestamp_value, read_file_or_none,
+};
 use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
+use serde_json::Value;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
@@ -142,29 +145,6 @@ pub(crate) fn droid_jsonl_path(path: &Path) -> Option<PathBuf> {
     Some(path.with_file_name(format!("{stem}.jsonl")))
 }
 
-/// Pick the instant a Droid session's cumulative `tokenUsage` is attributed to.
-///
-/// A Droid `*.settings.json` holds one running total for the whole session and
-/// is rewritten every time the agent spends tokens, so the parser emits a
-/// single record and has to anchor it somewhere.
-///
-/// `providerLockTimestamp` is the wrong anchor: it records when the provider
-/// was *selected*, not when the tokens were spent. Droid rewrites the totals
-/// in place without touching that field, so a session left running across days
-/// (a `/loop`, a long autonomous run) keeps reporting its very first instant
-/// while the totals climb. Every token it has ever spent lands in the bucket
-/// for the day it started, and the session reads as silent in `--today` and
-/// `--yesterday` even while it is actively burning tokens.
-///
-/// The file's mtime is when the totals being read were written, which is the
-/// closest available marker for when they were last accrued, so it wins. The
-/// lock timestamp becomes a floor rather than the answer: usage cannot predate
-/// provider selection, so a stale mtime (a restore or copy that rewound it)
-/// cannot drag the record earlier than the session could possibly have run.
-///
-/// When the filesystem reports no mtime at all, fall back to the lock
-/// timestamp, then to now() — a record with real token usage is never dropped
-/// just because its timestamp could not be resolved.
 /// Parse `providerLockTimestamp` into epoch milliseconds, rejecting values that
 /// cannot describe a real provider lock.
 ///
@@ -181,6 +161,25 @@ fn parse_lock_timestamp(raw: Option<&str>) -> Option<i64> {
         .filter(|&ts| ts > 0)
 }
 
+/// Pick the single instant a session's cumulative `tokenUsage` is attributed
+/// to, for the sessions whose transcript cannot spread it across the calls that
+/// spent it.
+///
+/// `providerLockTimestamp` is the wrong anchor: it records when the provider
+/// was *selected*, not when the tokens were spent. Droid rewrites the totals in
+/// place without touching that field, so a session left running across days
+/// keeps reporting its very first instant while the totals climb, and reads as
+/// silent in `--today` even while it is actively burning tokens.
+///
+/// The file's mtime is when the totals being read were written, which is the
+/// closest available marker for when they were last accrued, so it wins. The
+/// lock timestamp becomes a floor rather than the answer: usage cannot predate
+/// provider selection, so a stale mtime (a restore or copy that rewound it)
+/// cannot drag the record earlier than the session could possibly have run.
+///
+/// When the filesystem reports no mtime at all, fall back to the lock
+/// timestamp, then to now() — a record with real token usage is never dropped
+/// just because its timestamp could not be resolved.
 fn resolve_usage_timestamp(lock_timestamp: Option<i64>, modified: Option<i64>) -> i64 {
     match (modified, lock_timestamp) {
         (Some(modified), Some(lock)) => modified.max(lock),
@@ -188,6 +187,103 @@ fn resolve_usage_timestamp(lock_timestamp: Option<i64>, modified: Option<i64>) -
         (None, Some(lock)) => lock,
         (None, None) => chrono::Utc::now().timestamp_millis(),
     }
+}
+
+/// One assistant reply in a Droid transcript: when it was written, and how
+/// expensive it plausibly was relative to the session's other replies.
+struct TranscriptTurn {
+    timestamp: i64,
+    weight: u128,
+}
+
+/// Recover the shape of a session's spend from its transcript.
+///
+/// Droid records no token counts anywhere in the `*.jsonl` — only the
+/// cumulative total in `*.settings.json` — so the transcript cannot say what a
+/// reply cost. It can say *when* each reply happened and how much context was
+/// live at the time, and cost per call tracks context length closely: nearly
+/// every token in these sessions is a cache read of the conversation so far.
+/// Weighting each assistant reply by the bytes accumulated since the last
+/// compaction therefore recovers the relative cost of one reply against
+/// another, which is all the apportioning below needs.
+///
+/// Only assistant replies are counted, since one reply corresponds to one API
+/// call; user and tool records ride along inside the call that reads them.
+/// Compaction resets the running context because it discards the transcript
+/// the following calls would otherwise re-read.
+fn transcript_turns(jsonl: &Path) -> Vec<TranscriptTurn> {
+    let Ok(file) = std::fs::File::open(jsonl) else {
+        return Vec::new();
+    };
+
+    let mut turns = Vec::new();
+    let mut context_bytes: u128 = 0;
+
+    for line in lossy_lines(BufReader::new(file)) {
+        let line_bytes = line.len() as u128;
+        let Ok(record) = serde_json::from_str::<Value>(&line) else {
+            // A malformed line still occupied context in the real conversation.
+            context_bytes = context_bytes.saturating_add(line_bytes);
+            continue;
+        };
+
+        let record_type = record.get("type").and_then(|v| v.as_str());
+        if record_type == Some("compaction_state") {
+            context_bytes = line_bytes;
+            continue;
+        }
+        context_bytes = context_bytes.saturating_add(line_bytes);
+
+        if record_type != Some("message") {
+            continue;
+        }
+        if record
+            .get("message")
+            .and_then(|message| message.get("role"))
+            .and_then(|role| role.as_str())
+            != Some("assistant")
+        {
+            continue;
+        }
+
+        let Some(timestamp) = record.get("timestamp").and_then(parse_timestamp_value) else {
+            continue;
+        };
+
+        turns.push(TranscriptTurn {
+            timestamp,
+            weight: context_bytes.max(1),
+        });
+    }
+
+    turns
+}
+
+/// Split `total` across `weights` so the parts sum back to exactly `total`.
+///
+/// Allocates on the running total rather than rounding each share on its own:
+/// each part is the difference between two cumulative shares, so truncation
+/// error is carried forward instead of accumulating, and the final cumulative
+/// share is `total` by construction. That exactness is what lets a session be
+/// split across days without the daily figures drifting from the cumulative
+/// number Droid actually recorded.
+fn apportion(total: i64, weights: &[u128], total_weight: u128) -> Vec<i64> {
+    if total_weight == 0 {
+        return vec![0; weights.len()];
+    }
+
+    let mut parts = Vec::with_capacity(weights.len());
+    let mut consumed_weight: u128 = 0;
+    let mut allocated: i64 = 0;
+
+    for weight in weights {
+        consumed_weight += weight;
+        let up_to = ((total as i128 * consumed_weight as i128) / total_weight as i128) as i64;
+        parts.push(up_to - allocated);
+        allocated = up_to;
+    }
+
+    parts
 }
 
 /// Parse a Droid settings.json file
@@ -246,24 +342,59 @@ pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
         }
     };
 
-    let lock_timestamp = parse_lock_timestamp(settings.provider_lock_timestamp.as_deref());
+    let totals = TokenBreakdown {
+        input: usage.input_tokens.unwrap_or(0).max(0),
+        output: usage.output_tokens.unwrap_or(0).max(0),
+        cache_read: usage.cache_read_tokens.unwrap_or(0).max(0),
+        cache_write: usage.cache_creation_tokens.unwrap_or(0).max(0),
+        reasoning: usage.thinking_tokens.unwrap_or(0).max(0),
+    };
 
+    let turns = droid_jsonl_path(path)
+        .map(|jsonl| transcript_turns(&jsonl))
+        .unwrap_or_default();
+    let total_weight: u128 = turns.iter().map(|turn| turn.weight).sum();
+
+    if !turns.is_empty() && total_weight > 0 {
+        let weights: Vec<u128> = turns.iter().map(|turn| turn.weight).collect();
+        let input = apportion(totals.input, &weights, total_weight);
+        let output = apportion(totals.output, &weights, total_weight);
+        let cache_read = apportion(totals.cache_read, &weights, total_weight);
+        let cache_write = apportion(totals.cache_write, &weights, total_weight);
+        let reasoning = apportion(totals.reasoning, &weights, total_weight);
+
+        return turns
+            .iter()
+            .enumerate()
+            .map(|(index, turn)| {
+                UnifiedMessage::new(
+                    "droid",
+                    model.clone(),
+                    provider.clone(),
+                    session_id.clone(),
+                    turn.timestamp,
+                    TokenBreakdown {
+                        input: input[index],
+                        output: output[index],
+                        cache_read: cache_read[index],
+                        cache_write: cache_write[index],
+                        reasoning: reasoning[index],
+                    },
+                    0.0,
+                )
+            })
+            .collect();
+    }
+
+    // No usable transcript (missing, unreadable, or no assistant replies yet).
+    // Fall back to one record for the whole session, anchored at the last write
+    // so an active session still lands in the present rather than at the
+    // instant its provider was locked.
+    let lock_timestamp = parse_lock_timestamp(settings.provider_lock_timestamp.as_deref());
     let timestamp = resolve_usage_timestamp(lock_timestamp, file_modified_timestamp_ms_opt(path));
 
     vec![UnifiedMessage::new(
-        "droid",
-        model,
-        provider,
-        session_id,
-        timestamp,
-        TokenBreakdown {
-            input: usage.input_tokens.unwrap_or(0).max(0),
-            output: usage.output_tokens.unwrap_or(0).max(0),
-            cache_read: usage.cache_read_tokens.unwrap_or(0).max(0),
-            cache_write: usage.cache_creation_tokens.unwrap_or(0).max(0),
-            reasoning: usage.thinking_tokens.unwrap_or(0).max(0),
-        },
-        0.0,
+        "droid", model, provider, session_id, timestamp, totals, 0.0,
     )]
 }
 
@@ -319,6 +450,134 @@ mod tests {
         assert_eq!(get_default_model_from_provider("google"), "gemini-unknown");
         assert_eq!(get_default_model_from_provider("xai"), "grok-unknown");
         assert_eq!(get_default_model_from_provider("custom"), "custom-unknown");
+    }
+
+    fn write_session(dir: &Path, id: &str, usage: &str, transcript: &[&str]) -> PathBuf {
+        let settings = dir.join(format!("{id}.settings.json"));
+        std::fs::write(
+            &settings,
+            format!(r#"{{"model":"custom:Kimi-K3-0","tokenUsage":{usage}}}"#),
+        )
+        .unwrap();
+        std::fs::write(dir.join(format!("{id}.jsonl")), transcript.join("\n")).unwrap();
+        settings
+    }
+
+    fn assistant(timestamp: &str, filler: usize) -> String {
+        format!(
+            r#"{{"type":"message","timestamp":"{timestamp}","message":{{"role":"assistant","content":"{}"}}}}"#,
+            "x".repeat(filler)
+        )
+    }
+
+    #[test]
+    fn test_apportion_parts_sum_to_the_original_total() {
+        // Truncation must never lose or invent tokens: the daily figures have to
+        // add back up to the cumulative number Droid recorded.
+        let weights = vec![3u128, 1, 1, 1, 1];
+        let parts = apportion(1_000_003, &weights, weights.iter().sum());
+
+        assert_eq!(parts.len(), 5);
+        assert_eq!(parts.iter().sum::<i64>(), 1_000_003);
+        assert!(parts.iter().all(|&p| p >= 0));
+        // The heaviest turn gets the largest share.
+        assert!(parts[0] > parts[1]);
+    }
+
+    #[test]
+    fn test_apportion_without_weight_yields_no_tokens() {
+        assert_eq!(apportion(500, &[0, 0], 0), vec![0, 0]);
+    }
+
+    #[test]
+    fn test_usage_spreads_across_the_days_the_session_ran() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        // Two assistant replies a day apart, the second on a larger context.
+        let settings = write_session(
+            temp_dir.path(),
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            r#"{"inputTokens":900,"outputTokens":100}"#,
+            &[
+                r#"{"type":"session_start","id":"s"}"#,
+                &assistant("2026-08-07T12:00:00Z", 10),
+                &assistant("2026-08-09T12:00:00Z", 400),
+            ],
+        );
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(messages.len(), 2, "one record per assistant reply");
+        // Nothing is lost or invented by the split.
+        assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 900);
+        assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 100);
+        // Each record lands on the reply that earned it, not on one anchor.
+        assert!(messages[0].timestamp < messages[1].timestamp);
+        assert_ne!(messages[0].date, messages[1].date);
+        // The later reply read a longer conversation, so it carries more.
+        assert!(messages[1].tokens.input > messages[0].tokens.input);
+    }
+
+    #[test]
+    fn test_compaction_resets_the_context_weighting() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        // A big conversation, compacted, then one short reply afterwards. The
+        // post-compaction reply must not inherit the discarded context's weight.
+        let settings = write_session(
+            temp_dir.path(),
+            "11111111-1111-1111-1111-111111111111",
+            r#"{"inputTokens":1000}"#,
+            &[
+                &assistant("2026-08-07T12:00:00Z", 2000),
+                r#"{"type":"compaction_state","timestamp":"2026-08-08T12:00:00Z"}"#,
+                &assistant("2026-08-09T12:00:00Z", 10),
+            ],
+        );
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 1000);
+        assert!(
+            messages[0].tokens.input > messages[1].tokens.input,
+            "the compacted-away context should not keep charging later replies"
+        );
+    }
+
+    #[test]
+    fn test_session_without_assistant_replies_falls_back_to_one_record() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        // Usage recorded but the transcript has no assistant reply to hang it
+        // on — the record must still be emitted rather than silently dropped.
+        let settings = write_session(
+            temp_dir.path(),
+            "22222222-2222-2222-2222-222222222222",
+            r#"{"inputTokens":700,"outputTokens":7}"#,
+            &[r#"{"type":"session_start","id":"s"}"#],
+        );
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 700);
+        assert_eq!(messages[0].tokens.output, 7);
+    }
+
+    #[test]
+    fn test_missing_transcript_falls_back_to_one_record() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let settings = temp_dir
+            .path()
+            .join("33333333-3333-3333-3333-333333333333.settings.json");
+        std::fs::write(
+            &settings,
+            r#"{"model":"custom:Kimi-K3-0","tokenUsage":{"inputTokens":42}}"#,
+        )
+        .unwrap();
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 42);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -135,13 +135,27 @@ pub(crate) fn parse_timestamp_str(value: &str) -> Option<i64> {
     None
 }
 
-pub(crate) fn file_modified_timestamp_ms(path: &Path) -> i64 {
+/// Modification time in epoch milliseconds, or `None` when the filesystem does
+/// not report one.
+///
+/// `SystemTime::modified` is the one timestamp every tier-1 target supports
+/// (unlike `created`, which is absent on many Linux filesystems), so callers
+/// that need a portable "when was this last written" anchor use this.
+///
+/// Returns `None` rather than substituting a value so a caller with its own
+/// fallback can reach for it instead of silently anchoring on the wrong
+/// instant. Pre-epoch mtimes also collapse to `None`: `duration_since` fails
+/// for them, and a negative anchor would bucket the record before 1970.
+pub(crate) fn file_modified_timestamp_ms_opt(path: &Path) -> Option<i64> {
     std::fs::metadata(path)
         .and_then(|meta| meta.modified())
         .ok()
         .and_then(|time| time.duration_since(SystemTime::UNIX_EPOCH).ok())
         .map(|duration| duration.as_millis() as i64)
-        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis())
+}
+
+pub(crate) fn file_modified_timestamp_ms(path: &Path) -> i64 {
+    file_modified_timestamp_ms_opt(path).unwrap_or_else(|| chrono::Utc::now().timestamp_millis())
 }
 
 /// Open a SQLite file for read-only access with no mutex (single-threaded parser use).


### PR DESCRIPTION
## Problem

A Droid `*.settings.json` holds one cumulative `tokenUsage` total for the whole session, rewritten in place every time the agent spends tokens. `parse_droid_file` emitted a single record for it, anchored on `providerLockTimestamp` — which records when the provider was *selected*, not when the tokens were spent, and which Droid never updates as the totals climb.

For a session that stays open across days (a `/loop`, a long autonomous run), every token it ever spends is therefore attributed to the instant it started. The session reads as completely silent in `--today` and `--yesterday` while it is actively burning tokens:

```
$ tokscale --no-spinner --light --client droid --today
  Total: 0 messages, 0 tokens, $0.00
```

That machine had three Droid sessions mid-run. Here is the shape of the data — `providerLockTimestamp` frozen at session start while the totals kept being rewritten for three more days:

| `providerLockTimestamp` | file mtime | total tokens |
| --- | --- | --- |
| 2026-08-07T03:32:46Z | 2026-08-10T06:28:01Z | 203,852,824 |
| 2026-08-07T05:57:28Z | 2026-08-10T06:24:57Z | 155,503,988 |
| 2026-08-07T03:20:36Z | 2026-08-10T06:29:34Z | 149,761,299 |

Moving the anchor to the file's mtime makes those sessions visible again, but it does not make them *correct*: whichever single instant is chosen, one day absorbs every token the session ever spent. Checked against a provider-side API dashboard, anchoring at mtime reported **517,527,976** tokens for a day that had actually spent **24,226,571** — a 21× overstatement in place of the previous zero. A single cumulative blob stamped at one instant simply cannot describe multi-day spend.

## Fix

Droid records no token counts anywhere in the transcript, so there is nothing to read per call. But the transcript does say *when* each assistant reply happened and how much conversation was live at the time, and cost per call tracks that closely: nearly every token in these sessions is a cache read of the conversation so far. Weighting each assistant reply by the bytes accumulated since the last compaction recovers what one reply cost relative to another, which is all that apportioning the recorded total needs. Compaction resets the running weight, because it discards the transcript the following calls would otherwise re-read.

Each reply is weighted by the context standing *before* it, not including its own line. A reply's own bytes are output; the call's input and cache-read cost was already fixed by the conversation it read. Folding them in would let a verbose answer claim a larger share at the expense of other replies — including replies on other days, which makes it an attribution error rather than a rounding one.

The session's cumulative total is split across those replies and emitted as one record each. A multi-day session now reports against the days it actually ran, and hourly reports become meaningful for a client that previously had one timestamp per session.

Splitting allocates on the running total rather than rounding each share independently, so the parts sum back to exactly the total Droid recorded — daily figures cannot drift from the cumulative number.

Sessions whose transcript is missing, unreadable, or has no assistant reply yet keep the previous single-record behavior, anchored at mtime and floored at `providerLockTimestamp`, so usage is never dropped for want of a transcript. That fallback also fixes two smaller issues in the original anchoring: mtime beats a lock timestamp that Droid never updates, and a pre-epoch lock is now rejected rather than surviving into a 1969 bucket no date filter can reach.

**Cross-platform:** the fallback anchor relies only on `SystemTime::modified`, which every tier-1 target reports — unlike `created`, which is absent on many Linux filesystems. The timestamp and apportioning logic are pure functions, so their tests assert real ordering and conservation without depending on filesystem timestamp granularity.

## Verification

Measured against the same provider-side dashboard that exposed the problem:

| window | dashboard | before (lock anchor) | mtime anchor | this PR |
| --- | --- | --- | --- | --- |
| one day | 24,226,571 | 0 | 517,527,976 (21× over) | **24,547,118 (1.3% off)** |

Over a multi-day window the remaining gap is Droid's own under-recording, not attribution: 41 of 185 turns in that data ended in `"reason":"error"`, and an errored turn costs provider-side tokens that never reach `tokenUsage`. No parser of these files can see them.

Conservation holds against real data: summing every `tokenUsage` field across every `settings.json` on that machine gives 673,425,644, and `tokscale --client droid` reports exactly 673,425,644. The split moves usage between buckets without creating or losing any.

`cargo fmt --all -- --check`, `cargo clippy --locked --workspace --all-features -- -D warnings`, and `cargo test --workspace --all-features` are all clean.

The parser's test count goes from 6 to 20, covering apportioning conservation (parts sum to the original total), zero-weight handling, spreading across days, the compaction reset, a long reply not charging itself for its own output, both fallback paths, and the unusable-lock rules. I confirmed each regression test is not vacuous by restoring the old behavior and watching it fail — including one that initially passed under both and had to be rewritten around the ratio between shares rather than their order, since charging a reply for its own output leaves the two nearly equal (`[499, 501]`) rather than reversed.

### Scan cost

Reading the transcript is new work for this parser, so I measured it rather than assuming. Isolating parse cost with CPU time (wall clock on a loaded machine is dominated by fixed startup work), against a synthesized 197MB transcript holding 20,000 assistant replies:

| | CPU | peak RSS |
| --- | --- | --- |
| no Droid data (fixed overhead) | 0.22–0.24s | ~46MB |
| 197MB transcript, 20,000 replies | 0.64–0.67s | ~69MB |
| **attributable to parsing** | **~0.42s** | **~23MB** |

That is roughly 470MB/s, linear in transcript bytes, and the totals still come back exact. The ~23MB is the emitted records themselves (~1.2KB each) — the output the report consumes — not parser scratch space; a transcript is streamed a line at a time and nothing but the per-reply timestamp and weight is retained while scanning. Reaching even 1GB of resident records would take on the order of 800k replies, several gigabytes of transcripts. Cost is in line with the other JSONL parsers here; Grok's handles an 83MB `updates.jsonl` by design.

On the real corpus (20MB of transcripts) a cold scan is not measurably slower than `main`.

I deliberately did not add a size or turn cap that falls back to the single-record path. The cap would engage on exactly the largest, longest-running sessions — the ones this PR exists to fix — and silently return them to the 21× overcount, trading a bounded, measured cost for an unbounded correctness error with no signal to the user.

I also tried replacing the per-line `serde_json::Value` with a typed struct so reply bodies are skipped rather than materialized, and reverted it: peak RSS was unchanged (the memory is the emitted records, not the parse), the CPU difference was inside measurement noise, and it made the parser reject a whole line on any unexpected field shape instead of stepping over it — the opposite of the defensive parsing this codebase asks for, and the failure mode behind #1031.

## Cache invalidation

Bumps the Droid parser version to 4. This matters here for the same reason it did for Grok in #1031: a Droid session that has since ended never changes its bytes again, so its fingerprint keeps matching forever and warm caches would otherwise serve the old single-record shape indefinitely. Versions 2 and 3 only ever existed in pre-release builds of this change, and the bump past them keeps anyone who ran one from holding a superseded weighting. Droid is not covered by `retained_history_key_filter`, so the bump is merely cold, not lossy.

## Note on scope

The per-reply split is an estimate, not metering — Droid does not record per-call usage, so no parser can be exact here. It is reproducible from the files alone, which is why it is preferred over persisting cross-run snapshots of the cumulative counter: that would put history in the cache where re-parsing could not rebuild it, and make any future parser-version bump permanently lossy in the way `message_cache.rs` warns about for Claude.

## Disclosure

This patch is vibecoded — investigated, written, and tested by **Claude Opus 5** running as an agent in **Claude Code**, and reviewed by me before submitting. Happy to adjust anything that does not match how you would rather see this handled.
