### PR TITLE
fix(claude): show Fable usage limit

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -786,7 +786,7 @@ TUI では **Usage** タブに移動するとサブスクリプションデー�
 
 | プロバイダー | 認証方法 | メトリクス | セットアップ |
 |----------|-------------|---------|-------|
-| **Claude** | OAuth（資格情報ファイルまたは macOS Keychain） | Session（5時間）、Weekly、Opus クォータ | `claude` を実行してログイン |
+| **Claude** | OAuth（資格情報ファイルまたは macOS Keychain） | Session（5時間）、Weekly、モデル別クォータ | `claude` を実行してログイン |
 | **Codex**（OpenAI） | OAuth（Codex 認証、保存済み Tokscale アカウント、または OpenCode の `$XDG_DATA_HOME/opencode/auth.json`） | Session、Weekly クォータ | `[Add Codex]`、`codex`、`tokscale codex import --name work`、または OpenCode で OpenAI の ChatGPT Plus/Pro に接続 |
 | **Z.ai** | API キー（環境変数） | トークン上限、Web 検索 | `ZAI_API_KEY` または `GLM_API_KEY` を設定 |
 | **Amp** | API キー（`~/.local/share/amp/secrets.json`） | 無料枠残高、クレジット | `amp` を実行してログイン |

--- a/README.ko.md
+++ b/README.ko.md
@@ -783,7 +783,7 @@ TUI에서는 **Usage** 탭으로 이동해 구독 데이터를 확인하세요. 
 
 | 프로바이더 | 인증 방식 | 지표 | 설정 |
 |----------|-------------|---------|-------|
-| **Claude** | OAuth (자격 증명 파일 또는 macOS Keychain) | 세션(5시간), 주간, Opus 할당량 | `claude`를 실행해 로그인 |
+| **Claude** | OAuth (자격 증명 파일 또는 macOS Keychain) | 세션(5시간), 주간, 모델별 할당량 | `claude`를 실행해 로그인 |
 | **Codex** (OpenAI) | OAuth (Codex 인증, 저장된 Tokscale 계정 또는 OpenCode의 `$XDG_DATA_HOME/opencode/auth.json`) | 세션, 주간 할당량 | `[Add Codex]`, `codex`, `tokscale codex import --name work` 또는 OpenCode에서 OpenAI ChatGPT Plus/Pro 연결 사용 |
 | **Z.ai** | API 키 (환경 변수) | 토큰 한도, 웹 검색 | `ZAI_API_KEY` 또는 `GLM_API_KEY` 설정 |
 | **Amp** | API 키 (`~/.local/share/amp/secrets.json`) | 무료 티어 잔액, 크레딧 | `amp`를 실행해 로그인 |

