### PR TITLE
fix(cli): align month titles with bucket dates

### DIFF
--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -1,7 +1,7 @@
 use crate::tui::settings::{
     AutosubmitSettings, MAX_AUTOSUBMIT_INTERVAL_MINUTES, MIN_AUTOSUBMIT_INTERVAL_MINUTES,
 };
-use crate::{ClientFlags, DateRangeFlags};
+use crate::{build_date_filter_for_date, normalize_year_filter, ClientFlags, DateRangeFlags};
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Args, Subcommand, ValueEnum};
 use fs2::FileExt;
@@ -485,11 +485,7 @@ pub fn submit_filters(
         year: settings.year.clone(),
     };
     let (since, until) = build_date_filter_for_date(&date, current_bucket_date());
-    let year = if date.today || date.yesterday || date.week || date.month {
-        None
-    } else {
-        date.year
-    };
+    let year = normalize_year_filter(&date);
     (clients, since, until, year)
 }
 
@@ -1627,39 +1623,6 @@ fn systemd_escape_path(path: &Path) -> String {
     path.to_string_lossy()
         .replace('\\', "\\\\")
         .replace(' ', "\\x20")
-}
-
-fn build_date_filter_for_date(
-    date: &DateRangeFlags,
-    current_date: chrono::NaiveDate,
-) -> (Option<String>, Option<String>) {
-    use chrono::{Datelike, Duration};
-
-    if date.today {
-        let day = current_date.format("%Y-%m-%d").to_string();
-        return (Some(day.clone()), Some(day));
-    }
-    if date.yesterday {
-        let day = (current_date - Duration::days(1))
-            .format("%Y-%m-%d")
-            .to_string();
-        return (Some(day.clone()), Some(day));
-    }
-    if date.week {
-        let start = current_date - Duration::days(6);
-        return (
-            Some(start.format("%Y-%m-%d").to_string()),
-            Some(current_date.format("%Y-%m-%d").to_string()),
-        );
-    }
-    if date.month {
-        let start = current_date.with_day(1).unwrap_or(current_date);
-        return (
-            Some(start.format("%Y-%m-%d").to_string()),
-            Some(current_date.format("%Y-%m-%d").to_string()),
-        );
-    }
-    (date.since.clone(), date.until.clone())
 }
 
 #[cfg(test)]

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -763,13 +763,12 @@ fn main() -> Result<()> {
             benchmark,
             no_spinner,
         }) => {
-            let resolved_date = ResolvedReportDate::new(&date, &cli.home);
             let clients = build_client_filter(clients, &cli.home);
             run_graph_command(
                 output,
                 cli.home.clone(),
                 clients,
-                resolved_date,
+                &date,
                 benchmark,
                 no_spinner,
             )
@@ -893,9 +892,8 @@ fn main() -> Result<()> {
             date,
             no_spinner,
         }) => {
-            let resolved_date = ResolvedReportDate::new(&date, &cli.home);
             let clients = build_client_filter(clients, &cli.home);
-            run_time_metrics_report(json, cli.home.clone(), clients, resolved_date, no_spinner)
+            run_time_metrics_report(json, cli.home.clone(), clients, &date, no_spinner)
         }
         Some(Commands::WarmTuiCache) => run_warm_tui_cache(),
         Some(Commands::Config { subcommand }) => {
@@ -1768,11 +1766,6 @@ pub(crate) fn normalize_year_filter(date: &DateRangeFlags) -> Option<String> {
     }
 }
 
