### PR TITLE
refactor(core): consolidate direct cached parse lanes

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1154,6 +1154,40 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         )
     }
 
+    /// Parse one direct cached lane and merge it before the next lane starts.
+    ///
+    /// Outcomes are collected in parallel before either destination is mutated;
+    /// this preserves the existing per-lane collection and post-collection cache
+    /// insertion lifecycle. Callers invoke this helper in source order, so the
+    /// call order also preserves the sequential lane order of the parser.
+    ///
+    /// The scan key and cache identity are intentionally derived from the same
+    /// `ClientId`, making a same-client mapping impossible to mismatch. An
+    /// asymmetric lane should use a separately named helper with its own contract.
+    fn parse_cached_lane<F>(
+        scan_result: &scanner::ScanResult,
+        source_cache: &mut message_cache::SourceMessageCache,
+        pricing: Option<&pricing::PricingService>,
+        all_messages: &mut Vec<UnifiedMessage>,
+        scan_client: ClientId,
+        parse: F,
+    ) where
+        F: Fn(&Path) -> Vec<UnifiedMessage> + Sync,
+    {
+        let cache_identity = message_cache::CacheIdentity::for_client(scan_client);
+        let outcomes: Vec<CachedParseOutcome> = scan_result
+            .get(scan_client)
+            .par_iter()
+            .map(|path| load_or_parse_source(cache_identity, path, source_cache, pricing, &parse))
+            .collect();
+        for outcome in outcomes {
+            all_messages.extend(outcome.messages);
+            if let Some(entry) = outcome.cache_entry {
+                source_cache.insert(entry);
+            }
+        }
+    }
+
     fn uncached_prime_outcome(
         mut messages: Vec<UnifiedMessage>,
         accounting: sessions::prime_agent::PrimeFileAccounting,
@@ -1664,25 +1698,14 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         }
     }
 
-    let copilot_outcomes: Vec<CachedParseOutcome> = scan_result
-        .get(ClientId::Copilot)
-        .par_iter()
-        .map(|path| {
-            load_or_parse_source(
-                message_cache::CacheIdentity::for_client(ClientId::Copilot),
-                path,
-                &source_cache,
-                pricing,
-                sessions::copilot::parse_copilot_file,
-            )
-        })
-        .collect();
-    for outcome in copilot_outcomes {
-        all_messages.extend(outcome.messages);
-        if let Some(entry) = outcome.cache_entry {
-            source_cache.insert(entry);
-        }
-    }
+    parse_cached_lane(
+        &scan_result,
+        &mut source_cache,
+        pricing,
+        &mut all_messages,
+        ClientId::Copilot,
+        sessions::copilot::parse_copilot_file,
+    );
     if let Some(db_path) = &scan_result.copilot_desktop_db {
         let otel_sessions: HashSet<String> = all_messages
             .iter()
@@ -1765,45 +1788,23 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         }
     }
 
-    let cursor_outcomes: Vec<CachedParseOutcome> = scan_result
-        .get(ClientId::Cursor)
-        .par_iter()
-        .map(|path| {
-            load_or_parse_source(
-                message_cache::CacheIdentity::for_client(ClientId::Cursor),
-                path,
-                &source_cache,
-                pricing,
-                sessions::cursor::parse_cursor_file,
-            )
-        })
-        .collect();
-    for outcome in cursor_outcomes {
-        all_messages.extend(outcome.messages);
-        if let Some(entry) = outcome.cache_entry {
-            source_cache.insert(entry);
-        }
-    }
+    parse_cached_lane(
+        &scan_result,
+        &mut source_cache,
+        pricing,
+        &mut all_messages,
+        ClientId::Cursor,
+        sessions::cursor::parse_cursor_file,
+    );
 