--- a/README.md
+++ b/README.md
@@ -787,7 +787,7 @@ In the TUI, navigate to the **Usage** tab to see subscription data. Use `[Refres
 
 | Provider | Auth Method | Metrics | Setup |
 |----------|-------------|---------|-------|
-| **Claude** | OAuth (credentials file or macOS Keychain) | Session (5hr), Weekly, Opus quotas | Run `claude` to log in |
+| **Claude** | OAuth (credentials file or macOS Keychain) | Session (5hr), Weekly, model-scoped quotas | Run `claude` to log in |
 | **Codex** (OpenAI) | OAuth (Codex auth, saved Tokscale accounts, or OpenCode's `$XDG_DATA_HOME/opencode/auth.json`) | Session, Weekly quotas | Use `[Add Codex]`, run `codex`, import with `tokscale codex import --name work`, or connect OpenAI with ChatGPT Plus/Pro in OpenCode |
 | **Z.ai** | API key (env var) | Token limits, Web Searches | Set `ZAI_API_KEY` or `GLM_API_KEY` |
 | **Amp** | API key (`~/.local/share/amp/secrets.json`) | Free tier balance, Credits | Run `amp` to log in |

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -785,7 +785,7 @@ tokscale usage --light
 
 | 提供商 | 认证方式 | 指标 | 设置 |
 |----------|-------------|---------|-------|
-| **Claude** | OAuth（凭据文件或 macOS 钥匙串） | Session（5 小时）、Weekly、Opus 配额 | 运行 `claude` 登录 |
+| **Claude** | OAuth（凭据文件或 macOS 钥匙串） | Session（5 小时）、Weekly、模型专属配额 | 运行 `claude` 登录 |
 | **Codex**（OpenAI） | OAuth（Codex 认证、已保存的 Tokscale 账号，或 OpenCode 的 `$XDG_DATA_HOME/opencode/auth.json`） | Session、Weekly 配额 | 使用 `[Add Codex]`、运行 `codex`、通过 `tokscale codex import --name work` 导入，或在 OpenCode 中连接 OpenAI ChatGPT Plus/Pro |
 | **Z.ai** | API key（环境变量） | Token 限额、Web Searches | 设置 `ZAI_API_KEY` 或 `GLM_API_KEY` |
 | **Amp** | API key（`~/.local/share/amp/secrets.json`） | 免费额度余额、Credits | 运行 `amp` 登录 |

--- a/crates/tokscale-cli/src/commands/usage/claude.rs
+++ b/crates/tokscale-cli/src/commands/usage/claude.rs
@@ -39,12 +39,33 @@ struct UsageResponse {
     five_hour: Option<Window>,
     seven_day: Option<Window>,
     seven_day_opus: Option<Window>,
+    limits: Option<Vec<PlanLimit>>,
 }
 
 #[derive(Debug, Deserialize)]
 struct Window {
     utilization: f64,
     resets_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlanLimit {
+    kind: Option<String>,
+    percent: Option<f64>,
+    resets_at: Option<String>,
+    scope: Option<LimitScope>,
+    #[serde(default)]
+    is_active: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct LimitScope {
+    model: Option<ScopedModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ScopedModel {
+    display_name: Option<String>,
 }
 
 fn credentials_path() -> std::path::PathBuf {
@@ -116,6 +137,65 @@ fn window_metric(label: &str, w: &Window) -> UsageMetric {
     }
 }
 
+fn scoped_limit_metric(limit: &PlanLimit) -> Option<UsageMetric> {
+    if limit.kind.as_deref() != Some("weekly_scoped") || !limit.is_active {
+        return None;
+    }
+
+    let label = limit
+        .scope
+        .as_ref()?
+        .model
+        .as_ref()?
+        .display_name
+        .as_deref()?
+        .trim();
+    if label.is_empty() {
+        return None;
+    }
+
+    let used = limit.percent?.clamp(0.0, 100.0);
+    Some(UsageMetric {
+        label: label.to_string(),
+        used_percent: used,
+        remaining_percent: 100.0 - used,
+        remaining_label: None,
+        resets_at: limit.resets_at.clone(),
+    })
+}
+
+fn usage_metrics(resp: &UsageResponse) -> Vec<UsageMetric> {
+    let mut metrics = Vec::new();
+    if let Some(ref w) = resp.five_hour {
+        metrics.push(window_metric("Session", w));
+    }
+    if let Some(ref w) = resp.seven_day {
+        metrics.push(window_metric("Weekly", w));
+    }
+    if let Some(ref w) = resp.seven_day_opus {
+        metrics.push(window_metric("Opus", w));
+    }
+
+    for metric in resp
+        .limits
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(scoped_limit_metric)
+    {
+        if let Some(existing) = metrics
+            .iter_mut()
+            .find(|existing| existing.label.eq_ignore_ascii_case(&metric.label))
+        {
+            *existing = metric;
+        } else {
+            metrics.push(metric);
+        }
+    }
+
+    metrics
+}
+
 /// The whole Claude usage path, with the only two things a test cannot supply
 /// for real -- the usage endpoint and the credential source -- as parameters.
 /// The destructive refresh-and-write this module was fixed for lived in exactly
@@ -148,16 +228,7 @@ fn fetch_blocking(usage_url: &str, read: CredentialReader) -> Result<UsageOutput
         let client = reqwest::Client::new();
         let resp = fetch_usage(&client, usage_url, access_token).await?;
 
-        let mut metrics = Vec::new();
-        if let Some(ref w) = resp.five_hour {
-            metrics.push(window_metric("Session", w));
-        }
-        if let Some(ref w) = resp.seven_day {
-            metrics.push(window_metric("Weekly", w));
-        }
-        if let Some(ref w) = resp.seven_day_opus {
-            metrics.push(window_metric("Opus", w));
-        }
+        let metrics = usage_metrics(&resp);
 
         Ok(UsageOutput {
             provider: "Claude".into(),
@@ -202,6 +273,32 @@ mod tests {
 
     const USAGE_BODY: &str =
         r#"{"five_hour":{"utilization":12.5,"resets_at":"2026-08-03T12:00:00Z"}}"#;
+
+    const SCOPED_USAGE_BODY: &str = r#"{
+  "five_hour": { "utilization": 0, "resets_at": "2026-08-12T05:30:00Z" },
+  "seven_day": { "utilization": 30, "resets_at": "2026-08-17T04:00:00Z" },
+  "seven_day_opus": null,
+  "limits": [
+    { "kind": "session", "group": "session", "percent": 0, "is_active": false },
+    { "kind": "weekly_all", "group": "weekly", "percent": 30, "is_active": false },
+    {
+      "kind": "weekly_scoped",
+      "group": "weekly",
+      "percent": 47,
+      "resets_at": "2026-08-17T04:00:00Z",
+      "scope": { "model": { "id": null, "display_name": "Fable" } },
+      "is_active": true
+    },
+    {
+      "kind": "weekly_scoped",
+      "group": "weekly",
+      "percent": 90,
+      "scope": { "model": { "display_name": "Retired model" } },
+      "is_active": false
+    },
+    { "kind": "weekly_scoped", "percent": 99, "is_active": true }
+  ]
+}"#;
 
     /// Mirrors the path component of [`USAGE_URL`] so the recorded request line
     /// is the same string production would produce.
@@ -381,6 +478,50 @@ mod tests {
             "tokscale rewrote Claude Code's credential file"
         );
         assert_only_usage_request(&log);
+    }
+
+    #[test]
+    fn exposes_active_model_scoped_weekly_limit() {
+        let response: UsageResponse =
+            serde_json::from_str(SCOPED_USAGE_BODY).expect("scoped usage response parses");
+
+        let metrics = usage_metrics(&response);
+
+        assert_eq!(
+            metrics
+                .iter()
+                .map(|metric| metric.label.as_str())
+                .collect::<Vec<_>>(),
+            ["Session", "Weekly", "Fable"]
+        );
+        let fable = &metrics[2];
+        assert!((fable.used_percent - 47.0).abs() < f64::EPSILON);
+        assert!((fable.remaining_percent - 53.0).abs() < f64::EPSILON);
+        assert_eq!(fable.resets_at.as_deref(), Some("2026-08-17T04:00:00Z"));
+    }
+
+    #[test]
+    fn scoped_limit_replaces_matching_legacy_model_window() {
+        let response: UsageResponse = serde_json::from_str(
+            r#"{
+  "seven_day_opus": { "utilization": 60, "resets_at": "legacy" },
+  "limits": [{
+    "kind": "weekly_scoped",
+    "percent": 25,
+    "resets_at": "current",
+    "scope": { "model": { "display_name": "Opus" } },
+    "is_active": true
+  }]
+}"#,
+        )
+        .expect("legacy and scoped usage response parses");
+
+        let metrics = usage_metrics(&response);
+
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].label, "Opus");
+        assert!((metrics[0].used_percent - 25.0).abs() < f64::EPSILON);
+        assert_eq!(metrics[0].resets_at.as_deref(), Some("current"));
     }
 
     /// `read_credentials()` is the source of truth for what tokscale parses.


### PR DESCRIPTION
## Summary

- Parse active model-scoped weekly limits from Anthropic's `limits` array.
- Display the scoped model's server-provided name, including Fable, and replace a matching legacy `seven_day_opus` metric instead of duplicating it.
- Document Claude subscription usage as supporting model-scoped quotas.

## Why

Anthropic now reports the active Fable allowance as a `weekly_scoped` entry under `limits`, with the model name in `scope.model.display_name`. Tokscale only modeled the older `five_hour`, `seven_day`, and `seven_day_opus` fields, so it silently omitted the Fable meter even though the endpoint returned it.

## Validation

- `cargo test --locked -p tokscale-cli commands::usage::claude` (7 passed)
- `cargo test --locked -p tokscale-cli` (1,052 unit tests passed, 1 ignored; 154 CLI integration tests passed)
- `cargo clippy --locked --workspace --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- Live `tokscale --no-spinner usage --json` proof returned Session, Weekly, and Fable metrics, with the Claude credential file hash unchanged before and after the fetch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Display active model‑scoped weekly limits for Claude by parsing `weekly_scoped` entries in Anthropic’s `limits`. This shows the correct model name (e.g., Fable) and replaces the legacy `seven_day_opus` metric when applicable.

- **Bug Fixes**
  - Parse `limits` for active `weekly_scoped` entries and surface them in usage.
  - Use `scope.model.display_name` for labels; carry `resets_at` and percent.
  - Replace a matching legacy `seven_day_opus` metric to avoid duplicates.
  - Update READMEs (EN/JA/KO/ZH) to document model‑scoped quotas.

<sup>Written for commit 1a863f86a181930d273eea45571fa82758330c89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

