### PR TITLE
fix(core): preserve records after invalid JSONL bytes

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -13796,6 +13796,78 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn test_prime_agent_dropped_damaged_usage_keeps_later_adjustment_aligned_cold_and_warm() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let sessions_dir = source_home.path().join(".prime/agent/sessions");
+        let child_dir = source_home
+            .path()
+            .join(".prime/agent/session-artifacts/root/sub-child");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        std::fs::create_dir_all(&child_dir).unwrap();
+        let root_path = sessions_dir.join("root.jsonl");
+        std::fs::write(
+            &root_path,
+            r#"{"type":"session","version":3,"id":"root","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"damaged","timestamp":"2026-08-08T00:00:00.500Z","message":{"role":"assistant","provider":"anthropic","model":"damaged-model","responseId":"damaged-response","usage":{"in�put":999,"output":0}}}
+{"type":"message","id":"valid","timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"valid-model","responseId":"valid-response","usage":{"input":20,"output":0}}}
+{"type":"child_usage_attributed","id":"usage-valid","timestamp":"2026-08-08T00:00:02.000Z","targetId":"valid","childUsage":{"input":3,"output":0},"aggregateUsage":{"input":20,"output":0}}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            child_dir.join("child.jsonl"),
+            format!(
+                r#"{{"type":"session","version":3,"id":"child","timestamp":"2026-08-08T00:00:01.500Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child-message","timestamp":"2026-08-08T00:00:02.000Z","message":{{"role":"assistant","provider":"anthropic","model":"child-model","responseId":"child-response","usage":{{"input":3,"output":0}}}}}}
+"#,
+                paths::json_path_literal(&root_path)
+            ),
+        )
+        .unwrap();
+
+        let clients = ["prime-agent".to_string()];
+        sessions::prime_agent::reset_transcript_decode_call_counts(source_home.path());
+        let cold =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        let cold_decode_calls = sessions::prime_agent::transcript_decode_call_counts();
+        assert_eq!(cold_decode_calls, (2, 0));
+        let warm =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        assert_eq!(
+            sessions::prime_agent::transcript_decode_call_counts(),
+            cold_decode_calls,
+            "the unchanged warm scan must reuse aligned messages and accounting"
+        );
+
+        for messages in [cold, warm] {
+            assert_eq!(messages.len(), 2);
+            assert!(!messages
+                .iter()
+                .any(|message| message.model_id == "damaged-model"));
+            assert_eq!(
+                messages
+                    .iter()
+                    .find(|message| message.model_id == "valid-model")
+                    .unwrap()
+                    .tokens
+                    .input,
+                17,
+                "the later valid parent must retain its child-usage adjustment"
+            );
+            assert_eq!(
+                messages
+                    .iter()
+                    .map(|message| message.tokens.input)
+                    .sum::<i64>(),
+                20
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn test_prime_agent_warm_cache_preserves_distinct_invalid_utf8_ids() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -13796,6 +13796,150 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn test_prime_agent_rejects_damaged_child_lineage_and_timestamp_cold_and_warm() {
+        for damage in ["parent-value", "timestamp-value"] {
+            let cache_home = tempfile::TempDir::new().unwrap();
+            let source_home = tempfile::TempDir::new().unwrap();
+            let _cache_env = redirect_cache_home(cache_home.path());
+            let sessions_dir = source_home.path().join(".prime/agent/sessions");
+            let child_dir = source_home
+                .path()
+                .join(".prime/agent/session-artifacts/root/sub-child");
+            std::fs::create_dir_all(&sessions_dir).unwrap();
+            std::fs::create_dir_all(&child_dir).unwrap();
+            let root_path = sessions_dir.join("root.jsonl");
+            std::fs::write(
+                &root_path,
+                r#"{"type":"session","version":3,"id":"root","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":150,"output":0}}}
+{"type":"child_usage_attributed","id":"usage-1","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":50,"output":0},"aggregateUsage":{"input":150,"output":0}}
+"#,
+            )
+            .unwrap();
+
+            let child_path = child_dir.join(format!("{damage}.jsonl"));
+            let clean_parent = paths::json_path_literal(&root_path);
+            let mut child = Vec::new();
+            if damage == "parent-value" {
+                child.extend_from_slice(b"{\"type\":\"session\",\"version\":3,\"id\":\"child\",\"cwd\":\"/tmp/project\",\"parentSession\":");
+                child.extend_from_slice(
+                    clean_parent
+                        .as_bytes()
+                        .get(0..clean_parent.len() - 1)
+                        .unwrap(),
+                );
+                child.extend_from_slice(b"\xff\",\"rlmDepth\":1}\n");
+            } else {
+                child.extend_from_slice(format!("{{\"type\":\"session\",\"version\":3,\"id\":\"child\",\"cwd\":\"/tmp/project\",\"parentSession\":{clean_parent},\"rlmDepth\":1}}\n").as_bytes());
+            }
+            if damage == "timestamp-value" {
+                child.extend_from_slice(b"{\"type\":\"message\",\"id\":\"child-message\",\"timestamp\":\"2026-08-08T00:00:0\xffZ\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":50,\"output\":0}}}\n");
+            } else {
+                child.extend_from_slice(b"{\"type\":\"message\",\"id\":\"child-message\",\"timestamp\":\"2026-08-08T00:00:02.000Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":50,\"output\":0}}}\n");
+            }
+            std::fs::write(child_path, child).unwrap();
+
+            let clients = ["prime-agent".to_string()];
+            sessions::prime_agent::reset_transcript_decode_call_counts(source_home.path());
+            let cold = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &clients,
+                None,
+            );
+            let cold_calls = sessions::prime_agent::transcript_decode_call_counts();
+            assert_eq!(cold_calls, (2, 0), "{damage}");
+            let warm = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &clients,
+                None,
+            );
+            assert_eq!(
+                sessions::prime_agent::transcript_decode_call_counts(),
+                (3, 0),
+                "{damage}: warm scan may revalidate the intentionally empty child, but must reuse the parent"
+            );
+
+            for messages in [cold, warm] {
+                assert_eq!(messages.len(), 1, "{damage}");
+                assert_eq!(messages[0].tokens.input, 150, "{damage}");
+            }
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_prime_agent_escaped_lineage_key_damage_is_safe_cold_and_warm() {
+        for damaged_key_prefix in [r"rlmDepth", r"parentSession"] {
+            let cache_home = tempfile::TempDir::new().unwrap();
+            let source_home = tempfile::TempDir::new().unwrap();
+            let _cache_env = redirect_cache_home(cache_home.path());
+            let sessions_dir = source_home.path().join(".prime/agent/sessions");
+            let child_dir = source_home
+                .path()
+                .join(".prime/agent/session-artifacts/root/sub-child");
+            std::fs::create_dir_all(&sessions_dir).unwrap();
+            std::fs::create_dir_all(&child_dir).unwrap();
+            let root_path = sessions_dir.join("root.jsonl");
+            std::fs::write(
+            &root_path,
+            r#"{"type":"session","version":3,"id":"root","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","usage":{"input":150,"output":0}}}
+{"type":"child_usage_attributed","id":"usage-1","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":50,"output":0},"aggregateUsage":{"input":150,"output":0}}
+"#,
+        )
+        .unwrap();
+            let child_path = child_dir.join("child.jsonl");
+            let clean_parent = paths::json_path_literal(&root_path);
+            let mut child = if damaged_key_prefix.starts_with("rlm") {
+                format!(
+                "{{\"type\":\"session\",\"version\":3,\"id\":\"child\",\"cwd\":\"/tmp/project\",\"parentSession\":{clean_parent},\"{damaged_key_prefix}"
+            )
+            .into_bytes()
+            } else {
+                format!(
+                "{{\"type\":\"session\",\"version\":3,\"id\":\"child\",\"cwd\":\"/tmp/project\",\"{damaged_key_prefix}"
+            )
+            .into_bytes()
+            };
+            child.extend_from_slice(b"\xff\":1}\n");
+            child.extend_from_slice(b"{\"type\":\"message\",\"id\":\"child-message\",\"timestamp\":\"2026-08-08T00:00:02.000Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":50,\"output\":0}}}\n");
+            std::fs::write(child_path, child).unwrap();
+
+            let clients = ["prime-agent".to_string()];
+            sessions::prime_agent::reset_transcript_decode_call_counts(source_home.path());
+            let cold = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &clients,
+                None,
+            );
+            let cold_calls = sessions::prime_agent::transcript_decode_call_counts();
+            assert_eq!(cold_calls, (2, 0));
+            let warm = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &clients,
+                None,
+            );
+            assert_eq!(
+            sessions::prime_agent::transcript_decode_call_counts(),
+            (3, 0),
+            "the intentionally empty rejected child may be revalidated, but the parent stays warm"
+        );
+            for messages in [cold, warm] {
+                assert_eq!(messages.len(), 1);
+                assert_eq!(
+                messages
+                    .iter()
+                    .map(|message| message.tokens.input)
+                    .sum::<i64>(),
+                150,
+                "damaged rlmDepth key must not turn the child into a root and double count to 200"
+            );
+            }
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn test_prime_agent_dropped_damaged_usage_keeps_later_adjustment_aligned_cold_and_warm() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -13736,6 +13736,65 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn test_prime_agent_warm_cache_preserves_distinct_invalid_utf8_ids() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let sessions_dir = source_home.path().join(".prime/agent/sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let source_path = sessions_dir.join("damaged-ids.jsonl");
+        let mut source = std::fs::File::create(&source_path).unwrap();
+        use std::io::Write as _;
+        source
+            .write_all(
+                b"{\"type\":\"session\",\"version\":3,\"id\":\"root\",\"cwd\":\"/tmp/project\"}\n",
+            )
+            .unwrap();
+        source
+            .write_all(b"{\"type\":\"message\",\"id\":\"assistant-\xff\",\"timestamp\":\"2026-08-08T00:00:01Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":10,\"output\":5}}}\n")
+            .unwrap();
+        source
+            .write_all(b"{\"type\":\"message\",\"id\":\"assistant-\xfe\",\"timestamp\":\"2026-08-08T00:00:01Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":10,\"output\":5}}}\n")
+            .unwrap();
+        source.flush().unwrap();
+        drop(source);
+
+        let clients = ["prime-agent".to_string()];
+        sessions::prime_agent::reset_transcript_decode_call_counts(source_home.path());
+        let cold =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        let cold_calls = sessions::prime_agent::transcript_decode_call_counts();
+        assert_eq!(cold_calls, (1, 0));
+
+        let warm =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        assert_eq!(
+            sessions::prime_agent::transcript_decode_call_counts(),
+            cold_calls,
+            "the warm scan must reuse the two distinct cached records"
+        );
+
+        for messages in [cold, warm] {
+            assert_eq!(messages.len(), 2);
+            assert_eq!(
+                messages
+                    .iter()
+                    .map(|message| message.tokens.input)
+                    .sum::<i64>(),
+                20
+            );
+            assert_eq!(
+                messages
+                    .iter()
+                    .map(|message| message.tokens.output)
+                    .sum::<i64>(),
+                10
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn test_prime_agent_warm_cache_hashes_unsampled_semantic_rewrite() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -13736,6 +13736,66 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn test_prime_agent_cold_and_warm_reject_damaged_nested_attribution_usage() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let sessions_dir = source_home.path().join(".prime/agent/sessions");
+        let child_dir = source_home
+            .path()
+            .join(".prime/agent/session-artifacts/root/sub-child");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        std::fs::create_dir_all(&child_dir).unwrap();
+        let root_path = sessions_dir.join("root.jsonl");
+        std::fs::write(
+            &root_path,
+            r#"{"type":"session","version":3,"id":"root","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+{"type":"message","id":"parent","timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"parent-response","usage":{"input":100,"output":0}}}
+{"type":"child_usage_attributed","id":"usage-1","timestamp":"2026-08-08T00:00:02.000Z","targetId":"parent","childUsage":{"input":50,"out�put":999},"aggregateUsage":{"input":100,"output":0}}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            child_dir.join("child.jsonl"),
+            format!(
+                r#"{{"type":"session","version":3,"id":"child","timestamp":"2026-08-08T00:00:01.000Z","cwd":"/tmp/project","parentSession":{},"rlmDepth":1}}
+{{"type":"message","id":"child-message","timestamp":"2026-08-08T00:00:02.000Z","message":{{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"child-response","usage":{{"input":50,"output":0}}}}}}
+"#,
+                paths::json_path_literal(&root_path)
+            ),
+        )
+        .unwrap();
+
+        let clients = ["prime-agent".to_string()];
+        sessions::prime_agent::reset_transcript_decode_call_counts(source_home.path());
+        let cold =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        let cold_decode_calls = sessions::prime_agent::transcript_decode_call_counts();
+        assert_eq!(cold_decode_calls, (2, 0));
+
+        let warm =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        assert_eq!(
+            sessions::prime_agent::transcript_decode_call_counts(),
+            cold_decode_calls,
+            "the unchanged warm scan must reuse the safely rejected accounting record"
+        );
+
+        for messages in [cold, warm] {
+            assert_eq!(messages.len(), 2);
+            assert_eq!(
+                messages
+                    .iter()
+                    .map(|message| message.tokens.input)
+                    .sum::<i64>(),
+                150,
+                "damaged child usage must not subtract the matching child from the parent"
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn test_prime_agent_warm_cache_preserves_distinct_invalid_utf8_ids() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -13868,19 +13868,18 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn test_prime_agent_escaped_lineage_key_damage_is_safe_cold_and_warm() {
-        for damaged_key_prefix in [r"rlmDepth", r"parentSession"] {
-            let cache_home = tempfile::TempDir::new().unwrap();
-            let source_home = tempfile::TempDir::new().unwrap();
-            let _cache_env = redirect_cache_home(cache_home.path());
-            let sessions_dir = source_home.path().join(".prime/agent/sessions");
-            let child_dir = source_home
-                .path()
-                .join(".prime/agent/session-artifacts/root/sub-child");
-            std::fs::create_dir_all(&sessions_dir).unwrap();
-            std::fs::create_dir_all(&child_dir).unwrap();
-            let root_path = sessions_dir.join("root.jsonl");
-            std::fs::write(
+    fn test_prime_agent_escaped_replacement_lineage_key_is_safe_cold_and_warm() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let sessions_dir = source_home.path().join(".prime/agent/sessions");
+        let child_dir = source_home
+            .path()
+            .join(".prime/agent/session-artifacts/root/sub-child");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        std::fs::create_dir_all(&child_dir).unwrap();
+        let root_path = sessions_dir.join("root.jsonl");
+        std::fs::write(
             &root_path,
             r#"{"type":"session","version":3,"id":"root","cwd":"/tmp/project","rlmDepth":0}
 {"type":"message","id":"parent","timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","usage":{"input":150,"output":0}}}
@@ -13888,53 +13887,34 @@ mod tests {
 "#,
         )
         .unwrap();
-            let child_path = child_dir.join("child.jsonl");
-            let clean_parent = paths::json_path_literal(&root_path);
-            let mut child = if damaged_key_prefix.starts_with("rlm") {
-                format!(
-                "{{\"type\":\"session\",\"version\":3,\"id\":\"child\",\"cwd\":\"/tmp/project\",\"parentSession\":{clean_parent},\"{damaged_key_prefix}"
-            )
-            .into_bytes()
-            } else {
-                format!(
-                "{{\"type\":\"session\",\"version\":3,\"id\":\"child\",\"cwd\":\"/tmp/project\",\"{damaged_key_prefix}"
-            )
-            .into_bytes()
-            };
-            child.extend_from_slice(b"\xff\":1}\n");
-            child.extend_from_slice(b"{\"type\":\"message\",\"id\":\"child-message\",\"timestamp\":\"2026-08-08T00:00:02.000Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":50,\"output\":0}}}\n");
-            std::fs::write(child_path, child).unwrap();
+        let clean_parent = paths::json_path_literal(&root_path);
+        std::fs::write(
+            child_dir.join("child.jsonl"),
+            format!(
+                "{{\"type\":\"session\",\"version\":3,\"id\":\"child\",\"cwd\":\"/tmp/project\",\"unrelated\\uD800\":true,\"parentSession\":{clean_parent},\"rlmDep\\uFFFDth\":1}}\n{{\"type\":\"message\",\"id\":\"child-message\",\"timestamp\":\"2026-08-08T00:00:02.000Z\",\"message\":{{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{{\"input\":50,\"output\":0}}}}}}\n"
+            ),
+        )
+        .unwrap();
 
-            let clients = ["prime-agent".to_string()];
-            sessions::prime_agent::reset_transcript_decode_call_counts(source_home.path());
-            let cold = parse_all_messages_with_pricing(
-                source_home.path().to_str().unwrap(),
-                &clients,
-                None,
-            );
-            let cold_calls = sessions::prime_agent::transcript_decode_call_counts();
-            assert_eq!(cold_calls, (2, 0));
-            let warm = parse_all_messages_with_pricing(
-                source_home.path().to_str().unwrap(),
-                &clients,
-                None,
-            );
-            assert_eq!(
+        let clients = ["prime-agent".to_string()];
+        sessions::prime_agent::reset_transcript_decode_call_counts(source_home.path());
+        let cold =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        assert_eq!(
+            sessions::prime_agent::transcript_decode_call_counts(),
+            (2, 0)
+        );
+        let warm =
+            parse_all_messages_with_pricing(source_home.path().to_str().unwrap(), &clients, None);
+        assert_eq!(
             sessions::prime_agent::transcript_decode_call_counts(),
             (3, 0),
-            "the intentionally empty rejected child may be revalidated, but the parent stays warm"
+            "the rejected child may be revalidated, but the parent stays warm"
         );
-            for messages in [cold, warm] {
-                assert_eq!(messages.len(), 1);
-                assert_eq!(
-                messages
-                    .iter()
-                    .map(|message| message.tokens.input)
-                    .sum::<i64>(),
-                150,
-                "damaged rlmDepth key must not turn the child into a root and double count to 200"
-            );
-            }
+        for messages in [cold, warm] {
+            assert_eq!(messages.len(), 1, "only the parent aggregate is emitted");
+            assert_eq!(messages[0].session_id, "root");
+            assert_eq!(messages[0].tokens.input, 150);
         }
     }
 

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1044,13 +1044,15 @@ fn parser_version(client: ClientId) -> u32 {
         // rebuild; it makes the legacy v4 accounting-backfill path unreachable
         // for live caches, but avoids mixing v1 cached messages with v2 scans.
         // Without the bump, malformed-line loss could be mistaken for complete
-        // accounting rather than a truncated source.
-        ClientId::PrimeAgent => 2,
+        // accounting rather than a truncated source. v2->v3 rejects damaged
+        // lineage and usage structural keys before reconciliation bookkeeping.
+        ClientId::PrimeAgent => 3,
         // Initial Reasonix implementation. The fingerprint samples the
         // append-only stats JSONL source so appended records are reparsed.
         // v1->v2: strip a leading BOM and recover records containing
         // undecodable bytes instead of silently dropping the whole record.
-        ClientId::Reasonix => 2,
+        // v2->v3: damaged providers use delimiter-aware family inference.
+        ClientId::Reasonix => 3,
         // v1->v2: per-model token attribution now comes from
         // session_model_usage instead of crediting the whole session to
         // sessions.model, and dedup keys are namespaced per (session, model).
@@ -2976,9 +2978,97 @@ mod tests {
     }
 
     #[test]
-    fn test_lossy_jsonl_parser_versions_invalidate_v1_entries() {
-        assert_eq!(parser_version(ClientId::PrimeAgent), 2);
-        assert_eq!(parser_version(ClientId::Reasonix), 2);
+    fn test_lossy_jsonl_parser_versions_invalidate_v2_entries() {
+        assert_eq!(parser_version(ClientId::PrimeAgent), 3);
+        assert_eq!(parser_version(ClientId::Reasonix), 3);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn prime_and_reasonix_v2_shards_are_rejected_before_changed_bytes_are_parsed() {
+        for (client, source_bytes, stale_provider, expected_provider) in [
+            (
+                ClientId::PrimeAgent,
+                b"{\"type\":\"session\",\"version\":3,\"id\":\"root\",\"cwd\":\"/tmp/project\"}\n{\"type\":\"message\",\"id\":\"valid\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":20,\"output\":8}}}\n".as_slice(),
+                "stale-prime-v2",
+                "anthropic",
+            ),
+            (
+                ClientId::Reasonix,
+                b"{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"deepseek/chat\",\"prompt\":100,\"completion\":20,\"total\":120}\n".as_slice(),
+                "stale-reasonix-v2",
+                "deepseek",
+            ),
+        ] {
+            let temp_home = TempDir::new().unwrap();
+            let _cache_env = sandbox_cache_env(temp_home.path());
+            let source = write_temp_file(source_bytes);
+            let current_identity = CacheIdentity::for_client(client);
+            assert_eq!(current_identity.parser_version, 3);
+            let stale_identity = CacheIdentity {
+                namespace: current_identity.namespace,
+                parser_version: 2,
+            };
+            let fingerprint = SourceFingerprint::from_path(source.path()).unwrap();
+            let stale_entry = CachedSourceEntry::new(
+                stale_identity,
+                source.path(),
+                fingerprint.clone(),
+                vec![UnifiedMessage::new(
+                    current_identity.namespace,
+                    "stale-model",
+                    stale_provider,
+                    "stale-session",
+                    1,
+                    TokenBreakdown {
+                        input: 999,
+                        output: 0,
+                        cache_read: 0,
+                        cache_write: 0,
+                        reasoning: 0,
+                    },
+                    0.0,
+                )],
+                Vec::new(),
+                None,
+            );
+            let stale_path = cache_shard_path(current_identity, source.path());
+            ensure_cache_dir(stale_path.parent().unwrap()).unwrap();
+            write_shard_with_limit(
+                &stale_path,
+                stale_identity,
+                &[stale_entry],
+                MAX_CACHE_SHARD_BYTES,
+            )
+            .unwrap();
+
+            let mut cache = SourceMessageCache::load();
+            assert!(cache.get(current_identity, source.path()).is_none());
+            assert_eq!(SourceFingerprint::from_path(source.path()).unwrap(), fingerprint);
+
+            let rebuilt = match client {
+                ClientId::PrimeAgent => crate::sessions::prime_agent::parse_prime_agent_file(source.path()),
+                ClientId::Reasonix => crate::sessions::reasonix::parse_reasonix_file(source.path()),
+                _ => unreachable!(),
+            };
+            assert_eq!(rebuilt.len(), 1);
+            assert_eq!(rebuilt[0].provider_id, expected_provider);
+            assert_ne!(rebuilt[0].tokens.input, 999);
+            cache.insert(CachedSourceEntry::new(
+                current_identity,
+                source.path(),
+                fingerprint,
+                rebuilt.clone(),
+                Vec::new(),
+                None,
+            ));
+            cache.save_if_dirty();
+
+            let warm = SourceMessageCache::load();
+            let cached = warm.get(current_identity, source.path()).unwrap();
+            assert_eq!(cached.parser_version, 3);
+            assert_eq!(cached.messages, rebuilt);
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1037,9 +1037,20 @@ fn parser_version(client: ClientId) -> u32 {
         // v1->v2: Kimchi's Pi-compatible messages now carry stable namespaced
         // deduplication keys.
         ClientId::Kimchi => 2,
+        // v1->v2: Prime Agent now strips a leading BOM and recovers records
+        // containing undecodable bytes; its accounting scan also continues past
+        // those records instead of truncating and misaligning message indices.
+        // The bump intentionally forces a full re-decode and accounting/matching
+        // rebuild; it makes the legacy v4 accounting-backfill path unreachable
+        // for live caches, but avoids mixing v1 cached messages with v2 scans.
+        // Without the bump, malformed-line loss could be mistaken for complete
+        // accounting rather than a truncated source.
+        ClientId::PrimeAgent => 2,
         // Initial Reasonix implementation. The fingerprint samples the
         // append-only stats JSONL source so appended records are reparsed.
-        ClientId::Reasonix => 1,
+        // v1->v2: strip a leading BOM and recover records containing
+        // undecodable bytes instead of silently dropping the whole record.
+        ClientId::Reasonix => 2,
         // v1->v2: per-model token attribution now comes from
         // session_model_usage instead of crediting the whole session to
         // sessions.model, and dedup keys are namespaced per (session, model).
@@ -2962,6 +2973,12 @@ mod tests {
     #[test]
     fn test_kimi_parser_version_invalidates_v3_entries() {
         assert_eq!(parser_version(ClientId::Kimi), 4);
+    }
+
+    #[test]
+    fn test_lossy_jsonl_parser_versions_invalidate_v1_entries() {
+        assert_eq!(parser_version(ClientId::PrimeAgent), 2);
+        assert_eq!(parser_version(ClientId::Reasonix), 2);
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1046,13 +1046,17 @@ fn parser_version(client: ClientId) -> u32 {
         // Without the bump, malformed-line loss could be mistaken for complete
         // accounting rather than a truncated source. v2->v3 rejects damaged
         // lineage and usage structural keys before reconciliation bookkeeping.
-        ClientId::PrimeAgent => 3,
+        // v3->v4 rejects damaged lineage values and matching-critical child
+        // timestamps while preserving unrelated damaged usage extensions.
+        ClientId::PrimeAgent => 4,
         // Initial Reasonix implementation. The fingerprint samples the
         // append-only stats JSONL source so appended records are reparsed.
         // v1->v2: strip a leading BOM and recover records containing
         // undecodable bytes instead of silently dropping the whole record.
         // v2->v3: damaged providers use delimiter-aware family inference.
-        ClientId::Reasonix => 3,
+        // v3->v4 applies that recovery to every family with version-aware
+        // boundaries, rejecting family-name substrings inside ordinary words.
+        ClientId::Reasonix => 4,
         // v1->v2: per-model token attribution now comes from
         // session_model_usage instead of crediting the whole session to
         // sessions.model, and dedup keys are namespaced per (session, model).
@@ -2978,25 +2982,25 @@ mod tests {
     }
 
     #[test]
-    fn test_lossy_jsonl_parser_versions_invalidate_v2_entries() {
-        assert_eq!(parser_version(ClientId::PrimeAgent), 3);
-        assert_eq!(parser_version(ClientId::Reasonix), 3);
+    fn test_lossy_jsonl_parser_versions_invalidate_v3_entries() {
+        assert_eq!(parser_version(ClientId::PrimeAgent), 4);
+        assert_eq!(parser_version(ClientId::Reasonix), 4);
     }
 
     #[test]
     #[serial_test::serial]
-    fn prime_and_reasonix_v2_shards_are_rejected_before_changed_bytes_are_parsed() {
+    fn prime_and_reasonix_v3_shards_are_rejected_before_changed_bytes_are_parsed() {
         for (client, source_bytes, stale_provider, expected_provider) in [
             (
                 ClientId::PrimeAgent,
                 b"{\"type\":\"session\",\"version\":3,\"id\":\"root\",\"cwd\":\"/tmp/project\"}\n{\"type\":\"message\",\"id\":\"valid\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":20,\"output\":8}}}\n".as_slice(),
-                "stale-prime-v2",
+                "stale-prime-v3",
                 "anthropic",
             ),
             (
                 ClientId::Reasonix,
                 b"{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"deepseek/chat\",\"prompt\":100,\"completion\":20,\"total\":120}\n".as_slice(),
-                "stale-reasonix-v2",
+                "stale-reasonix-v3",
                 "deepseek",
             ),
         ] {
@@ -3004,10 +3008,10 @@ mod tests {
             let _cache_env = sandbox_cache_env(temp_home.path());
             let source = write_temp_file(source_bytes);
             let current_identity = CacheIdentity::for_client(client);
-            assert_eq!(current_identity.parser_version, 3);
+            assert_eq!(current_identity.parser_version, 4);
             let stale_identity = CacheIdentity {
                 namespace: current_identity.namespace,
-                parser_version: 2,
+                parser_version: 3,
             };
             let fingerprint = SourceFingerprint::from_path(source.path()).unwrap();
             let stale_entry = CachedSourceEntry::new(
@@ -3066,7 +3070,7 @@ mod tests {
 
             let warm = SourceMessageCache::load();
             let cached = warm.get(current_identity, source.path()).unwrap();
-            assert_eq!(cached.parser_version, 3);
+            assert_eq!(cached.parser_version, 4);
             assert_eq!(cached.messages, rebuilt);
         }
     }

--- a/crates/tokscale-core/src/provider_identity.rs
+++ b/crates/tokscale-core/src/provider_identity.rs
@@ -220,6 +220,17 @@ fn contains_delimited(haystack: &str, needle: &str) -> bool {
 }
 
 pub fn inferred_provider_from_model(model: &str) -> Option<&'static str> {
+    inferred_provider_from_model_inner(model, false)
+}
+
+pub(crate) fn inferred_provider_from_model_delimited(model: &str) -> Option<&'static str> {
+    inferred_provider_from_model_inner(model, true)
+}
+
+fn inferred_provider_from_model_inner(
+    model: &str,
+    delimit_family_names: bool,
+) -> Option<&'static str> {
     let lower = model.to_lowercase();
 
     // Ollama is a routing prefix, not part of the upstream model family. In
@@ -227,11 +238,14 @@ pub fn inferred_provider_from_model(model: &str) -> Option<&'static str> {
     // otherwise-unknown Ollama model as Meta. Re-run inference on the routed
     // model so known families retain their actual providers.
     if let Some(routed_model) = lower.strip_prefix("ollama/") {
-        return inferred_provider_from_model(routed_model);
+        return inferred_provider_from_model_inner(routed_model, delimit_family_names);
     }
 
-    if lower.contains("claude")
-        || lower.contains("anthropic")
+    if (if delimit_family_names {
+        contains_delimited(&lower, "claude")
+    } else {
+        lower.contains("claude")
+    }) || lower.contains("anthropic")
         || contains_delimited(&lower, "opus")
         || contains_delimited(&lower, "sonnet")
         || contains_delimited(&lower, "haiku")
@@ -240,8 +254,11 @@ pub fn inferred_provider_from_model(model: &str) -> Option<&'static str> {
         return Some("anthropic");
     }
 
-    if lower.contains("gpt")
-        || lower.contains("openai")
+    if (if delimit_family_names {
+        contains_delimited(&lower, "gpt")
+    } else {
+        lower.contains("gpt")
+    }) || lower.contains("openai")
         || contains_delimited(&lower, "o1")
         || contains_delimited(&lower, "o3")
         || contains_delimited(&lower, "o4")

--- a/crates/tokscale-core/src/provider_identity.rs
+++ b/crates/tokscale-core/src/provider_identity.rs
@@ -219,6 +219,36 @@ fn contains_delimited(haystack: &str, needle: &str) -> bool {
     false
 }
 
+/// Match a model-family token at a real leading boundary. A decimal digit may
+/// immediately follow the family because catalog ids commonly concatenate a
+/// major version (`gpt4`, `claude3`, `qwen3`); an ASCII letter may not, which
+/// rejects ordinary words that merely contain a family name.
+fn contains_versioned_family(haystack: &str, family: &str) -> bool {
+    for (pos, _) in haystack.match_indices(family) {
+        let before_ok = haystack[..pos]
+            .chars()
+            .next_back()
+            .is_none_or(|character| !character.is_alphanumeric());
+        let after_pos = pos + family.len();
+        let after_ok = haystack[after_pos..]
+            .chars()
+            .next()
+            .is_none_or(|character| character.is_ascii_digit() || !character.is_alphanumeric());
+        if before_ok && after_ok {
+            return true;
+        }
+    }
+    false
+}
+
+fn contains_family(haystack: &str, family: &str, delimiter_aware: bool) -> bool {
+    if delimiter_aware {
+        contains_versioned_family(haystack, family)
+    } else {
+        haystack.contains(family)
+    }
+}
+
 pub fn inferred_provider_from_model(model: &str) -> Option<&'static str> {
     inferred_provider_from_model_inner(model, false)
 }
@@ -241,24 +271,18 @@ fn inferred_provider_from_model_inner(
         return inferred_provider_from_model_inner(routed_model, delimit_family_names);
     }
 
-    if (if delimit_family_names {
-        contains_delimited(&lower, "claude")
-    } else {
-        lower.contains("claude")
-    }) || lower.contains("anthropic")
-        || contains_delimited(&lower, "opus")
-        || contains_delimited(&lower, "sonnet")
-        || contains_delimited(&lower, "haiku")
-        || contains_delimited(&lower, "fable")
+    if contains_family(&lower, "claude", delimit_family_names)
+        || contains_family(&lower, "anthropic", delimit_family_names)
+        || contains_versioned_family(&lower, "opus")
+        || contains_versioned_family(&lower, "sonnet")
+        || contains_versioned_family(&lower, "haiku")
+        || contains_versioned_family(&lower, "fable")
     {
         return Some("anthropic");
     }
 
-    if (if delimit_family_names {
-        contains_delimited(&lower, "gpt")
-    } else {
-        lower.contains("gpt")
-    }) || lower.contains("openai")
+    if contains_family(&lower, "gpt", delimit_family_names)
+        || contains_family(&lower, "openai", delimit_family_names)
         || contains_delimited(&lower, "o1")
         || contains_delimited(&lower, "o3")
         || contains_delimited(&lower, "o4")
@@ -266,31 +290,37 @@ fn inferred_provider_from_model_inner(
         return Some("openai");
     }
 
-    if lower.contains("gemini") || lower.contains("google") {
+    if contains_family(&lower, "gemini", delimit_family_names)
+        || contains_family(&lower, "google", delimit_family_names)
+    {
         return Some("google");
     }
 
-    if lower.contains("grok") {
+    if contains_family(&lower, "grok", delimit_family_names) {
         return Some("xai");
     }
 
-    if lower.contains("deepseek") {
+    if contains_family(&lower, "deepseek", delimit_family_names) {
         return Some("deepseek");
     }
 
-    if lower.contains("minimax") {
+    if contains_family(&lower, "minimax", delimit_family_names) {
         return Some("minimax");
     }
 
-    if lower.contains("mistral") || lower.contains("mixtral") {
+    if contains_family(&lower, "mistral", delimit_family_names)
+        || contains_family(&lower, "mixtral", delimit_family_names)
+    {
         return Some("mistral");
     }
 
-    if lower.contains("llama") || contains_delimited(&lower, "meta") {
+    if contains_family(&lower, "llama", delimit_family_names)
+        || contains_versioned_family(&lower, "meta")
+    {
         return Some("meta");
     }
 
-    if lower.contains("qwen") {
+    if contains_family(&lower, "qwen", delimit_family_names) {
         return Some("qwen");
     }
 
@@ -298,12 +328,12 @@ fn inferred_provider_from_model_inner(
     // still mapped to the sakana provider here (provider identity is independent
     // of whether we can price the model — see build_sakana_overrides, which
     // deliberately does NOT price bare `fugu`).
-    if lower.contains("fugu") {
+    if contains_family(&lower, "fugu", delimit_family_names) {
         return Some("sakana");
     }
 
-    // Kimi (Moonshot AI) — `kimi`, `kimi-k2.5`, `kimi-code` variants
-    if contains_delimited(&lower, "kimi") {
+    // Kimi (Moonshot AI) — `kimi`, `kimi-k2.5`, `kimi-code` variants.
+    if contains_versioned_family(&lower, "kimi") {
         return Some("moonshotai");
     }
     // Kimi's own coding-plan catalog also serves bare `k2`/`k3`-style ids with
@@ -316,11 +346,11 @@ fn inferred_provider_from_model_inner(
         return Some("moonshotai");
     }
     // MiMo (Xiaomi) — `mimo-v2.5` etc.
-    if contains_delimited(&lower, "mimo") {
+    if contains_versioned_family(&lower, "mimo") {
         return Some("xiaomi");
     }
     // GLM (Zhipu AI / Zai) — `glm-4.6`, `glm-5.2` etc.
-    if contains_delimited(&lower, "glm") {
+    if contains_versioned_family(&lower, "glm") {
         return Some("zai");
     }
 
@@ -492,6 +522,65 @@ mod tests {
         assert_eq!(inferred_provider_from_model("co4pilot-v2"), None);
         assert_eq!(inferred_provider_from_model("metadata-model"), None);
         assert_eq!(inferred_provider_from_model("metamorphic-v1"), None);
+    }
+
+    #[test]
+    fn delimiter_aware_inference_accepts_family_versions_not_word_substrings() {
+        let genuine = [
+            ("gpt4-turbo", "openai"),
+            ("claude3-opus", "anthropic"),
+            ("opus4", "anthropic"),
+            ("sonnet4", "anthropic"),
+            ("haiku3", "anthropic"),
+            ("fable5", "anthropic"),
+            ("gemini2-pro", "google"),
+            ("grok3", "xai"),
+            ("deepseek3", "deepseek"),
+            ("minimax2", "minimax"),
+            ("mistral4", "mistral"),
+            ("mixtral8x7b", "mistral"),
+            ("llama3", "meta"),
+            ("meta3", "meta"),
+            ("qwen3-coder", "qwen"),
+            ("fugu2", "sakana"),
+            ("kimi2", "moonshotai"),
+            ("mimo2", "xiaomi"),
+            ("glm5", "zai"),
+        ];
+        for (model, provider) in genuine {
+            assert_eq!(
+                inferred_provider_from_model_delimited(model),
+                Some(provider),
+                "{model}"
+            );
+        }
+
+        for model in [
+            "agpt-model",
+            "declaude-x",
+            "pregeminified",
+            "engroked",
+            "deepseeking",
+            "minimaximal",
+            "demistralized",
+            "remixtralized",
+            "collamated",
+            "unqwened-model",
+            "defugued",
+            "skimimoed",
+            "glimmer",
+            "unkimied",
+            "unsonneted",
+            "alphabetafablegamma",
+            "préqwened",
+            "qwené-model",
+        ] {
+            assert_eq!(
+                inferred_provider_from_model_delimited(model),
+                None,
+                "{model} is not a genuine family token"
+            );
+        }
     }
 
     /// The families below are matched with plain `contains`, not

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -32,6 +32,47 @@ pub struct PiSessionHeader {
     pub parent_session: Option<String>,
     #[serde(rename = "rlmDepth")]
     pub rlm_depth: Option<u32>,
+    #[serde(flatten)]
+    extra_fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl PiSessionHeader {
+    pub(crate) fn has_damaged_lineage_key(&self) -> bool {
+        self.extra_fields.keys().any(|key| {
+            damaged_key_may_name(key, "parentSession") || damaged_key_may_name(key, "rlmDepth")
+        })
+    }
+}
+
+fn damaged_key_may_name(key: &str, expected: &str) -> bool {
+    if !has_replacement_character(key) {
+        return false;
+    }
+
+    let pattern: Vec<char> = key.chars().collect();
+    let expected: Vec<char> = expected.chars().collect();
+    let mut matches = vec![vec![false; expected.len() + 1]; pattern.len() + 1];
+    matches[0][0] = true;
+    for pattern_index in 0..pattern.len() {
+        for expected_index in 0..=expected.len() {
+            if !matches[pattern_index][expected_index] {
+                continue;
+            }
+            if pattern[pattern_index] == char::REPLACEMENT_CHARACTER {
+                for matched in matches[pattern_index + 1]
+                    .iter_mut()
+                    .skip(expected_index + 1)
+                {
+                    *matched = true;
+                }
+            } else if expected_index < expected.len()
+                && pattern[pattern_index] == expected[expected_index]
+            {
+                matches[pattern_index + 1][expected_index + 1] = true;
+            }
+        }
+    }
+    matches[pattern.len()][expected.len()]
 }
 
 /// Loose type-only probe for a JSONL line, used to identify pre-session
@@ -392,6 +433,9 @@ fn parse_pi_format_file_inner(
                 Ok(h) => h,
                 Err(_) => return Vec::new(),
             };
+            if options.lossy_line_reader && header.has_damaged_lineage_key() {
+                return Vec::new();
+            }
 
             observer.observe_header(&header);
             let clean_cwd = header
@@ -459,7 +503,6 @@ fn parse_pi_format_file_inner(
             continue;
         };
         if options.lossy_line_reader && usage.has_damaged_key() {
-            observer.observe_entry(&entry, None);
             continue;
         }
 

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -8,7 +8,7 @@
 //! Pi descendants reuse this record layout verbatim, so [`parse_pi_format_file`]
 //! is shared: see `sessions::senpi` for Senpi (OmO Native).
 
-use super::utils::{file_modified_timestamp_ms, lossy_lines};
+use super::utils::{file_modified_timestamp_ms, lossy_lines_with_bytes, LossyLine};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::provider_identity::inferred_provider_from_model;
 use crate::TokenBreakdown;
@@ -259,17 +259,22 @@ impl PiParseOptions {
 
 enum PiLines {
     Standard(std::io::Lines<BufReader<std::fs::File>>),
-    Lossy(super::utils::LossyLines<BufReader<std::fs::File>>),
+    Lossy(super::utils::LossyLinesWithBytes<BufReader<std::fs::File>>),
 }
 
 impl Iterator for PiLines {
-    type Item = String;
+    type Item = LossyLine;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             match self {
                 Self::Standard(lines) => match lines.next() {
-                    Some(Ok(line)) => return Some(line),
+                    Some(Ok(line)) => {
+                        return Some(LossyLine {
+                            bytes: line.as_bytes().to_vec(),
+                            text: line,
+                        });
+                    }
                     Some(Err(error)) if error.kind() == std::io::ErrorKind::InvalidData => continue,
                     Some(Err(_)) => return None,
                     None => return None,
@@ -284,11 +289,11 @@ fn accepts_replacement_field(value: &str, lossy_line_reader: bool) -> bool {
     !lossy_line_reader || !has_replacement_character(value)
 }
 
-fn damaged_cross_session_dedup_key(namespace: &str, damaged_id: &str, raw_line: &str) -> String {
+fn damaged_cross_session_dedup_key(namespace: &str, raw_line: &[u8]) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(damaged_id.as_bytes());
-    hasher.update([0]);
-    hasher.update(raw_line.as_bytes());
+    // Exact source bytes distinguish invalid UTF-8 sequences that lossy decode
+    // maps to the same U+FFFD while keeping copied fork records stable.
+    hasher.update(raw_line);
     format!("{namespace}:damaged:{:x}", hasher.finalize())
 }
 
@@ -315,7 +320,7 @@ fn parse_pi_format_file_inner(
 
     let reader = BufReader::new(file);
     let lines = if options.lossy_line_reader {
-        PiLines::Lossy(lossy_lines(reader))
+        PiLines::Lossy(lossy_lines_with_bytes(reader))
     } else {
         PiLines::Standard(reader.lines())
     };
@@ -328,8 +333,7 @@ fn parse_pi_format_file_inner(
     let mut agent: Option<String> = None;
     let mut is_rlm_subagent = false;
     for line in lines {
-        let trimmed = line.trim();
-        let raw_line = trimmed;
+        let trimmed = line.text.trim();
         if trimmed.is_empty() {
             continue;
         }
@@ -511,19 +515,14 @@ fn parse_pi_format_file_inner(
                     })
                 });
                 if unified.dedup_key.is_none() && options.lossy_line_reader {
-                    if let Some(damaged_id) = entry
-                        .id
-                        .as_deref()
-                        .filter(|id| !accepts_replacement_field(id, options.lossy_line_reader))
-                        .or_else(|| {
-                            message.response_id.as_deref().filter(|id| {
-                                !accepts_replacement_field(id, options.lossy_line_reader)
-                            })
-                        })
-                    {
-                        unified.dedup_key = Some(damaged_cross_session_dedup_key(
-                            namespace, damaged_id, raw_line,
-                        ));
+                    let has_damaged_id = entry.id.as_deref().is_some_and(|id| {
+                        !accepts_replacement_field(id, options.lossy_line_reader)
+                    }) || message.response_id.as_deref().is_some_and(|id| {
+                        !accepts_replacement_field(id, options.lossy_line_reader)
+                    });
+                    if has_damaged_id {
+                        unified.dedup_key =
+                            Some(damaged_cross_session_dedup_key(namespace, &line.bytes));
                     }
                 }
             } else if let Some(message_id) = entry.id.as_deref().filter(|id| !id.trim().is_empty())

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -8,11 +8,12 @@
 //! Pi descendants reuse this record layout verbatim, so [`parse_pi_format_file`]
 //! is shared: see `sessions::senpi` for Senpi (OmO Native).
 
-use super::utils::file_modified_timestamp_ms;
+use super::utils::{file_modified_timestamp_ms, lossy_lines};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::provider_identity::inferred_provider_from_model;
 use crate::TokenBreakdown;
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
@@ -44,7 +45,18 @@ struct PiEntryTypeProbe {
 /// auto-generated-title record). The parser skips these while looking for
 /// `session` rather than discarding the whole file. Any other unrecognized
 /// type before `session` is still treated as a malformed file.
-const PRE_SESSION_METADATA_TYPES: &[&str] = &["title"];
+pub(crate) const PRE_SESSION_METADATA_TYPES: &[&str] = &["title"];
+
+/// A lossy pre-header line is skippable only when it could not be parsed for
+/// its record type. A replacement-bearing line that parses as a real type is
+/// still treated as a foreign/malformed file, keeping both Prime scans aligned.
+pub(crate) fn has_replacement_character(value: &str) -> bool {
+    value.contains(char::REPLACEMENT_CHARACTER)
+}
+
+pub(crate) fn pre_header_line_is_skippable(trimmed: &str, parsed_type: Option<&str>) -> bool {
+    parsed_type.is_none() && has_replacement_character(trimmed)
+}
 
 /// Pi session entry (subsequent lines of JSONL)
 #[derive(Debug, Deserialize)]
@@ -151,8 +163,7 @@ pub(crate) fn parse_pi_format_file(
         client,
         fallback_provider,
         None,
-        false,
-        false,
+        PiParseOptions::standard(),
         &mut observer,
     )
 }
@@ -171,8 +182,7 @@ pub(crate) fn parse_pi_format_file_with_dedup(
         client,
         fallback_provider,
         Some(client),
-        false,
-        false,
+        PiParseOptions::standard(),
         &mut observer,
     )
 }
@@ -192,12 +202,16 @@ struct NoopPiFormatObserver;
 
 impl PiFormatObserver for NoopPiFormatObserver {}
 
-/// Parse a Pi-format session whose `session_info.name` identifies an RLM
-/// subagent when the session header has `rlmDepth > 0`.
+/// Parse the Prime Agent Pi-compatible format whose `session_info.name`
+/// identifies an RLM subagent when the session header has `rlmDepth > 0`.
 ///
 /// Deduplication is intentionally cross-session: Prime Agent forks copy prior
 /// message entries into a file with a new session id. Provider response ids are
 /// preferred; the message id plus immutable event fields is the fallback.
+///
+/// Prime Agent's append-only JSONL may contain a UTF-8 BOM or undecodable
+/// records. Lossy line handling keeps malformed records local to their own
+/// line without changing the historical behavior of other Pi clients.
 pub(crate) fn parse_pi_format_rlm_file_with_observer(
     path: &Path,
     client: &str,
@@ -209,10 +223,79 @@ pub(crate) fn parse_pi_format_rlm_file_with_observer(
         client,
         fallback_provider,
         Some(client),
-        true,
-        true,
+        PiParseOptions::prime_agent(),
         observer,
     )
+}
+
+#[derive(Clone, Copy)]
+struct PiParseOptions {
+    rlm_session_name_as_agent: bool,
+    cross_session_dedup: bool,
+    lossy_line_reader: bool,
+}
+
+impl PiParseOptions {
+    /// Keep the historical byte-strict behavior for Pi, Senpi, and Kimchi.
+    /// Their cache namespaces are intentionally not invalidated by this
+    /// Prime-Agent-only migration; revisit this when those clients opt into
+    /// lossy decoding and receive their own parser-version bumps.
+    const fn standard() -> Self {
+        Self {
+            rlm_session_name_as_agent: false,
+            cross_session_dedup: false,
+            lossy_line_reader: false,
+        }
+    }
+
+    const fn prime_agent() -> Self {
+        Self {
+            rlm_session_name_as_agent: true,
+            cross_session_dedup: true,
+            lossy_line_reader: true,
+        }
+    }
+}
+
+enum PiLines {
+    Standard(std::io::Lines<BufReader<std::fs::File>>),
+    Lossy(super::utils::LossyLines<BufReader<std::fs::File>>),
+}
+
+impl Iterator for PiLines {
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self {
+                Self::Standard(lines) => match lines.next() {
+                    Some(Ok(line)) => return Some(line),
+                    Some(Err(error)) if error.kind() == std::io::ErrorKind::InvalidData => continue,
+                    Some(Err(_)) => return None,
+                    None => return None,
+                },
+                Self::Lossy(lines) => return lines.next(),
+            }
+        }
+    }
+}
+
+fn accepts_replacement_field(value: &str, lossy_line_reader: bool) -> bool {
+    !lossy_line_reader || !has_replacement_character(value)
+}
+
+fn damaged_cross_session_dedup_key(namespace: &str, damaged_id: &str, raw_line: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(damaged_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(raw_line.as_bytes());
+    format!("{namespace}:damaged:{:x}", hasher.finalize())
+}
+
+fn damaged_session_placeholder(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .map_or_else(|| "unknown".to_string(), |stem| format!("unknown:{stem}"))
 }
 
 fn parse_pi_format_file_inner(
@@ -220,8 +303,7 @@ fn parse_pi_format_file_inner(
     client: &str,
     fallback_provider: &'static str,
     dedup_namespace: Option<&str>,
-    rlm_session_name_as_agent: bool,
-    cross_session_dedup: bool,
+    options: PiParseOptions,
     observer: &mut impl PiFormatObserver,
 ) -> Vec<UnifiedMessage> {
     let file = match std::fs::File::open(path) {
@@ -232,6 +314,11 @@ fn parse_pi_format_file_inner(
     let fallback_timestamp = file_modified_timestamp_ms(path);
 
     let reader = BufReader::new(file);
+    let lines = if options.lossy_line_reader {
+        PiLines::Lossy(lossy_lines(reader))
+    } else {
+        PiLines::Standard(reader.lines())
+    };
     let mut messages: Vec<UnifiedMessage> = Vec::with_capacity(64);
     let mut buffer = Vec::with_capacity(4096);
 
@@ -240,13 +327,9 @@ fn parse_pi_format_file_inner(
     let mut workspace_label: Option<String> = None;
     let mut agent: Option<String> = None;
     let mut is_rlm_subagent = false;
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
-
+    for line in lines {
         let trimmed = line.trim();
+        let raw_line = trimmed;
         if trimmed.is_empty() {
             continue;
         }
@@ -256,6 +339,11 @@ fn parse_pi_format_file_inner(
             buffer.extend_from_slice(trimmed.as_bytes());
             let entry_type = match simd_json::from_slice::<PiEntryTypeProbe>(&mut buffer) {
                 Ok(probe) => probe.entry_type,
+                Err(_)
+                    if options.lossy_line_reader && pre_header_line_is_skippable(trimmed, None) =>
+                {
+                    continue;
+                }
                 Err(_) => return Vec::new(),
             };
 
@@ -274,8 +362,18 @@ fn parse_pi_format_file_inner(
             };
 
             observer.observe_header(&header);
-            session_id = Some(header.id.clone());
-            workspace_key = header.cwd.as_deref().and_then(normalize_workspace_key);
+            let clean_cwd = header
+                .cwd
+                .as_deref()
+                .filter(|cwd| accepts_replacement_field(cwd, options.lossy_line_reader));
+            session_id = Some(
+                if !accepts_replacement_field(&header.id, options.lossy_line_reader) {
+                    damaged_session_placeholder(path)
+                } else {
+                    header.id.clone()
+                },
+            );
+            workspace_key = clean_cwd.and_then(normalize_workspace_key);
             workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
             is_rlm_subagent = header.rlm_depth.unwrap_or(0) > 0;
             continue;
@@ -289,14 +387,21 @@ fn parse_pi_format_file_inner(
         };
 
         if entry.entry_type == "session_info" {
-            agent = if rlm_session_name_as_agent && is_rlm_subagent {
+            agent = if options.rlm_session_name_as_agent && is_rlm_subagent {
                 entry
                     .name
                     .as_ref()
-                    .filter(|name| !name.trim().is_empty())
+                    .filter(|name| {
+                        !name.trim().is_empty()
+                            && accepts_replacement_field(name, options.lossy_line_reader)
+                    })
                     .cloned()
             } else {
-                entry.name.as_deref().and_then(pi_subagent_name)
+                entry
+                    .name
+                    .as_deref()
+                    .filter(|name| accepts_replacement_field(name, options.lossy_line_reader))
+                    .and_then(pi_subagent_name)
             };
             observer.observe_entry(&entry, None);
             continue;
@@ -322,9 +427,14 @@ fn parse_pi_format_file_inner(
             continue;
         };
 
-        let Some(model) = message.model.as_deref() else {
+        let Some(recorded_model) = message.model.as_deref() else {
             observer.observe_entry(&entry, None);
             continue;
+        };
+        let model = if !accepts_replacement_field(recorded_model, options.lossy_line_reader) {
+            "unknown"
+        } else {
+            recorded_model
         };
 
         // A missing/blank provider field is recoverable: infer it from the
@@ -333,7 +443,12 @@ fn parse_pi_format_file_inner(
         // identify the model, rather than dropping a message that carries
         // valid tokens.
         let provider = match message.provider.as_deref() {
-            Some(provider) if !provider.is_empty() => provider.to_string(),
+            Some(provider)
+                if !provider.is_empty()
+                    && accepts_replacement_field(provider, options.lossy_line_reader) =>
+            {
+                provider.to_string()
+            }
             _ => inferred_provider_from_model(model)
                 .unwrap_or(fallback_provider)
                 .to_string(),
@@ -368,30 +483,49 @@ fn parse_pi_format_file_inner(
             agent.clone(),
         );
         if let Some(namespace) = dedup_namespace {
-            if cross_session_dedup {
-                unified.dedup_key = message
+            if options.cross_session_dedup {
+                let clean_response_key = message
                     .response_id
                     .as_deref()
-                    .filter(|id| !id.trim().is_empty())
-                    .map(|id| format!("{namespace}:response:{id}"))
-                    .or_else(|| {
-                        entry
-                            .id
-                            .as_deref()
-                            .filter(|id| !id.trim().is_empty())
-                            .map(|id| {
-                                let stable_timestamp = recorded_timestamp
-                                    .map(|timestamp| timestamp.to_string())
-                                    .unwrap_or_else(|| "missing".to_string());
-                                format!(
-                                    "{namespace}:message:{id}:{stable_timestamp}:{provider}:{model}:{}:{}:{}:{}",
-                                    unified.tokens.input,
-                                    unified.tokens.output,
-                                    unified.tokens.cache_read,
-                                    unified.tokens.cache_write,
-                                )
+                    .filter(|id| {
+                        !id.trim().is_empty()
+                            && accepts_replacement_field(id, options.lossy_line_reader)
+                    })
+                    .map(|id| format!("{namespace}:response:{id}"));
+                let clean_message_key = entry.id.as_deref().filter(|id| {
+                    !id.trim().is_empty()
+                        && accepts_replacement_field(id, options.lossy_line_reader)
+                });
+                unified.dedup_key = clean_response_key.or_else(|| {
+                    clean_message_key.map(|id| {
+                        let stable_timestamp = recorded_timestamp
+                            .map(|timestamp| timestamp.to_string())
+                            .unwrap_or_else(|| "missing".to_string());
+                        format!(
+                            "{namespace}:message:{id}:{stable_timestamp}:{provider}:{model}:{}:{}:{}:{}",
+                            unified.tokens.input,
+                            unified.tokens.output,
+                            unified.tokens.cache_read,
+                            unified.tokens.cache_write,
+                        )
+                    })
+                });
+                if unified.dedup_key.is_none() && options.lossy_line_reader {
+                    if let Some(damaged_id) = entry
+                        .id
+                        .as_deref()
+                        .filter(|id| !accepts_replacement_field(id, options.lossy_line_reader))
+                        .or_else(|| {
+                            message.response_id.as_deref().filter(|id| {
+                                !accepts_replacement_field(id, options.lossy_line_reader)
                             })
-                    });
+                        })
+                    {
+                        unified.dedup_key = Some(damaged_cross_session_dedup_key(
+                            namespace, damaged_id, raw_line,
+                        ));
+                    }
+                }
             } else if let Some(message_id) = entry.id.as_deref().filter(|id| !id.trim().is_empty())
             {
                 let session_id = session_id.as_deref().unwrap_or("unknown");

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -84,7 +84,16 @@ fn damaged_key_may_name(key: &str, expected: &str) -> bool {
     matches[pattern.len()][expected.len()]
 }
 
-pub(crate) fn raw_json_has_damaged_top_level_key(raw: &[u8], expected: &str) -> bool {
+const PRIME_LINEAGE_HEADER_KEYS: &[&str] = &["parentSession", "rlmDepth"];
+
+/// Inspect every top-level JSON key after JSON string decoding and reject a
+/// replacement-bearing spelling that may be a damaged Prime lineage key.
+///
+/// Valid U+FFFD characters are not inherently damage: unrelated extension
+/// keys, including `rlmDepth�`, remain valid. Invalid UTF-8 is tracked
+/// separately because a replacement immediately beside a complete structural
+/// key may have replaced rather than extended that key.
+pub(crate) fn raw_json_has_damaged_lineage_header_key(raw: &[u8]) -> bool {
     let mut index = 0usize;
     let mut depth = 0usize;
     while index < raw.len() {
@@ -98,8 +107,8 @@ pub(crate) fn raw_json_has_damaged_top_level_key(raw: &[u8], expected: &str) -> 
                 index += 1;
             }
             b'"' => {
-                let key_start = index + 1;
-                index = key_start;
+                let quoted_start = index;
+                index += 1;
                 let mut escaped = false;
                 while index < raw.len() {
                     let byte = raw[index];
@@ -115,25 +124,27 @@ pub(crate) fn raw_json_has_damaged_top_level_key(raw: &[u8], expected: &str) -> 
                 if index >= raw.len() {
                     return false;
                 }
-                let key = &raw[key_start..index];
+
+                let quoted = &raw[quoted_start..=index];
+                let key_bytes = &raw[quoted_start + 1..index];
                 let mut after = index + 1;
                 while after < raw.len() && raw[after].is_ascii_whitespace() {
                     after += 1;
                 }
-                if depth == 1 && raw.get(after) == Some(&b':') && std::str::from_utf8(key).is_err()
-                {
-                    let lossy = String::from_utf8_lossy(key);
-                    let quoted = format!(r#""{lossy}""#);
-                    let Ok(decoded) = serde_json::from_str::<String>(&quoted) else {
-                        return false;
-                    };
-                    let without_replacements: String = decoded
-                        .chars()
-                        .filter(|character| *character != char::REPLACEMENT_CHARACTER)
-                        .collect();
-                    if without_replacements == expected || damaged_key_may_name(&decoded, expected)
-                    {
-                        return true;
+                if depth == 1 && raw.get(after) == Some(&b':') {
+                    let key_had_invalid_utf8 = std::str::from_utf8(key_bytes).is_err();
+                    let lossy_quoted = String::from_utf8_lossy(quoted);
+                    if let Ok(decoded) = serde_json::from_str::<String>(&lossy_quoted) {
+                        let without_replacements: String = decoded
+                            .chars()
+                            .filter(|character| *character != char::REPLACEMENT_CHARACTER)
+                            .collect();
+                        if PRIME_LINEAGE_HEADER_KEYS.iter().any(|expected| {
+                            damaged_key_may_name(&decoded, expected)
+                                || (key_had_invalid_utf8 && without_replacements == *expected)
+                        }) {
+                            return true;
+                        }
                     }
                 }
                 index += 1;
@@ -530,10 +541,9 @@ fn parse_pi_format_file_inner(
                 Ok(h) => h,
                 Err(_) => return Vec::new(),
             };
-            let has_raw_damaged_lineage_key = line.raw_bytes().is_some_and(|raw| {
-                raw_json_has_damaged_top_level_key(raw, "parentSession")
-                    || raw_json_has_damaged_top_level_key(raw, "rlmDepth")
-            });
+            let has_raw_damaged_lineage_key = line
+                .raw_bytes()
+                .is_some_and(raw_json_has_damaged_lineage_header_key);
             if options.lossy_line_reader
                 && (header.has_invalid_lineage() || has_raw_damaged_lineage_key)
             {

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -14,6 +14,7 @@ use crate::provider_identity::inferred_provider_from_model;
 use crate::TokenBreakdown;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
@@ -102,6 +103,16 @@ pub struct PiUsage {
     /// of the schema, but never summed: see the note at the emit site.
     #[allow(dead_code)]
     pub reasoning: Option<i64>,
+    #[serde(flatten)]
+    extra_fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl PiUsage {
+    pub(crate) fn has_damaged_key(&self) -> bool {
+        self.extra_fields
+            .keys()
+            .any(|key| has_replacement_character(key))
+    }
 }
 
 fn is_generated_id(value: &str) -> bool {
@@ -262,24 +273,40 @@ enum PiLines {
     Lossy(super::utils::LossyLinesWithBytes<BufReader<std::fs::File>>),
 }
 
+enum PiLine {
+    Standard(String),
+    Lossy(LossyLine),
+}
+
+impl PiLine {
+    fn text(&self) -> &str {
+        match self {
+            Self::Standard(text) => text,
+            Self::Lossy(line) => &line.text,
+        }
+    }
+
+    fn raw_bytes(&self) -> Option<&[u8]> {
+        match self {
+            Self::Standard(_) => None,
+            Self::Lossy(line) => Some(&line.bytes),
+        }
+    }
+}
+
 impl Iterator for PiLines {
-    type Item = LossyLine;
+    type Item = PiLine;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             match self {
                 Self::Standard(lines) => match lines.next() {
-                    Some(Ok(line)) => {
-                        return Some(LossyLine {
-                            bytes: line.as_bytes().to_vec(),
-                            text: line,
-                        });
-                    }
+                    Some(Ok(line)) => return Some(PiLine::Standard(line)),
                     Some(Err(error)) if error.kind() == std::io::ErrorKind::InvalidData => continue,
                     Some(Err(_)) => return None,
                     None => return None,
                 },
-                Self::Lossy(lines) => return lines.next(),
+                Self::Lossy(lines) => return lines.next().map(PiLine::Lossy),
             }
         }
     }
@@ -298,9 +325,10 @@ fn damaged_cross_session_dedup_key(namespace: &str, raw_line: &[u8]) -> String {
 }
 
 fn damaged_session_placeholder(path: &Path) -> String {
-    path.file_stem()
-        .and_then(|stem| stem.to_str())
-        .map_or_else(|| "unknown".to_string(), |stem| format!("unknown:{stem}"))
+    let source_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let mut hasher = Sha256::new();
+    hasher.update(source_path.as_os_str().as_encoded_bytes());
+    format!("unknown:path:{:x}", hasher.finalize())
 }
 
 fn parse_pi_format_file_inner(
@@ -333,7 +361,7 @@ fn parse_pi_format_file_inner(
     let mut agent: Option<String> = None;
     let mut is_rlm_subagent = false;
     for line in lines {
-        let trimmed = line.text.trim();
+        let trimmed = line.text().trim();
         if trimmed.is_empty() {
             continue;
         }
@@ -430,6 +458,10 @@ fn parse_pi_format_file_inner(
             observer.observe_entry(&entry, None);
             continue;
         };
+        if options.lossy_line_reader && usage.has_damaged_key() {
+            observer.observe_entry(&entry, None);
+            continue;
+        }
 
         let Some(recorded_model) = message.model.as_deref() else {
             observer.observe_entry(&entry, None);
@@ -521,8 +553,9 @@ fn parse_pi_format_file_inner(
                         !accepts_replacement_field(id, options.lossy_line_reader)
                     });
                     if has_damaged_id {
+                        let raw_line = line.raw_bytes().unwrap_or_else(|| line.text().as_bytes());
                         unified.dedup_key =
-                            Some(damaged_cross_session_dedup_key(namespace, &line.bytes));
+                            Some(damaged_cross_session_dedup_key(namespace, raw_line));
                     }
                 }
             } else if let Some(message_id) = entry.id.as_deref().filter(|id| !id.trim().is_empty())
@@ -550,6 +583,63 @@ mod tests {
         file.write_all(content.as_bytes()).unwrap();
         file.flush().unwrap();
         file
+    }
+
+    fn parse_prime_test_file(path: &Path) -> Vec<UnifiedMessage> {
+        let mut observer = NoopPiFormatObserver;
+        parse_pi_format_rlm_file_with_observer(path, "prime-agent", "prime-agent", &mut observer)
+    }
+
+    #[test]
+    fn prime_rejects_replacement_mangled_usage_keys() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"{\"type\":\"session\",\"id\":\"root\",\"cwd\":\"/tmp/project\"}\n")
+            .unwrap();
+        file.write_all(
+            b"{\"type\":\"message\",\"id\":\"damaged-byte\",\"timestamp\":\"2026-08-08T00:00:01Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"in\xffput\":100,\"output\":5}}}\n",
+        )
+        .unwrap();
+        file.write_all(
+            "{\"type\":\"message\",\"id\":\"damaged-unicode\",\"timestamp\":\"2026-08-08T00:00:02Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"out�put\":7,\"input\":10}}}\n"
+                .as_bytes(),
+        )
+        .unwrap();
+        file.write_all(
+            b"{\"type\":\"message\",\"id\":\"clean\",\"timestamp\":\"2026-08-08T00:00:03Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":20,\"output\":8}}}\n",
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_prime_test_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0]
+            .dedup_key
+            .as_deref()
+            .is_some_and(|key| key.starts_with("prime-agent:message:clean:")));
+        assert_eq!(messages[0].tokens.total(), 28);
+    }
+
+    #[test]
+    fn damaged_prime_session_placeholders_are_unique_by_source_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let first_dir = temp.path().join("first");
+        let second_dir = temp.path().join("second");
+        std::fs::create_dir_all(&first_dir).unwrap();
+        std::fs::create_dir_all(&second_dir).unwrap();
+        let first = first_dir.join("session.jsonl");
+        let second = second_dir.join("session.jsonl");
+        let contents = b"{\"type\":\"session\",\"id\":\"root-\xff\",\"cwd\":\"/tmp/project\"}\n{\"type\":\"message\",\"id\":\"clean\",\"timestamp\":\"2026-08-08T00:00:03Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":20,\"output\":8}}}\n";
+        std::fs::write(&first, contents).unwrap();
+        std::fs::write(&second, contents).unwrap();
+
+        let first_messages = parse_prime_test_file(&first);
+        let second_messages = parse_prime_test_file(&second);
+
+        assert_eq!(first_messages.len(), 1);
+        assert_eq!(second_messages.len(), 1);
+        assert!(first_messages[0].session_id.starts_with("unknown:path:"));
+        assert_ne!(first_messages[0].session_id, second_messages[0].session_id);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -32,15 +32,16 @@ pub struct PiSessionHeader {
     pub parent_session: Option<String>,
     #[serde(rename = "rlmDepth")]
     pub rlm_depth: Option<u32>,
-    #[serde(flatten)]
-    extra_fields: BTreeMap<String, serde_json::Value>,
 }
 
 impl PiSessionHeader {
-    pub(crate) fn has_damaged_lineage_key(&self) -> bool {
-        self.extra_fields.keys().any(|key| {
-            damaged_key_may_name(key, "parentSession") || damaged_key_may_name(key, "rlmDepth")
-        })
+    pub(crate) fn has_invalid_lineage(&self) -> bool {
+        let is_rlm_child = self.rlm_depth.unwrap_or(0) > 0;
+        is_rlm_child
+            && self
+                .parent_session
+                .as_deref()
+                .is_none_or(|parent| parent.trim().is_empty() || has_replacement_character(parent))
     }
 }
 
@@ -59,10 +60,18 @@ fn damaged_key_may_name(key: &str, expected: &str) -> bool {
                 continue;
             }
             if pattern[pattern_index] == char::REPLACEMENT_CHARACTER {
-                for matched in matches[pattern_index + 1]
-                    .iter_mut()
-                    .skip(expected_index + 1)
-                {
+                // A replacement in the middle may represent either damaged
+                // bytes that replaced key characters or an undecodable byte
+                // inserted between otherwise intact characters. At an edge it
+                // must consume at least one expected character, so complete
+                // known keys with a damaged extension prefix/suffix are not
+                // mistaken for the known key itself.
+                let minimum = if pattern_index > 0 && pattern_index + 1 < pattern.len() {
+                    expected_index
+                } else {
+                    expected_index + 1
+                };
+                for matched in matches[pattern_index + 1].iter_mut().skip(minimum) {
                     *matched = true;
                 }
             } else if expected_index < expected.len()
@@ -73,6 +82,66 @@ fn damaged_key_may_name(key: &str, expected: &str) -> bool {
         }
     }
     matches[pattern.len()][expected.len()]
+}
+
+pub(crate) fn raw_json_has_damaged_top_level_key(raw: &[u8], expected: &str) -> bool {
+    let mut index = 0usize;
+    let mut depth = 0usize;
+    while index < raw.len() {
+        match raw[index] {
+            b'{' | b'[' => {
+                depth += 1;
+                index += 1;
+            }
+            b'}' | b']' => {
+                depth = depth.saturating_sub(1);
+                index += 1;
+            }
+            b'"' => {
+                let key_start = index + 1;
+                index = key_start;
+                let mut escaped = false;
+                while index < raw.len() {
+                    let byte = raw[index];
+                    if escaped {
+                        escaped = false;
+                    } else if byte == b'\\' {
+                        escaped = true;
+                    } else if byte == b'"' {
+                        break;
+                    }
+                    index += 1;
+                }
+                if index >= raw.len() {
+                    return false;
+                }
+                let key = &raw[key_start..index];
+                let mut after = index + 1;
+                while after < raw.len() && raw[after].is_ascii_whitespace() {
+                    after += 1;
+                }
+                if depth == 1 && raw.get(after) == Some(&b':') && std::str::from_utf8(key).is_err()
+                {
+                    let lossy = String::from_utf8_lossy(key);
+                    let quoted = format!(r#""{lossy}""#);
+                    let Ok(decoded) = serde_json::from_str::<String>(&quoted) else {
+                        return false;
+                    };
+                    let without_replacements: String = decoded
+                        .chars()
+                        .filter(|character| *character != char::REPLACEMENT_CHARACTER)
+                        .collect();
+                    if without_replacements == expected || damaged_key_may_name(&decoded, expected)
+                    {
+                        return true;
+                    }
+                }
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+    false
 }
 
 /// Loose type-only probe for a JSONL line, used to identify pre-session
@@ -119,6 +188,21 @@ pub struct PiSessionEntry {
     pub child_usage: Option<PiUsage>,
     #[serde(rename = "aggregateUsage")]
     pub aggregate_usage: Option<PiUsage>,
+    #[serde(flatten)]
+    #[allow(dead_code)]
+    extra_fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl PiSessionEntry {
+    fn has_damaged_timestamp(&self) -> bool {
+        self.timestamp
+            .as_deref()
+            .is_some_and(has_replacement_character)
+            || self
+                .extra_fields
+                .keys()
+                .any(|key| damaged_key_may_name(key, "timestamp"))
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -150,9 +234,20 @@ pub struct PiUsage {
 
 impl PiUsage {
     pub(crate) fn has_damaged_key(&self) -> bool {
-        self.extra_fields
-            .keys()
-            .any(|key| has_replacement_character(key))
+        const TOKEN_COUNTER_KEYS: &[&str] = &[
+            "input",
+            "output",
+            "cacheRead",
+            "cacheWrite",
+            "totalTokens",
+            "reasoning",
+        ];
+
+        self.extra_fields.keys().any(|key| {
+            TOKEN_COUNTER_KEYS
+                .iter()
+                .any(|expected| damaged_key_may_name(key, expected))
+        })
     }
 }
 
@@ -343,8 +438,10 @@ impl Iterator for PiLines {
             match self {
                 Self::Standard(lines) => match lines.next() {
                     Some(Ok(line)) => return Some(PiLine::Standard(line)),
-                    Some(Err(error)) if error.kind() == std::io::ErrorKind::InvalidData => continue,
-                    Some(Err(_)) => return None,
+                    // `reader.lines()` historically skipped all unreadable
+                    // records and continued. In particular, an invalid-UTF-8
+                    // line must not truncate valid records that follow it.
+                    Some(Err(_)) => continue,
                     None => return None,
                 },
                 Self::Lossy(lines) => return lines.next().map(PiLine::Lossy),
@@ -433,7 +530,13 @@ fn parse_pi_format_file_inner(
                 Ok(h) => h,
                 Err(_) => return Vec::new(),
             };
-            if options.lossy_line_reader && header.has_damaged_lineage_key() {
+            let has_raw_damaged_lineage_key = line.raw_bytes().is_some_and(|raw| {
+                raw_json_has_damaged_top_level_key(raw, "parentSession")
+                    || raw_json_has_damaged_top_level_key(raw, "rlmDepth")
+            });
+            if options.lossy_line_reader
+                && (header.has_invalid_lineage() || has_raw_damaged_lineage_key)
+            {
                 return Vec::new();
             }
 
@@ -494,6 +597,23 @@ fn parse_pi_format_file_inner(
         };
 
         if message.role.as_deref() != Some("assistant") {
+            observer.observe_entry(&entry, None);
+            continue;
+        }
+
+        // An RLM child's completion timestamp participates in matching its
+        // usage back to the parent attribution. Recovering a replacement-
+        // damaged value as "missing" would make that match impossible while
+        // still emitting the child, so the parent's aggregate and child would
+        // both be counted. Other Pi messages do not use this timestamp as a
+        // reconciliation join and remain recoverable.
+        if options.lossy_line_reader
+            && is_rlm_subagent
+            && (entry.has_damaged_timestamp()
+                || entry.timestamp.as_deref().is_some_and(|timestamp| {
+                    chrono::DateTime::parse_from_rfc3339(timestamp).is_err()
+                }))
+        {
             observer.observe_entry(&entry, None);
             continue;
         }
@@ -661,6 +781,89 @@ mod tests {
             .as_deref()
             .is_some_and(|key| key.starts_with("prime-agent:message:clean:")));
         assert_eq!(messages[0].tokens.total(), 28);
+    }
+
+    #[test]
+    fn damaged_usage_extension_keys_do_not_hide_known_counters() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"{\"type\":\"session\",\"id\":\"root\"}\n")
+            .unwrap();
+        file.write_all(
+            b"{\"type\":\"message\",\"id\":\"kept\",\"timestamp\":\"2026-08-08T00:00:01Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":20,\"output\":8,\"future-\xff-field\":999}}}\n",
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_prime_test_file(file.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.total(), 28);
+    }
+
+    #[test]
+    fn standard_pi_skips_invalid_utf8_line_and_reads_later_records() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"{\"type\":\"session\",\"id\":\"root\"}\n")
+            .unwrap();
+        file.write_all(b"invalid \xff record\n").unwrap();
+        file.write_all(
+            b"{\"type\":\"message\",\"id\":\"later\",\"timestamp\":\"2026-08-08T00:00:01Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":20,\"output\":8}}}\n",
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_pi_file(file.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.total(), 28);
+    }
+
+    #[test]
+    fn prime_rejects_only_matching_critical_child_timestamps() {
+        for (depth, expected_ids) in [(1, vec!["clean"]), (0, vec!["damaged", "clean"])] {
+            let mut file = NamedTempFile::new().unwrap();
+            writeln!(
+                file,
+                "{{\"type\":\"session\",\"id\":\"root\",\"parentSession\":\"/tmp/parent.jsonl\",\"rlmDepth\":{depth}}}"
+            )
+            .unwrap();
+            file.write_all(
+                b"{\"type\":\"message\",\"id\":\"damaged\",\"timestamp\":\"2026-08-08T00:00:0\xffZ\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":10}}}\n",
+            ).unwrap();
+            file.write_all(b"{\"type\":\"message\",\"id\":\"clean\",\"timestamp\":\"2026-08-08T00:00:02Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":20}}}\n").unwrap();
+            file.flush().unwrap();
+
+            let messages = parse_prime_test_file(file.path());
+            let ids = messages
+                .iter()
+                .map(|message| {
+                    message
+                        .dedup_key
+                        .as_deref()
+                        .unwrap()
+                        .split(':')
+                        .nth(2)
+                        .unwrap()
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(ids, expected_ids, "rlmDepth={depth}");
+        }
+    }
+
+    #[test]
+    fn prime_rejects_child_message_with_damaged_timestamp_key() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"{\"type\":\"session\",\"id\":\"child\",\"parentSession\":\"/tmp/parent.jsonl\",\"rlmDepth\":1}\n")
+            .unwrap();
+        file.write_all(b"{\"type\":\"message\",\"id\":\"damaged\",\"time\xffstamp\":\"2026-08-08T00:00:01Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":10}}}\n").unwrap();
+        file.write_all(b"{\"type\":\"message\",\"id\":\"clean\",\"timestamp\":\"2026-08-08T00:00:02Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":20}}}\n").unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_prime_test_file(file.path());
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0]
+            .dedup_key
+            .as_deref()
+            .unwrap()
+            .contains(":clean:"));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -10,7 +10,7 @@
 
 use super::pi::{
     has_replacement_character, parse_pi_format_rlm_file_with_observer,
-    pre_header_line_is_skippable, raw_json_has_damaged_top_level_key, PiFormatObserver,
+    pre_header_line_is_skippable, raw_json_has_damaged_lineage_header_key, PiFormatObserver,
     PiSessionEntry, PiSessionHeader, PiUsage, PRE_SESSION_METADATA_TYPES,
 };
 use super::utils::{lossy_lines_with_bytes, parse_timestamp_str};
@@ -469,8 +469,7 @@ pub(crate) fn analyze_prime_agent_accounting(
             if let Some(header) = parse_pi_json_line::<PiSessionHeader>(trimmed, &mut buffer) {
                 if header.entry_type == "session" {
                     let has_raw_damaged_lineage_key =
-                        raw_json_has_damaged_top_level_key(&line.bytes, "parentSession")
-                            || raw_json_has_damaged_top_level_key(&line.bytes, "rlmDepth");
+                        raw_json_has_damaged_lineage_header_key(&line.bytes);
                     if header.has_invalid_lineage() || has_raw_damaged_lineage_key {
                         return PrimeFileAccounting::default();
                     }
@@ -1225,6 +1224,39 @@ mod tests {
 {"type":"message","id":"assistant","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","usage":{"input":10,"output":5}}}"#,
         );
         assert_eq!(parse_prime_agent_file(file.path()).len(), 1);
+
+        for (encoded_key, rejected) in [
+            (r"rlmDep\uFFFDth", true),
+            (r#"unrelated\uD800":1,"rlmDep\uFFFDth"#, true),
+            (r"parentSess\uFFFDon", true),
+            (r"extension\uFFFDField", false),
+            (r#"unrelated\uD800":1,"extension\uFFFDField"#, false),
+            (r"rlmDepth\uFFFD", false),
+            (r"\uFFFDparentSession", false),
+            (r"parentSession\uFFFD", false),
+        ] {
+            let file = session_file(&format!(
+                "{{\"type\":\"session\",\"version\":3,\"id\":\"child\",\"cwd\":\"/tmp/project\",\"parentSession\":\"/tmp/parent.jsonl\",\"rlmDepth\":1,\"{encoded_key}\":1}}\n{{\"type\":\"message\",\"id\":\"assistant\",\"message\":{{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{{\"input\":10,\"output\":5}}}}}}"
+            ));
+            let (messages, accounting) = parse_prime_agent_file_with_accounting(file.path());
+            assert_eq!(messages.is_empty(), rejected, "escaped key {encoded_key:?}");
+            assert_eq!(
+                accounting.child_parent_path.is_none(),
+                rejected,
+                "the shared parser and accounting analyzer must agree for {encoded_key:?}"
+            );
+        }
+        for damaged_key in ["rlmDep�th", "parentSess�on"] {
+            let file = session_file(&format!(
+                "{{\"type\":\"session\",\"version\":3,\"id\":\"child\",\"cwd\":\"/tmp/project\",\"parentSession\":\"/tmp/parent.jsonl\",\"rlmDepth\":1,\"{damaged_key}\":1}}\n{{\"type\":\"message\",\"id\":\"assistant\",\"message\":{{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{{\"input\":10,\"output\":5}}}}}}"
+            ));
+            let (messages, accounting) = parse_prime_agent_file_with_accounting(file.path());
+            assert!(messages.is_empty(), "literal damaged key {damaged_key:?}");
+            assert!(
+                accounting.child_parent_path.is_none(),
+                "literal damaged key {damaged_key:?}"
+            );
+        }
 
         for extension_key in ["rlmDepth�", "�parentSession", "parentSession�"] {
             let file = session_file(&format!(

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -10,10 +10,10 @@
 
 use super::pi::{
     has_replacement_character, parse_pi_format_rlm_file_with_observer,
-    pre_header_line_is_skippable, PiFormatObserver, PiSessionEntry, PiSessionHeader, PiUsage,
-    PRE_SESSION_METADATA_TYPES,
+    pre_header_line_is_skippable, raw_json_has_damaged_top_level_key, PiFormatObserver,
+    PiSessionEntry, PiSessionHeader, PiUsage, PRE_SESSION_METADATA_TYPES,
 };
-use super::utils::{lossy_lines, parse_timestamp_str};
+use super::utils::{lossy_lines_with_bytes, parse_timestamp_str};
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -460,15 +460,18 @@ pub(crate) fn analyze_prime_agent_accounting(
     let mut found_header = false;
     let mut message_index = 0usize;
     let mut buffer = Vec::with_capacity(4096);
-    for line in lossy_lines(BufReader::new(file)) {
-        let trimmed = line.trim();
+    for line in lossy_lines_with_bytes(BufReader::new(file)) {
+        let trimmed = line.text.trim();
         if trimmed.is_empty() {
             continue;
         }
         if !found_header {
             if let Some(header) = parse_pi_json_line::<PiSessionHeader>(trimmed, &mut buffer) {
                 if header.entry_type == "session" {
-                    if header.has_damaged_lineage_key() {
+                    let has_raw_damaged_lineage_key =
+                        raw_json_has_damaged_top_level_key(&line.bytes, "parentSession")
+                            || raw_json_has_damaged_top_level_key(&line.bytes, "rlmDepth");
+                    if header.has_invalid_lineage() || has_raw_damaged_lineage_key {
                         return PrimeFileAccounting::default();
                     }
                     found_header = true;
@@ -1179,11 +1182,15 @@ mod tests {
             (b"".as_slice(), b"arentSession".as_slice(), true),
             // These can only be damaged extension keys adjacent to, rather
             // than damaged spellings of, the complete structural key.
-            (b"parentSession".as_slice(), b"".as_slice(), false),
-            (b"".as_slice(), b"parentSession".as_slice(), false),
+            // Raw-byte identity distinguishes invalid UTF-8 damage from a
+            // clean literal replacement-bearing extension name.
+            (b"parentSession".as_slice(), b"".as_slice(), true),
+            (b"".as_slice(), b"parentSession".as_slice(), true),
             (b"parentSession".as_slice(), b"Extra".as_slice(), false),
             (b"xparentSess".as_slice(), b"on".as_slice(), false),
-            (b"rlmDepth".as_slice(), b"".as_slice(), false),
+            (b"rlmDepth".as_slice(), b"".as_slice(), true),
+            (br"rlmDepth".as_slice(), b"".as_slice(), true),
+            (br"parentSession".as_slice(), b"".as_slice(), true),
             (b"extension".as_slice(), b"Field".as_slice(), false),
         ] {
             let mut file = NamedTempFile::new().unwrap();
@@ -1218,6 +1225,17 @@ mod tests {
 {"type":"message","id":"assistant","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","usage":{"input":10,"output":5}}}"#,
         );
         assert_eq!(parse_prime_agent_file(file.path()).len(), 1);
+
+        for extension_key in ["rlmDepth�", "�parentSession", "parentSession�"] {
+            let file = session_file(&format!(
+                "{{\"type\":\"session\",\"version\":3,\"id\":\"root\",\"cwd\":\"/tmp/project\",\"{extension_key}\":1}}\n{{\"type\":\"message\",\"id\":\"assistant\",\"message\":{{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{{\"input\":10,\"output\":5}}}}}}"
+            ));
+            assert_eq!(
+                parse_prime_agent_file(file.path()).len(),
+                1,
+                "valid UTF-8 extension key {extension_key:?}"
+            );
+        }
     }
 
     #[test]
@@ -1368,7 +1386,19 @@ mod tests {
     }
 
     #[test]
-    fn ignores_mangled_parent_session_join_key() {
+    fn rejects_rlm_child_without_usable_parent_session() {
+        for parent_field in ["", ",\"parentSession\":\"\""] {
+            let file = session_file(&format!(
+                "{{\"type\":\"session\",\"id\":\"child\",\"rlmDepth\":1{parent_field}}}\n{{\"type\":\"message\",\"id\":\"assistant\",\"timestamp\":\"2026-08-08T00:00:01Z\",\"message\":{{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{{\"input\":10}}}}}}"
+            ));
+            let (messages, accounting) = parse_prime_agent_file_with_accounting(file.path());
+            assert!(messages.is_empty(), "parent field {parent_field:?}");
+            assert!(accounting.child_message_usages.is_empty());
+        }
+    }
+
+    #[test]
+    fn rejects_mangled_parent_session_value() {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(
             b"{\"type\":\"session\",\"version\":3,\"id\":\"child\",\"cwd\":\"/tmp/project\",\"parentSession\":\"/tmp/parent-\xff.jsonl\",\"rlmDepth\":1}\n",
@@ -1384,15 +1414,16 @@ mod tests {
         let messages = parse_prime_agent_file(file.path());
         let accounting = analyze_prime_agent_accounting(file.path(), &messages);
 
-        assert_eq!(messages.len(), 1);
+        assert!(messages.is_empty());
         assert!(accounting.child_parent_path.is_none());
+        assert!(accounting.child_message_usages.is_empty());
     }
 
     #[test]
     fn sanitizes_replacement_mangled_model_and_provider() {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(
-            b"{\"type\":\"session\",\"version\":3,\"id\":\"root\",\"cwd\":\"/tmp/\xff/project\",\"rlmDepth\":1}\n",
+            b"{\"type\":\"session\",\"version\":3,\"id\":\"root\",\"cwd\":\"/tmp/\xff/project\",\"rlmDepth\":0}\n",
         )
         .unwrap();
         file.write_all(b"{\"type\":\"session_info\",\"name\":\"agent-\xff\"}\n")

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -468,6 +468,9 @@ pub(crate) fn analyze_prime_agent_accounting(
         if !found_header {
             if let Some(header) = parse_pi_json_line::<PiSessionHeader>(trimmed, &mut buffer) {
                 if header.entry_type == "session" {
+                    if header.has_damaged_lineage_key() {
+                        return PrimeFileAccounting::default();
+                    }
                     found_header = true;
                     accounting.observe_header(&header);
                     continue;
@@ -500,7 +503,10 @@ pub(crate) fn analyze_prime_agent_accounting(
             .filter(|message| {
                 entry.entry_type == "message"
                     && message.role.as_deref() == Some("assistant")
-                    && message.usage.is_some()
+                    && message
+                        .usage
+                        .as_ref()
+                        .is_some_and(|usage| !usage.has_damaged_key())
                     && message.model.is_some()
             })
             .and_then(|_| {
@@ -1162,6 +1168,85 @@ mod tests {
             "prime-agent:response:response-2"
         );
         assert_eq!(accounting.adjustments[0].attributions[0].id, "usage-2");
+    }
+
+    #[test]
+    fn rejects_only_headers_with_damaged_lineage_keys() {
+        for (prefix, suffix, rejected) in [
+            // A replacement consumes at least one byte of a real lineage key.
+            (b"parentSess".as_slice(), b"on".as_slice(), true),
+            (b"rlmDep".as_slice(), b"h".as_slice(), true),
+            (b"".as_slice(), b"arentSession".as_slice(), true),
+            // These can only be damaged extension keys adjacent to, rather
+            // than damaged spellings of, the complete structural key.
+            (b"parentSession".as_slice(), b"".as_slice(), false),
+            (b"".as_slice(), b"parentSession".as_slice(), false),
+            (b"parentSession".as_slice(), b"Extra".as_slice(), false),
+            (b"xparentSess".as_slice(), b"on".as_slice(), false),
+            (b"rlmDepth".as_slice(), b"".as_slice(), false),
+            (b"extension".as_slice(), b"Field".as_slice(), false),
+        ] {
+            let mut file = NamedTempFile::new().unwrap();
+            file.write_all(
+                b"{\"type\":\"session\",\"version\":3,\"id\":\"child\",\"cwd\":\"/tmp/project\",\"",
+            )
+            .unwrap();
+            file.write_all(prefix).unwrap();
+            file.write_all(b"\xff").unwrap();
+            file.write_all(suffix).unwrap();
+            file.write_all(b"\":1}\n").unwrap();
+            file.write_all(
+                br#"{"type":"message","id":"assistant","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","usage":{"input":10,"output":5}}}
+"#,
+            )
+            .unwrap();
+            file.flush().unwrap();
+
+            let (messages, accounting) = parse_prime_agent_file_with_accounting(file.path());
+
+            assert_eq!(messages.is_empty(), rejected);
+            if rejected {
+                assert!(accounting.attributions.is_empty());
+                assert!(accounting.adjustments.is_empty());
+                assert!(accounting.child_parent_path.is_none());
+                assert!(accounting.fork_parent_path.is_none());
+            }
+        }
+
+        let file = session_file(
+            r#"{"type":"session","version":3,"id":"root","cwd":"/tmp/project","extensionField":1}
+{"type":"message","id":"assistant","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","usage":{"input":10,"output":5}}}"#,
+        );
+        assert_eq!(parse_prime_agent_file(file.path()).len(), 1);
+    }
+
+    #[test]
+    fn damaged_message_usage_does_not_advance_accounting_alignment() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(
+            r#"{"type":"session","version":3,"id":"root","cwd":"/tmp/project"}
+{"type":"message","id":"assistant-damaged","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"response-damaged","usage":{"in�put":999,"output":1}}}
+{"type":"message","id":"assistant-valid","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"response-valid","usage":{"input":20,"output":8}}}
+{"type":"child_usage_attributed","id":"usage-valid","targetId":"assistant-valid","childUsage":{"input":3,"output":2},"aggregateUsage":{"input":20,"output":8}}
+"#.as_bytes(),
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_prime_agent_file(file.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("prime-agent:response:response-valid")
+        );
+
+        let accounting = analyze_prime_agent_accounting(file.path(), &messages);
+        assert_eq!(accounting.adjustments.len(), 1);
+        assert_eq!(
+            accounting.adjustments[0].dedup_key,
+            "prime-agent:response:response-valid"
+        );
+        assert_eq!(accounting.adjustments[0].attributions[0].id, "usage-valid");
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -236,7 +236,11 @@ impl PiFormatObserver for PrimeAccountingBuilder<'_> {
                 entry.child_usage.as_ref(),
                 entry.aggregate_usage.as_ref(),
             ) {
-                if has_replacement_character(id) || has_replacement_character(target_id) {
+                if has_replacement_character(id)
+                    || has_replacement_character(target_id)
+                    || child_usage.has_damaged_key()
+                    || aggregate_usage.has_damaged_key()
+                {
                     return;
                 }
                 self.attributions
@@ -1217,6 +1221,63 @@ mod tests {
             messages[0].dedup_key.as_deref(),
             Some("prime-agent:response:response-clean")
         );
+        assert!(accounting.attributions.is_empty());
+        assert!(accounting.adjustments.is_empty());
+    }
+
+    #[test]
+    fn skips_attributions_with_damaged_nested_usage_keys() {
+        for damaged_key in ["out�put", "cache�Read"] {
+            let mut file = NamedTempFile::new().unwrap();
+            file.write_all(
+                br#"{"type":"session","version":3,"id":"root","cwd":"/tmp/project"}
+"#,
+            )
+            .unwrap();
+            file.write_all(
+                br#"{"type":"message","id":"assistant-clean","timestamp":"2026-08-08T00:00:01Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"response-clean","usage":{"input":100,"output":8}}}
+"#,
+            )
+            .unwrap();
+            writeln!(
+                file,
+                "{{\"type\":\"child_usage_attributed\",\"id\":\"usage-clean\",\"targetId\":\"assistant-clean\",\"childUsage\":{{\"input\":50,\"{damaged_key}\":999}},\"aggregateUsage\":{{\"input\":100,\"output\":8}}}}"
+            )
+            .unwrap();
+            file.flush().unwrap();
+
+            let messages = parse_prime_agent_file(file.path());
+            let accounting = analyze_prime_agent_accounting(file.path(), &messages);
+
+            assert_eq!(messages.len(), 1);
+            assert!(accounting.attributions.is_empty());
+            assert!(accounting.adjustments.is_empty());
+        }
+    }
+
+    #[test]
+    fn skips_attributions_with_invalid_bytes_in_nested_usage_keys() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(
+            br#"{"type":"session","version":3,"id":"root","cwd":"/tmp/project"}
+{"type":"message","id":"assistant-clean","timestamp":"2026-08-08T00:00:01Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"response-clean","usage":{"input":100,"output":8}}}
+"#,
+        )
+        .unwrap();
+        file.write_all(
+            b"{\"type\":\"child_usage_attributed\",\"id\":\"usage-child\",\"targetId\":\"assistant-clean\",\"childUsage\":{\"input\":50,\"out\xffput\":999},\"aggregateUsage\":{\"input\":100,\"output\":8}}\n",
+        )
+        .unwrap();
+        file.write_all(
+            b"{\"type\":\"child_usage_attributed\",\"id\":\"usage-aggregate\",\"targetId\":\"assistant-clean\",\"childUsage\":{\"input\":50,\"output\":0},\"aggregateUsage\":{\"in\xfeput\":100,\"output\":8}}\n",
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_prime_agent_file(file.path());
+        let accounting = analyze_prime_agent_accounting(file.path(), &messages);
+
+        assert_eq!(messages.len(), 1);
         assert!(accounting.attributions.is_empty());
         assert!(accounting.adjustments.is_empty());
     }

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -1565,6 +1565,46 @@ mod tests {
     }
 
     #[test]
+    fn distinct_invalid_utf8_ids_keep_distinct_dedup_keys() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(
+            br#"{"type":"session","version":3,"id":"root","cwd":"/tmp/project"}
+"#,
+        )
+        .unwrap();
+        file.write_all(
+            b"{\"type\":\"message\",\"id\":\"assistant-\xff\",\"timestamp\":\"2026-08-08T00:00:01Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":10,\"output\":5}}}\n",
+        )
+        .unwrap();
+        file.write_all(
+            b"{\"type\":\"message\",\"id\":\"assistant-\xfe\",\"timestamp\":\"2026-08-08T00:00:01Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":10,\"output\":5}}}\n",
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_prime_agent_file(file.path());
+        assert_eq!(messages.len(), 2);
+        assert_ne!(messages[0].dedup_key, messages[1].dedup_key);
+
+        let reconciled = reconcile_prime_agent_messages(messages, &[]);
+        assert_eq!(reconciled.len(), 2);
+        assert_eq!(
+            reconciled
+                .iter()
+                .map(|message| message.tokens.input)
+                .sum::<i64>(),
+            20
+        );
+        assert_eq!(
+            reconciled
+                .iter()
+                .map(|message| message.tokens.output)
+                .sum::<i64>(),
+            10
+        );
+    }
+
+    #[test]
     fn copied_fork_history_without_response_or_event_timestamp_still_deduplicates() {
         let original = session_file(
             r#"{"type":"session","version":3,"id":"root-1","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -9,15 +9,16 @@
 //! serializing a fork, before the copied parent is deduplicated across files.
 
 use super::pi::{
-    parse_pi_format_rlm_file_with_observer, PiFormatObserver, PiSessionEntry, PiSessionHeader,
-    PiUsage,
+    has_replacement_character, parse_pi_format_rlm_file_with_observer,
+    pre_header_line_is_skippable, PiFormatObserver, PiSessionEntry, PiSessionHeader, PiUsage,
+    PRE_SESSION_METADATA_TYPES,
 };
-use super::utils::parse_timestamp_str;
+use super::utils::{lossy_lines, parse_timestamp_str};
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::io::{BufRead, BufReader};
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 #[cfg(test)]
@@ -216,6 +217,7 @@ impl PiFormatObserver for PrimeAccountingBuilder<'_> {
         let parent_path = header
             .parent_session
             .as_deref()
+            .filter(|parent| !has_replacement_character(parent))
             .map(Path::new)
             .map(|parent| referenced_lineage_path(self.path, parent));
         if self.is_rlm_child {
@@ -234,6 +236,9 @@ impl PiFormatObserver for PrimeAccountingBuilder<'_> {
                 entry.child_usage.as_ref(),
                 entry.aggregate_usage.as_ref(),
             ) {
+                if has_replacement_character(id) || has_replacement_character(target_id) {
+                    return;
+                }
                 self.attributions
                     .entry(target_id.clone())
                     .or_default()
@@ -257,8 +262,10 @@ impl PiFormatObserver for PrimeAccountingBuilder<'_> {
             });
         }
         if let (Some(id), Some(dedup_key)) = (entry.id.as_ref(), parsed.dedup_key.as_ref()) {
-            self.targets
-                .insert(id.clone(), (dedup_key.clone(), parsed.tokens.clone()));
+            if !has_replacement_character(id) {
+                self.targets
+                    .insert(id.clone(), (dedup_key.clone(), parsed.tokens.clone()));
+            }
         }
     }
 }
@@ -425,6 +432,12 @@ fn referenced_lineage_path(source_file: &Path, referenced: &Path) -> PathBuf {
     }
 }
 
+fn parse_pi_json_line<T: DeserializeOwned>(line: &str, buffer: &mut Vec<u8>) -> Option<T> {
+    buffer.clear();
+    buffer.extend_from_slice(line.as_bytes());
+    simd_json::from_slice(buffer).ok()
+}
+
 /// Read Prime-only accounting records that are intentionally absent from the
 /// shared Pi message representation. `messages` may come from the source cache;
 /// their stable order is used to associate target entry ids with emitted rows.
@@ -442,35 +455,39 @@ pub(crate) fn analyze_prime_agent_accounting(
     let mut accounting = PrimeAccountingBuilder::new(path);
     let mut found_header = false;
     let mut message_index = 0usize;
-    for line in BufReader::new(file).lines().map_while(Result::ok) {
+    let mut buffer = Vec::with_capacity(4096);
+    for line in lossy_lines(BufReader::new(file)) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
         }
         if !found_header {
-            if let Ok(header) = serde_json::from_str::<PiSessionHeader>(trimmed) {
+            if let Some(header) = parse_pi_json_line::<PiSessionHeader>(trimmed, &mut buffer) {
                 if header.entry_type == "session" {
                     found_header = true;
                     accounting.observe_header(&header);
                     continue;
                 }
             }
-            let is_pre_session_title = serde_json::from_str::<serde_json::Value>(trimmed)
-                .ok()
+            let parsed_type = parse_pi_json_line::<serde_json::Value>(trimmed, &mut buffer)
                 .and_then(|value| {
                     value
                         .get("type")
                         .and_then(|kind| kind.as_str())
                         .map(str::to_owned)
-                })
-                .is_some_and(|kind| kind == "title");
-            if is_pre_session_title {
+                });
+            let is_pre_session_metadata = parsed_type
+                .as_deref()
+                .is_some_and(|kind| PRE_SESSION_METADATA_TYPES.contains(&kind));
+            if is_pre_session_metadata
+                || pre_header_line_is_skippable(trimmed, parsed_type.as_deref())
+            {
                 continue;
             }
             return PrimeFileAccounting::default();
         }
 
-        let Ok(entry) = serde_json::from_str::<PiSessionEntry>(trimmed) else {
+        let Some(entry) = parse_pi_json_line::<PiSessionEntry>(trimmed, &mut buffer) else {
             continue;
         };
         let emitted = entry
@@ -1085,6 +1102,171 @@ mod tests {
     }
 
     #[test]
+    fn accepts_bom_crlf_and_later_records_after_invalid_utf8() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(
+            b"\xef\xbb\xbf{\"type\":\"session\",\"version\":3,\"id\":\"root\",\"cwd\":\"/tmp/project\"}\r\n",
+        )
+        .unwrap();
+        file.write_all(b"invalid \xff record\r\n").unwrap();
+        file.write_all(
+            br#"{"type":"message","id":"assistant","timestamp":"2026-08-08T00:00:01Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","usage":{"input":100,"output":50,"cacheRead":20,"cacheWrite":10}}}"#,
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_prime_agent_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "root");
+        assert_eq!(messages[0].tokens.total(), 180);
+    }
+
+    #[test]
+    fn lossy_records_before_header_and_between_messages_preserve_accounting_alignment() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"garbage \xff before header\r\n").unwrap();
+        file.write_all(
+            br#"{"type":"session","version":3,"id":"root","cwd":"/tmp/project"}
+"#,
+        )
+        .unwrap();
+        file.write_all(
+            br#"{"type":"message","id":"assistant-1","timestamp":"2026-08-08T00:00:01Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"response-1","usage":{"input":10,"output":5}}}
+"#,
+        )
+        .unwrap();
+        file.write_all(b"damaged \xff record\r\n").unwrap();
+        file.write_all(
+            br#"{"type":"message","id":"assistant-2","timestamp":"2026-08-08T00:00:03Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"response-2","usage":{"input":20,"output":8}}}
+"#,
+        )
+        .unwrap();
+        file.write_all(
+            br#"{"type":"child_usage_attributed","id":"usage-2","targetId":"assistant-2","childUsage":{"input":3,"output":2},"aggregateUsage":{"input":20,"output":8}}"#,
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_prime_agent_file(file.path());
+        let accounting = analyze_prime_agent_accounting(file.path(), &messages);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(accounting.adjustments.len(), 1);
+        assert_eq!(
+            accounting.adjustments[0].dedup_key,
+            "prime-agent:response:response-2"
+        );
+        assert_eq!(accounting.adjustments[0].attributions[0].id, "usage-2");
+    }
+
+    #[test]
+    fn skips_replacement_mangled_prime_join_keys() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(
+            br#"{"type":"session","version":3,"id":"root","cwd":"/tmp/project"}
+"#,
+        )
+        .unwrap();
+        file.write_all(
+            b"{\"type\":\"message\",\"id\":\"assistant-\xff\",\"timestamp\":\"2026-08-08T00:00:01Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":20,\"output\":8}}}\n",
+        )
+        .unwrap();
+        file.write_all(
+            b"{\"type\":\"child_usage_attributed\",\"id\":\"usage-clean\",\"targetId\":\"assistant-\xff\",\"childUsage\":{\"input\":3,\"output\":2},\"aggregateUsage\":{\"input\":20,\"output\":8}}\n",
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_prime_agent_file(file.path());
+        let accounting = analyze_prime_agent_accounting(file.path(), &messages);
+
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0]
+            .dedup_key
+            .as_deref()
+            .is_some_and(|key| key.starts_with("prime-agent:damaged:")));
+        assert!(accounting.attributions.is_empty());
+        assert!(accounting.adjustments.is_empty());
+    }
+
+    #[test]
+    fn skips_mangled_attribution_ids_even_with_clean_message_joins() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(
+            br#"{"type":"session","version":3,"id":"root","cwd":"/tmp/project"}
+"#,
+        )
+        .unwrap();
+        file.write_all(
+            br#"{"type":"message","id":"assistant-clean","timestamp":"2026-08-08T00:00:01Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"response-clean","usage":{"input":20,"output":8}}}
+"#,
+        )
+        .unwrap();
+        file.write_all(
+            b"{\"type\":\"child_usage_attributed\",\"id\":\"usage-\xff\",\"targetId\":\"assistant-clean\",\"childUsage\":{\"input\":3,\"output\":2},\"aggregateUsage\":{\"input\":20,\"output\":8}}\n",
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_prime_agent_file(file.path());
+        let accounting = analyze_prime_agent_accounting(file.path(), &messages);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("prime-agent:response:response-clean")
+        );
+        assert!(accounting.attributions.is_empty());
+        assert!(accounting.adjustments.is_empty());
+    }
+
+    #[test]
+    fn ignores_mangled_parent_session_join_key() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(
+            b"{\"type\":\"session\",\"version\":3,\"id\":\"child\",\"cwd\":\"/tmp/project\",\"parentSession\":\"/tmp/parent-\xff.jsonl\",\"rlmDepth\":1}\n",
+        )
+        .unwrap();
+        file.write_all(
+            br#"{"type":"message","id":"assistant-clean","timestamp":"2026-08-08T00:00:01Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"response-clean","usage":{"input":20,"output":8}}}
+"#,
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_prime_agent_file(file.path());
+        let accounting = analyze_prime_agent_accounting(file.path(), &messages);
+
+        assert_eq!(messages.len(), 1);
+        assert!(accounting.child_parent_path.is_none());
+    }
+
+    #[test]
+    fn sanitizes_replacement_mangled_model_and_provider() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(
+            b"{\"type\":\"session\",\"version\":3,\"id\":\"root\",\"cwd\":\"/tmp/\xff/project\",\"rlmDepth\":1}\n",
+        )
+        .unwrap();
+        file.write_all(b"{\"type\":\"session_info\",\"name\":\"agent-\xff\"}\n")
+            .unwrap();
+        file.write_all(
+            b"{\"type\":\"message\",\"id\":\"assistant-clean\",\"timestamp\":\"2026-08-08T00:00:01Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"bad-\xff-provider\",\"model\":\"bad-\xff-model\",\"usage\":{\"input\":20,\"output\":8}}}\n",
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_prime_agent_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "unknown");
+        assert_eq!(messages[0].provider_id, "prime-agent");
+        assert!(messages[0].workspace_key.is_none());
+        assert!(messages[0].agent.is_none());
+    }
+
+    #[test]
     fn parses_root_session_without_counting_child_attribution_records() {
         let file = session_file(
             r#"{"type":"session","version":3,"id":"root-1","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
@@ -1344,6 +1526,42 @@ mod tests {
         assert_eq!(original.len(), 1);
         assert_eq!(fork.len(), 1);
         assert_eq!(original[0].dedup_key, fork[0].dedup_key);
+    }
+
+    #[test]
+    fn copied_fork_history_with_corrupt_id_deduplicates_once() {
+        let mut original = NamedTempFile::new().unwrap();
+        original
+            .write_all(
+                br#"{"type":"session","version":3,"id":"root-1","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","rlmDepth":0}
+"#,
+            )
+            .unwrap();
+        let message = b"{\"type\":\"message\",\"id\":\"assistant-\xff\",\"timestamp\":\"2026-08-08T00:00:01.000Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"anthropic\",\"model\":\"claude-opus-5\",\"usage\":{\"input\":100,\"output\":50}}}\n";
+        original.write_all(message).unwrap();
+        original.flush().unwrap();
+
+        let mut fork = NamedTempFile::new().unwrap();
+        fork.write_all(
+            br#"{"type":"session","version":3,"id":"fork-2","timestamp":"2026-08-08T01:00:00.000Z","cwd":"/tmp/project","parentSession":"/tmp/root.jsonl","rlmDepth":0}
+"#,
+        )
+        .unwrap();
+        fork.write_all(message).unwrap();
+        fork.flush().unwrap();
+
+        let original_messages = parse_prime_agent_file(original.path());
+        let fork_messages = parse_prime_agent_file(fork.path());
+
+        assert_eq!(original_messages.len(), 1);
+        assert_eq!(fork_messages.len(), 1);
+        assert!(original_messages[0].dedup_key.is_some());
+        assert_eq!(original_messages[0].dedup_key, fork_messages[0].dedup_key);
+        let deduped = reconcile_prime_agent_messages(
+            vec![original_messages[0].clone(), fork_messages[0].clone()],
+            &[],
+        );
+        assert_eq!(deduped.len(), 1);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/reasonix.rs
+++ b/crates/tokscale-core/src/sessions/reasonix.rs
@@ -4,12 +4,13 @@
 //! `<REASONIX_HOME>/stats/YYYY-MM-DD.jsonl`. Session transcript JSONL is not
 //! scanned: it has no authoritative usage counters and would overlap stats.
 
-use super::utils::parse_timestamp_value;
+use super::pi::has_replacement_character;
+use super::utils::{lossy_lines, parse_timestamp_value};
 use super::UnifiedMessage;
 use crate::provider_identity::{canonical_provider, inferred_provider_from_model};
 use crate::TokenBreakdown;
 use serde::Deserialize;
-use std::io::{BufRead, BufReader};
+use std::io::BufReader;
 use std::path::Path;
 
 #[derive(Debug, Deserialize)]
@@ -37,8 +38,22 @@ struct ReasonixStat {
 fn split_model_ref(model_ref: &str) -> (String, String) {
     let model_ref = model_ref.trim();
     if let Some((provider, model)) = model_ref.split_once('/') {
-        let provider = canonical_provider(provider).unwrap_or_else(|| provider.to_string());
+        let model = if has_replacement_character(model) {
+            "unknown"
+        } else {
+            model
+        };
+        let provider = if has_replacement_character(provider) {
+            inferred_provider_from_model(model)
+                .unwrap_or("reasonix")
+                .to_string()
+        } else {
+            canonical_provider(provider).unwrap_or_else(|| provider.to_string())
+        };
         return (provider, model.to_string());
+    }
+    if has_replacement_character(model_ref) {
+        return ("reasonix".to_string(), "unknown".to_string());
     }
     let provider = inferred_provider_from_model(model_ref)
         .unwrap_or("reasonix")
@@ -55,11 +70,9 @@ pub fn parse_reasonix_file(path: &Path) -> Vec<UnifiedMessage> {
         return Vec::new();
     };
 
-    BufReader::new(file)
-        .lines()
+    lossy_lines(BufReader::new(file))
         .enumerate()
         .filter_map(|(line_index, line)| {
-            let line = line.ok()?;
             let record: ReasonixStat = serde_json::from_str(line.trim()).ok()?;
             if record.turn
                 || record.model.trim().is_empty()
@@ -111,7 +124,45 @@ pub fn parse_reasonix_file(path: &Path) -> Vec<UnifiedMessage> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn accepts_bom_crlf_and_later_records_after_invalid_utf8() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(
+            b"\xef\xbb\xbf{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"deepseek/chat\",\"prompt\":100,\"completion\":20,\"cache_hit\":30,\"cache_miss\":70,\"total\":120}\r\n",
+        )
+        .unwrap();
+        file.write_all(b"invalid \xff record\r\n").unwrap();
+        file.write_all(
+            br#"{"ts":"2026-08-04T09:11:11Z","model":"deepseek/chat","prompt":10,"completion":2,"total":12}"#,
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_reasonix_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].tokens.total(), 120);
+        assert_eq!(messages[1].tokens.total(), 12);
+    }
+
+    #[test]
+    fn sanitizes_replacement_mangled_provider_and_model() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(
+            b"{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"bad-\xff/bad-\xff-model\",\"prompt\":100,\"completion\":20,\"total\":120}\n",
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_reasonix_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].provider_id, "reasonix");
+        assert_eq!(messages[0].model_id, "unknown");
+    }
 
     #[test]
     fn parses_authoritative_stats_with_provider_usage_and_timestamp() {

--- a/crates/tokscale-core/src/sessions/reasonix.rs
+++ b/crates/tokscale-core/src/sessions/reasonix.rs
@@ -10,6 +10,7 @@ use super::UnifiedMessage;
 use crate::provider_identity::{canonical_provider, inferred_provider_from_model};
 use crate::TokenBreakdown;
 use serde::Deserialize;
+use std::collections::BTreeMap;
 use std::io::BufReader;
 use std::path::Path;
 
@@ -33,6 +34,16 @@ struct ReasonixStat {
     requests: i64,
     #[serde(default)]
     turn: bool,
+    #[serde(flatten)]
+    extra_fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl ReasonixStat {
+    fn has_damaged_key(&self) -> bool {
+        self.extra_fields
+            .keys()
+            .any(|key| has_replacement_character(key))
+    }
 }
 
 fn split_model_ref(model_ref: &str) -> (String, String) {
@@ -74,7 +85,8 @@ pub fn parse_reasonix_file(path: &Path) -> Vec<UnifiedMessage> {
         .enumerate()
         .filter_map(|(line_index, line)| {
             let record: ReasonixStat = serde_json::from_str(line.trim()).ok()?;
-            if record.turn
+            if record.has_damaged_key()
+                || record.turn
                 || record.model.trim().is_empty()
                 || (record.total <= 0 && record.requests <= 0)
             {
@@ -146,6 +158,30 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].tokens.total(), 120);
         assert_eq!(messages[1].tokens.total(), 12);
+    }
+
+    #[test]
+    fn rejects_replacement_mangled_counter_keys() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(
+            b"{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"deepseek/chat\",\"prom\xffpt\":100,\"completion\":20,\"total\":120}\n",
+        )
+        .unwrap();
+        file.write_all(
+            "{\"ts\":\"2026-08-04T09:10:12Z\",\"model\":\"deepseek/chat\",\"cache_�hit\":30,\"prompt\":100,\"completion\":20,\"total\":120}\n"
+                .as_bytes(),
+        )
+        .unwrap();
+        file.write_all(
+            b"{\"ts\":\"2026-08-04T09:10:13Z\",\"model\":\"deepseek/chat\",\"prompt\":10,\"completion\":2,\"total\":12}\n",
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_reasonix_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.total(), 12);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/reasonix.rs
+++ b/crates/tokscale-core/src/sessions/reasonix.rs
@@ -207,8 +207,13 @@ mod tests {
         for (model, expected_provider) in [
             ("agpt-foo", "reasonix"),
             ("declaude-x", "reasonix"),
+            ("unqwened-model", "reasonix"),
+            ("minimaximal", "reasonix"),
             ("gpt-5", "openai"),
+            ("gpt4-turbo", "openai"),
             ("claude-sonnet-4", "anthropic"),
+            ("claude3-opus", "anthropic"),
+            ("qwen3-coder", "qwen"),
         ] {
             let mut file = NamedTempFile::new().unwrap();
             writeln!(

--- a/crates/tokscale-core/src/sessions/reasonix.rs
+++ b/crates/tokscale-core/src/sessions/reasonix.rs
@@ -7,7 +7,9 @@
 use super::pi::has_replacement_character;
 use super::utils::{lossy_lines, parse_timestamp_value};
 use super::UnifiedMessage;
-use crate::provider_identity::{canonical_provider, inferred_provider_from_model};
+use crate::provider_identity::{
+    canonical_provider, inferred_provider_from_model, inferred_provider_from_model_delimited,
+};
 use crate::TokenBreakdown;
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -55,7 +57,7 @@ fn split_model_ref(model_ref: &str) -> (String, String) {
             model
         };
         let provider = if has_replacement_character(provider) {
-            inferred_provider_from_model(model)
+            inferred_provider_from_model_delimited(model)
                 .unwrap_or("reasonix")
                 .to_string()
         } else {
@@ -198,6 +200,30 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].provider_id, "reasonix");
         assert_eq!(messages[0].model_id, "unknown");
+    }
+
+    #[test]
+    fn damaged_provider_uses_delimiter_aware_model_inference() {
+        for (model, expected_provider) in [
+            ("agpt-foo", "reasonix"),
+            ("declaude-x", "reasonix"),
+            ("gpt-5", "openai"),
+            ("claude-sonnet-4", "anthropic"),
+        ] {
+            let mut file = NamedTempFile::new().unwrap();
+            writeln!(
+                file,
+                "{{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"bad-�/{model}\",\"prompt\":100,\"completion\":20,\"total\":120}}"
+            )
+            .unwrap();
+            file.flush().unwrap();
+
+            let messages = parse_reasonix_file(file.path());
+
+            assert_eq!(messages.len(), 1, "{model}");
+            assert_eq!(messages[0].provider_id, expected_provider, "{model}");
+            assert_eq!(messages[0].model_id, model, "{model}");
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -20,22 +20,51 @@ use std::time::SystemTime;
 /// stripped, and a final line without a newline is still yielded.
 pub(crate) fn lossy_lines<R: BufRead>(reader: R) -> LossyLines<R> {
     LossyLines {
+        inner: lossy_lines_with_bytes(reader),
+    }
+}
+
+/// Iterate lossy-decoded lines while retaining their exact source bytes.
+///
+/// Most parsers need only [`lossy_lines`]. Prime Agent additionally derives a
+/// stable fallback deduplication key from corrupted records, where hashing the
+/// decoded string would collapse distinct invalid UTF-8 sequences to the same
+/// replacement character.
+pub(crate) fn lossy_lines_with_bytes<R: BufRead>(reader: R) -> LossyLinesWithBytes<R> {
+    LossyLinesWithBytes {
         reader,
         buf: Vec::new(),
         at_start: true,
     }
 }
 
+pub(crate) struct LossyLine {
+    pub text: String,
+    pub bytes: Vec<u8>,
+}
+
 pub(crate) struct LossyLines<R> {
-    reader: R,
-    buf: Vec<u8>,
-    at_start: bool,
+    inner: LossyLinesWithBytes<R>,
 }
 
 impl<R: BufRead> Iterator for LossyLines<R> {
     type Item = String;
 
-    fn next(&mut self) -> Option<String> {
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|line| line.text)
+    }
+}
+
+pub(crate) struct LossyLinesWithBytes<R> {
+    reader: R,
+    buf: Vec<u8>,
+    at_start: bool,
+}
+
+impl<R: BufRead> Iterator for LossyLinesWithBytes<R> {
+    type Item = LossyLine;
+
+    fn next(&mut self) -> Option<Self::Item> {
         self.buf.clear();
         match self.reader.read_until(b'\n', &mut self.buf) {
             Ok(0) => None,
@@ -55,7 +84,10 @@ impl<R: BufRead> Iterator for LossyLines<R> {
                     bytes = bytes.strip_prefix("\u{feff}".as_bytes()).unwrap_or(bytes);
                 }
 
-                Some(String::from_utf8_lossy(bytes).into_owned())
+                Some(LossyLine {
+                    text: String::from_utf8_lossy(bytes).into_owned(),
+                    bytes: bytes.to_vec(),
+                })
             }
             // Decode failures cannot reach this arm — lossy decoding never
             // fails — so an error here is a hard I/O failure (vanished network
@@ -219,6 +251,15 @@ mod tests {
         let raw: &[u8] = b"a\n\nb\n";
         let lines: Vec<String> = lossy_lines(raw).collect();
         assert_eq!(lines, vec!["a", "", "b"]);
+    }
+
+    #[test]
+    fn lossy_lines_with_bytes_preserves_distinct_invalid_sequences() {
+        let raw: &[u8] = b"a\xff\na\xfe\n";
+        let lines: Vec<LossyLine> = lossy_lines_with_bytes(raw).collect();
+        assert_eq!(lines[0].text, lines[1].text);
+        assert_eq!(lines[0].bytes, b"a\xff");
+        assert_eq!(lines[1].bytes, b"a\xfe");
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -20,7 +20,9 @@ use std::time::SystemTime;
 /// stripped, and a final line without a newline is still yielded.
 pub(crate) fn lossy_lines<R: BufRead>(reader: R) -> LossyLines<R> {
     LossyLines {
-        inner: lossy_lines_with_bytes(reader),
+        reader,
+        buf: Vec::new(),
+        at_start: true,
     }
 }
 
@@ -44,14 +46,42 @@ pub(crate) struct LossyLine {
 }
 
 pub(crate) struct LossyLines<R> {
-    inner: LossyLinesWithBytes<R>,
+    reader: R,
+    buf: Vec<u8>,
+    at_start: bool,
+}
+
+fn read_lossy_line<R: BufRead>(
+    reader: &mut R,
+    buf: &mut Vec<u8>,
+    at_start: &mut bool,
+) -> Option<String> {
+    buf.clear();
+    match reader.read_until(b'\n', buf) {
+        Ok(0) => None,
+        Ok(_) => {
+            if buf.last() == Some(&b'\n') {
+                buf.pop();
+                if buf.last() == Some(&b'\r') {
+                    buf.pop();
+                }
+            }
+
+            let mut bytes = buf.as_slice();
+            if std::mem::take(at_start) {
+                bytes = bytes.strip_prefix("\u{feff}".as_bytes()).unwrap_or(bytes);
+            }
+            Some(String::from_utf8_lossy(bytes).into_owned())
+        }
+        Err(_) => None,
+    }
 }
 
 impl<R: BufRead> Iterator for LossyLines<R> {
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|line| line.text)
+        read_lossy_line(&mut self.reader, &mut self.buf, &mut self.at_start)
     }
 }
 


### PR DESCRIPTION
## Summary

- Parse Prime Agent and Reasonix JSONL through byte-tolerant line readers so BOMs and undecodable records do not silently discard later valid records.
- Reject replacement-damaged structural token-counter keys in Prime message usage, Prime nested attribution usage, and Reasonix statistics instead of silently defaulting damaged buckets to zero.
- Preserve Prime Agent lineage and fork/accounting safety by rejecting replacement-damaged `parentSession`/`rlmDepth` keys without rejecting damaged unrelated extensions, and keep parser/accounting message indices aligned before any bookkeeping.
- Continue the raw lineage-key scan after a top-level extension key cannot be decoded by serde, covering simd-json's acceptance of a lone-surrogate unknown key followed by an escaped damaged lineage key.
- Recover Reasonix damaged providers with delimiter-aware model-family inference so genuine GPT/Claude models retain attribution without substring false positives.
- Derive fallback deduplication keys for damaged Prime records from exact per-line bytes, and derive damaged session placeholders from the full canonical source path.
- Keep the common `lossy_lines` iterator byte-free; exact raw-byte retention is opt-in only for Prime damaged-record deduplication.
- Bump the Prime Agent and Reasonix parser cache versions and add direct, reconciliation, path-identity, and cold-to-warm cache regressions.

## Rebase assessment

Rebased cleanly onto current `main` at `243a3774`, which includes #1096, #1097, and #1098. The rebase applied all six branch commits without conflicts or substantive hunk changes. Prime's lossy message/accounting pass remains compatible with #1094's full-fingerprint warm-hit validation and lazy cache-shard loading, and #1098's cache-fixture isolation required no branch changes.

## Validation

Run on rebased head `8747ea6b`:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --locked --workspace --all-features --all-targets -- -D warnings`
- `cargo test --locked --workspace --all-features` — all workspace and doc-test suites passed; 1,671 core tests passed and 1 was ignored
- Exact cold/warm Prime regression: parent aggregate stays at 150 input with one emitted parent when a child header contains preceding `unrelated\uD800` and later damaged escaped `rlmDep\uFFFDth`, rather than double-counting to 200
- Shared parser/legacy-accounting regressions verify both reject the damaged lineage consistently and continue to accept genuine unrelated replacement-bearing extensions
- Unit regressions cover invalid UTF-8 and literal U+FFFD in Prime message usage, both Prime nested attribution usage objects, and Reasonix counter keys
- Regression verifies same-basename damaged sessions under distinct directories receive distinct path-derived placeholders

Fresh adversarial reviews were run iteratively over the uncommitted remediation. Findings on nested attribution keys, persistent cache invalidation, header extension-key collisions, replacement wildcard boundaries, and the serde/simd-json lone-surrogate mismatch were fixed. The final Round 9 GPT-5.6 Terra review approved the exact candidate, including an independent poison-key cold/warm probe. The subsequent rebase onto `243a3774` was clean and mechanical.

## Caveat

The exact-byte fallback hashes JSONL record bytes after line framing: a stream-start BOM and CRLF/LF terminators are normalized by the reader. Those framing differences do not alter the JSON record or distinguish independent damaged events; copied record content remains stable across files.