-    let warp_outcomes: Vec<CachedParseOutcome> = scan_result
-        .get(ClientId::Warp)
-        .par_iter()
-        .map(|path| {
-            load_or_parse_source(
-                message_cache::CacheIdentity::for_client(ClientId::Warp),
-                path,
-                &source_cache,
-                pricing,
-                sessions::warp::parse_warp_file,
-            )
-        })
-        .collect();
-    for outcome in warp_outcomes {
-        all_messages.extend(outcome.messages);
-        if let Some(entry) = outcome.cache_entry {
-            source_cache.insert(entry);
-        }
-    }
+    parse_cached_lane(
+        &scan_result,
+        &mut source_cache,
+        pricing,
+        &mut all_messages,
+        ClientId::Warp,
+        sessions::warp::parse_warp_file,
+    );
 
     let grok_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Grok)
@@ -1860,25 +1861,14 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         }
     }
 
-    let amp_outcomes: Vec<CachedParseOutcome> = scan_result
-        .get(ClientId::Amp)
-        .par_iter()
-        .map(|path| {
-            load_or_parse_source(
-                message_cache::CacheIdentity::for_client(ClientId::Amp),
-                path,
-                &source_cache,
-                pricing,
-                sessions::amp::parse_amp_file,
-            )
-        })
-        .collect();
-    for outcome in amp_outcomes {
-        all_messages.extend(outcome.messages);
-        if let Some(entry) = outcome.cache_entry {
-            source_cache.insert(entry);
-        }
-    }
+    parse_cached_lane(
+        &scan_result,
+        &mut source_cache,
+        pricing,
+        &mut all_messages,
+        ClientId::Amp,
+        sessions::amp::parse_amp_file,
+    );
 
     let codebuff_outcomes: Vec<CachedParseOutcome> = if include_codebuff {
         scan_result
@@ -1954,45 +1944,23 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         }
     }
 
-    let openclaw_outcomes: Vec<CachedParseOutcome> = scan_result
-        .get(ClientId::OpenClaw)
-        .par_iter()
-        .map(|path| {
-            load_or_parse_source(
-                message_cache::CacheIdentity::for_client(ClientId::OpenClaw),
-                path,
-                &source_cache,
-                pricing,
-                sessions::openclaw::parse_openclaw_transcript,
-            )
-        })
-        .collect();
-    for outcome in openclaw_outcomes {
-        all_messages.extend(outcome.messages);
-        if let Some(entry) = outcome.cache_entry {
-            source_cache.insert(entry);
-        }
-    }
+    parse_cached_lane(
+        &scan_result,
+        &mut source_cache,
+        pricing,
+        &mut all_messages,
+        ClientId::OpenClaw,
+        sessions::openclaw::parse_openclaw_transcript,
+    );
 
-    let pi_outcomes: Vec<CachedParseOutcome> = scan_result
-        .get(ClientId::Pi)
-        .par_iter()
-        .map(|path| {
-            load_or_parse_source(
-                message_cache::CacheIdentity::for_client(ClientId::Pi),
-                path,
-                &source_cache,
-                pricing,
-                sessions::pi::parse_pi_file,
-            )
-        })
-        .collect();
-    for outcome in pi_outcomes {
-        all_messages.extend(outcome.messages);
-        if let Some(entry) = outcome.cache_entry {
-            source_cache.insert(entry);
-        }
-    }
+    parse_cached_lane(
+        &scan_result,
+        &mut source_cache,
+        pricing,
+        &mut all_messages,
+        ClientId::Pi,
+        sessions::pi::parse_pi_file,
+    );
 
     let prime_agent_outcomes: Vec<(
         CachedParseOutcome,
@@ -2065,25 +2033,14 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         }
     }
 
-    let senpi_outcomes: Vec<CachedParseOutcome> = scan_result
-        .get(ClientId::Senpi)
-        .par_iter()
-        .map(|path| {
-            load_or_parse_source(
-                message_cache::CacheIdentity::for_client(ClientId::Senpi),
-                path,
-                &source_cache,
-                pricing,
-                sessions::senpi::parse_senpi_file,
-            )
-        })
-        .collect();
-    for outcome in senpi_outcomes {
-        all_messages.extend(outcome.messages);
-        if let Some(entry) = outcome.cache_entry {
-            source_cache.insert(entry);
-        }
-    }
+    parse_cached_lane(
+        &scan_result,
+        &mut source_cache,
+        pricing,
+        &mut all_messages,
+        ClientId::Senpi,
+        sessions::senpi::parse_senpi_file,
+    );
 
     let augment_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Augment)
