### PR TITLE
fix(claude): discover sessions under CLAUDE_CONFIG_DIR instead of a fixed ~/.claude root

### DIFF
--- a/crates/tokscale-cli/src/claude_diagnostics.rs
+++ b/crates/tokscale-cli/src/claude_diagnostics.rs
@@ -103,15 +103,18 @@ fn diagnostic_paths(home_dir: &Path, desktop_paths: Vec<PathBuf>) -> Vec<Diagnos
         })
         .collect();
 
+    // Resolve through the client registry (CLAUDE_CONFIG_DIR-aware) instead of
+    // a fixed `.claude` offset from home, so this diagnostic reports the same
+    // paths the scanner actually reads.
+    let claude_root = PathBuf::from(
+        tokscale_core::ClientId::Claude
+            .data()
+            .root
+            .resolve(&home_dir.to_string_lossy()),
+    );
     for (label, path) in [
-        (
-            "claudeCodeProjects",
-            home_dir.join(".claude").join("projects"),
-        ),
-        (
-            "claudeCodeTranscripts",
-            home_dir.join(".claude").join("transcripts"),
-        ),
+        ("claudeCodeProjects", claude_root.join("projects")),
+        ("claudeCodeTranscripts", claude_root.join("transcripts")),
     ] {
         let exists = path.exists();
         paths.push(DiagnosticPath {

--- a/crates/tokscale-cli/src/claude_diagnostics.rs
+++ b/crates/tokscale-cli/src/claude_diagnostics.rs
@@ -24,12 +24,13 @@ const CLAUDE_DESKTOP_MESSAGE: &str =
 
 const CLAUDE_DESKTOP_HELP: &str = "Claude Desktop chat storage and Claude data exports do not expose a documented per-message token ledger. Use `tokscale usage` for Claude subscription quota bars; organization/API billing requires Anthropic Admin Usage/Cost API outside local scanning.";
 
-pub fn diagnostics_for_clients_row(home_dir: &Path) -> Vec<ClientDiagnostic> {
-    claude_diagnostics(home_dir, true)
+pub fn diagnostics_for_clients_row(home_dir: &Path, use_env_roots: bool) -> Vec<ClientDiagnostic> {
+    claude_diagnostics(home_dir, use_env_roots, true)
 }
 
 pub fn diagnostics_for_empty_explicit_report(
     home_dir: &Path,
+    use_env_roots: bool,
     clients: &Option<Vec<String>>,
     claude_message_count: i32,
 ) -> Vec<ClientDiagnostic> {
@@ -37,7 +38,7 @@ pub fn diagnostics_for_empty_explicit_report(
         return Vec::new();
     }
 
-    claude_diagnostics(home_dir, false)
+    claude_diagnostics(home_dir, use_env_roots, false)
 }
 
 fn explicitly_requests_claude(clients: &Option<Vec<String>>) -> bool {
@@ -46,7 +47,11 @@ fn explicitly_requests_claude(clients: &Option<Vec<String>>) -> bool {
         .is_some_and(|ids| ids.iter().any(|id| id == "claude"))
 }
 
-fn claude_diagnostics(home_dir: &Path, include_info: bool) -> Vec<ClientDiagnostic> {
+fn claude_diagnostics(
+    home_dir: &Path,
+    use_env_roots: bool,
+    include_info: bool,
+) -> Vec<ClientDiagnostic> {
     let mut diagnostics = Vec::new();
 
     let desktop_paths: Vec<PathBuf> = claude_desktop_storage_paths(home_dir)
@@ -60,7 +65,7 @@ fn claude_diagnostics(home_dir: &Path, include_info: bool) -> Vec<ClientDiagnost
             severity: "warning",
             message: CLAUDE_DESKTOP_MESSAGE,
             help: CLAUDE_DESKTOP_HELP,
-            paths: diagnostic_paths(home_dir, desktop_paths),
+            paths: diagnostic_paths(home_dir, use_env_roots, desktop_paths),
         });
     }
 
@@ -93,7 +98,11 @@ fn claude_desktop_storage_paths(home_dir: &Path) -> Vec<PathBuf> {
     ]
 }
 
-fn diagnostic_paths(home_dir: &Path, desktop_paths: Vec<PathBuf>) -> Vec<DiagnosticPath> {
+fn diagnostic_paths(
+    home_dir: &Path,
+    use_env_roots: bool,
+    desktop_paths: Vec<PathBuf>,
+) -> Vec<DiagnosticPath> {
     let mut paths: Vec<DiagnosticPath> = desktop_paths
         .into_iter()
         .map(|path| DiagnosticPath {
@@ -105,12 +114,14 @@ fn diagnostic_paths(home_dir: &Path, desktop_paths: Vec<PathBuf>) -> Vec<Diagnos
 
     // Resolve through the client registry (CLAUDE_CONFIG_DIR-aware) instead of
     // a fixed `.claude` offset from home, so this diagnostic reports the same
-    // paths the scanner actually reads.
+    // paths the scanner actually reads — and respect `use_env_roots` so a
+    // `--home` override keeps its documented ignore-conflicting-env-vars
+    // semantics instead of always following CLAUDE_CONFIG_DIR.
     let claude_root = PathBuf::from(
         tokscale_core::ClientId::Claude
             .data()
             .root
-            .resolve(&home_dir.to_string_lossy()),
+            .resolve_with_env_strategy(&home_dir.to_string_lossy(), use_env_roots),
     );
     for (label, path) in [
         ("claudeCodeProjects", claude_root.join("projects")),

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -4061,7 +4061,8 @@ fn run_clients_command(json: bool, home_dir: Option<String>) -> Result<()> {
     } else {
         Vec::new()
     };
-    let built_in_extra_paths = built_in_extra_scan_paths_for(&home_dir_str, &all_clients);
+    let built_in_extra_paths =
+        built_in_extra_scan_paths_for(&home_dir_str, &all_clients, use_env_roots);
     let settings_extra_dirs = extra_scan_paths_for(&scanner_settings, &all_clients);
     let copilot_exporter_path =
         tokscale_core::copilot_exporter_path_with_env_strategy(use_env_roots);

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2014,6 +2014,7 @@ fn run_models_report(
         .map(|home| {
             claude_diagnostics::diagnostics_for_empty_explicit_report(
                 home,
+                use_env_roots,
                 &clients,
                 claude_message_count,
             )
@@ -4197,7 +4198,7 @@ fn run_clients_command(json: bool, home_dir: Option<String>) -> Result<()> {
                 ));
 
                 let diagnostics = if client == ClientId::Claude {
-                    claude_diagnostics::diagnostics_for_clients_row(&home_dir)
+                    claude_diagnostics::diagnostics_for_clients_row(&home_dir, use_env_roots)
                 } else {
                     Vec::new()
                 };

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -809,6 +809,7 @@ fn cmd_with_home(tmp: &Path) -> Command {
         .env_remove("TOKSCALE_EXTRA_DIRS")
         .env_remove("TOKSCALE_HEADLESS_DIR")
         .env_remove("CODEX_HOME")
+        .env_remove("CLAUDE_CONFIG_DIR")
         .env_remove("COPILOT_OTEL_FILE_EXPORTER_PATH")
         .env_remove("GOOSE_PATH_ROOT")
         .env_remove("CODEBUFF_DATA_DIR")
@@ -848,6 +849,7 @@ fn offline_cmd_with_home(tmp: &Path) -> Command {
         .env_remove("TOKSCALE_EXTRA_DIRS")
         .env_remove("TOKSCALE_HEADLESS_DIR")
         .env_remove("CODEX_HOME")
+        .env_remove("CLAUDE_CONFIG_DIR")
         .env_remove("COPILOT_OTEL_FILE_EXPORTER_PATH")
         .env_remove("GOOSE_PATH_ROOT")
         .env_remove("CODEBUFF_DATA_DIR")
@@ -3603,6 +3605,61 @@ fn test_clients_json_includes_claude_desktop_diagnostic() {
                 .unwrap()
                 .contains("Claude Desktop app data was detected")
     }));
+}
+
+#[test]
+fn test_clients_home_override_ignores_conflicting_claude_config_dir_env() {
+    let real_home = create_empty_fixture_dir();
+    fs::create_dir_all(real_home.path().join("Library/Application Support/Claude")).unwrap();
+    let conflicting_home = TempDir::new().expect("failed to create temp dir");
+    let conflicting_claude_dir = TempDir::new().expect("failed to create temp dir");
+
+    let output = cmd_with_conflicting_env(conflicting_home.path())
+        .env("CLAUDE_CONFIG_DIR", conflicting_claude_dir.path())
+        .args([
+            "clients",
+            "--json",
+            "--home",
+            real_home.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let claude = json["clients"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["client"] == "claude")
+        .unwrap();
+    let diagnostics = claude["diagnostics"].as_array().unwrap();
+    let desktop_diagnostic = diagnostics
+        .iter()
+        .find(|item| item["code"] == "claude_desktop_not_scanned")
+        .expect("claude_desktop_not_scanned diagnostic should be present");
+    let paths = desktop_diagnostic["paths"].as_array().unwrap();
+
+    for label in ["claudeCodeProjects", "claudeCodeTranscripts"] {
+        let path = paths
+            .iter()
+            .find(|p| p["label"] == label)
+            .unwrap_or_else(|| panic!("expected a {label} diagnostic path"))["path"]
+            .as_str()
+            .unwrap();
+        assert!(
+            path.starts_with(real_home.path().to_str().unwrap()),
+            "{label} should stay under the --home override, got {path}"
+        );
+        assert!(
+            !path.contains(conflicting_claude_dir.path().to_str().unwrap()),
+            "{label} must not follow CLAUDE_CONFIG_DIR when --home is explicit, got {path}"
+        );
+    }
 }
 
 #[test]

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -318,8 +318,11 @@ define_clients!(
     Claude = 1 => {
         id: "claude",
         display: "Claude Code",
-        logo: Some("https://tokscale.ai/assets/logos/claude.jpg"),root: PathRoot::Home,
-        relative: ".claude/projects",
+        logo: Some("https://tokscale.ai/assets/logos/claude.jpg"),root: PathRoot::EnvVar {
+            var: "CLAUDE_CONFIG_DIR",
+            fallback_relative: ".claude",
+        },
+        relative: "projects",
         pattern: "*.jsonl",
         headless: false,
         parse_local: true,
@@ -1598,6 +1601,41 @@ mod tests {
                 var: "CODEX_HOME",
                 fallback_relative: ".codex",
             }
+        );
+    }
+
+    #[test]
+    fn test_claude_root_uses_claude_config_dir_env_var() {
+        assert_eq!(
+            ClientId::Claude.data().root,
+            PathRoot::EnvVar {
+                var: "CLAUDE_CONFIG_DIR",
+                fallback_relative: ".claude",
+            }
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_claude_defaults_to_home_dot_claude_without_env_override() {
+        let mut env = EnvGuard::capture(&["CLAUDE_CONFIG_DIR"]);
+        env.remove("CLAUDE_CONFIG_DIR");
+
+        assert_eq!(
+            ClientId::Claude.data().resolve_path("/tmp/home"),
+            native_join(std::path::Path::new("/tmp/home"), ".claude/projects")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_claude_honors_claude_config_dir_env_override() {
+        let mut env = EnvGuard::capture(&["CLAUDE_CONFIG_DIR"]);
+        env.set("CLAUDE_CONFIG_DIR", "/custom/claude");
+
+        assert_eq!(
+            ClientId::Claude.data().resolve_path("/tmp/home"),
+            native_join(std::path::Path::new("/custom/claude"), "projects")
         );
     }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -598,13 +598,24 @@ fn join_native(root: &str, relative: &str) -> String {
 pub fn built_in_extra_scan_paths_for(
     home_dir: &str,
     enabled: &HashSet<ClientId>,
+    use_env_roots: bool,
 ) -> Vec<(ClientId, PathBuf)> {
     let mut paths = Vec::new();
 
     if enabled.contains(&ClientId::Claude) {
+        // `transcripts` is a sibling of the registered `projects` root, not a
+        // fixed offset from `home_dir` — resolving through the client's own
+        // `root` keeps this in sync with CLAUDE_CONFIG_DIR (#1048-adjacent:
+        // this dir moves whenever the primary root does), and respecting
+        // `use_env_roots` keeps parity with the `Grok` root resolved just
+        // above this function's only caller.
+        let claude_root = ClientId::Claude
+            .data()
+            .root
+            .resolve_with_env_strategy(home_dir, use_env_roots);
         paths.push((
             ClientId::Claude,
-            PathBuf::from(join_native(home_dir, ".claude/transcripts")),
+            PathBuf::from(join_native(&claude_root, "transcripts")),
         ));
         paths.extend(
             crate::cc_mirror::discover_claude_project_roots(Path::new(home_dir))
@@ -1406,7 +1417,7 @@ fn scan_all_clients_with_env_strategy_inner(
         }
     }
 
-    for (client_id, path) in built_in_extra_scan_paths_for(home_dir, &enabled) {
+    for (client_id, path) in built_in_extra_scan_paths_for(home_dir, &enabled, use_env_roots) {
         push_unique_scan_task(&mut tasks, &mut seen_scan_roots, client_id, path);
     }
 
@@ -4446,6 +4457,62 @@ mod tests {
 
         assert_eq!(result.get(ClientId::Claude), &vec![transcript]);
         assert!(result.get(ClientId::OpenCode).is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_claude_honors_claude_config_dir() {
+        let mut env = EnvGuard::capture(&["CLAUDE_CONFIG_DIR"]);
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        // A stray ~/.claude/projects entry must be ignored once
+        // CLAUDE_CONFIG_DIR redirects the client elsewhere.
+        setup_mock_claude_dir(home);
+
+        let custom_root = home.join("custom-claude-config");
+        let custom_projects = custom_root.join("projects").join("myproject");
+        fs::create_dir_all(&custom_projects).unwrap();
+        let custom_conversation = custom_projects.join("conversation.jsonl");
+        File::create(&custom_conversation)
+            .unwrap()
+            .write_all(b"")
+            .unwrap();
+        let custom_transcripts = custom_root.join("transcripts");
+        fs::create_dir_all(&custom_transcripts).unwrap();
+        let custom_transcript = custom_transcripts.join("ses_123456789012345678901234567.jsonl");
+        File::create(&custom_transcript)
+            .unwrap()
+            .write_all(b"")
+            .unwrap();
+
+        env.set("CLAUDE_CONFIG_DIR", custom_root);
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["claude".to_string()],
+            true,
+        );
+
+        assert_eq!(result.get(ClientId::Claude).len(), 2);
+        assert!(
+            result
+                .get(ClientId::Claude)
+                .iter()
+                .any(|p| p == &custom_conversation),
+            "expected {} in {:?}",
+            custom_conversation.display(),
+            result.get(ClientId::Claude)
+        );
+        assert!(
+            result
+                .get(ClientId::Claude)
+                .iter()
+                .any(|p| p == &custom_transcript),
+            "expected {} in {:?}",
+            custom_transcript.display(),
+            result.get(ClientId::Claude)
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -1,6 +1,8 @@
 //! Claude Code session parser
 //!
-//! Parses JSONL files from ~/.claude/projects/
+//! Parses JSONL files from `<claude_config_dir>/projects/`, where
+//! `claude_config_dir` defaults to `~/.claude` but honors `CLAUDE_CONFIG_DIR`
+//! (see `ClientId::Claude` in `clients.rs`).
 
 use super::utils::{
     extract_i64, extract_string, file_modified_timestamp_ms, parse_timestamp_value,


### PR DESCRIPTION
## Summary

Fixes #1101. Claude Code's own CLI honors `CLAUDE_CONFIG_DIR` to relocate its config directory, but the `claude` client here was registered as a fixed `PathRoot::Home` + `.claude/projects`, so relocating via that variable silently drops all Claude usage. `codex` already has this exact pattern for `CODEX_HOME` via `PathRoot::EnvVar`; this gives `claude` the same treatment.

- `crates/tokscale-core/src/clients.rs`: registers `claude`'s root as `PathRoot::EnvVar { var: "CLAUDE_CONFIG_DIR", fallback_relative: ".claude" }` with `relative: "projects"`, matching the existing `codex` pattern exactly. Unset behavior is unchanged (`~/.claude/projects`).
- `crates/tokscale-core/src/scanner.rs`: `built_in_extra_scan_paths_for`'s `.claude/transcripts` extra path was a second, independent `home_dir`-relative literal — resolved it through the same client registry root instead so it moves together with `CLAUDE_CONFIG_DIR`, and threaded the existing `use_env_roots` flag through to it (mirroring how `Grok`'s root is resolved just above the same call site).
- `crates/tokscale-cli/src/claude_diagnostics.rs`: the `clients` diagnostics output independently hardcoded both `.claude/projects` and `.claude/transcripts` for its existence checks; switched to the same resolved root so diagnostics don't disagree with what's actually scanned.

## Test plan

- [x] New tests: `test_claude_root_uses_claude_config_dir_env_var`-equivalent coverage — `test_claude_defaults_to_home_dot_claude_without_env_override` and `test_claude_honors_claude_config_dir_env_override` in `clients.rs`, mirroring the existing Codex env-var tests
- [x] New test: `test_scan_all_clients_claude_honors_claude_config_dir` in `scanner.rs`, verifying both the `projects` and `transcripts` paths are discovered under a custom `CLAUDE_CONFIG_DIR` and a stray `~/.claude` entry is ignored
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --workspace --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` — all passing except one pre-existing, unrelated failure (`test_submit_excluding_only_generic_gemini_usage_does_not_promise_submission`) that fails identically on unmodified `main` in this sandbox because it requires a live fetch to `models.dev` that the sandbox's network policy blocks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `CLAUDE_CONFIG_DIR` to discover Claude Code sessions instead of a fixed `~/.claude` root, and keep `projects` and `transcripts` in sync with it. Diagnostics now follow the same env strategy, so `--home` overrides ignore `CLAUDE_CONFIG_DIR`; default behavior is unchanged when the env var is unset.

- **Bug Fixes**
  - Resolve Claude’s root via `CLAUDE_CONFIG_DIR` (fallback to `~/.claude`) and set `relative: "projects"`.
  - Scanner resolves the `transcripts` path from the same root and respects `use_env_roots`.
  - Diagnostics resolve through the same root and respect `use_env_roots`, so reported paths match the scanner and `--home` overrides don’t follow `CLAUDE_CONFIG_DIR`.

<sup>Written for commit cf5256b87f06829cc7174bfb499b38d9a90fc0d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