-#[cfg(test)]
-fn get_date_range_label(date: &DateRangeFlags) -> Option<String> {
-    get_date_range_label_for_date(date, chrono::Local::now().date_naive())
-}
-
 fn get_date_range_label_for_date(
     date: &DateRangeFlags,
     current_date: chrono::NaiveDate,
@@ -1981,26 +1974,12 @@ impl LocalReportContext {
         spinner_message: Option<&'static str>,
     ) -> Self {
         let resolved_date = ResolvedReportDate::new(date, &home_dir);
-        let mut context =
-            Self::from_resolved_date(home_dir, clients, resolved_date, spinner_message);
-        context.complete_timing_setup();
-        context
-    }
-
-    fn from_resolved_date(
-        home_dir: Option<String>,
-        clients: Option<Vec<String>>,
-        resolved_date: ResolvedReportDate,
-        spinner_message: Option<&'static str>,
-    ) -> Self {
-        let (had_cursor_cache, explicit_cursor_filter, (spinner, cursor_sync_result)) =
-            prepare_cursor_report_setup(
-                || has_cursor_usage_cache_for_report(&home_dir),
-                || client_filter_explicitly_requests_cursor(&clients),
-                || spinner_message.map(LightSpinner::start),
-                || auto_sync_cursor_for_local_report(&home_dir, &clients),
-            );
+        let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
+        let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
+        let spinner = spinner_message.map(LightSpinner::start);
+        let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
         let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
+        let use_env_roots = use_env_roots(&home_dir);
 
         Self {
             home_dir,
@@ -2015,21 +1994,15 @@ impl LocalReportContext {
             spinner,
             cursor_sync_result,
             cursor_setup_warnings,
-            use_env_roots: false,
+            use_env_roots,
             start: std::time::Instant::now(),
         }
     }
 
-    fn complete_timing_setup(&mut self) {
-        self.resolve_env_roots();
-        self.start_timing();
-    }
-
-    fn resolve_env_roots(&mut self) {
-        self.use_env_roots = use_env_roots(&self.home_dir);
-    }
-
-    fn start_timing(&mut self) {
+    /// Graph emits progress before scanning, so restart its benchmark clock
+    /// after the progress prelude while retaining the constructor's complete
+    /// environment setup.
+    fn restart_timing(&mut self) {
         self.start = std::time::Instant::now();
     }
 
@@ -2055,29 +2028,6 @@ impl LocalReportContext {
             scanner_settings: self.scanner_settings.clone(),
         }
     }
-}
-
-fn prepare_cursor_report_setup<FCache, FExplicit, FSpinner, FSync, Spinner, Sync>(
-    sample_cache: FCache,
-    explicit_filter: FExplicit,
-    spinner: FSpinner,
-    sync: FSync,
-) -> (bool, bool, (Spinner, Sync))
-where
-    FCache: FnOnce() -> bool,
-    FExplicit: FnOnce() -> bool,
-    FSpinner: FnOnce() -> Spinner,
-    FSync: FnOnce() -> Sync,
-{
-    let had_cursor_cache = sample_cache();
-    let explicit_cursor_filter = explicit_filter();
-    let spinner = spinner();
-    let sync_result = sync();
-    (
-        had_cursor_cache,
-        explicit_cursor_filter,
-        (spinner, sync_result),
-    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -5074,19 +5024,18 @@ fn run_time_metrics_report(
     json: bool,
     home_dir: Option<String>,
     clients: Option<Vec<String>>,
-    resolved_date: ResolvedReportDate,
+    date: &DateRangeFlags,
     no_spinner: bool,
 ) -> Result<()> {
     use tokio::runtime::Runtime;
     use tokscale_core::{get_time_metrics_report, GroupBy};
 
-    let mut context = LocalReportContext::from_resolved_date(
+    let mut context = LocalReportContext::new(
         home_dir,
         clients,
-        resolved_date,
+        date,
         (!no_spinner).then_some("Computing time metrics..."),
     );
-    context.complete_timing_setup();
     let rt = Runtime::new()?;
     let report = rt
         .block_on(async {
@@ -5166,7 +5115,7 @@ fn run_graph_command(
     output: Option<String>,
     home_dir: Option<String>,
     clients: Option<Vec<String>>,
-    resolved_date: ResolvedReportDate,
+    date: &DateRangeFlags,
     benchmark: bool,
     no_spinner: bool,
 ) -> Result<()> {
@@ -5174,18 +5123,16 @@ fn run_graph_command(
     use tokscale_core::{generate_local_graph_report, GroupBy};
 
     let show_progress = output.is_some() && !no_spinner;
-    let mut context =
-        LocalReportContext::from_resolved_date(home_dir, clients, resolved_date, None);
+    let mut context = LocalReportContext::new(home_dir, clients, date, None);
 
     if show_progress {
         eprintln!("  Scanning session data...");
     }
-    context.start_timing();
+    context.restart_timing();
 
     if show_progress {
         eprintln!("  Generating graph data...");
     }
-    context.resolve_env_roots();
     let rt = tokio::runtime::Runtime::new()?;
     let graph_result = rt
         .block_on(async {
@@ -7484,9 +7431,15 @@ mod tests {
         let kiritimati =
             current_bucket_date(&Some(kiritimati_home.path().to_string_lossy().into_owned()));
         let niue = current_bucket_date(&Some(niue_home.path().to_string_lossy().into_owned()));
-        let report_settings = tui::settings::load_scanner_settings_for_home(&Some(
-            kiritimati_home.path().to_string_lossy().into_owned(),
-        ));
+        let kiritimati_home_path = Some(kiritimati_home.path().to_string_lossy().into_owned());
+        let niue_home_path = Some(niue_home.path().to_string_lossy().into_owned());
+        let today = DateRangeFlags {
+            today: true,
+            ..DateRangeFlags::default()
+        };
+        let kiritimati_report_date = ResolvedReportDate::new(&today, &kiritimati_home_path);
+        let niue_report_date = ResolvedReportDate::new(&today, &niue_home_path);
+        let report_settings = tui::settings::load_scanner_settings_for_home(&kiritimati_home_path);
 
         assert_eq!(
             kiritimati,
@@ -7503,6 +7456,20 @@ mod tests {
             Some("Pacific/Kiritimati"),
             "report must rebucket sessions with the --home profile's timezone"
         );
+        let expected_kiritimati = kiritimati.to_string();
+        let expected_niue = niue.to_string();
+        assert_eq!(
+            kiritimati_report_date.since.as_deref(),
+            Some(expected_kiritimati.as_str()),
+            "resolved report dates must use the pinned --home timezone"
+        );
+        assert_eq!(
+            niue_report_date.since.as_deref(),
+            Some(expected_niue.as_str()),
+            "resolved report dates must use the pinned --home timezone"
+        );
+        assert_eq!(kiritimati_report_date.date_range.as_deref(), Some("Today"));
+        assert_eq!(niue_report_date.date_range.as_deref(), Some("Today"));
     }
 
     #[test]
@@ -7518,35 +7485,6 @@ mod tests {
         assert_eq!(since.as_deref(), Some("2026-03-01"));
         assert_eq!(until.as_deref(), Some("2026-03-01"));
         assert_eq!(label.as_deref(), Some("March 2026"));
-    }
-
-    #[test]
-    fn test_cursor_setup_preserves_cache_before_sync_order() {
-        let events = std::cell::RefCell::new(Vec::new());
-        let (had_cache, explicit_filter, (spinner, sync_result)) = prepare_cursor_report_setup(
-            || {
-                events.borrow_mut().push("sample");
-                true
-            },
-            || {
-                events.borrow_mut().push("explicit");
-                false
-            },
-            || {
-                events.borrow_mut().push("spinner");
-                7
-            },
-            || {
-                events.borrow_mut().push("sync");
-                42
-            },
-        );
-
-        assert!(had_cache);
-        assert!(!explicit_filter);
-        assert_eq!(spinner, 7);
-        assert_eq!(sync_result, 42);
-        assert_eq!(*events.borrow(), ["sample", "explicit", "spinner", "sync"]);
     }
 
     #[test]
@@ -7864,84 +7802,107 @@ mod tests {
 
     #[test]
     fn test_get_date_range_label_today() {
-        let label = get_date_range_label(&DateRangeFlags {
-            today: true,
-            ..DateRangeFlags::default()
-        });
+        let label = get_date_range_label_for_date(
+            &DateRangeFlags {
+                today: true,
+                ..DateRangeFlags::default()
+            },
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap(),
+        );
         assert_eq!(label, Some("Today".to_string()));
     }
 
     #[test]
     fn test_get_date_range_label_yesterday() {
-        let label = get_date_range_label(&DateRangeFlags {
-            yesterday: true,
-            ..DateRangeFlags::default()
-        });
+        let label = get_date_range_label_for_date(
+            &DateRangeFlags {
+                yesterday: true,
+                ..DateRangeFlags::default()
+            },
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap(),
+        );
         assert_eq!(label, Some("Yesterday".to_string()));
     }
 
     #[test]
     fn test_get_date_range_label_week() {
-        let label = get_date_range_label(&DateRangeFlags {
-            week: true,
-            ..DateRangeFlags::default()
-        });
+        let label = get_date_range_label_for_date(
+            &DateRangeFlags {
+                week: true,
+                ..DateRangeFlags::default()
+            },
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap(),
+        );
         assert_eq!(label, Some("Last 7 days".to_string()));
     }
 
     #[test]
     fn test_get_date_range_label_month_uses_provided_local_date() {
-        let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 1).unwrap();
         let label = get_date_range_label_for_date(
             &DateRangeFlags {
                 month: true,
                 ..DateRangeFlags::default()
             },
-            today,
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 1).unwrap(),
         );
         assert_eq!(label, Some("March 2026".to_string()));
     }
 
     #[test]
     fn test_get_date_range_label_year() {
-        let label = get_date_range_label(&DateRangeFlags {
-            year: Some("2024".to_string()),
-            ..DateRangeFlags::default()
-        });
+        let label = get_date_range_label_for_date(
+            &DateRangeFlags {
+                year: Some("2024".to_string()),
+                ..DateRangeFlags::default()
+            },
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap(),
+        );
         assert_eq!(label, Some("2024".to_string()));
     }
 
     #[test]
     fn test_get_date_range_label_custom_since() {
-        let label = get_date_range_label(&DateRangeFlags {
-            since: Some("2024-01-01".to_string()),
-            ..DateRangeFlags::default()
-        });
+        let label = get_date_range_label_for_date(
+            &DateRangeFlags {
+                since: Some("2024-01-01".to_string()),
+                ..DateRangeFlags::default()
+            },
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap(),
+        );
         assert_eq!(label, Some("from 2024-01-01".to_string()));
     }
 
     #[test]
     fn test_get_date_range_label_custom_until() {
-        let label = get_date_range_label(&DateRangeFlags {
-            until: Some("2024-12-31".to_string()),
-            ..DateRangeFlags::default()
-        });
+        let label = get_date_range_label_for_date(
+            &DateRangeFlags {
+                until: Some("2024-12-31".to_string()),
+                ..DateRangeFlags::default()
+            },
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap(),
+        );
         assert_eq!(label, Some("to 2024-12-31".to_string()));
     }
 
     #[test]
     fn test_get_date_range_label_custom_range() {
-        let label = get_date_range_label(&DateRangeFlags {
-            since: Some("2024-01-01".to_string()),
-            until: Some("2024-12-31".to_string()),
-            ..DateRangeFlags::default()
-        });
+        let label = get_date_range_label_for_date(
+            &DateRangeFlags {
+                since: Some("2024-01-01".to_string()),
+                until: Some("2024-12-31".to_string()),
+                ..DateRangeFlags::default()
+            },
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap(),
+        );
         assert_eq!(label, Some("from 2024-01-01 to 2024-12-31".to_string()));
     }
 
     #[test]
     fn test_get_date_range_label_none() {
-        let label = get_date_range_label(&DateRangeFlags::default());
+        let label = get_date_range_label_for_date(
+            &DateRangeFlags::default(),
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap(),
+        );
         assert_eq!(label, None);
     }
 

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1929,6 +1929,87 @@ impl Drop for LightSpinner {
     }
 }
 
+/// Shared setup for the local, non-TUI report commands.
+///
+/// Keeping this context separate from the renderers makes the report variants
+/// use the same date, scanner, cursor, and timing setup without changing the
+/// operation ordering that their output relies on.
+struct LocalReportContext {
+    home_dir: Option<String>,
+    clients: Option<Vec<String>>,
+    since: Option<String>,
+    until: Option<String>,
+    year: Option<String>,
+    date_range: Option<String>,
+    effective_home_dir: Option<PathBuf>,
+    had_cursor_cache: bool,
+    explicit_cursor_filter: bool,
+    spinner: Option<LightSpinner>,
+    cursor_sync_result: Option<cursor::SyncCursorResult>,
+    cursor_setup_warnings: Vec<String>,
+    use_env_roots: bool,
+    start: std::time::Instant,
+}
+
+impl LocalReportContext {
+    fn new(
+        home_dir: Option<String>,
+        clients: Option<Vec<String>>,
+        date: &DateRangeFlags,
+        no_spinner: bool,
+        resolve_effective_home: bool,
+    ) -> Self {
+        let (since, until) = build_date_filter(date, &home_dir);
+        let year = normalize_year_filter(date);
+        let date_range = get_date_range_label(date);
+        let effective_home_dir = resolve_effective_home
+            .then(|| resolve_effective_home_dir(&home_dir))
+            .flatten();
+
+        let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
+        let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
+        let spinner = if no_spinner {
+            None
+        } else {
+            Some(LightSpinner::start("Scanning session data..."))
+        };
+        let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
+        let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
+        let use_env_roots = use_env_roots(&home_dir);
+        let start = std::time::Instant::now();
+
+        Self {
+            home_dir,
+            clients,
+            since,
+            until,
+            year,
+            date_range,
+            effective_home_dir,
+            had_cursor_cache,
+            explicit_cursor_filter,
+            spinner,
+            cursor_sync_result,
+            cursor_setup_warnings,
+            use_env_roots,
+            start,
+        }
+    }
+
+    fn report_options(&self, group_by: tokscale_core::GroupBy) -> tokscale_core::ReportOptions {
+        tokscale_core::ReportOptions {
+            home_dir: self.home_dir.clone(),
+            use_env_roots: self.use_env_roots,
+            clients: self.clients.clone(),
+            since: self.since.clone(),
+            until: self.until.clone(),
+            year: self.year.clone(),
+            group_by,
+            scanner_settings: tui::settings::load_scanner_settings_for_home(&self.home_dir),
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_models_report(
     json: bool,
@@ -1942,41 +2023,13 @@ fn run_models_report(
     cli_no_write_cache: bool,
     hide_zero: bool,
 ) -> Result<()> {
-    use std::time::Instant;
     use tokio::runtime::Runtime;
-    use tokscale_core::{get_model_report, GroupBy, ReportOptions};
+    use tokscale_core::{get_model_report, GroupBy};
 
-    let (since, until) = build_date_filter(date, &home_dir);
-    let year = normalize_year_filter(date);
-    let date_range = get_date_range_label(date);
-    let effective_home_dir = resolve_effective_home_dir(&home_dir);
-
-    let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
-    let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
-    let spinner = if no_spinner {
-        None
-    } else {
-        Some(LightSpinner::start("Scanning session data..."))
-    };
-    let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
-    let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
-    let use_env_roots = use_env_roots(&home_dir);
-    let start = Instant::now();
+    let mut context = LocalReportContext::new(home_dir, clients, date, no_spinner, true);
     let rt = Runtime::new()?;
     let report = rt
-        .block_on(async {
-            get_model_report(ReportOptions {
-                home_dir: home_dir.clone(),
-                use_env_roots,
-                clients: clients.clone(),
-                since: since.clone(),
-                until: until.clone(),
-                year: year.clone(),
-                group_by: group_by.clone(),
-                scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
-            })
-            .await
-        })
+        .block_on(async { get_model_report(context.report_options(group_by.clone())).await })
         .map_err(|e| anyhow::anyhow!(e))?;
     let mut report = report;
     if hide_zero {
@@ -1994,28 +2047,29 @@ fn run_models_report(
     }
     let report = report;
 
-    if let Some(spinner) = spinner {
+    if let Some(spinner) = context.spinner.take() {
         spinner.stop();
     }
     emit_cursor_sync_warning(
-        cursor_sync_result.as_ref(),
-        had_cursor_cache,
-        explicit_cursor_filter,
+        context.cursor_sync_result.as_ref(),
+        context.had_cursor_cache,
+        context.explicit_cursor_filter,
     );
-    let processing_time_ms = start.elapsed().as_millis();
+    let processing_time_ms = context.start.elapsed().as_millis();
     let claude_message_count = report
         .entries
         .iter()
         .filter(|entry| model_usage_includes_client(entry, "claude"))
         .map(|entry| entry.message_count)
         .sum();
-    let diagnostics = effective_home_dir
+    let diagnostics = context
+        .effective_home_dir
         .as_deref()
         .map(|home| {
             claude_diagnostics::diagnostics_for_empty_explicit_report(
                 home,
-                use_env_roots,
-                &clients,
+                context.use_env_roots,
+                &context.clients,
                 claude_message_count,
             )
         })
@@ -2109,7 +2163,7 @@ fn run_models_report(
             total_messages: report.total_messages,
             total_cost: report.total_cost,
             processing_time_ms: report.processing_time_ms,
-            warnings: cursor_setup_warnings,
+            warnings: context.cursor_setup_warnings,
             diagnostics,
         };
         println!("{}", serde_json::to_string_pretty(&output)?);
@@ -2117,7 +2171,7 @@ fn run_models_report(
         use comfy_table::{Attribute, Cell, CellAlignment, Color, ContentArrangement, Table};
         emit_client_diagnostics(&diagnostics);
 
-        emit_cursor_setup_warnings(&cursor_setup_warnings);
+        emit_cursor_setup_warnings(&context.cursor_setup_warnings);
         let total_performance = aggregate_model_report_performance(&report.entries);
         let term_width = crossterm::terminal::size()
             .map(|(w, _)| w as usize)
@@ -2762,7 +2816,7 @@ fn run_models_report(
             }
         }
 
-        let title = match &date_range {
+        let title = match &context.date_range {
             Some(range) => format!("Token Usage Report by Model ({})", range),
             None => "Token Usage Report by Model".to_string(),
         };
@@ -2794,7 +2848,14 @@ fn run_models_report(
 
         let settings = tui::settings::Settings::load();
         if resolve_should_write_cache(cli_write_cache, cli_no_write_cache, &settings) {
-            write_light_cache(&home_dir, &clients, &since, &until, &year, &group_by);
+            write_light_cache(
+                &context.home_dir,
+                &context.clients,
+                &context.since,
+                &context.until,
+                &context.year,
+                &group_by,
+            );
         }
     }
 
@@ -2810,40 +2871,13 @@ fn run_monthly_report(
     no_spinner: bool,
     hide_zero: bool,
 ) -> Result<()> {
-    use std::time::Instant;
     use tokio::runtime::Runtime;
-    use tokscale_core::{get_monthly_report_v2, GroupBy, ReportOptions};
+    use tokscale_core::{get_monthly_report_v2, GroupBy};
 
-    let (since, until) = build_date_filter(date, &home_dir);
-    let year = normalize_year_filter(date);
-    let date_range = get_date_range_label(date);
-
-    let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
-    let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
-    let spinner = if no_spinner {
-        None
-    } else {
-        Some(LightSpinner::start("Scanning session data..."))
-    };
-    let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
-    let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
-    let use_env_roots = use_env_roots(&home_dir);
-    let start = Instant::now();
+    let mut context = LocalReportContext::new(home_dir, clients, date, no_spinner, false);
     let rt = Runtime::new()?;
     let report = rt
-        .block_on(async {
-            get_monthly_report_v2(ReportOptions {
-                home_dir: home_dir.clone(),
-                use_env_roots,
-                clients,
-                since,
-                until,
-                year,
-                group_by: GroupBy::default(),
-                scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
-            })
-            .await
-        })
+        .block_on(async { get_monthly_report_v2(context.report_options(GroupBy::default())).await })
         .map_err(|e| anyhow::anyhow!(e))?;
     let mut report = report;
     if hide_zero {
@@ -2859,16 +2893,16 @@ fn run_monthly_report(
     }
     let report = report;
 
-    if let Some(spinner) = spinner {
+    if let Some(spinner) = context.spinner.take() {
         spinner.stop();
     }
     emit_cursor_sync_warning(
-        cursor_sync_result.as_ref(),
-        had_cursor_cache,
-        explicit_cursor_filter,
+        context.cursor_sync_result.as_ref(),
+        context.had_cursor_cache,
+        context.explicit_cursor_filter,
     );
 
-    let processing_time_ms = start.elapsed().as_millis();
+    let processing_time_ms = context.start.elapsed().as_millis();
 
     if json {
         #[derive(serde::Serialize)]
@@ -2913,14 +2947,14 @@ fn run_monthly_report(
                 .collect(),
             total_cost: report.total_cost,
             processing_time_ms: report.processing_time_ms,
-            warnings: cursor_setup_warnings,
+            warnings: context.cursor_setup_warnings,
         };
 
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
         use comfy_table::{Attribute, Cell, CellAlignment, Color, ContentArrangement, Table};
 
-        emit_cursor_setup_warnings(&cursor_setup_warnings);
+        emit_cursor_setup_warnings(&context.cursor_setup_warnings);
         let term_width = crossterm::terminal::size()
             .map(|(w, _)| w as usize)
             .unwrap_or(120);
@@ -3113,7 +3147,7 @@ fn run_monthly_report(
             ]);
         }
 
-        let title = match &date_range {
+        let title = match &context.date_range {
             Some(range) => format!("Monthly Token Usage Report ({})", range),
             None => "Monthly Token Usage Report".to_string(),
         };
@@ -3146,40 +3180,13 @@ fn run_hourly_report(
     no_spinner: bool,
     hide_zero: bool,
 ) -> Result<()> {
-    use std::time::Instant;
     use tokio::runtime::Runtime;
-    use tokscale_core::{get_hourly_report, GroupBy, ReportOptions};
+    use tokscale_core::{get_hourly_report, GroupBy};
 
-    let (since, until) = build_date_filter(date, &home_dir);
-    let year = normalize_year_filter(date);
-    let date_range = get_date_range_label(date);
-
-    let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
-    let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
-    let spinner = if no_spinner {
-        None
-    } else {
-        Some(LightSpinner::start("Scanning session data..."))
-    };
-    let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
-    let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
-    let use_env_roots = use_env_roots(&home_dir);
-    let start = Instant::now();
+    let mut context = LocalReportContext::new(home_dir, clients, date, no_spinner, false);
     let rt = Runtime::new()?;
     let report = rt
-        .block_on(async {
-            get_hourly_report(ReportOptions {
-                home_dir: home_dir.clone(),
-                use_env_roots,
-                clients,
-                since,
-                until,
-                year,
-                group_by: GroupBy::default(),
-                scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
-            })
-            .await
-        })
+        .block_on(async { get_hourly_report(context.report_options(GroupBy::default())).await })
         .map_err(|e| anyhow::anyhow!(e))?;
     let mut report = report;
     if hide_zero {
@@ -3195,16 +3202,16 @@ fn run_hourly_report(
     }
     let report = report;
 
-    if let Some(spinner) = spinner {
+    if let Some(spinner) = context.spinner.take() {
         spinner.stop();
     }
     emit_cursor_sync_warning(
-        cursor_sync_result.as_ref(),
-        had_cursor_cache,
-        explicit_cursor_filter,
+        context.cursor_sync_result.as_ref(),
+        context.had_cursor_cache,
+        context.explicit_cursor_filter,
     );
 
-    let processing_time_ms = start.elapsed().as_millis();
+    let processing_time_ms = context.start.elapsed().as_millis();
 
     if json {
         #[derive(serde::Serialize)]
@@ -3251,14 +3258,14 @@ fn run_hourly_report(
                 .collect(),
             total_cost: report.total_cost,
             processing_time_ms: report.processing_time_ms,
-            warnings: cursor_setup_warnings,
+            warnings: context.cursor_setup_warnings,
         };
 
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
         use comfy_table::{Cell, CellAlignment, Color, ContentArrangement, Table};
 
-        emit_cursor_setup_warnings(&cursor_setup_warnings);
+        emit_cursor_setup_warnings(&context.cursor_setup_warnings);
         let term_width = crossterm::terminal::size()
             .map(|(w, _)| w as usize)
             .unwrap_or(120);
@@ -3411,7 +3418,7 @@ fn run_hourly_report(
 
         // Title
         use colored::Colorize;
-        let title = if let Some(ref range) = date_range {
+        let title = if let Some(ref range) = context.date_range {
             format!("Hourly Usage ({})", range)
         } else {
             "Hourly Usage".to_string()

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1932,6 +1932,14 @@ impl ResolvedReportDate {
         let scanner_settings = tui::settings::load_scanner_settings_for_home(home_dir);
         let current_date =
             tokscale_core::BucketTimezone::from_scanner_settings(&scanner_settings).today();
+        Self::from_current_date(date, scanner_settings, current_date)
+    }
+
+    fn from_current_date(
+        date: &DateRangeFlags,
+        scanner_settings: tokscale_core::ScannerSettings,
+        current_date: chrono::NaiveDate,
+    ) -> Self {
         let (since, until) = build_date_filter_for_date(date, current_date);
         let year = normalize_year_filter(date);
         let date_range = get_date_range_label_for_date(date, current_date);
@@ -7441,8 +7449,18 @@ mod tests {
             month: true,
             ..DateRangeFlags::default()
         };
-        let kiritimati_report_date = ResolvedReportDate::new(&month, &kiritimati_home_path);
-        let niue_report_date = ResolvedReportDate::new(&month, &niue_home_path);
+        let kiritimati_settings =
+            tui::settings::load_scanner_settings_for_home(&kiritimati_home_path);
+        let niue_settings = tui::settings::load_scanner_settings_for_home(&niue_home_path);
+        let kiritimati_fixed_date = chrono::NaiveDate::from_ymd_opt(2026, 1, 31).unwrap();
+        let niue_fixed_date = chrono::NaiveDate::from_ymd_opt(2026, 2, 1).unwrap();
+        let kiritimati_report_date = ResolvedReportDate::from_current_date(
+            &month,
+            kiritimati_settings,
+            kiritimati_fixed_date,
+        );
+        let niue_report_date =
+            ResolvedReportDate::from_current_date(&month, niue_settings, niue_fixed_date);
         let report_settings = tui::settings::load_scanner_settings_for_home(&kiritimati_home_path);
 
         assert_eq!(
@@ -7460,12 +7478,12 @@ mod tests {
             Some("Pacific/Kiritimati"),
             "report must rebucket sessions with the --home profile's timezone"
         );
-        let expected_kiritimati = kiritimati.to_string();
-        let expected_niue = niue.to_string();
-        let expected_kiritimati_start = kiritimati.with_day(1).unwrap().to_string();
-        let expected_niue_start = niue.with_day(1).unwrap().to_string();
-        let expected_kiritimati_label = kiritimati.format("%B %Y").to_string();
-        let expected_niue_label = niue.format("%B %Y").to_string();
+        let expected_kiritimati = kiritimati_fixed_date.to_string();
+        let expected_niue = niue_fixed_date.to_string();
+        let expected_kiritimati_start = kiritimati_fixed_date.with_day(1).unwrap().to_string();
+        let expected_niue_start = niue_fixed_date.with_day(1).unwrap().to_string();
+        let expected_kiritimati_label = kiritimati_fixed_date.format("%B %Y").to_string();
+        let expected_niue_label = niue_fixed_date.format("%B %Y").to_string();
         assert_eq!(
             kiritimati_report_date.since.as_deref(),
             Some(expected_kiritimati_start.as_str()),

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1735,7 +1735,7 @@ fn current_bucket_date(home_dir: &Option<String>) -> chrono::NaiveDate {
     .today()
 }
 
-fn build_date_filter_for_date(
+pub(crate) fn build_date_filter_for_date(
     date: &DateRangeFlags,
     current_date: chrono::NaiveDate,
 ) -> (Option<String>, Option<String>) {
@@ -1772,7 +1772,7 @@ fn build_date_filter_for_date(
     (date.since.clone(), date.until.clone())
 }
 
-fn normalize_year_filter(date: &DateRangeFlags) -> Option<String> {
+pub(crate) fn normalize_year_filter(date: &DateRangeFlags) -> Option<String> {
     if date.today || date.yesterday || date.week || date.month {
         None
     } else {

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -7462,6 +7462,12 @@ mod tests {
         let niue_report_date =
             ResolvedReportDate::from_current_date(&month, niue_settings, niue_fixed_date);
         let report_settings = tui::settings::load_scanner_settings_for_home(&kiritimati_home_path);
+        let today = DateRangeFlags {
+            today: true,
+            ..DateRangeFlags::default()
+        };
+        let kiritimati_today = ResolvedReportDate::new(&today, &kiritimati_home_path);
+        let niue_today = ResolvedReportDate::new(&today, &niue_home_path);
 
         assert_eq!(
             kiritimati,
@@ -7478,6 +7484,22 @@ mod tests {
             Some("Pacific/Kiritimati"),
             "report must rebucket sessions with the --home profile's timezone"
         );
+        let expected_kiritimati_today = kiritimati.to_string();
+        let expected_niue_today = niue.to_string();
+        assert_eq!(
+            kiritimati_today.until.as_deref(),
+            Some(expected_kiritimati_today.as_str()),
+            "production date resolution must use the --home profile's pinned zone"
+        );
+        assert_eq!(
+            niue_today.until.as_deref(),
+            Some(expected_niue_today.as_str()),
+            "production date resolution must use the --home profile's pinned zone"
+        );
+        assert_ne!(
+            kiritimati_today.until, niue_today.until,
+            "profiles 25 hours apart must resolve today to different dates"
+        );
         let expected_kiritimati = kiritimati_fixed_date.to_string();
         let expected_niue = niue_fixed_date.to_string();
         let expected_kiritimati_start = kiritimati_fixed_date.with_day(1).unwrap().to_string();
@@ -7487,22 +7509,22 @@ mod tests {
         assert_eq!(
             kiritimati_report_date.since.as_deref(),
             Some(expected_kiritimati_start.as_str()),
-            "resolved month filters must use the pinned --home timezone"
+            "fixed-date month bounds must use the injected date"
         );
         assert_eq!(
             kiritimati_report_date.until.as_deref(),
             Some(expected_kiritimati.as_str()),
-            "resolved month filters must use the pinned --home timezone"
+            "fixed-date month bounds must use the injected date"
         );
         assert_eq!(
             niue_report_date.since.as_deref(),
             Some(expected_niue_start.as_str()),
-            "resolved month filters must use the pinned --home timezone"
+            "fixed-date month bounds must use the injected date"
         );
         assert_eq!(
             niue_report_date.until.as_deref(),
             Some(expected_niue.as_str()),
-            "resolved month filters must use the pinned --home timezone"
+            "fixed-date month bounds must use the injected date"
         );
         assert_eq!(
             kiritimati_report_date.date_range.as_deref(),
@@ -7512,21 +7534,6 @@ mod tests {
             niue_report_date.date_range.as_deref(),
             Some(expected_niue_label.as_str())
         );
-    }
-
-    #[test]
-    fn test_resolved_month_filter_and_label_share_bucket_boundary() {
-        let date = DateRangeFlags {
-            month: true,
-            ..DateRangeFlags::default()
-        };
-        let current_date = chrono::NaiveDate::from_ymd_opt(2026, 3, 1).unwrap();
-        let (since, until) = build_date_filter_for_date(&date, current_date);
-        let label = get_date_range_label_for_date(&date, current_date);
-
-        assert_eq!(since.as_deref(), Some("2026-03-01"));
-        assert_eq!(until.as_deref(), Some("2026-03-01"));
-        assert_eq!(label.as_deref(), Some("March 2026"));
     }
 
     #[test]

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1993,15 +1993,13 @@ impl LocalReportContext {
         resolved_date: ResolvedReportDate,
         spinner_message: Option<&'static str>,
     ) -> Self {
-        let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
-        let (had_cursor_cache, (spinner, cursor_sync_result)) = sample_cursor_cache_before_sync(
-            || has_cursor_usage_cache_for_report(&home_dir),
-            || {
-                let spinner = spinner_message.map(LightSpinner::start);
-                let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
-                (spinner, cursor_sync_result)
-            },
-        );
+        let (had_cursor_cache, explicit_cursor_filter, (spinner, cursor_sync_result)) =
+            prepare_cursor_report_setup(
+                || has_cursor_usage_cache_for_report(&home_dir),
+                || client_filter_explicitly_requests_cursor(&clients),
+                || spinner_message.map(LightSpinner::start),
+                || auto_sync_cursor_for_local_report(&home_dir, &clients),
+            );
         let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
 
         Self {
@@ -2059,14 +2057,27 @@ impl LocalReportContext {
     }
 }
 
-fn sample_cursor_cache_before_sync<FCache, FSync, T>(sample_cache: FCache, sync: FSync) -> (bool, T)
+fn prepare_cursor_report_setup<FCache, FExplicit, FSpinner, FSync, Spinner, Sync>(
+    sample_cache: FCache,
+    explicit_filter: FExplicit,
+    spinner: FSpinner,
+    sync: FSync,
+) -> (bool, bool, (Spinner, Sync))
 where
     FCache: FnOnce() -> bool,
-    FSync: FnOnce() -> T,
+    FExplicit: FnOnce() -> bool,
+    FSpinner: FnOnce() -> Spinner,
+    FSync: FnOnce() -> Sync,
 {
     let had_cursor_cache = sample_cache();
+    let explicit_cursor_filter = explicit_filter();
+    let spinner = spinner();
     let sync_result = sync();
-    (had_cursor_cache, sync_result)
+    (
+        had_cursor_cache,
+        explicit_cursor_filter,
+        (spinner, sync_result),
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -7510,12 +7521,20 @@ mod tests {
     }
 
     #[test]
-    fn test_cursor_cache_is_sampled_before_sync() {
+    fn test_cursor_setup_preserves_cache_before_sync_order() {
         let events = std::cell::RefCell::new(Vec::new());
-        let (had_cache, sync_result) = sample_cursor_cache_before_sync(
+        let (had_cache, explicit_filter, (spinner, sync_result)) = prepare_cursor_report_setup(
             || {
                 events.borrow_mut().push("sample");
                 true
+            },
+            || {
+                events.borrow_mut().push("explicit");
+                false
+            },
+            || {
+                events.borrow_mut().push("spinner");
+                7
             },
             || {
                 events.borrow_mut().push("sync");
@@ -7524,8 +7543,10 @@ mod tests {
         );
 
         assert!(had_cache);
+        assert!(!explicit_filter);
+        assert_eq!(spinner, 7);
         assert_eq!(sync_result, 42);
-        assert_eq!(*events.borrow(), ["sample", "sync"]);
+        assert_eq!(*events.borrow(), ["sample", "explicit", "spinner", "sync"]);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -763,16 +763,13 @@ fn main() -> Result<()> {
             benchmark,
             no_spinner,
         }) => {
-            let (since, until) = build_date_filter(&date, &cli.home);
-            let year = normalize_year_filter(&date);
+            let resolved_date = ResolvedReportDate::new(&date, &cli.home);
             let clients = build_client_filter(clients, &cli.home);
             run_graph_command(
                 output,
                 cli.home.clone(),
                 clients,
-                since,
-                until,
-                year,
+                resolved_date,
                 benchmark,
                 no_spinner,
             )
@@ -896,18 +893,9 @@ fn main() -> Result<()> {
             date,
             no_spinner,
         }) => {
-            let (since, until) = build_date_filter(&date, &cli.home);
-            let year = normalize_year_filter(&date);
+            let resolved_date = ResolvedReportDate::new(&date, &cli.home);
             let clients = build_client_filter(clients, &cli.home);
-            run_time_metrics_report(
-                json,
-                cli.home.clone(),
-                clients,
-                since,
-                until,
-                year,
-                no_spinner,
-            )
+            run_time_metrics_report(json, cli.home.clone(), clients, resolved_date, no_spinner)
         }
         Some(Commands::WarmTuiCache) => run_warm_tui_cache(),
         Some(Commands::Config { subcommand }) => {
@@ -1780,6 +1768,7 @@ pub(crate) fn normalize_year_filter(date: &DateRangeFlags) -> Option<String> {
     }
 }
 
+#[cfg(test)]
 fn get_date_range_label(date: &DateRangeFlags) -> Option<String> {
     get_date_range_label_for_date(date, chrono::Local::now().date_naive())
 }
@@ -1929,11 +1918,44 @@ impl Drop for LightSpinner {
     }
 }
 
-/// Shared setup for the local, non-TUI report commands.
+/// Date bounds and scanner settings resolved from one pinned bucket date.
 ///
-/// Keeping this context separate from the renderers makes the report variants
-/// use the same date, scanner, cursor, and timing setup without changing the
-/// operation ordering that their output relies on.
+/// Loading scanner settings once is deliberate: the same settings choose both
+/// the date keys and the scanner's bucket timezone. Report options clone the
+/// settings instead of reading the profile again, so filtering and scanning
+/// cannot disagree after a settings change.
+struct ResolvedReportDate {
+    since: Option<String>,
+    until: Option<String>,
+    year: Option<String>,
+    date_range: Option<String>,
+    scanner_settings: tokscale_core::ScannerSettings,
+}
+
+impl ResolvedReportDate {
+    fn new(date: &DateRangeFlags, home_dir: &Option<String>) -> Self {
+        let scanner_settings = tui::settings::load_scanner_settings_for_home(home_dir);
+        let current_date =
+            tokscale_core::BucketTimezone::from_scanner_settings(&scanner_settings).today();
+        let (since, until) = build_date_filter_for_date(date, current_date);
+        let year = normalize_year_filter(date);
+        let date_range = get_date_range_label_for_date(date, current_date);
+
+        Self {
+            since,
+            until,
+            year,
+            date_range,
+            scanner_settings,
+        }
+    }
+}
+
+/// Shared setup for local report commands.
+///
+/// The cursor cache snapshot is intentionally taken before the best-effort
+/// sync. A failed sync must still be reported as "using cached data" when a
+/// cache existed before the sync attempt.
 struct LocalReportContext {
     home_dir: Option<String>,
     clients: Option<Vec<String>>,
@@ -1941,7 +1963,7 @@ struct LocalReportContext {
     until: Option<String>,
     year: Option<String>,
     date_range: Option<String>,
-    effective_home_dir: Option<PathBuf>,
+    scanner_settings: tokscale_core::ScannerSettings,
     had_cursor_cache: bool,
     explicit_cursor_filter: bool,
     spinner: Option<LightSpinner>,
@@ -1956,43 +1978,70 @@ impl LocalReportContext {
         home_dir: Option<String>,
         clients: Option<Vec<String>>,
         date: &DateRangeFlags,
-        no_spinner: bool,
-        resolve_effective_home: bool,
+        spinner_message: Option<&'static str>,
     ) -> Self {
-        let (since, until) = build_date_filter(date, &home_dir);
-        let year = normalize_year_filter(date);
-        let date_range = get_date_range_label(date);
-        let effective_home_dir = resolve_effective_home
-            .then(|| resolve_effective_home_dir(&home_dir))
-            .flatten();
+        let resolved_date = ResolvedReportDate::new(date, &home_dir);
+        let mut context =
+            Self::from_resolved_date(home_dir, clients, resolved_date, spinner_message);
+        context.complete_timing_setup();
+        context
+    }
 
-        let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
+    fn from_resolved_date(
+        home_dir: Option<String>,
+        clients: Option<Vec<String>>,
+        resolved_date: ResolvedReportDate,
+        spinner_message: Option<&'static str>,
+    ) -> Self {
         let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
-        let spinner = if no_spinner {
-            None
-        } else {
-            Some(LightSpinner::start("Scanning session data..."))
-        };
-        let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
+        let (had_cursor_cache, (spinner, cursor_sync_result)) = sample_cursor_cache_before_sync(
+            || has_cursor_usage_cache_for_report(&home_dir),
+            || {
+                let spinner = spinner_message.map(LightSpinner::start);
+                let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
+                (spinner, cursor_sync_result)
+            },
+        );
         let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
-        let use_env_roots = use_env_roots(&home_dir);
-        let start = std::time::Instant::now();
 
         Self {
             home_dir,
             clients,
-            since,
-            until,
-            year,
-            date_range,
-            effective_home_dir,
+            since: resolved_date.since,
+            until: resolved_date.until,
+            year: resolved_date.year,
+            date_range: resolved_date.date_range,
+            scanner_settings: resolved_date.scanner_settings,
             had_cursor_cache,
             explicit_cursor_filter,
             spinner,
             cursor_sync_result,
             cursor_setup_warnings,
-            use_env_roots,
-            start,
+            use_env_roots: false,
+            start: std::time::Instant::now(),
+        }
+    }
+
+    fn complete_timing_setup(&mut self) {
+        self.resolve_env_roots();
+        self.start_timing();
+    }
+
+    fn resolve_env_roots(&mut self) {
+        self.use_env_roots = use_env_roots(&self.home_dir);
+    }
+
+    fn start_timing(&mut self) {
+        self.start = std::time::Instant::now();
+    }
+
+    fn effective_home_dir(&self) -> Option<PathBuf> {
+        resolve_effective_home_dir(&self.home_dir)
+    }
+
+    fn stop_spinner(&mut self) {
+        if let Some(spinner) = self.spinner.take() {
+            spinner.stop();
         }
     }
 
@@ -2005,9 +2054,19 @@ impl LocalReportContext {
             until: self.until.clone(),
             year: self.year.clone(),
             group_by,
-            scanner_settings: tui::settings::load_scanner_settings_for_home(&self.home_dir),
+            scanner_settings: self.scanner_settings.clone(),
         }
     }
+}
+
+fn sample_cursor_cache_before_sync<FCache, FSync, T>(sample_cache: FCache, sync: FSync) -> (bool, T)
+where
+    FCache: FnOnce() -> bool,
+    FSync: FnOnce() -> T,
+{
+    let had_cursor_cache = sample_cache();
+    let sync_result = sync();
+    (had_cursor_cache, sync_result)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2026,7 +2085,12 @@ fn run_models_report(
     use tokio::runtime::Runtime;
     use tokscale_core::{get_model_report, GroupBy};
 
-    let mut context = LocalReportContext::new(home_dir, clients, date, no_spinner, true);
+    let mut context = LocalReportContext::new(
+        home_dir,
+        clients,
+        date,
+        (!no_spinner).then_some("Scanning session data..."),
+    );
     let rt = Runtime::new()?;
     let report = rt
         .block_on(async { get_model_report(context.report_options(group_by.clone())).await })
@@ -2047,9 +2111,7 @@ fn run_models_report(
     }
     let report = report;
 
-    if let Some(spinner) = context.spinner.take() {
-        spinner.stop();
-    }
+    context.stop_spinner();
     emit_cursor_sync_warning(
         context.cursor_sync_result.as_ref(),
         context.had_cursor_cache,
@@ -2063,7 +2125,7 @@ fn run_models_report(
         .map(|entry| entry.message_count)
         .sum();
     let diagnostics = context
-        .effective_home_dir
+        .effective_home_dir()
         .as_deref()
         .map(|home| {
             claude_diagnostics::diagnostics_for_empty_explicit_report(
@@ -2874,7 +2936,12 @@ fn run_monthly_report(
     use tokio::runtime::Runtime;
     use tokscale_core::{get_monthly_report_v2, GroupBy};
 
-    let mut context = LocalReportContext::new(home_dir, clients, date, no_spinner, false);
+    let mut context = LocalReportContext::new(
+        home_dir,
+        clients,
+        date,
+        (!no_spinner).then_some("Scanning session data..."),
+    );
     let rt = Runtime::new()?;
     let report = rt
         .block_on(async { get_monthly_report_v2(context.report_options(GroupBy::default())).await })
@@ -2893,9 +2960,7 @@ fn run_monthly_report(
     }
     let report = report;
 
-    if let Some(spinner) = context.spinner.take() {
-        spinner.stop();
-    }
+    context.stop_spinner();
     emit_cursor_sync_warning(
         context.cursor_sync_result.as_ref(),
         context.had_cursor_cache,
@@ -3183,7 +3248,12 @@ fn run_hourly_report(
     use tokio::runtime::Runtime;
     use tokscale_core::{get_hourly_report, GroupBy};
 
-    let mut context = LocalReportContext::new(home_dir, clients, date, no_spinner, false);
+    let mut context = LocalReportContext::new(
+        home_dir,
+        clients,
+        date,
+        (!no_spinner).then_some("Scanning session data..."),
+    );
     let rt = Runtime::new()?;
     let report = rt
         .block_on(async { get_hourly_report(context.report_options(GroupBy::default())).await })
@@ -3202,9 +3272,7 @@ fn run_hourly_report(
     }
     let report = report;
 
-    if let Some(spinner) = context.spinner.take() {
-        spinner.stop();
-    }
+    context.stop_spinner();
     emit_cursor_sync_warning(
         context.cursor_sync_result.as_ref(),
         context.had_cursor_cache,
@@ -4995,48 +5063,31 @@ fn run_time_metrics_report(
     json: bool,
     home_dir: Option<String>,
     clients: Option<Vec<String>>,
-    since: Option<String>,
-    until: Option<String>,
-    year: Option<String>,
+    resolved_date: ResolvedReportDate,
     no_spinner: bool,
 ) -> Result<()> {
     use tokio::runtime::Runtime;
-    use tokscale_core::{get_time_metrics_report, GroupBy, ReportOptions};
+    use tokscale_core::{get_time_metrics_report, GroupBy};
 
-    let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
-    let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
-    let spinner = if no_spinner {
-        None
-    } else {
-        Some(LightSpinner::start("Computing time metrics..."))
-    };
-    let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
-    let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
-    let use_env_roots = use_env_roots(&home_dir);
+    let mut context = LocalReportContext::from_resolved_date(
+        home_dir,
+        clients,
+        resolved_date,
+        (!no_spinner).then_some("Computing time metrics..."),
+    );
+    context.complete_timing_setup();
     let rt = Runtime::new()?;
     let report = rt
         .block_on(async {
-            get_time_metrics_report(ReportOptions {
-                home_dir: home_dir.clone(),
-                use_env_roots,
-                clients,
-                since,
-                until,
-                year,
-                group_by: GroupBy::default(),
-                scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
-            })
-            .await
+            get_time_metrics_report(context.report_options(GroupBy::default())).await
         })
         .map_err(|e| anyhow::anyhow!(e))?;
 
-    if let Some(spinner) = spinner {
-        spinner.stop();
-    }
+    context.stop_spinner();
     emit_cursor_sync_warning(
-        cursor_sync_result.as_ref(),
-        had_cursor_cache,
-        explicit_cursor_filter,
+        context.cursor_sync_result.as_ref(),
+        context.had_cursor_cache,
+        context.explicit_cursor_filter,
     );
 
     let m = &report.metrics;
@@ -5054,11 +5105,11 @@ fn run_time_metrics_report(
         let output = TimeMetricsReportJson {
             metrics: &report.metrics,
             processing_time_ms: report.processing_time_ms,
-            warnings: cursor_setup_warnings,
+            warnings: context.cursor_setup_warnings,
         };
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
-        emit_cursor_setup_warnings(&cursor_setup_warnings);
+        emit_cursor_setup_warnings(&context.cursor_setup_warnings);
         println!("Session Time Metrics");
         println!("====================");
         println!(
@@ -5104,55 +5155,40 @@ fn run_graph_command(
     output: Option<String>,
     home_dir: Option<String>,
     clients: Option<Vec<String>>,
-    since: Option<String>,
-    until: Option<String>,
-    year: Option<String>,
+    resolved_date: ResolvedReportDate,
     benchmark: bool,
     no_spinner: bool,
 ) -> Result<()> {
     use colored::Colorize;
-    use std::time::Instant;
-    use tokscale_core::{generate_local_graph_report, GroupBy, ReportOptions};
+    use tokscale_core::{generate_local_graph_report, GroupBy};
 
     let show_progress = output.is_some() && !no_spinner;
-    let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
-    let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
-    let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
-    let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
+    let mut context =
+        LocalReportContext::from_resolved_date(home_dir, clients, resolved_date, None);
 
     if show_progress {
         eprintln!("  Scanning session data...");
     }
-    let start = Instant::now();
+    context.start_timing();
 
     if show_progress {
         eprintln!("  Generating graph data...");
     }
-    let use_env_roots = use_env_roots(&home_dir);
+    context.resolve_env_roots();
     let rt = tokio::runtime::Runtime::new()?;
     let graph_result = rt
         .block_on(async {
-            generate_local_graph_report(ReportOptions {
-                home_dir: home_dir.clone(),
-                use_env_roots,
-                clients,
-                since,
-                until,
-                year,
-                group_by: GroupBy::default(),
-                scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
-            })
-            .await
+            generate_local_graph_report(context.report_options(GroupBy::default())).await
         })
         .map_err(|e| anyhow::anyhow!(e))?;
     emit_cursor_sync_warning(
-        cursor_sync_result.as_ref(),
-        had_cursor_cache,
-        explicit_cursor_filter,
+        context.cursor_sync_result.as_ref(),
+        context.had_cursor_cache,
+        context.explicit_cursor_filter,
     );
-    emit_cursor_setup_warnings(&cursor_setup_warnings);
+    emit_cursor_setup_warnings(&context.cursor_setup_warnings);
 
-    let processing_time_ms = start.elapsed().as_millis() as u32;
+    let processing_time_ms = context.start.elapsed().as_millis() as u32;
     let output_data = to_ts_token_contribution_data(&graph_result, None, None);
     let json_output = serde_json::to_string_pretty(&output_data)?;
 
@@ -5187,7 +5223,7 @@ fn run_graph_command(
                 "{}",
                 format!("  Processing time: {}ms (Rust native)", processing_time_ms).bright_black()
             );
-            if let Some(sync) = cursor_sync_result {
+            if let Some(sync) = context.cursor_sync_result.as_ref() {
                 if sync.synced {
                     eprintln!(
                         "{}",
@@ -5197,8 +5233,8 @@ fn run_graph_command(
                         )
                         .bright_black()
                     );
-                } else if let Some(err) = sync.error {
-                    if had_cursor_cache {
+                } else if let Some(err) = sync.error.as_ref() {
+                    if context.had_cursor_cache {
                         eprintln!("{}", format!("  Cursor: sync failed - {}", err).yellow());
                     }
                 }
@@ -7456,6 +7492,40 @@ mod tests {
             Some("Pacific/Kiritimati"),
             "report must rebucket sessions with the --home profile's timezone"
         );
+    }
+
+    #[test]
+    fn test_resolved_month_filter_and_label_share_bucket_boundary() {
+        let date = DateRangeFlags {
+            month: true,
+            ..DateRangeFlags::default()
+        };
+        let current_date = chrono::NaiveDate::from_ymd_opt(2026, 3, 1).unwrap();
+        let (since, until) = build_date_filter_for_date(&date, current_date);
+        let label = get_date_range_label_for_date(&date, current_date);
+
+        assert_eq!(since.as_deref(), Some("2026-03-01"));
+        assert_eq!(until.as_deref(), Some("2026-03-01"));
+        assert_eq!(label.as_deref(), Some("March 2026"));
+    }
+
+    #[test]
+    fn test_cursor_cache_is_sampled_before_sync() {
+        let events = std::cell::RefCell::new(Vec::new());
+        let (had_cache, sync_result) = sample_cursor_cache_before_sync(
+            || {
+                events.borrow_mut().push("sample");
+                true
+            },
+            || {
+                events.borrow_mut().push("sync");
+                42
+            },
+        );
+
+        assert!(had_cache);
+        assert_eq!(sync_result, 42);
+        assert_eq!(*events.borrow(), ["sample", "sync"]);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1921,6 +1921,8 @@ struct ResolvedReportDate {
     since: Option<String>,
     until: Option<String>,
     year: Option<String>,
+    // Text report renderers use this label; graph and time-metrics intentionally
+    // share the context without rendering a date-range title.
     date_range: Option<String>,
     scanner_settings: tokscale_core::ScannerSettings,
 }
@@ -7409,6 +7411,8 @@ mod tests {
     /// ignores its argument returns the same day for both homes.
     #[test]
     fn test_current_bucket_date_follows_the_home_overrides_pinned_zone() {
+        use chrono::Datelike;
+
         fn home_pinned_to(zone: &str) -> tempfile::TempDir {
             let home = tempfile::TempDir::new().unwrap();
             let config = home.path().join(if cfg!(windows) {
@@ -7433,12 +7437,12 @@ mod tests {
         let niue = current_bucket_date(&Some(niue_home.path().to_string_lossy().into_owned()));
         let kiritimati_home_path = Some(kiritimati_home.path().to_string_lossy().into_owned());
         let niue_home_path = Some(niue_home.path().to_string_lossy().into_owned());
-        let today = DateRangeFlags {
-            today: true,
+        let month = DateRangeFlags {
+            month: true,
             ..DateRangeFlags::default()
         };
-        let kiritimati_report_date = ResolvedReportDate::new(&today, &kiritimati_home_path);
-        let niue_report_date = ResolvedReportDate::new(&today, &niue_home_path);
+        let kiritimati_report_date = ResolvedReportDate::new(&month, &kiritimati_home_path);
+        let niue_report_date = ResolvedReportDate::new(&month, &niue_home_path);
         let report_settings = tui::settings::load_scanner_settings_for_home(&kiritimati_home_path);
 
         assert_eq!(
@@ -7458,18 +7462,38 @@ mod tests {
         );
         let expected_kiritimati = kiritimati.to_string();
         let expected_niue = niue.to_string();
+        let expected_kiritimati_start = kiritimati.with_day(1).unwrap().to_string();
+        let expected_niue_start = niue.with_day(1).unwrap().to_string();
+        let expected_kiritimati_label = kiritimati.format("%B %Y").to_string();
+        let expected_niue_label = niue.format("%B %Y").to_string();
         assert_eq!(
             kiritimati_report_date.since.as_deref(),
+            Some(expected_kiritimati_start.as_str()),
+            "resolved month filters must use the pinned --home timezone"
+        );
+        assert_eq!(
+            kiritimati_report_date.until.as_deref(),
             Some(expected_kiritimati.as_str()),
-            "resolved report dates must use the pinned --home timezone"
+            "resolved month filters must use the pinned --home timezone"
         );
         assert_eq!(
             niue_report_date.since.as_deref(),
-            Some(expected_niue.as_str()),
-            "resolved report dates must use the pinned --home timezone"
+            Some(expected_niue_start.as_str()),
+            "resolved month filters must use the pinned --home timezone"
         );
-        assert_eq!(kiritimati_report_date.date_range.as_deref(), Some("Today"));
-        assert_eq!(niue_report_date.date_range.as_deref(), Some("Today"));
+        assert_eq!(
+            niue_report_date.until.as_deref(),
+            Some(expected_niue.as_str()),
+            "resolved month filters must use the pinned --home timezone"
+        );
+        assert_eq!(
+            kiritimati_report_date.date_range.as_deref(),
+            Some(expected_kiritimati_label.as_str())
+        );
+        assert_eq!(
+            niue_report_date.date_range.as_deref(),
+            Some(expected_niue_label.as_str())
+        );
     }
 
     #[test]

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3923,6 +3923,26 @@ fn test_monthly_light_output() {
 }
 
 #[test]
+fn test_monthly_light_title_includes_year_filter() {
+    let tmp = create_temp_fixture_dir();
+    cmd_with_home(tmp.path())
+        .args([
+            "monthly",
+            "--light",
+            "--client",
+            "opencode",
+            "--no-spinner",
+            "--year",
+            "2024",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Monthly Token Usage Report (2024)",
+        ));
+}
+
+#[test]
 fn test_models_light_with_client_filter() {
     let tmp = create_temp_fixture_dir();
     cmd_with_home(tmp.path())

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3923,8 +3923,25 @@ fn test_monthly_light_output() {
 }
 
 #[test]
-fn test_monthly_light_title_includes_year_filter() {
+fn test_monthly_light_title_uses_pinned_bucket_month() {
     let tmp = create_temp_fixture_dir();
+    let config = tmp.path().join(if cfg!(windows) {
+        "AppData/Roaming/tokscale"
+    } else {
+        ".config/tokscale"
+    });
+    fs::create_dir_all(&config).unwrap();
+    fs::write(
+        config.join("settings.json"),
+        r#"{"scanner":{"bucketTimezone":"Pacific/Kiritimati"}}"#,
+    )
+    .unwrap();
+    let expected_month =
+        tokscale_core::BucketTimezone::from_pinned_name(Some("Pacific/Kiritimati"))
+            .today()
+            .format("%B %Y")
+            .to_string();
+
     cmd_with_home(tmp.path())
         .args([
             "monthly",
@@ -3932,14 +3949,13 @@ fn test_monthly_light_title_includes_year_filter() {
             "--client",
             "opencode",
             "--no-spinner",
-            "--year",
-            "2024",
+            "--month",
         ])
         .assert()
         .success()
-        .stdout(predicate::str::contains(
-            "Monthly Token Usage Report (2024)",
-        ));
+        .stdout(predicate::str::contains(format!(
+            "Monthly Token Usage Report ({expected_month})"
+        )));
 }
 
 #[test]

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3925,17 +3925,10 @@ fn test_monthly_light_output() {
 #[test]
 fn test_monthly_light_title_uses_pinned_bucket_month() {
     let tmp = create_temp_fixture_dir();
-    let config = tmp.path().join(if cfg!(windows) {
-        "AppData/Roaming/tokscale"
-    } else {
-        ".config/tokscale"
-    });
-    fs::create_dir_all(&config).unwrap();
-    fs::write(
-        config.join("settings.json"),
+    write_settings_json(
+        tmp.path(),
         r#"{"scanner":{"bucketTimezone":"Pacific/Kiritimati"}}"#,
-    )
-    .unwrap();
+    );
     let expected_month =
         tokscale_core::BucketTimezone::from_pinned_name(Some("Pacific/Kiritimati"))
             .today()


### PR DESCRIPTION
## Summary

- Fix monthly report titles to derive their month label from the same pinned bucket date used for filtering, so a profile near a UTC date boundary no longer displays the host machine's month.
- Resolve scanner settings, date bounds, and the rendered label once, then pass the same scanner settings through local reports, graph, and time metrics.
- Reuse the canonical date-filter and year-normalization helpers in autosubmit without changing its pinned bucket-date behavior.
- Preserve cursor-cache snapshot, spinner, sync, warning, progress, and graph benchmark timing order.
- Add deterministic timezone-boundary coverage and a hermetic CLI regression test for the rendered month title.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-features --no-fail-fast`
- `cargo test -p tokscale-cli --locked --bin tokscale test_current_bucket_date_follows_the_home_overrides_pinned_zone`
- `cargo test -p tokscale-cli --locked --test cli_tests test_monthly_light_title_uses_pinned_bucket_month`

All commands passed after rebasing onto current `origin/main`. A fresh read-only adversarial review approved the rebased head with no blocker; the PR remains draft for maintainer review and CI.