@@ -2230,25 +2187,14 @@ fn parse_all_messages_with_pricing_with_cache_policy(
     // above, there is no authoritative embedded cost for cached_messages()'s
     // unconditional reprice to overwrite. The parser also dedups within a file
     // on its own, so no cross-file `should_keep_deduped_message` pass is needed.
-    let opencodereview_outcomes: Vec<CachedParseOutcome> = scan_result
-        .get(ClientId::OpenCodeReview)
-        .par_iter()
-        .map(|path| {
-            load_or_parse_source(
-                message_cache::CacheIdentity::for_client(ClientId::OpenCodeReview),
-                path,
-                &source_cache,
-                pricing,
-                sessions::opencodereview::parse_opencodereview_file,
-            )
-        })
-        .collect();
-    for outcome in opencodereview_outcomes {
-        all_messages.extend(outcome.messages);
-        if let Some(entry) = outcome.cache_entry {
-            source_cache.insert(entry);
-        }
-    }
+    parse_cached_lane(
+        &scan_result,
+        &mut source_cache,
+        pricing,
+        &mut all_messages,
+        ClientId::OpenCodeReview,
+        sessions::opencodereview::parse_opencodereview_file,
+    );
 
     let kimi_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Kimi)
@@ -2278,25 +2224,14 @@ fn parse_all_messages_with_pricing_with_cache_policy(
     }
 
     // Parse Qwen files
-    let qwen_outcomes: Vec<CachedParseOutcome> = scan_result
-        .get(ClientId::Qwen)
-        .par_iter()
-        .map(|path| {
-            load_or_parse_source(
-                message_cache::CacheIdentity::for_client(ClientId::Qwen),
-                path,
-                &source_cache,
-                pricing,
-                sessions::qwen::parse_qwen_file,
-            )
-        })
-        .collect();
-    for outcome in qwen_outcomes {
-        all_messages.extend(outcome.messages);
-        if let Some(entry) = outcome.cache_entry {
-            source_cache.insert(entry);
-        }
-    }
+    parse_cached_lane(
+        &scan_result,
+        &mut source_cache,
+        pricing,
+        &mut all_messages,
+        ClientId::Qwen,
+        sessions::qwen::parse_qwen_file,
+    );
 
     let roocode_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::RooCode)
@@ -2367,25 +2302,14 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         }
     }
 
