### PR TITLE
fix(cache): keep a completed Claude replay from losing to a retained partial

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -911,9 +911,9 @@ fn parse_all_messages_with_pricing_with_cache_policy(
     /// still contains: a key present on both sides keeps the freshly parsed
     /// message, so a corrected re-parse still wins and nothing is frozen at a
     /// stale value. Only keys the file no longer carries are carried forward.
-    /// (Across entries the Claude lane is first-wins on lexical path order, so
-    /// a retained copy in an earlier-sorting file still beats a live copy of
-    /// the same key in a later one.)
+    /// (Across entries the Claude lane reconciles a duplicate key field by
+    /// field instead of picking a file order to trust — see the cross-file
+    /// merge below and `absorb_retained_history` in `message_cache.rs`.)
     ///
     /// Messages without a dedup key are never retained. The key is what lets a
     /// later scan recognise the message as already-seen; re-emitting an
@@ -1628,12 +1628,36 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         }
     }
 
-    let mut seen_keys: HashSet<String> = HashSet::new();
-    let claude_messages: Vec<UnifiedMessage> = claude_messages_raw
-        .into_iter()
-        .filter(|(key, _)| key.is_empty() || seen_keys.insert(key.clone()))
-        .map(|(_, msg)| msg)
-        .collect();
+    // A retained message survives an in-place transcript rewrite (see
+    // `HistoryRetention::RetainObserved`), and the same turn's completed form
+    // can independently show up live in another file (e.g. a forked/resumed
+    // transcript) if a scan observed the retained copy while its usage was
+    // still partial. Neither copy is authoritative over the other — a scan
+    // can equally land mid-stream on the "live" side — so a duplicate key is
+    // reconciled field by field instead of one file's copy winning by sort
+    // order. Reconciliation is symmetric, so file iteration order does not
+    // matter.
+    let mut seen_keys: HashMap<String, usize> = HashMap::new();
+    let mut claude_messages: Vec<UnifiedMessage> = Vec::new();
+    for (key, msg) in claude_messages_raw {
+        if key.is_empty() {
+            claude_messages.push(msg);
+            continue;
+        }
+        match seen_keys.get(&key) {
+            Some(&index) => {
+                sessions::claudecode::reconcile_claude_duplicate_message(
+                    &mut claude_messages[index],
+                    &msg,
+                    pricing,
+                );
+            }
+            None => {
+                seen_keys.insert(key, claude_messages.len());
+                claude_messages.push(msg);
+            }
+        }
+    }
     all_messages.extend(claude_messages);
 
     let codex_outcomes: Vec<(PathBuf, CachedParseOutcome)> = scan_result
