### PR TITLE
test(tui): isolate cache and widget config tests

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -280,23 +280,29 @@ impl UsageOutput {
 
 // ── Cache ──
 
-fn cache_path() -> Option<std::path::PathBuf> {
-    // Unit tests must opt into a temporary config root before any cache
-    // helper can create, write, or remove a subscription cache.
-    #[cfg(test)]
-    if !crate::paths::is_config_dir_overridden() {
-        return None;
-    }
+const SUBSCRIPTION_CACHE_FILE: &str = "subscription-usage-cache.json";
 
-    let dir = crate::paths::get_cache_dir();
-    if std::fs::create_dir_all(&dir).is_err() {
+fn cache_path_in(dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    if std::fs::create_dir_all(dir).is_err() {
         return None;
     }
-    Some(dir.join("subscription-usage-cache.json"))
+    Some(dir.join(SUBSCRIPTION_CACHE_FILE))
 }
 
-pub fn save_cache(data: &[UsageOutput]) {
-    let Some(path) = cache_path() else { return };
+#[cfg(not(test))]
+fn cache_path() -> Option<std::path::PathBuf> {
+    cache_path_in(&crate::paths::get_cache_dir())
+}
+
+// Unit-test callers must use the explicit-path helpers below. Making the
+// production resolver unavailable prevents an unrelated parallel test from
+// reading, writing, or deleting the developer's real subscription cache.
+#[cfg(test)]
+fn cache_path() -> Option<std::path::PathBuf> {
+    None
+}
+
+fn save_cache_at(path: &std::path::Path, data: &[UsageOutput]) {
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -305,19 +311,27 @@ pub fn save_cache(data: &[UsageOutput]) {
         "timestamp": timestamp,
         "data": data,
     });
-    let _ = std::fs::write(&path, serde_json::to_string(&json).unwrap_or_default());
+    let _ = std::fs::write(path, serde_json::to_string(&json).unwrap_or_default());
+}
+
+pub fn save_cache(data: &[UsageOutput]) {
+    if let Some(path) = cache_path() {
+        save_cache_at(&path, data);
+    }
+}
+
+fn clear_cache_at(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
 }
 
 pub fn clear_cache() {
     if let Some(path) = cache_path() {
-        let _ = std::fs::remove_file(&path);
+        clear_cache_at(&path);
     }
 }
 
-#[cfg_attr(test, allow(dead_code))]
-pub fn load_cache() -> Option<Vec<UsageOutput>> {
-    let path = cache_path()?;
-    let content = std::fs::read_to_string(&path).ok()?;
+fn load_cache_at(path: &std::path::Path) -> Option<Vec<UsageOutput>> {
+    let content = std::fs::read_to_string(path).ok()?;
     let doc: serde_json::Value = serde_json::from_str(&content).ok()?;
     let timestamp = doc.get("timestamp")?.as_u64()?;
     let age = std::time::SystemTime::now()
@@ -330,6 +344,11 @@ pub fn load_cache() -> Option<Vec<UsageOutput>> {
         return None;
     }
     serde_json::from_value(doc.get("data")?.clone()).ok()
+}
+
+#[cfg_attr(test, allow(dead_code))]
+pub fn load_cache() -> Option<Vec<UsageOutput>> {
+    load_cache_at(&cache_path()?)
 }
 
 // ── Public API ──
@@ -552,76 +571,30 @@ pub fn run(json: bool, _light: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
-    use std::ffi::{OsStr, OsString};
     use tempfile::TempDir;
 
-    struct TestEnvGuard(Vec<(&'static str, Option<OsString>)>);
-
-    impl TestEnvGuard {
-        fn new() -> Self {
-            Self(Vec::new())
-        }
-
-        fn capture(&mut self, key: &'static str) {
-            if !self.0.iter().any(|(captured, _)| *captured == key) {
-                self.0.push((key, std::env::var_os(key)));
-            }
-        }
-
-        fn set(&mut self, key: &'static str, value: impl AsRef<OsStr>) {
-            self.capture(key);
-            unsafe { std::env::set_var(key, value) };
-        }
-
-        fn remove(&mut self, key: &'static str) {
-            self.capture(key);
-            unsafe { std::env::remove_var(key) };
-        }
-    }
-
-    impl Drop for TestEnvGuard {
-        fn drop(&mut self) {
-            for (key, value) in self.0.drain(..).rev() {
-                unsafe {
-                    match value {
-                        Some(value) => std::env::set_var(key, value),
-                        None => std::env::remove_var(key),
-                    }
-                }
-            }
-        }
-    }
-
     #[test]
-    #[serial]
-    fn subscription_cache_helpers_are_noop_without_explicit_override() {
-        let temp = TempDir::new().unwrap();
-        let mut env = TestEnvGuard::new();
-        env.set("HOME", temp.path());
-        env.set("XDG_CONFIG_HOME", temp.path().join(".xdg-config"));
-        env.remove("TOKSCALE_CONFIG_DIR");
-
+    fn subscription_cache_public_helpers_are_noop_in_tests() {
         assert!(cache_path().is_none());
         save_cache(&[sample_output("Codex")]);
+        assert!(load_cache().is_none());
         clear_cache();
-        assert!(!temp.path().join(".xdg-config/tokscale/cache").exists());
     }
 
     #[test]
-    #[serial]
-    fn subscription_cache_helpers_use_explicit_override_root() {
+    fn subscription_cache_helpers_use_explicit_path() {
         let temp = TempDir::new().unwrap();
-        let mut env = TestEnvGuard::new();
-        env.set("TOKSCALE_CONFIG_DIR", temp.path());
+        let expected = cache_path_in(&temp.path().join("cache")).unwrap();
         let data = vec![sample_output("Codex")];
-        let expected = temp.path().join("cache/subscription-usage-cache.json");
 
-        assert_eq!(cache_path(), Some(expected.clone()));
-        save_cache(&data);
-        assert_eq!(load_cache().unwrap().len(), 1);
+        assert_eq!(
+            expected,
+            temp.path().join("cache/subscription-usage-cache.json")
+        );
+        save_cache_at(&expected, &data);
+        assert_eq!(load_cache_at(&expected).unwrap().len(), 1);
         assert!(expected.exists());
-        clear_cache();
+        clear_cache_at(&expected);
         assert!(!expected.exists());
     }
 

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -281,6 +281,13 @@ impl UsageOutput {
 // ── Cache ──
 
 fn cache_path() -> Option<std::path::PathBuf> {
+    // Unit tests must opt into a temporary config root before any cache
+    // helper can create, write, or remove a subscription cache.
+    #[cfg(test)]
+    if !crate::paths::is_config_dir_overridden() {
+        return None;
+    }
+
     let dir = crate::paths::get_cache_dir();
     if std::fs::create_dir_all(&dir).is_err() {
         return None;
@@ -545,6 +552,78 @@ pub fn run(json: bool, _light: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+    use std::ffi::{OsStr, OsString};
+    use tempfile::TempDir;
+
+    struct TestEnvGuard(Vec<(&'static str, Option<OsString>)>);
+
+    impl TestEnvGuard {
+        fn new() -> Self {
+            Self(Vec::new())
+        }
+
+        fn capture(&mut self, key: &'static str) {
+            if !self.0.iter().any(|(captured, _)| *captured == key) {
+                self.0.push((key, std::env::var_os(key)));
+            }
+        }
+
+        fn set(&mut self, key: &'static str, value: impl AsRef<OsStr>) {
+            self.capture(key);
+            unsafe { std::env::set_var(key, value) };
+        }
+
+        fn remove(&mut self, key: &'static str) {
+            self.capture(key);
+            unsafe { std::env::remove_var(key) };
+        }
+    }
+
+    impl Drop for TestEnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in self.0.drain(..).rev() {
+                unsafe {
+                    match value {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn subscription_cache_helpers_are_noop_without_explicit_override() {
+        let temp = TempDir::new().unwrap();
+        let mut env = TestEnvGuard::new();
+        env.set("HOME", temp.path());
+        env.set("XDG_CONFIG_HOME", temp.path().join(".xdg-config"));
+        env.remove("TOKSCALE_CONFIG_DIR");
+
+        assert!(cache_path().is_none());
+        save_cache(&[sample_output("Codex")]);
+        clear_cache();
+        assert!(!temp.path().join(".xdg-config/tokscale/cache").exists());
+    }
+
+    #[test]
+    #[serial]
+    fn subscription_cache_helpers_use_explicit_override_root() {
+        let temp = TempDir::new().unwrap();
+        let mut env = TestEnvGuard::new();
+        env.set("TOKSCALE_CONFIG_DIR", temp.path());
+        let data = vec![sample_output("Codex")];
+        let expected = temp.path().join("cache/subscription-usage-cache.json");
+
+        assert_eq!(cache_path(), Some(expected.clone()));
+        save_cache(&data);
+        assert_eq!(load_cache().unwrap().len(), 1);
+        assert!(expected.exists());
+        clear_cache();
+        assert!(!expected.exists());
+    }
 
     #[test]
     fn usage_output_display_name_includes_account_label() {

--- a/crates/tokscale-cli/src/tui/config.rs
+++ b/crates/tokscale-cli/src/tui/config.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::OnceLock;
 
 use ratatui::style::Color;
@@ -33,16 +33,30 @@ pub struct DisplayNamesConfig {
 }
 
 impl TokscaleConfig {
-    fn config_path() -> Option<PathBuf> {
-        crate::paths::home_dir().map(|h| h.join(".tokscale"))
+    fn load_from_path(path: &Path) -> Self {
+        fs::read_to_string(path)
+            .ok()
+            .and_then(|content| toml::from_str(&content).ok())
+            .unwrap_or_default()
     }
 
     pub fn load() -> &'static TokscaleConfig {
         CONFIG.get_or_init(|| {
-            Self::config_path()
-                .and_then(|path| fs::read_to_string(path).ok())
-                .and_then(|content| toml::from_str(&content).ok())
-                .unwrap_or_default()
+            // Keep unit tests deterministic at the irreversible OnceLock
+            // boundary. Parser and widget-injection tests exercise disk/config
+            // behavior through explicit values without reading ambient files.
+            #[cfg(test)]
+            {
+                Self::default()
+            }
+            #[cfg(not(test))]
+            {
+                crate::paths::home_dir()
+                    .map(|home| home.join(".tokscale"))
+                    .as_deref()
+                    .map(Self::load_from_path)
+                    .unwrap_or_default()
+            }
         })
     }
 
@@ -84,4 +98,41 @@ fn parse_hex_color(hex: &str) -> Option<Color> {
     let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
     let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
     Some(Color::Rgb(r, g, b))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn load_from_path_parses_custom_colors_and_display_names() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tokscale.toml");
+        fs::write(
+            &path,
+            r##"[colors.providers]
+anthropic = "#123456"
+
+[display_names.clients]
+claude = "My Claude"
+"##,
+        )
+        .unwrap();
+
+        let config = TokscaleConfig::load_from_path(&path);
+        assert_eq!(
+            config.get_provider_color("Anthropic"),
+            Some(Color::Rgb(18, 52, 86))
+        );
+        assert_eq!(config.get_client_display_name("CLAUDE"), Some("My Claude"));
+    }
+
+    #[test]
+    fn load_from_path_uses_defaults_for_missing_file() {
+        let temp = TempDir::new().unwrap();
+        let config = TokscaleConfig::load_from_path(&temp.path().join("missing.toml"));
+        assert!(config.colors.providers.is_empty());
+        assert!(config.display_names.clients.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

- transplant the remaining TUI test-hermeticity work onto current `main`
- keep subscription-usage cache helpers inert in unit tests unless a temporary `TOKSCALE_CONFIG_DIR` is explicitly selected
- parse widget color/display-name fixtures from explicit temporary paths and keep the global config `OnceLock` deterministic in test builds
- drop the previously overlapping `main.rs`, shared test-env, app, and TUI cache changes; those are either superseded by current main or belong outside this focused PR

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-features`
- hostile-home probe for the subscription-cache and config tests; the seeded ambient `.tokscale` file remained byte-identical and no other file was created

## Current-main reassessment

After #1094 and #1108, the broad cache/app patch was no longer an appropriate standalone change. This PR is now dependency-free and touches only `commands/usage/mod.rs` and `tui/config.rs`, with no file overlap with #1098. It remains draft while CI validates the rewritten head.