-    let mux_outcomes: Vec<CachedParseOutcome> = scan_result
-        .get(ClientId::Mux)
-        .par_iter()
-        .map(|path| {
-            load_or_parse_source(
-                message_cache::CacheIdentity::for_client(ClientId::Mux),
-                path,
-                &source_cache,
-                pricing,
-                sessions::mux::parse_mux_file,
-            )
-        })
-        .collect();
-    for outcome in mux_outcomes {
-        all_messages.extend(outcome.messages);
-        if let Some(entry) = outcome.cache_entry {
-            source_cache.insert(entry);
-        }
-    }
+    parse_cached_lane(
+        &scan_result,
+        &mut source_cache,
+        pricing,
+        &mut all_messages,
+        ClientId::Mux,
+        sessions::mux::parse_mux_file,
+    );
 
     // Kilo CLI: SQLite database
     if let Some(db_path) = &scan_result.kilo_db {
@@ -6382,7 +6306,10 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_cursor_parse_path_reprices_zero_cost_composer_1_5_rows() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
         let temp_dir = tempfile::TempDir::new().unwrap();
         let cursor_cache_dir = temp_dir.path().join(".config/tokscale/cursor-cache");
         std::fs::create_dir_all(&cursor_cache_dir).unwrap();
@@ -6402,6 +6329,71 @@ mod tests {
         assert_eq!(messages[0].client, "cursor");
         assert_eq!(messages[0].model_id, "Composer 1.5");
         assert!(messages[0].cost > 0.0);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_cursor_cached_lane_matches_cold_parse_on_warm_hit() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let cursor_cache_dir = source_home.path().join(".config/tokscale/cursor-cache");
+        std::fs::create_dir_all(&cursor_cache_dir).unwrap();
+        let usage_path = cursor_cache_dir.join("usage.csv");
+
+        let csv = r#"Date,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost
+"2026-03-04T12:00:00.000Z","Included","Composer 1.5","No","1200","1000","5000","2000","8000","0""#;
+        std::fs::write(&usage_path, csv).unwrap();
+
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "composer-1.5".to_string(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(0.001),
+                output_cost_per_token: Some(0.002),
+                cache_read_input_token_cost: Some(0.0001),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new(litellm, HashMap::new());
+        let _parse_counter =
+            sessions::cursor::register_parse_cursor_file_counter(source_home.path());
+
+        let cold = parse_all_messages_with_pricing(
+            source_home.path().to_str().unwrap(),
+            &["cursor".to_string()],
+            Some(&pricing),
+        );
+        assert_eq!(cold.len(), 1);
+        assert!(cold[0].cost > 0.0);
+        assert_eq!(
+            sessions::cursor::parse_cursor_file_call_count(source_home.path()),
+            1,
+            "cold parse should invoke the Cursor parser once"
+        );
+
+        let persisted = message_cache::SourceMessageCache::load();
+        let cached = persisted
+            .get(
+                message_cache::CacheIdentity::for_client(ClientId::Cursor),
+                &usage_path,
+            )
+            .expect("cold parse should persist the Cursor source entry");
+        assert_eq!(cached.messages.len(), 1);
+
+        let warm = parse_all_messages_with_pricing(
+            source_home.path().to_str().unwrap(),
+            &["cursor".to_string()],
+            Some(&pricing),
+        );
+        assert_eq!(warm.len(), 1);
+        assert!(warm[0].cost > 0.0);
+        assert_eq!(warm, cold);
+        assert_eq!(
+            sessions::cursor::parse_cursor_file_call_count(source_home.path()),
+            1,
+            "warm cache hit must not invoke the Cursor parser again"
+        );
     }
 
     /// MiMo Code records carry an authoritative per-message cost. The micode

--- a/crates/tokscale-core/src/sessions/cursor.rs
+++ b/crates/tokscale-core/src/sessions/cursor.rs
@@ -13,6 +13,82 @@ use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
 use std::path::Path;
 
+#[cfg(test)]
+use std::collections::HashMap;
+#[cfg(test)]
+use std::path::PathBuf;
+#[cfg(test)]
+use std::sync::Mutex;
+
+#[cfg(test)]
+static PARSE_CURSOR_FILE_CALLS: Mutex<Option<HashMap<PathBuf, usize>>> = Mutex::new(None);
+
+/// Keeps a path-scoped parser counter registered for the lifetime of a test.
+///
+/// The guard removes only its own root on drop, preventing stale registrations
+/// from accumulating or a later test from accidentally observing old counts.
+#[cfg(test)]
+pub(crate) struct ParseCursorFileCounterGuard {
+    root: PathBuf,
+}
+
+#[cfg(test)]
+impl Drop for ParseCursorFileCounterGuard {
+    fn drop(&mut self) {
+        let Ok(mut counters) = PARSE_CURSOR_FILE_CALLS.lock() else {
+            return;
+        };
+        if let Some(counters) = counters.as_mut() {
+            counters.remove(&self.root);
+        }
+        if matches!(counters.as_ref(), Some(counters) if counters.is_empty()) {
+            *counters = None;
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn register_parse_cursor_file_counter(root: &Path) -> ParseCursorFileCounterGuard {
+    let root = root.to_path_buf();
+    let inserted = {
+        let mut counters = PARSE_CURSOR_FILE_CALLS.lock().unwrap();
+        let counters = counters.get_or_insert_with(HashMap::new);
+        if counters.contains_key(&root) {
+            false
+        } else {
+            counters.insert(root.clone(), 0);
+            true
+        }
+    };
+    assert!(
+        inserted,
+        "a Cursor parser counter is already registered for this root"
+    );
+    ParseCursorFileCounterGuard { root }
+}
+
+#[cfg(test)]
+pub(crate) fn parse_cursor_file_call_count(root: &Path) -> usize {
+    PARSE_CURSOR_FILE_CALLS
+        .lock()
+        .unwrap()
+        .as_ref()
+        .and_then(|counters| counters.get(root).copied())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+fn record_parse_cursor_file_call(path: &Path) {
+    let mut counters = PARSE_CURSOR_FILE_CALLS.lock().unwrap();
+    if let Some(counters) = counters.as_mut() {
+        for (root, count) in counters {
+            if path.starts_with(root) {
+                *count += 1;
+            }
+        }
+    }
+}
+
 fn account_id_from_cursor_cache_path(path: &Path) -> String {
     let file_name = path
         .file_name()
@@ -75,6 +151,9 @@ fn parse_cost(cost_str: &str) -> f64 {
 /// - New: Date,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost
 /// - Old: Date,Model,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost,Cost to you
 pub fn parse_cursor_file(path: &Path) -> Vec<UnifiedMessage> {
+    #[cfg(test)]
+    record_parse_cursor_file_call(path);
+
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(_) => return vec![],
@@ -259,6 +338,23 @@ fn parse_date_to_timestamp(date_str: &str) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_duplicate_parse_counter_registration_does_not_poison_sibling() {
+        let root = tempfile::tempdir().unwrap();
+        let sibling = tempfile::tempdir().unwrap();
+        let _root_counter = register_parse_cursor_file_counter(root.path());
+
+        let duplicate = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _duplicate_counter = register_parse_cursor_file_counter(root.path());
+        }));
+        assert!(duplicate.is_err());
+        assert_eq!(parse_cursor_file_call_count(root.path()), 0);
+
+        let _sibling_counter = register_parse_cursor_file_counter(sibling.path());
+        record_parse_cursor_file_call(&sibling.path().join("usage.csv"));
+        assert_eq!(parse_cursor_file_call_count(sibling.path()), 1);
+    }
 
     #[test]
     fn test_infer_provider() {


### PR DESCRIPTION
## Summary

Replace the repeated cached-source loops for Copilot, Cursor, Warp, Amp, OpenClaw, Pi, Senpi, OpenCodeReview, Qwen, and Mux with one typed private generic helper invocation per lane.

## Behavior-preservation rationale

Each helper call retains the existing `scan_result.get(...).par_iter().collect()` path, the exact parser function and pricing argument, and post-collection message extension/cache insertion. The ten invocations remain in their original sequential positions, so lane order, per-lane collection order, cache identity, and cache write timing are unchanged.

The helper derives `CacheIdentity::for_client(scan_client)` from the same scanner key used for lookup, making a same-client mapping impossible to mismatch. An asymmetric lane should use a separately named helper with its own contract. The helper documentation records that parallel outcomes are collected before either destination is mutated and that callers must preserve invocation order.

The change does not touch fingerprint-specific loaders, deduplication, special lanes, scanner behavior, the local dispatcher, or MiMo pricing. A focused Cursor regression uses a real nonempty `PricingService`, asserts exact one-message cold/warm results and positive repriced cost, verifies the persisted Cursor cache entry, compares the warm result with the cold parse, and uses a path-scoped `cfg(test)` parser-call counter to prove the warm run did not decode the CSV again. The counter is owned by an RAII guard that removes only its unique root when the test ends, and a `catch_unwind` regression proves duplicate registration cannot poison the mutex or prevent a sibling counter from working. The existing Cursor pricing/cache test is serial and redirects its cache home to a test-only directory.

## Gates

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test -p tokscale-core --locked`
- `cargo test --workspace --all-features --locked`