@@ -6715,6 +6739,284 @@ mod tests {
     /// collapse against the same tool result replayed under a fork's filename
     /// — both would count — so retention has to leave those records behind
     /// even though it means a compaction still retires their input tokens.
+    /// The sibling tests below assume both copies of a replayed turn carry the
+    /// same tokens. A scan that lands mid-stream breaks that assumption: the
+    /// parser merges duplicates with a per-field max precisely because an
+    /// assistant record can be observed before its usage is final. When one
+    /// copy of a turn is retained across a rewrite and the other shows up live
+    /// in a different (forked) file, first-occurrence-wins cross-file dedup
+    /// keeps whichever file the scanner happens to sort first and discards
+    /// the other copy's fields outright, however incomplete.
+    ///
+    /// One helper drives every direction and file-order combination below: it
+    /// writes an original transcript holding `turn_one` plus a first version
+    /// of `turn_two` (`retained_usage`), scans cold so that version gets
+    /// cached, rewrites the original to compact `turn_two` away, and writes a
+    /// second transcript — named `second_file_name`, so callers control
+    /// whether it sorts before or after the original — holding a second
+    /// version of `turn_two` (`other_usage`). It returns the post-rewrite
+    /// scan's messages for the caller to assert on.
+    ///
+    /// Every fixture below picks `retained_usage`/`other_usage` so neither
+    /// holds the maximum of both fields: one leads on input, the other on
+    /// output. A fix that resolved the duplicate by picking one whole message
+    /// — by file order, or by which copy retention labeled — would still
+    /// under-report one of the two fields, and a fix that only reconciles in
+    /// one direction would pass some combinations here and fail others.
+    fn run_claude_two_copy_merge_scan(
+        second_file_name: &str,
+        retained_input: i64,
+        retained_output: i64,
+        other_input: i64,
+        other_output: i64,
+    ) -> Vec<UnifiedMessage> {
+        run_claude_two_copy_merge_scan_priced(
+            second_file_name,
+            retained_input,
+            retained_output,
+            other_input,
+            other_output,
+            None,
+        )
+    }
+
+    fn run_claude_two_copy_merge_scan_priced(
+        second_file_name: &str,
+        retained_input: i64,
+        retained_output: i64,
+        other_input: i64,
+        other_output: i64,
+        pricing: Option<&pricing::PricingService>,
+    ) -> Vec<UnifiedMessage> {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+
+        let claude_dir = source_home.path().join(".claude/projects/myproject");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let original = claude_dir.join("original.jsonl");
+
+        let turn_one = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}"#.to_string();
+        let turn_two_retained = format!(
+            r#"{{"type":"assistant","timestamp":"2024-12-01T10:05:00.000Z","requestId":"req_002","message":{{"id":"msg_002","model":"claude-3-5-sonnet","usage":{{"input_tokens":{retained_input},"output_tokens":{retained_output}}}}}}}"#
+        );
+        let turn_two_other = format!(
+            r#"{{"type":"assistant","timestamp":"2024-12-01T10:05:00.000Z","requestId":"req_002","message":{{"id":"msg_002","model":"claude-3-5-sonnet","usage":{{"input_tokens":{other_input},"output_tokens":{other_output}}}}}}}"#
+        );
+
+        std::fs::write(&original, format!("{turn_one}\n{turn_two_retained}\n")).unwrap();
+        let before = parse_all_messages_with_pricing_with_env_strategy(
+            source_home.path().to_str().unwrap(),
+            &["claude".to_string()],
+            pricing,
+            false,
+            &scanner::ScannerSettings::default(),
+        );
+        assert_eq!(
+            before.len(),
+            2,
+            "cold scan caches the first version of turn two"
+        );
+
+        // Compaction drops turn two from the original file; the second file
+        // (a fork, or an independent resumed session) carries the other
+        // version of the same turn.
+        std::fs::write(&original, format!("{turn_one}\n")).unwrap();
+        std::fs::write(
+            claude_dir.join(second_file_name),
+            format!("{turn_two_other}\n"),
+        )
+        .unwrap();
+
+        parse_all_messages_with_pricing_with_env_strategy(
+            source_home.path().to_str().unwrap(),
+            &["claude".to_string()],
+            pricing,
+            false,
+            &scanner::ScannerSettings::default(),
+        )
+    }
+
+    fn assert_claude_two_copy_merge(
+        messages: &[UnifiedMessage],
+        expected_input: i64,
+        expected_output: i64,
+    ) {
+        assert_eq!(messages.len(), 2, "turn two must survive exactly once");
+        assert_eq!(
+            messages.iter().map(|m| m.tokens.input).sum::<i64>(),
+            100 + expected_input,
+            "input must reconcile to the max across both copies"
+        );
+        assert_eq!(
+            messages.iter().map(|m| m.tokens.output).sum::<i64>(),
+            50 + expected_output,
+            "output must reconcile to the max across both copies"
+        );
+    }
+
+    /// The reported case (#1050): a retained partial versus a live completed
+    /// replay, with the retaining file sorting before the fork.
+    #[test]
+    #[serial_test::serial]
+    fn test_claude_retained_partial_reconciles_with_completed_live_replay() {
+        // Retained (partial-shaped): leads on input, trails on output.
+        // Other (completed-shaped): trails on input, leads on output.
+        let messages = run_claude_two_copy_merge_scan("zzz-fork.jsonl", 500, 60, 200, 999);
+        assert_claude_two_copy_merge(&messages, 500, 999);
+    }
+
+    /// Same direction, opposite file order: the fork sorts before the
+    /// retaining file. A symmetric reconciliation must not care.
+    #[test]
+    #[serial_test::serial]
+    fn test_claude_retained_partial_reconciles_with_completed_live_replay_reordered() {
+        let messages = run_claude_two_copy_merge_scan("aaa-fork.jsonl", 500, 60, 200, 999);
+        assert_claude_two_copy_merge(&messages, 500, 999);
+    }
+
+    /// The mirror case: the *retained* copy is the completed one and the
+    /// other file holds only a partial. Ranking a live copy over a retained
+    /// one gets this backwards — it would admit the partial and discard the
+    /// completed row. Reconciliation does not have a preferred side, so this
+    /// must reach the same merged values as the direct case above.
+    #[test]
+    #[serial_test::serial]
+    fn test_claude_retained_completed_reconciles_with_live_partial() {
+        // Retained (completed-shaped): trails on input, leads on output.
+        // Other (partial-shaped): leads on input, trails on output.
+        let messages = run_claude_two_copy_merge_scan("zzz-fork.jsonl", 200, 999, 500, 60);
+        assert_claude_two_copy_merge(&messages, 500, 999);
+    }
+
+    /// Mirror case, opposite file order.
+    #[test]
+    #[serial_test::serial]
+    fn test_claude_retained_completed_reconciles_with_live_partial_reordered() {
+        let messages = run_claude_two_copy_merge_scan("aaa-fork.jsonl", 200, 999, 500, 60);
+        assert_claude_two_copy_merge(&messages, 500, 999);
+    }
+
+    /// End-to-end through the real scan pipeline (not a direct call into
+    /// `reconcile_claude_duplicate_message`): with a pricing service in
+    /// scope, the reconciled turn's cost must equal the price of its merged
+    /// tokens, not `max` of the two copies' individually-priced costs.
+    /// `input_cost_per_token: 0.001`, `output_cost_per_token: 0.002`. Turn
+    /// one (100 in / 50 out) prices to 0.1 + 0.1 = 0.2. Turn two reconciles
+    /// to input=max(500,200)=500, output=max(60,999)=999, pricing to
+    /// 500 * 0.001 + 999 * 0.002 = 0.5 + 1.998 = 2.498 -- strictly more than
+    /// either input copy's own cost (0.5 and 0.2 + 1.998 = 2.198), which is
+    /// what a `max(a, b)` merge would have reported instead.
+    #[test]
+    #[serial_test::serial]
+    fn test_claude_two_copy_merge_reprices_from_reconciled_tokens() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-3-5-sonnet".into(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(0.001),
+                output_cost_per_token: Some(0.002),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new(litellm, HashMap::new());
+
+        let messages = run_claude_two_copy_merge_scan_priced(
+            "zzz-fork.jsonl",
+            500,
+            60,
+            200,
+            999,
+            Some(&pricing),
+        );
+        assert_claude_two_copy_merge(&messages, 500, 999);
+
+        let turn_two = messages
+            .iter()
+            .find(|m| m.tokens.input == 500)
+            .expect("reconciled turn two must be present");
+        assert!(
+            (turn_two.cost - 2.498).abs() < 1e-9,
+            "expected merged-token price 2.498, got {}",
+            turn_two.cost
+        );
+
+        let turn_one = messages
+            .iter()
+            .find(|m| m.tokens.input == 100)
+            .expect("turn one must be present");
+        assert!(
+            (turn_one.cost - 0.2).abs() < 1e-9,
+            "turn one is unaffected by reconciliation, expected 0.2, got {}",
+            turn_one.cost
+        );
+    }
+
+    /// A rewrite's reconciled value must survive a further, completely
+    /// unchanged scan — a warm cache hit for both source files, not a
+    /// reparse. With no persisted provenance this has to hold structurally:
+    /// each file's own cache entry already carries the values that scan
+    /// contributed (retention bakes a carried-forward message straight into
+    /// the messages a cache hit returns), and the cross-file merge re-runs
+    /// fresh from those on every scan. If this failed, the design would be
+    /// relying on some form of hidden state the previous ranking-based
+    /// version needed a dedicated `CACHE_FORMAT_VERSION` bump to persist.
+    #[test]
+    #[serial_test::serial]
+    fn test_claude_reconciled_duplicate_survives_a_third_unchanged_scan() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+
+        let claude_dir = source_home.path().join(".claude/projects/myproject");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let original = claude_dir.join("aaa-original.jsonl");
+
+        let turn_one = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}"#;
+        let turn_two_partial = r#"{"type":"assistant","timestamp":"2024-12-01T10:05:00.000Z","requestId":"req_002","message":{"id":"msg_002","model":"claude-3-5-sonnet","usage":{"input_tokens":500,"output_tokens":60}}}"#;
+        let turn_two_complete = r#"{"type":"assistant","timestamp":"2024-12-01T10:05:00.000Z","requestId":"req_002","message":{"id":"msg_002","model":"claude-3-5-sonnet","usage":{"input_tokens":200,"output_tokens":999}}}"#;
+
+        std::fs::write(&original, format!("{turn_one}\n{turn_two_partial}\n")).unwrap();
+        let before = parse_all_messages_with_pricing_with_env_strategy(
+            source_home.path().to_str().unwrap(),
+            &["claude".to_string()],
+            None,
+            false,
+            &scanner::ScannerSettings::default(),
+        );
+        assert_eq!(before.len(), 2, "cold scan caches the partial");
+
+        // Compaction drops turn two from the live file; the fork carries a
+        // second version of the same turn. This scan performs the merge and
+        // writes each file's own (unmerged) parse back to its own cache entry.
+        std::fs::write(&original, format!("{turn_one}\n")).unwrap();
+        std::fs::write(
+            claude_dir.join("zzz-fork.jsonl"),
+            format!("{turn_two_complete}\n"),
+        )
+        .unwrap();
+        let second = parse_all_messages_with_pricing_with_env_strategy(
+            source_home.path().to_str().unwrap(),
+            &["claude".to_string()],
+            None,
+            false,
+            &scanner::ScannerSettings::default(),
+        );
+        assert_claude_two_copy_merge(&second, 500, 999);
+
+        // Nothing on disk changes between the second and third scan: both the
+        // compacted original and the fork are unchanged, so both cache
+        // entries are warm hits, not reparses.
+        let third = parse_all_messages_with_pricing_with_env_strategy(
+            source_home.path().to_str().unwrap(),
+            &["claude".to_string()],
+            None,
+            false,
+            &scanner::ScannerSettings::default(),
+        );
+        assert_claude_two_copy_merge(&third, 500, 999);
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_claude_path_scoped_tool_result_is_not_retained_across_a_rewrite() {

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1203,6 +1203,20 @@ impl CachedSourceEntry {
     ///
     /// Same filter as the parse-time merge: a key that is only unique within
     /// one file must not outlive the bytes that produced it.
+    ///
+    /// A key present in both entries is never resolved by picking one copy
+    /// over the other. Two scanners can fingerprint the same partial file and
+    /// have the response complete between their parses, so even two live
+    /// copies under one fingerprint can disagree; and across a fingerprint
+    /// mismatch neither side can reparse what the other saw once compaction
+    /// drops the turn. Every way two copies of one key can differ is the same
+    /// disagreement — one observed the turn before its usage was final, the
+    /// other after — so content is always reconciled field by field via
+    /// `sessions::claudecode::reconcile_claude_duplicate_message`, the same
+    /// per-field max convention `merge_claude_duplicate` uses to fold
+    /// same-file streaming duplicates. No provenance label is tracked:
+    /// reconciliation does not need to know which side was retained, only
+    /// that neither side is discarded.
     fn absorb_retained_history(&mut self, stored: &CachedSourceEntry) {
         let Some(key_is_globally_stable) = retained_history_key_filter(&self.parser_namespace)
         else {
@@ -1216,10 +1230,11 @@ impl CachedSourceEntry {
             return;
         }
 
-        let mut seen: HashSet<String> = self
+        let mut self_keys: HashMap<String, usize> = self
             .messages
             .iter()
-            .filter_map(|message| message.dedup_key.clone())
+            .enumerate()
+            .filter_map(|(index, message)| message.dedup_key.clone().map(|key| (key, index)))
             .collect();
         for message in &stored.messages {
             let Some(key) = message.dedup_key.as_ref() else {
@@ -1228,8 +1243,24 @@ impl CachedSourceEntry {
             if !key_is_globally_stable(key) {
                 continue;
             }
-            if seen.insert(key.clone()) {
-                self.messages.push(message.clone());
+
+            match self_keys.get(key) {
+                None => {
+                    self.messages.push(message.clone());
+                    self_keys.insert(key.clone(), self.messages.len() - 1);
+                }
+                Some(&index) => {
+                    // Both entries hold their own copy of this key: reconcile
+                    // field by field rather than preferring either side.
+                    // No pricing service is reachable at the cache layer;
+                    // see `reconcile_claude_duplicate_message`'s doc comment
+                    // for why that is fine here.
+                    crate::sessions::claudecode::reconcile_claude_duplicate_message(
+                        &mut self.messages[index],
+                        message,
+                        None,
+                    );
+                }
             }
         }
     }
@@ -4111,6 +4142,181 @@ mod tests {
             let loaded = SourceMessageCache::load();
             let entry = loaded.get(identity, &path).expect("entry should survive");
             assert_eq!(entry.messages.len(), 1);
+        }
+    }
+
+    /// Neither copy of a key is ever authoritative over the other once both
+    /// entries hold their own. A scan can observe an assistant record while
+    /// its usage is still partial (the same reason `merge_claude_duplicate`
+    /// folds same-file duplicates with a per-field max), so when a straddled
+    /// rewrite leaves one writer holding a partial under one fingerprint and
+    /// another holding the completed form under a different one, picking
+    /// either whole message loses something.
+    ///
+    /// The partial writer saves *last* — the direction that can actually lose
+    /// data, since the last writer's own in-memory entry is the one doing the
+    /// merging and already holds its own values regardless of whether the
+    /// reconciliation runs at all.
+    #[test]
+    #[serial_test::serial]
+    fn test_save_if_dirty_reconciles_two_copies_under_a_fingerprint_mismatch() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+
+        {
+            let source_dir = TempDir::new().unwrap();
+            let path = source_dir.path().join("conversation.jsonl");
+            let identity = CacheIdentity::for_client(ClientId::Claude);
+            let namespace = ClientId::Claude.as_str();
+            let key = "msg_shared:req_shared";
+
+            // `completed` leads on output, cache_read, cache_write and
+            // duration; `partial` leads on input. Neither is the true
+            // maximum, so a fix that picks one whole message over the other
+            // would still fail this.
+            let mut completed = keyed_message(namespace, "session", key);
+            completed.tokens.output = 999;
+            completed.tokens.cache_read = 10;
+            completed.tokens.cache_write = 5;
+            completed.duration_ms = Some(4_200);
+
+            let mut partial = keyed_message(namespace, "session", key);
+            partial.tokens.input = 100;
+            partial.tokens.output = 50;
+            partial.duration_ms = Some(900);
+
+            // Writer B parses the completed form and saves first, under this
+            // generation's fingerprint.
+            std::fs::write(&path, b"{\"id\":\"generation-b\"}\n").unwrap();
+            let mut writer_b = SourceMessageCache::load();
+            writer_b.insert(entry_with_messages(identity, &path, vec![completed]));
+            writer_b.save_if_dirty();
+
+            // The file changes generation again (a straddled rewrite), and
+            // writer A -- which had already parsed a stalled partial of the
+            // same turn under its own earlier generation -- saves last.
+            std::fs::write(&path, b"{\"id\":\"generation-a\"}\n").unwrap();
+            let mut writer_a = SourceMessageCache::load();
+            writer_a.insert(entry_with_messages(identity, &path, vec![partial]));
+            writer_a.save_if_dirty();
+
+            let loaded = SourceMessageCache::load();
+            let entry = loaded.get(identity, &path).expect("entry should survive");
+            assert_eq!(
+                entry.messages.len(),
+                1,
+                "the shared turn must not duplicate"
+            );
+            let merged = &entry.messages[0];
+            assert_eq!(
+                merged.tokens.input, 100,
+                "input: partial's field was the max"
+            );
+            assert_eq!(
+                merged.tokens.output, 999,
+                "output: completed's field was the max"
+            );
+            assert_eq!(
+                merged.duration_ms,
+                Some(4_200),
+                "duration: the completed timing must not be lost to the partial's shorter one"
+            );
+            assert_eq!(
+                merged.tokens.cache_read, 10,
+                "cache_read: completed's field was the max"
+            );
+            assert_eq!(
+                merged.tokens.cache_write, 5,
+                "cache_write: completed's field was the max"
+            );
+
+            // A following cache-hit scan (no further writes) must keep
+            // reporting the reconciled figures, not just hold them in memory.
+            let rescan = SourceMessageCache::load();
+            let entry = rescan.get(identity, &path).expect("entry should survive");
+            assert_eq!(entry.messages.len(), 1);
+            let merged = &entry.messages[0];
+            assert_eq!(merged.tokens.input, 100);
+            assert_eq!(merged.tokens.output, 999);
+            assert_eq!(merged.duration_ms, Some(4_200));
+        }
+    }
+
+    /// Two scanners can fingerprint the same partial file and have the
+    /// response complete between their parses, so two *live* copies can
+    /// disagree under one fingerprint too. Preferring the stored one because
+    /// it is live discards the completed usage whenever the completed writer
+    /// saved first and the partial writer saved last.
+    #[test]
+    #[serial_test::serial]
+    fn test_save_if_dirty_reconciles_two_live_copies_under_one_fingerprint() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+
+        {
+            let source_dir = TempDir::new().unwrap();
+            let path = source_dir.path().join("transcript.jsonl");
+            std::fs::write(&path, b"{\"id\":\"one-generation\"}\n").unwrap();
+
+            let identity = CacheIdentity::for_client(ClientId::Claude);
+            let namespace = ClientId::Claude.as_str();
+            let key = "msg_shared:req_shared";
+
+            // Neither writer labels the key retained: both parsed it live.
+            let mut partial = keyed_message(namespace, "session", key);
+            partial.tokens.input = 100;
+            partial.tokens.output = 50;
+            partial.duration_ms = Some(900);
+
+            let mut completed = keyed_message(namespace, "session", key);
+            completed.tokens.output = 999;
+            completed.tokens.cache_read = 10;
+            completed.duration_ms = Some(4_200);
+            completed.cost = 0.25;
+            // The full generation still had the preceding user row, so it saw
+            // this reply as a turn start; the compacted parse does not.
+            completed.is_turn_start = true;
+
+            // The completed writer saves first, so its copy is the one
+            // already on disk; the partial writer saves last and its entry
+            // is the one doing the merging. This is the losing direction:
+            // whatever the merge fails to pull across from the stored copy
+            // is gone.
+            let mut writer_completed = SourceMessageCache::load();
+            writer_completed.insert(entry_with_messages(identity, &path, vec![completed]));
+            writer_completed.save_if_dirty();
+
+            let mut writer_partial = SourceMessageCache::load();
+            writer_partial.insert(entry_with_messages(identity, &path, vec![partial]));
+            writer_partial.save_if_dirty();
+
+            let loaded = SourceMessageCache::load();
+            let entry = loaded.get(identity, &path).expect("entry should survive");
+            assert_eq!(
+                entry.messages.len(),
+                1,
+                "the shared turn must not duplicate"
+            );
+            let merged = &entry.messages[0];
+            assert_eq!(merged.tokens.input, 100, "input: partial held the max");
+            assert_eq!(merged.tokens.output, 999, "output: completed held the max");
+            assert_eq!(
+                merged.tokens.cache_read, 10,
+                "cache_read: completed held the max"
+            );
+            assert_eq!(
+                merged.duration_ms,
+                Some(4_200),
+                "duration: the completed timing must survive"
+            );
+            assert!(
+                merged.is_turn_start,
+                "turn start: a marker either side asserted must survive"
+            );
+            assert_eq!(
+                merged.cost, 0.25,
+                "cost must track the reconciled tokens, not the copy this entry started from"
+            );
         }
     }
 

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -884,6 +884,80 @@ fn duration_between_ms(start_ms: Option<i64>, end_ms: Option<i64>) -> Option<i64
     (duration > 0).then_some(duration)
 }
 
+/// Reconcile two already-parsed copies of the same Claude turn (same dedup
+/// key) into `existing`, field by field, rather than picking one whole
+/// message over the other.
+///
+/// Retention can carry a message across an in-place transcript rewrite, and a
+/// scan can equally observe an assistant record before its usage is final —
+/// the same reason `merge_claude_duplicate` folds same-file duplicates with a
+/// per-field max. Once two copies of one key exist in different places
+/// (across files, or across cache-writer generations for the same file),
+/// neither is authoritative: every way they can differ is the same
+/// disagreement, one side observed the turn before its usage was final and
+/// the other after. So this uses the same per-field max convention, plus
+/// `is_turn_start` by OR since that marker is a claim that something was
+/// observed.
+///
+/// `cost` cannot be taken as `max(a, b)`: each copy was already priced from
+/// its own token vector before reaching this merge, and when the maxima are
+/// complementary (one copy high on input, the other high on output) the
+/// reconciled token vector prices strictly higher than either input whenever
+/// both buckets carry a positive rate. So cost is re-derived from the
+/// reconciled tokens via `apply_pricing_if_available` -- the same helper
+/// every parser uses to price a `UnifiedMessage` from its tokens, kept as the
+/// one pricing path -- unless either copy's cost is `CostSource::
+/// ProviderReported`: that figure came from the provider directly, not from
+/// this crate's rate table, and recomputing over it would replace a real
+/// number with a guess. `cost_source` itself is merged by authority
+/// (`ProviderReported` > `Estimated` > `Unknown`) so a reconciled message
+/// never regresses to a less trustworthy label than either input carried.
+/// The plain `max(a, b)` on cost still runs first as the floor this produces
+/// when no pricing service is reachable at the call site (`absorb_retained_
+/// history` in `message_cache.rs` reconciles cache entries before pricing is
+/// ever applied to them, so both copies' cost there is 0 in practice; the
+/// floor is what keeps this function correct if that ever changes).
+///
+/// Used both by the cross-file Claude merge in `lib.rs` and by
+/// `absorb_retained_history` in `message_cache.rs`, which hits the same
+/// disagreement when two cache writers race to save the same source file.
+/// The cache layer has no pricing service in scope, so it passes `None`;
+/// repricing happens at read time regardless, via the same `apply_pricing_
+/// if_available` call every cache hit already makes over the (correctly
+/// merged) stored tokens.
+pub(crate) fn reconcile_claude_duplicate_message(
+    existing: &mut UnifiedMessage,
+    other: &UnifiedMessage,
+    pricing: Option<&pricing::PricingService>,
+) {
+    let t = &mut existing.tokens;
+    t.input = t.input.max(other.tokens.input);
+    t.output = t.output.max(other.tokens.output);
+    t.cache_read = t.cache_read.max(other.tokens.cache_read);
+    t.cache_write = t.cache_write.max(other.tokens.cache_write);
+    t.reasoning = t.reasoning.max(other.tokens.reasoning);
+
+    if let Some(other_duration) = other.duration_ms {
+        existing.duration_ms = Some(existing.duration_ms.unwrap_or(0).max(other_duration));
+    }
+    existing.is_turn_start |= other.is_turn_start;
+
+    let merged_cost_source = match (existing.cost_source, other.cost_source) {
+        (super::CostSource::ProviderReported, _) | (_, super::CostSource::ProviderReported) => {
+            super::CostSource::ProviderReported
+        }
+        (super::CostSource::Estimated, _) | (_, super::CostSource::Estimated) => {
+            super::CostSource::Estimated
+        }
+        _ => super::CostSource::Unknown,
+    };
+    existing.cost = existing.cost.max(other.cost);
+    existing.cost_source = merged_cost_source;
+    if merged_cost_source != super::CostSource::ProviderReported {
+        crate::apply_pricing_if_available(existing, pricing);
+    }
+}
+
 fn merge_claude_duplicate(
     existing: &mut UnifiedMessage,
     usage: &ClaudeUsage,
@@ -3427,6 +3501,133 @@ mod tests {
             msgs_b[0].agent,
             Some("Executor".to_string()),
             "Second agent should be executor"
+        );
+    }
+
+    fn priced_reconcile_fixture() -> (
+        UnifiedMessage,
+        UnifiedMessage,
+        crate::pricing::PricingService,
+    ) {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-3-5-sonnet".into(),
+            crate::pricing::ModelPricing {
+                input_cost_per_token: Some(0.001),
+                output_cost_per_token: Some(0.002),
+                ..Default::default()
+            },
+        );
+        let pricing = crate::pricing::PricingService::new(litellm, HashMap::new());
+
+        // Partial-shaped: leads on input, trails on output. Priced from its
+        // own tokens: 500 * 0.001 = 0.5.
+        let mut existing = UnifiedMessage::new(
+            "claude",
+            "claude-3-5-sonnet",
+            "anthropic",
+            "session-1",
+            1_733_011_200_000,
+            TokenBreakdown {
+                input: 500,
+                output: 60,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            0.5,
+        );
+        existing.mark_estimated_cost();
+
+        // Completed-shaped: trails on input, leads on output. Priced from its
+        // own tokens: 200 * 0.001 + 999 * 0.002 = 0.2 + 1.998 = 2.198.
+        let mut other = UnifiedMessage::new(
+            "claude",
+            "claude-3-5-sonnet",
+            "anthropic",
+            "session-1",
+            1_733_011_200_000,
+            TokenBreakdown {
+                input: 200,
+                output: 999,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            2.198,
+        );
+        other.mark_estimated_cost();
+
+        (existing, other, pricing)
+    }
+
+    /// The defect: `existing.cost.max(other.cost)` (0.5 vs 2.198 => 2.198)
+    /// understates the reconciled token vector's actual price. Reconciled
+    /// tokens are input=max(500,200)=500, output=max(60,999)=999, which
+    /// prices to 500 * 0.001 + 999 * 0.002 = 0.5 + 1.998 = 2.498 -- higher
+    /// than either input cost because the maxima are complementary.
+    #[test]
+    fn reconcile_claude_duplicate_message_reprices_from_merged_tokens() {
+        let (mut existing, other, pricing) = priced_reconcile_fixture();
+
+        reconcile_claude_duplicate_message(&mut existing, &other, Some(&pricing));
+
+        assert_eq!(existing.tokens.input, 500);
+        assert_eq!(existing.tokens.output, 999);
+        assert!(
+            (existing.cost - 2.498).abs() < 1e-9,
+            "expected merged-token price 2.498, got {}",
+            existing.cost
+        );
+        assert!(
+            existing.cost > other.cost.max(0.5),
+            "reconciled cost must exceed max(a, b) = 2.198, got {}",
+            existing.cost
+        );
+        assert_eq!(existing.cost_source, super::super::CostSource::Estimated);
+    }
+
+    /// No pricing service reachable (the cache-layer call site): cost falls
+    /// back to `max(a, b)`, same as before this fix, since there is nothing
+    /// to reprice from.
+    #[test]
+    fn reconcile_claude_duplicate_message_falls_back_to_max_without_pricing_service() {
+        let (mut existing, other, _pricing) = priced_reconcile_fixture();
+
+        reconcile_claude_duplicate_message(&mut existing, &other, None);
+
+        assert!(
+            (existing.cost - 2.198).abs() < 1e-9,
+            "expected max(0.5, 2.198) = 2.198 fallback, got {}",
+            existing.cost
+        );
+        assert_eq!(existing.cost_source, super::super::CostSource::Estimated);
+    }
+
+    /// A provider-reported cost is a real number, not a rate-table guess.
+    /// When either copy carries one, the merge must not call the pricing
+    /// service over the reconciled tokens -- that would silently replace an
+    /// authoritative figure with an estimate -- and the merged `cost_source`
+    /// must record that authority rather than regressing to `Estimated`.
+    #[test]
+    fn reconcile_claude_duplicate_message_preserves_provider_reported_cost_and_skips_repricing() {
+        let (mut existing, mut other, pricing) = priced_reconcile_fixture();
+        // `other` carries the provider's own figure for its own tokens,
+        // distinct from what repricing the merged tokens would produce.
+        other.cost = 9.0;
+        other.mark_provider_reported_cost();
+
+        reconcile_claude_duplicate_message(&mut existing, &other, Some(&pricing));
+
+        assert_eq!(
+            existing.cost_source,
+            super::super::CostSource::ProviderReported,
+            "merged cost_source must carry the authoritative label forward"
+        );
+        assert!(
+            (existing.cost - 9.0).abs() < 1e-9,
+            "expected max(0.5, 9.0) = 9.0, not a repriced 2.498, got {}",
+            existing.cost
         );
     }
 }


### PR DESCRIPTION
Fixes #1050.

Retention added in #1008 carries an observed message across an in-place transcript rewrite whenever its dedup key is stable across files. Cross-file dedup then keeps the first occurrence of a key without merging fields. When one copy is a streaming partial and the other the completed replay of the same turn, whichever sorts first wins and the other's usage is discarded.

The parser already expects partial observations — `merge_claude_duplicate` folds same-file duplicates with a per-field max precisely because an assistant record can be seen before its usage is final. Retention makes that situation reachable *across* files, where nothing merges.

Reproduction on `d8b23d14`, before the fix:

```
assertion `left == right` failed
  left: 110
 right: 1049
```

## The change

Cross-file Claude duplicates are reconciled field by field instead of one being chosen. `reconcile_claude_duplicate_message` applies the same convention `merge_claude_duplicate` already uses for same-file duplicates — per-field max over the token buckets and `duration_ms` — plus `is_turn_start` by OR, since that marker is a claim that something was observed, and `cost` by max alongside the tokens it tracks.

Two call sites hit the identical disagreement and now share it: the cross-file merge, and `absorb_retained_history`, where two cache writers race on the same source file.

**Claude lane only.** Every other client keeps first-occurrence-wins. Reconciliation is sound here because retention can produce two observations of one turn; that is not true generally, and changing global dedup semantics is not in scope.

## Why reconcile rather than rank

The first version of this PR ranked provenance instead: a live-parsed copy outranked a retained one. That required knowing which messages were retained, which required persisting that provenance on the cache entry, which required a `CACHE_FORMAT_VERSION` bump. Review found three problems, and they share one root.

Ranking assumes one copy is more complete. It is not. **Every way two copies of one key can differ is the same disagreement — one observed the turn before its usage was final, the other after.** Provenance says which file a copy came from, not which observation is later.

Concretely, ranking is backwards in the mirror case: if the *retained* copy is the completed one and the fork currently holds only a partial, preferring live admits the partial and discards the completed row. That case is now covered by a test in both file orders.

Dropping the ranking removes the whole chain behind it:

| Removed | Consequence |
|---|---|
| provenance ranking | mirror case fixed |
| `retained_keys` on the cache entry | no persisted provenance |
| the `CACHE_FORMAT_VERSION` bump | **no format migration at all** |

That last one matters beyond tidiness. Since #1008 shipped, a format-5 cache can hold retained-only turns that exist in no live transcript. A version bump without a format-5 migration would have invalidated those shards, and a cold reparse cannot recover them — the bump would have destroyed usage it was meant to protect. `CACHE_FORMAT_VERSION` is byte-identical to `d8b23d14` in this version.

Reconciliation is symmetric, so file iteration order stops mattering and no provenance needs to survive a restart. The warm-cache-hit test passes structurally rather than by construction.

## Tests

| Test | Covers |
|---|---|
| `test_claude_retained_partial_reconciles_with_completed_live_replay` (+ `_reordered`) | the reported case, both file orders |
| `test_claude_retained_completed_reconciles_with_live_partial` (+ `_reordered`) | the mirror case, both file orders |
| `test_claude_reconciled_duplicate_survives_a_third_unchanged_scan` | reconciled totals hold on a warm cache hit |
| `test_save_if_dirty_reconciles_two_copies_under_a_fingerprint_mismatch` | the save-time writer race |
| `test_save_if_dirty_reconciles_two_live_copies_under_one_fingerprint` | two live copies can still disagree |

Every two-copy fixture is arranged so neither side holds the maximum of every field, so a fix that picks one whole message fails.

Mutation: reverting the cross-file reconciliation to first-occurrence-wins fails all four direction and order tests with concrete wrong values (110 against 1049), and leaves the unrelated fork-collapse test passing.

Deletion safety is untouched; `test_claude_deleted_transcript_is_not_resurrected_by_retention` passes unmodified.

## Gates

```
cargo test --lib                            1610 passed / 0 failed   (baseline 1603 + 7)
cargo clippy --all-targets -- -D warnings   clean
cargo fmt -- --check                        clean
```

Baseline measured on unmodified `d8b23d14`.
