### PR TITLE
refactor(sessions): share read-only SQLite opening

### DIFF
--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -301,7 +301,8 @@ fn find_cursor_state_vscdb(home_dir: &Path) -> Option<PathBuf> {
 pub fn read_access_token_from_state_vscdb(db_path: &Path) -> Result<String> {
     use rusqlite::{Connection, OpenFlags};
 
-    // Prefer URI read-only so a running Cursor IDE holding a write lock does
+    // This opener deliberately stays separate from sessions::utils: Cursor's
+    // state DB needs the URI `mode=ro` form so a running IDE's write lock does
     // not block us (WAL readers are allowed while the app is open).
     let uri = format!("file:{}?mode=ro", db_path.display());
     let conn = Connection::open_with_flags(

--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -301,9 +301,10 @@ fn find_cursor_state_vscdb(home_dir: &Path) -> Option<PathBuf> {
 pub fn read_access_token_from_state_vscdb(db_path: &Path) -> Result<String> {
     use rusqlite::{Connection, OpenFlags};
 
-    // This opener deliberately stays separate from sessions::utils: Cursor's
-    // state DB needs the URI `mode=ro` form so a running IDE's write lock does
-    // not block us (WAL readers are allowed while the app is open).
+    // Keep this opener separate from sessions::utils::open_readonly_sqlite:
+    // it accepts a URI string (`file:...?mode=ro`), intentionally omits
+    // SQLITE_OPEN_NO_MUTEX, and adds the anyhow context needed by this CLI
+    // token lookup.
     let uri = format!("file:{}?mode=ro", db_path.display());
     let conn = Connection::open_with_flags(
         &uri,

--- a/crates/tokscale-core/src/content_extractor.rs
+++ b/crates/tokscale-core/src/content_extractor.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
-use super::sessions::utils::open_readonly_sqlite;
+use super::sessions::utils::open_readonly_sqlite_opt;
 
 const MAX_CONTENT_CHARS: usize = 1000;
 
@@ -14,7 +14,7 @@ pub struct SessionContent {
 }
 
 pub fn extract_opencode_content(db_path: &Path, session_id: &str) -> Option<SessionContent> {
-    let conn = open_readonly_sqlite(db_path)?;
+    let conn = open_readonly_sqlite_opt(db_path)?;
 
     let sql = r#"
         SELECT json_extract(data, '$.parts') as parts

--- a/crates/tokscale-core/src/sessions/antigravity_cli.rs
+++ b/crates/tokscale-core/src/sessions/antigravity_cli.rs
@@ -41,7 +41,7 @@
 //! server-supplied name that gets renamed (`Gemini 3 Flash` → `Gemini 3.5 Flash
 //! (High)`) and could be localized.
 
-use super::utils::open_readonly_sqlite;
+use super::utils::open_readonly_sqlite_opt;
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::{pricing, provider_identity, TokenBreakdown};
 use rusqlite::Connection;
@@ -49,7 +49,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 pub fn parse_antigravity_cli_file(path: &Path) -> Vec<UnifiedMessage> {
-    let Some(conn) = open_readonly_sqlite(path) else {
+    let Some(conn) = open_readonly_sqlite_opt(path) else {
         return Vec::new();
     };
 

--- a/crates/tokscale-core/src/sessions/copilot_desktop.rs
+++ b/crates/tokscale-core/src/sessions/copilot_desktop.rs
@@ -3,11 +3,10 @@
 //! The macOS desktop app stores aggregate token totals in `~/.copilot/data.db`
 //! and per-session event metadata in `~/.copilot/session-state/{session_id}`.
 
-use super::utils::lossy_lines;
+use super::utils::{lossy_lines, open_readonly_sqlite_result};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::provider_identity::inferred_provider_from_model;
 use chrono::{DateTime, NaiveDateTime};
-use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -240,10 +239,7 @@ fn shutdown_deltas(
 }
 
 pub fn parse_copilot_desktop_db(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match Connection::open_with_flags(
-        db_path,
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    ) {
+    let conn = match open_readonly_sqlite_result(db_path) {
         Ok(conn) => conn,
         Err(err) => {
             warn!(

--- a/crates/tokscale-core/src/sessions/copilot_desktop.rs
+++ b/crates/tokscale-core/src/sessions/copilot_desktop.rs
@@ -3,7 +3,7 @@
 //! The macOS desktop app stores aggregate token totals in `~/.copilot/data.db`
 //! and per-session event metadata in `~/.copilot/session-state/{session_id}`.
 
-use super::utils::{lossy_lines, open_readonly_sqlite_result};
+use super::utils::{lossy_lines, open_readonly_sqlite};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::provider_identity::inferred_provider_from_model;
 use chrono::{DateTime, NaiveDateTime};
@@ -239,7 +239,7 @@ fn shutdown_deltas(
 }
 
 pub fn parse_copilot_desktop_db(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match open_readonly_sqlite_result(db_path) {
+    let conn = match open_readonly_sqlite(db_path) {
         Ok(conn) => conn,
         Err(err) => {
             warn!(

--- a/crates/tokscale-core/src/sessions/copilot_desktop.rs
+++ b/crates/tokscale-core/src/sessions/copilot_desktop.rs
@@ -663,6 +663,9 @@ fn parse_iso8601_timestamp_ms(value: &str) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::{params, Connection};
+    use std::fs::{self, File};
+    use std::io::Write;
 
     #[test]
     fn parse_copilot_desktop_db_returns_empty_for_missing_database() {
@@ -670,9 +673,6 @@ mod tests {
         let missing = dir.path().join("missing.db");
         assert!(parse_copilot_desktop_db(&missing).is_empty());
     }
-    use rusqlite::{params, Connection};
-    use std::fs::{self, File};
-    use std::io::Write;
 
     fn create_copilot_desktop_db(path: &Path) -> Connection {
         let conn = Connection::open(path).unwrap();

--- a/crates/tokscale-core/src/sessions/copilot_desktop.rs
+++ b/crates/tokscale-core/src/sessions/copilot_desktop.rs
@@ -663,6 +663,13 @@ fn parse_iso8601_timestamp_ms(value: &str) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_copilot_desktop_db_returns_empty_for_missing_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.db");
+        assert!(parse_copilot_desktop_db(&missing).is_empty());
+    }
     use rusqlite::{params, Connection};
     use std::fs::{self, File};
     use std::io::Write;

--- a/crates/tokscale-core/src/sessions/crush.rs
+++ b/crates/tokscale-core/src/sessions/crush.rs
@@ -11,7 +11,7 @@
 //! report showing 0 tokens for crush is EXPECTED behavior, NOT a bug — the
 //! signal Crush provides is cost, not tokens.
 
-use super::utils::open_readonly_sqlite;
+use super::utils::open_readonly_sqlite_opt;
 use super::UnifiedMessage;
 use crate::bucket_tz::BucketTimezone;
 use crate::TokenBreakdown;
@@ -61,7 +61,7 @@ pub fn parse_crush_sqlite_in(
     db_path: &Path,
     bucket_timezone: &BucketTimezone,
 ) -> Vec<UnifiedMessage> {
-    let Some(conn) = open_readonly_sqlite(db_path) else {
+    let Some(conn) = open_readonly_sqlite_opt(db_path) else {
         return Vec::new();
     };
 

--- a/crates/tokscale-core/src/sessions/devin.rs
+++ b/crates/tokscale-core/src/sessions/devin.rs
@@ -4,7 +4,7 @@
 //! - Devin CLI SQLite database (`~/.local/share/devin/cli/sessions.db`)
 //! - Devin Desktop NDJSON event streams (`~/Library/Application Support/Devin/User/acp-events/*.ndjson`)
 
-use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms, open_readonly_sqlite};
+use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms, open_readonly_sqlite_opt};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
@@ -109,7 +109,7 @@ pub fn load_devin_desktop_session_lookup(
     let mut lookup = DevinDesktopSessionLookup::default();
 
     for db_path in db_paths {
-        let Some(conn) = open_readonly_sqlite(db_path) else {
+        let Some(conn) = open_readonly_sqlite_opt(db_path) else {
             continue;
         };
         let mut stmt = match conn.prepare(
@@ -153,7 +153,7 @@ pub fn load_devin_desktop_session_lookup(
 
 pub fn parse_devin_cli_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
     let fallback_timestamp = file_modified_timestamp_ms(db_path);
-    let Some(conn) = open_readonly_sqlite(db_path) else {
+    let Some(conn) = open_readonly_sqlite_opt(db_path) else {
         return Vec::new();
     };
 

--- a/crates/tokscale-core/src/sessions/goose.rs
+++ b/crates/tokscale-core/src/sessions/goose.rs
@@ -6,9 +6,9 @@
 //! - Legacy Block/goose: `~/.local/share/Block/goose/sessions/sessions.db`
 //! - Custom: `$GOOSE_PATH_ROOT/data/sessions/sessions.db`
 
+use super::utils::open_readonly_sqlite_result;
 use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
-use rusqlite::Connection;
 use serde::Deserialize;
 use std::path::Path;
 use tracing::warn;
@@ -71,10 +71,7 @@ fn parse_created_at(s: &str) -> f64 {
 }
 
 pub fn parse_goose_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match Connection::open_with_flags(
-        db_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    ) {
+    let conn = match open_readonly_sqlite_result(db_path) {
         Ok(c) => c,
         Err(err) => {
             warn!(

--- a/crates/tokscale-core/src/sessions/goose.rs
+++ b/crates/tokscale-core/src/sessions/goose.rs
@@ -6,7 +6,7 @@
 //! - Legacy Block/goose: `~/.local/share/Block/goose/sessions/sessions.db`
 //! - Custom: `$GOOSE_PATH_ROOT/data/sessions/sessions.db`
 
-use super::utils::open_readonly_sqlite_result;
+use super::utils::open_readonly_sqlite;
 use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
@@ -71,7 +71,7 @@ fn parse_created_at(s: &str) -> f64 {
 }
 
 pub fn parse_goose_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match open_readonly_sqlite_result(db_path) {
+    let conn = match open_readonly_sqlite(db_path) {
         Ok(c) => c,
         Err(err) => {
             warn!(
@@ -217,6 +217,14 @@ pub fn parse_goose_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_goose_sqlite_returns_empty_for_missing_database() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing_db = temp_dir.path().join("missing.db");
+
+        assert!(parse_goose_sqlite(&missing_db).is_empty());
+    }
 
     #[test]
     fn test_parse_model_config_valid() {

--- a/crates/tokscale-core/src/sessions/hermes.rs
+++ b/crates/tokscale-core/src/sessions/hermes.rs
@@ -4,6 +4,7 @@
 //! - `~/.hermes/state.db`
 //! - `$HERMES_HOME/state.db`
 
+use super::utils::open_readonly_sqlite_result;
 use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
 use rusqlite::Connection;
@@ -222,10 +223,7 @@ fn has_session_model_usage(db_path: &Path, conn: &Connection) -> bool {
 }
 
 pub fn parse_hermes_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match Connection::open_with_flags(
-        db_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    ) {
+    let conn = match open_readonly_sqlite_result(db_path) {
         Ok(c) => c,
         Err(err) => {
             warn!(

--- a/crates/tokscale-core/src/sessions/hermes.rs
+++ b/crates/tokscale-core/src/sessions/hermes.rs
@@ -4,7 +4,7 @@
 //! - `~/.hermes/state.db`
 //! - `$HERMES_HOME/state.db`
 
-use super::utils::open_readonly_sqlite_result;
+use super::utils::open_readonly_sqlite;
 use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
 use rusqlite::Connection;
@@ -223,7 +223,7 @@ fn has_session_model_usage(db_path: &Path, conn: &Connection) -> bool {
 }
 
 pub fn parse_hermes_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match open_readonly_sqlite_result(db_path) {
+    let conn = match open_readonly_sqlite(db_path) {
         Ok(c) => c,
         Err(err) => {
             warn!(

--- a/crates/tokscale-core/src/sessions/kilo.rs
+++ b/crates/tokscale-core/src/sessions/kilo.rs
@@ -5,7 +5,7 @@
 //!
 //! Kilo CLI uses a SQLite database similar to OpenCode.
 
-use super::utils::{file_modified_timestamp_ms, open_readonly_sqlite};
+use super::utils::{file_modified_timestamp_ms, open_readonly_sqlite_opt};
 use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
@@ -59,7 +59,7 @@ pub fn parse_kilo_sqlite_with_fallback(
     db_path: &Path,
     fallback_timestamp: i64,
 ) -> Vec<UnifiedMessage> {
-    let Some(conn) = open_readonly_sqlite(db_path) else {
+    let Some(conn) = open_readonly_sqlite_opt(db_path) else {
         return Vec::new();
     };
 

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -13,9 +13,7 @@
 //! estimated from context_usage_percentage * context_window (input) and
 //! response_size / 4 (output).
 
-use super::utils::{
-    back_anchor_timestamp, file_modified_timestamp_ms, open_readonly_sqlite_result,
-};
+use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms, open_readonly_sqlite};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde::Deserialize;
@@ -1270,7 +1268,7 @@ pub(crate) fn suppress_snapshots_covered_by_executions(
 }
 
 pub fn parse_kiro_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match open_readonly_sqlite_result(db_path) {
+    let conn = match open_readonly_sqlite(db_path) {
         Ok(c) => c,
         Err(err) => {
             warn!(

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -1418,6 +1418,10 @@ struct KiroDbRequestMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::Connection;
+    use std::fs;
+    use std::io::Write;
+    use tempfile::TempDir;
 
     #[test]
     fn parse_kiro_sqlite_returns_empty_for_missing_database() {
@@ -1425,10 +1429,6 @@ mod tests {
         let missing = dir.path().join("missing.db");
         assert!(parse_kiro_sqlite(&missing).is_empty());
     }
-    use rusqlite::Connection;
-    use std::fs;
-    use std::io::Write;
-    use tempfile::TempDir;
 
     fn create_session_files(
         dir: &TempDir,

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -1418,6 +1418,13 @@ struct KiroDbRequestMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_kiro_sqlite_returns_empty_for_missing_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.db");
+        assert!(parse_kiro_sqlite(&missing).is_empty());
+    }
     use rusqlite::Connection;
     use std::fs;
     use std::io::Write;

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -13,10 +13,11 @@
 //! estimated from context_usage_percentage * context_window (input) and
 //! response_size / 4 (output).
 
-use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms};
+use super::utils::{
+    back_anchor_timestamp, file_modified_timestamp_ms, open_readonly_sqlite_result,
+};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
-use rusqlite::Connection;
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -1269,10 +1270,7 @@ pub(crate) fn suppress_snapshots_covered_by_executions(
 }
 
 pub fn parse_kiro_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match Connection::open_with_flags(
-        db_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    ) {
+    let conn = match open_readonly_sqlite_result(db_path) {
         Ok(c) => c,
         Err(err) => {
             warn!(
@@ -1422,6 +1420,7 @@ struct KiroDbRequestMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::Connection;
     use std::fs;
     use std::io::Write;
     use tempfile::TempDir;

--- a/crates/tokscale-core/src/sessions/micode.rs
+++ b/crates/tokscale-core/src/sessions/micode.rs
@@ -3,7 +3,7 @@
 //! Parses messages from:
 //! - SQLite database: ~/.local/share/mimocode/mimocode.db
 
-use super::utils::open_readonly_sqlite;
+use super::utils::open_readonly_sqlite_opt;
 use super::{
     normalize_opencode_agent_name, normalize_workspace_key, workspace_label_from_key,
     UnifiedMessage,
@@ -158,7 +158,7 @@ fn micode_duration_ms(time: &MiMoCodeTime) -> Option<i64> {
 }
 
 pub fn parse_micode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let Some(conn) = open_readonly_sqlite(db_path) else {
+    let Some(conn) = open_readonly_sqlite_opt(db_path) else {
         return Vec::new();
     };
 

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -4,7 +4,7 @@
 //! - SQLite database (OpenCode 1.2+): ~/.local/share/opencode/opencode.db
 //! - Legacy JSON files: ~/.local/share/opencode/storage/message/
 
-use super::utils::{open_readonly_sqlite, read_file_or_none};
+use super::utils::{open_readonly_sqlite_opt, read_file_or_none};
 use super::{
     normalize_opencode_agent_name, normalize_workspace_key, workspace_label_from_key,
     UnifiedMessage,
@@ -458,7 +458,7 @@ fn collect_opencode_rows(
 }
 
 pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let Some(conn) = open_readonly_sqlite(db_path) else {
+    let Some(conn) = open_readonly_sqlite_opt(db_path) else {
         return Vec::new();
     };
 

--- a/crates/tokscale-core/src/sessions/synthetic.rs
+++ b/crates/tokscale-core/src/sessions/synthetic.rs
@@ -3,7 +3,7 @@
 //! Detects synthetic.new API usage across existing agent sessions by model/provider patterns,
 //! and parses Octofriend's SQLite database when token data is available.
 
-use super::utils::open_readonly_sqlite;
+use super::utils::open_readonly_sqlite_opt;
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use std::path::Path;
@@ -110,7 +110,7 @@ pub fn matches_synthetic_filter(client: &str, model_id: &str, provider_id: &str)
 /// This function checks for token-related tables and parses them when available,
 /// making it future-proof for when Octofriend adds token persistence.
 pub fn parse_octofriend_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let Some(conn) = open_readonly_sqlite(db_path) else {
+    let Some(conn) = open_readonly_sqlite_opt(db_path) else {
         return Vec::new();
     };
 

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -191,6 +191,7 @@ pub(crate) fn back_anchor_timestamp(end: i64, duration: i64) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::ErrorCode;
 
     #[test]
     fn lossy_lines_survives_undecodable_bytes_and_strips_a_bom() {
@@ -256,8 +257,6 @@ mod tests {
 
     #[test]
     fn open_readonly_sqlite_rejects_writes_but_reads_existing_data() {
-        use rusqlite::ffi::ErrorCode;
-
         let temp_dir = tempfile::tempdir().unwrap();
         let db_path = temp_dir.path().join("state.db");
         let conn = Connection::open(&db_path).unwrap();
@@ -273,23 +272,29 @@ mod tests {
         let error = conn
             .execute("INSERT INTO sessions (id) VALUES ('session')", [])
             .unwrap_err();
-        assert!(matches!(
-            error,
-            rusqlite::Error::SqliteFailure(error, _) if error.code == ErrorCode::ReadOnly
-        ));
+        assert!(
+            matches!(
+                &error,
+                rusqlite::Error::SqliteFailure(sqlite_error, _)
+                    if sqlite_error.code == ErrorCode::ReadOnly
+            ),
+            "expected SQLITE_READONLY, got {error:?}"
+        );
     }
 
     #[test]
     fn open_readonly_sqlite_preserves_cannot_open_error() {
-        use rusqlite::ffi::ErrorCode;
-
         let temp_dir = tempfile::tempdir().unwrap();
         let db_path = temp_dir.path().join("missing.db");
         let error = open_readonly_sqlite(&db_path).unwrap_err();
 
-        assert!(matches!(
-            error,
-            rusqlite::Error::SqliteFailure(error, _) if error.code == ErrorCode::CannotOpen
-        ));
+        assert!(
+            matches!(
+                &error,
+                rusqlite::Error::SqliteFailure(sqlite_error, _)
+                    if sqlite_error.code == ErrorCode::CannotOpen
+            ),
+            "expected SQLITE_CANTOPEN, got {error:?}"
+        );
     }
 }

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -145,17 +145,21 @@ pub(crate) fn file_modified_timestamp_ms(path: &Path) -> i64 {
 }
 
 /// Open a SQLite file for read-only access with no mutex (single-threaded parser use).
-pub(crate) fn open_readonly_sqlite_result(path: &Path) -> rusqlite::Result<Connection> {
+///
+/// The `NO_MUTEX` flag is safe here because each parser uses its connection on
+/// one thread. Returning the original `rusqlite::Error` lets callers preserve
+/// useful open-failure context in their logs.
+pub(crate) fn open_readonly_sqlite(path: &Path) -> rusqlite::Result<Connection> {
     Connection::open_with_flags(
         path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )
 }
 
-/// Open a SQLite file for read-only access with no mutex (single-threaded parser use).
+/// Open a SQLite file for read-only access, discarding open errors.
 /// Returns `None` if the file cannot be opened — the caller treats that as "no sessions".
-pub(crate) fn open_readonly_sqlite(path: &Path) -> Option<Connection> {
-    open_readonly_sqlite_result(path).ok()
+pub(crate) fn open_readonly_sqlite_opt(path: &Path) -> Option<Connection> {
+    open_readonly_sqlite(path).ok()
 }
 
 /// Read a file into bytes, returning `None` on any I/O error instead of propagating.
@@ -251,25 +255,41 @@ mod tests {
     }
 
     #[test]
-    fn open_readonly_sqlite_result_uses_read_only_flags() {
+    fn open_readonly_sqlite_rejects_writes_but_reads_existing_data() {
+        use rusqlite::ffi::ErrorCode;
+
         let temp_dir = tempfile::tempdir().unwrap();
         let db_path = temp_dir.path().join("state.db");
         let conn = Connection::open(&db_path).unwrap();
         conn.execute("CREATE TABLE sessions (id TEXT)", []).unwrap();
         drop(conn);
 
-        let conn = open_readonly_sqlite_result(&db_path).unwrap();
-        assert!(conn
+        let conn = open_readonly_sqlite(&db_path).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+
+        let error = conn
             .execute("INSERT INTO sessions (id) VALUES ('session')", [])
-            .is_err());
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            rusqlite::Error::SqliteFailure(error, _) if error.code == ErrorCode::ReadOnly
+        ));
     }
 
     #[test]
-    fn open_readonly_sqlite_result_preserves_open_error() {
+    fn open_readonly_sqlite_preserves_cannot_open_error() {
+        use rusqlite::ffi::ErrorCode;
+
         let temp_dir = tempfile::tempdir().unwrap();
         let db_path = temp_dir.path().join("missing.db");
-        let error = open_readonly_sqlite_result(&db_path).unwrap_err();
+        let error = open_readonly_sqlite(&db_path).unwrap_err();
 
-        assert!(error.to_string().contains("unable to open database file"));
+        assert!(matches!(
+            error,
+            rusqlite::Error::SqliteFailure(error, _) if error.code == ErrorCode::CannotOpen
+        ));
     }
 }

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -145,13 +145,17 @@ pub(crate) fn file_modified_timestamp_ms(path: &Path) -> i64 {
 }
 
 /// Open a SQLite file for read-only access with no mutex (single-threaded parser use).
-/// Returns `None` if the file cannot be opened — the caller treats that as "no sessions".
-pub(crate) fn open_readonly_sqlite(path: &Path) -> Option<Connection> {
+pub(crate) fn open_readonly_sqlite_result(path: &Path) -> rusqlite::Result<Connection> {
     Connection::open_with_flags(
         path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )
-    .ok()
+}
+
+/// Open a SQLite file for read-only access with no mutex (single-threaded parser use).
+/// Returns `None` if the file cannot be opened — the caller treats that as "no sessions".
+pub(crate) fn open_readonly_sqlite(path: &Path) -> Option<Connection> {
+    open_readonly_sqlite_result(path).ok()
 }
 
 /// Read a file into bytes, returning `None` on any I/O error instead of propagating.
@@ -244,5 +248,28 @@ mod tests {
             parse_timestamp_str("2026-06-16T12:00:00Z"),
             Some(1_781_611_200_000)
         );
+    }
+
+    #[test]
+    fn open_readonly_sqlite_result_uses_read_only_flags() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("state.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute("CREATE TABLE sessions (id TEXT)", []).unwrap();
+        drop(conn);
+
+        let conn = open_readonly_sqlite_result(&db_path).unwrap();
+        assert!(conn
+            .execute("INSERT INTO sessions (id) VALUES ('session')", [])
+            .is_err());
+    }
+
+    #[test]
+    fn open_readonly_sqlite_result_preserves_open_error() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("missing.db");
+        let error = open_readonly_sqlite_result(&db_path).unwrap_err();
+
+        assert!(error.to_string().contains("unable to open database file"));
     }
 }

--- a/crates/tokscale-core/src/sessions/workbuddy.rs
+++ b/crates/tokscale-core/src/sessions/workbuddy.rs
@@ -4,9 +4,9 @@
 //! Older installs also expose an aggregate `~/.workbuddy/workbuddy.db`; that
 //! database is kept as a fallback when detailed token sources are unavailable.
 
+use super::utils::open_readonly_sqlite_result;
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::{provider_identity, TokenBreakdown};
-use rusqlite::{Connection, OpenFlags};
 use std::path::Path;
 use tracing::warn;
 
@@ -42,10 +42,7 @@ struct WorkBuddyUsageRow {
 }
 
 pub fn parse_workbuddy_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match Connection::open_with_flags(
-        db_path,
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    ) {
+    let conn = match open_readonly_sqlite_result(db_path) {
         Ok(conn) => conn,
         Err(err) => {
             warn!(

--- a/crates/tokscale-core/src/sessions/workbuddy.rs
+++ b/crates/tokscale-core/src/sessions/workbuddy.rs
@@ -4,7 +4,7 @@
 //! Older installs also expose an aggregate `~/.workbuddy/workbuddy.db`; that
 //! database is kept as a fallback when detailed token sources are unavailable.
 
-use super::utils::open_readonly_sqlite_result;
+use super::utils::open_readonly_sqlite;
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::{provider_identity, TokenBreakdown};
 use std::path::Path;
@@ -42,7 +42,7 @@ struct WorkBuddyUsageRow {
 }
 
 pub fn parse_workbuddy_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match open_readonly_sqlite_result(db_path) {
+    let conn = match open_readonly_sqlite(db_path) {
         Ok(conn) => conn,
         Err(err) => {
             warn!(

--- a/crates/tokscale-core/src/sessions/workbuddy.rs
+++ b/crates/tokscale-core/src/sessions/workbuddy.rs
@@ -165,6 +165,13 @@ fn normalize_timestamp_ms(timestamp: i64) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_workbuddy_sqlite_returns_empty_for_missing_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.db");
+        assert!(parse_workbuddy_sqlite(&missing).is_empty());
+    }
     use rusqlite::{params, Connection};
 
     fn create_workbuddy_db(path: &Path) -> Connection {

--- a/crates/tokscale-core/src/sessions/workbuddy.rs
+++ b/crates/tokscale-core/src/sessions/workbuddy.rs
@@ -165,6 +165,7 @@ fn normalize_timestamp_ms(timestamp: i64) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::{params, Connection};
 
     #[test]
     fn parse_workbuddy_sqlite_returns_empty_for_missing_database() {
@@ -172,7 +173,6 @@ mod tests {
         let missing = dir.path().join("missing.db");
         assert!(parse_workbuddy_sqlite(&missing).is_empty());
     }
-    use rusqlite::{params, Connection};
 
     fn create_workbuddy_db(path: &Path) -> Connection {
         let conn = Connection::open(path).unwrap();

--- a/crates/tokscale-core/src/sessions/zcode.rs
+++ b/crates/tokscale-core/src/sessions/zcode.rs
@@ -13,7 +13,7 @@
 //! counts are used. When absent, tokens are estimated at ~4 chars/token,
 //! consistent with tokscale's other estimated sources (see CommandCode, Kiro).
 
-use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms, open_readonly_sqlite};
+use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms, open_readonly_sqlite_opt};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde::Deserialize;
@@ -289,7 +289,7 @@ fn normalize_zcode_input_and_output(
 }
 
 pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let Some(conn) = open_readonly_sqlite(db_path) else {
+    let Some(conn) = open_readonly_sqlite_opt(db_path) else {
         return Vec::new();
     };
 

--- a/crates/tokscale-core/src/sessions/zed.rs
+++ b/crates/tokscale-core/src/sessions/zed.rs
@@ -9,10 +9,10 @@
 //! ACP agents are billed and logged by their own providers/CLIs, and counting
 //! their Zed UI rows would duplicate those sources.
 
-use super::utils::parse_timestamp_str;
+use super::utils::{open_readonly_sqlite_result, parse_timestamp_str};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
-use rusqlite::{Connection, OpenFlags};
+use rusqlite::Connection;
 use serde_json::Value;
 use std::collections::HashSet;
 use std::io::Read;
@@ -34,10 +34,7 @@ struct ZedThreadRow {
 }
 
 pub fn parse_zed_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match Connection::open_with_flags(
-        db_path,
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    ) {
+    let conn = match open_readonly_sqlite_result(db_path) {
         Ok(conn) => conn,
         Err(err) => {
             warn!(

--- a/crates/tokscale-core/src/sessions/zed.rs
+++ b/crates/tokscale-core/src/sessions/zed.rs
@@ -9,7 +9,7 @@
 //! ACP agents are billed and logged by their own providers/CLIs, and counting
 //! their Zed UI rows would duplicate those sources.
 
-use super::utils::{open_readonly_sqlite_result, parse_timestamp_str};
+use super::utils::{open_readonly_sqlite, parse_timestamp_str};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use rusqlite::Connection;
@@ -34,7 +34,7 @@ struct ZedThreadRow {
 }
 
 pub fn parse_zed_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match open_readonly_sqlite_result(db_path) {
+    let conn = match open_readonly_sqlite(db_path) {
         Ok(conn) => conn,
         Err(err) => {
             warn!(

--- a/crates/tokscale-core/tests/hermes.rs
+++ b/crates/tokscale-core/tests/hermes.rs
@@ -3,6 +3,13 @@ use std::collections::HashSet;
 use tempfile::TempDir;
 use tokscale_core::sessions::hermes::parse_hermes_sqlite;
 
+#[test]
+fn test_parse_hermes_sqlite_returns_empty_for_missing_database() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("missing.db");
+    assert!(parse_hermes_sqlite(&missing).is_empty());
+}
+
 fn create_test_db(dir: &TempDir) -> std::path::PathBuf {
     let db_path = dir.path().join("state.db");
     let conn = Connection::open(&db_path).unwrap();


### PR DESCRIPTION
## Summary

- Make the Result-returning shared read-only SQLite opener the primary `open_readonly_sqlite` helper and retain an explicit `open_readonly_sqlite_opt` wrapper for callers that intentionally discard errors.
- Migrate Copilot Desktop, Goose, Hermes, Kiro, WorkBuddy, and Zed SQLite parsers without changing flags, logging, or error text.
- Add coverage for read-only behavior, SQLite error codes, and missing-database wiring across all six converted parsers.
- Keep the specialized CLI Cursor opener separate because it consumes a URI string, intentionally omits `SQLITE_OPEN_NO_MUTEX`, and attaches the `anyhow` context required by the token lookup; wiki read-write access and test fixture database creation remain unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- Targeted parser tests for Copilot Desktop, Goose, Hermes, Kiro, WorkBuddy, and Zed
- `cargo test -p tokscale-core --test hermes --all-features --locked`
- `cargo test --workspace --all-features --locked`
