### PR TITLE
fix(cache): read source cache shards lazily and release consumed payloads

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -785,11 +785,15 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         }
     }
 
+    /// Takes the entry's messages by value: the cache handed this entry to
+    /// its one consumer (see `SourceMessageCache::take`), so cloning here
+    /// would put a second copy of the transcript alongside the first for no
+    /// reason.
     fn cached_messages(
-        cached: &message_cache::CachedSourceEntry,
+        cached: message_cache::CachedSourceEntry,
         pricing: Option<&pricing::PricingService>,
     ) -> Vec<UnifiedMessage> {
-        let mut messages = cached.messages.clone();
+        let mut messages = cached.messages;
         apply_pricing_to_messages(&mut messages, pricing);
         messages
     }
@@ -973,7 +977,7 @@ fn parse_all_messages_with_pricing_with_cache_policy(
             Option<&message_cache::SourceFingerprint>,
         ) -> Option<message_cache::FingerprintStatus>,
     {
-        let cached = source_cache.get(identity, path);
+        let mut cached = source_cache.take(identity, path);
         // An entry written before retention provenance existed cannot say
         // which of its rows the live transcript already dropped, so serving it
         // warm presents a retained copy of a response as a live one — and the
@@ -984,13 +988,14 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         // the entry back with the provenance marker, so the next scan is a
         // plain warm hit.
         let rebuild_retention_provenance = cached
+            .as_ref()
             .is_some_and(message_cache::CachedSourceEntry::needs_retention_provenance_migration);
         #[cfg(test)]
         if rebuild_retention_provenance {
             RETENTION_PROVENANCE_REBUILDS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
         let Some(fingerprint_status) =
-            fingerprint_from_path(path, cached.map(|entry| &entry.fingerprint))
+            fingerprint_from_path(path, cached.as_ref().map(|entry| &entry.fingerprint))
         else {
             let (mut messages, _) = parse(path, None);
             apply_pricing_to_messages(&mut messages, pricing);
@@ -1004,34 +1009,39 @@ fn parse_all_messages_with_pricing_with_cache_policy(
 
         let fingerprint = match fingerprint_status {
             message_cache::FingerprintStatus::Unchanged => {
-                let Some(cached) = cached else {
+                let Some(entry) = cached.take() else {
                     unreachable!("an uncached source always builds a complete fingerprint")
                 };
-                if !rebuild_retention_provenance && !cached.messages.is_empty() {
+                if !rebuild_retention_provenance && !entry.messages.is_empty() {
+                    let retained_message_keys = entry.retained_message_keys();
                     return CachedParseOutcome {
-                        messages: cached_messages(cached, pricing),
-                        retained_message_keys: cached.retained_message_keys(),
+                        messages: cached_messages(entry, pricing),
+                        retained_message_keys,
                         cache_entry: None,
                         invalidate_cache: false,
                     };
                 }
-                cached.fingerprint.clone()
+                let fingerprint = entry.fingerprint.clone();
+                cached = Some(entry);
+                fingerprint
             }
             message_cache::FingerprintStatus::Changed(fingerprint) => fingerprint,
         };
 
-        if let Some(cached) = cached {
+        if let Some(entry) = cached.take() {
             if !rebuild_retention_provenance
-                && cached.fingerprint == fingerprint
-                && !cached.messages.is_empty()
+                && entry.fingerprint == fingerprint
+                && !entry.messages.is_empty()
             {
+                let retained_message_keys = entry.retained_message_keys();
                 return CachedParseOutcome {
-                    messages: cached_messages(cached, pricing),
-                    retained_message_keys: cached.retained_message_keys(),
+                    messages: cached_messages(entry, pricing),
+                    retained_message_keys,
                     cache_entry: None,
                     invalidate_cache: false,
                 };
             }
+            cached = Some(entry);
         }
 
         let (mut messages, cacheable) = parse(path, Some(&fingerprint));
@@ -1048,7 +1058,7 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         } = history
         {
             if cacheable {
-                if let Some(cached) = cached {
+                if let Some(cached) = cached.as_ref() {
                     retained_message_keys = retain_observed_messages(
                         &mut messages,
                         &cached.messages,
@@ -1290,10 +1300,10 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         sessions::prime_agent::PrimeFileAccounting,
     ) {
         let identity = message_cache::CacheIdentity::for_client(ClientId::PrimeAgent);
-        let cached = source_cache.get(identity, path);
+        let cached = source_cache.take(identity, path);
         let Some(fingerprint_status) = message_cache::SourceFingerprint::check_path(
             path,
-            cached.map(|entry| &entry.fingerprint),
+            cached.as_ref().map(|entry| &entry.fingerprint),
         ) else {
             let (messages, accounting) =
                 sessions::prime_agent::parse_prime_agent_file_with_accounting(path);
@@ -1302,6 +1312,7 @@ fn parse_all_messages_with_pricing_with_cache_policy(
 
         let mut fingerprint = match fingerprint_status {
             message_cache::FingerprintStatus::Unchanged => cached
+                .as_ref()
                 .expect("an uncached source always builds a complete fingerprint")
                 .fingerprint
                 .clone(),
@@ -1310,7 +1321,7 @@ fn parse_all_messages_with_pricing_with_cache_policy(
 
         if let Some(cached) = cached {
             if cached.fingerprint == fingerprint && !cached.messages.is_empty() {
-                if let Some(accounting) = cached.prime_accounting.as_ref() {
+                if let Some(accounting) = cached.prime_accounting.clone() {
                     // Prime's accounting is byte-coupled to its messages. Warm
                     // v5 scans therefore hash the complete transcript before a
                     // hit, while still avoiding JSON decode and accounting walk.
@@ -1323,7 +1334,7 @@ fn parse_all_messages_with_pricing_with_cache_policy(
                                     cache_entry: None,
                                     invalidate_cache: false,
                                 },
-                                accounting.clone(),
+                                accounting,
                             );
                         }
                         Some(refreshed) => fingerprint = refreshed,
@@ -1348,13 +1359,13 @@ fn parse_all_messages_with_pricing_with_cache_policy(
                     );
                     match message_cache::SourceFingerprint::from_path(path) {
                         Some(refreshed) if refreshed == fingerprint => {
+                            let cache_entry =
+                                cached.clone().with_prime_accounting(accounting.clone());
                             return (
                                 CachedParseOutcome {
                                     messages: cached_messages(cached, pricing),
                                     retained_message_keys: HashSet::new(),
-                                    cache_entry: Some(
-                                        cached.clone().with_prime_accounting(accounting.clone()),
-                                    ),
+                                    cache_entry: Some(cache_entry),
                                     invalidate_cache: false,
                                 },
                                 accounting,
@@ -1402,7 +1413,7 @@ fn parse_all_messages_with_pricing_with_cache_policy(
     ) -> CachedParseOutcome {
         let identity = message_cache::CacheIdentity::for_client(ClientId::Codex);
         let is_headless = is_headless_path(path, headless_roots);
-        let cached = source_cache.get(identity, path);
+        let cached = source_cache.take(identity, path);
         if cached.is_none() {
             // The post-parse cache build computes the authoritative fingerprint
             // after reading the file. Avoid hashing an uncached source here
@@ -1411,12 +1422,13 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         }
         let Some(fingerprint_status) = message_cache::SourceFingerprint::check_path(
             path,
-            cached.map(|entry| &entry.fingerprint),
+            cached.as_ref().map(|entry| &entry.fingerprint),
         ) else {
             return parse_full_log_source(path, pricing, is_headless);
         };
         let fingerprint = match fingerprint_status {
             message_cache::FingerprintStatus::Unchanged => cached
+                .as_ref()
                 .expect("an uncached source always builds a complete fingerprint")
                 .fingerprint
                 .clone(),
@@ -1432,10 +1444,10 @@ fn parse_all_messages_with_pricing_with_cache_policy(
             };
 
             if cached.fingerprint == fingerprint {
-                if message_cache::codex_cache_entry_matches_fingerprint(cached, &fingerprint) {
+                if message_cache::codex_cache_entry_matches_fingerprint(&cached, &fingerprint) {
                     return CachedParseOutcome {
                         messages: finalize_codex_messages(
-                            cached.messages.clone(),
+                            cached.messages,
                             pricing,
                             is_headless,
                             &cached.fallback_timestamp_indices,
@@ -1470,7 +1482,7 @@ fn parse_all_messages_with_pricing_with_cache_policy(
                                 .iter()
                                 .map(|index| existing_len + index),
                         );
-                        raw_messages.extend(parsed.messages.clone());
+                        raw_messages.extend(parsed.messages);
                         let cache_entry = build_codex_cache_entry(
                             path,
                             raw_messages.clone(),
@@ -1511,12 +1523,12 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         scanner_settings,
     );
     let headless_roots = scanner::headless_roots_with_env_strategy(home_dir, use_env_roots);
+    // `load` reads no shard: each namespace is deserialized the first time a
+    // lane asks for one of its sources, and entries whose file is gone are
+    // pruned as that namespace loads. A scan therefore pays for the clients it
+    // actually reads instead of for every client the machine has ever cached.
     let mut source_cache = match cache_policy {
-        SourceCachePolicy::Persistent => {
-            let mut cache = message_cache::SourceMessageCache::load();
-            cache.prune_missing_files();
-            cache
-        }
+        SourceCachePolicy::Persistent => message_cache::SourceMessageCache::load(),
         SourceCachePolicy::InMemory => message_cache::SourceMessageCache::default(),
     };
     let mut all_messages: Vec<UnifiedMessage> = Vec::new();
@@ -6927,10 +6939,9 @@ mod tests {
             // before this one would have left on disk.
             let mut cache = message_cache::SourceMessageCache::load();
             let legacy: Vec<message_cache::CachedSourceEntry> = cache
-                .entries
-                .values()
-                .filter(|entry| entry.is_claude_namespace())
-                .cloned()
+                .all_entries()
+                .into_iter()
+                .filter(message_cache::CachedSourceEntry::is_claude_namespace)
                 .collect();
             assert_eq!(legacy.len(), 2, "both transcripts must be cached");
             assert!(
@@ -6987,10 +6998,10 @@ mod tests {
             );
 
             let migrated = message_cache::SourceMessageCache::load();
-            let claude_entries: Vec<&message_cache::CachedSourceEntry> = migrated
-                .entries
-                .values()
-                .filter(|entry| entry.is_claude_namespace())
+            let claude_entries: Vec<message_cache::CachedSourceEntry> = migrated
+                .all_entries()
+                .into_iter()
+                .filter(message_cache::CachedSourceEntry::is_claude_namespace)
                 .collect();
             assert_eq!(claude_entries.len(), 2);
             assert!(
@@ -8735,7 +8746,7 @@ mod tests {
                     message_cache::CacheIdentity::for_client(ClientId::Codex),
                     &path,
                 )
-                .and_then(|entry| entry.codex_incremental.as_ref())
+                .and_then(|entry| entry.codex_incremental)
                 .is_some());
 
             std::thread::sleep(std::time::Duration::from_millis(5));

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1265,6 +1265,22 @@ impl CachedSourceEntry {
                 .contains(&CLAUDE_RETENTION_PROVENANCE_MARKER)
     }
 
+    /// Whether this entry is carrying rows the live file may no longer
+    /// contain — either an identified retained set, or a pre-provenance entry
+    /// that cannot say which of its rows are retained and has to be assumed to
+    /// hold some.
+    ///
+    /// Only meaningful for a namespace [`retained_history_key_filter`] covers;
+    /// elsewhere the index vector means something else entirely.
+    pub(crate) fn holds_retained_history(&self) -> bool {
+        self.is_claude_namespace()
+            && (self.needs_retention_provenance_migration()
+                || self
+                    .fallback_timestamp_indices
+                    .iter()
+                    .any(|index| *index != CLAUDE_RETENTION_PROVENANCE_MARKER))
+    }
+
     pub(crate) fn retained_message_keys(&self) -> HashSet<String> {
         if !self.is_claude_namespace() {
             return HashSet::new();
@@ -1650,11 +1666,14 @@ impl SourceMessageCache {
     ///
     /// Two cases keep their payload:
     ///
-    /// * A namespace that retains history (see [`retained_history_key_filter`])
-    ///   holds messages the live file no longer contains, and the cache is the
-    ///   only copy. A second lookup of a drained entry would look like a cold
-    ///   source and re-derive history from the live bytes alone, retiring rows
-    ///   that can never come back (#994).
+    /// * An entry that is actually carrying retained history (see
+    ///   [`CachedSourceEntry::holds_retained_history`]) holds messages the live
+    ///   file no longer contains, and the cache is the only copy. A second
+    ///   lookup of a drained entry would look like a cold source and re-derive
+    ///   history from the live bytes alone, retiring rows that can never come
+    ///   back (#994). An entry in the same namespace whose retained set is
+    ///   empty is fully reproducible from the live bytes, so it drains like any
+    ///   other.
     /// * An entry already marked dirty is written back from memory by
     ///   `save_if_dirty`, so its payload has to still be there.
     pub(crate) fn take(&self, identity: CacheIdentity, path: &Path) -> Option<CachedSourceEntry> {
@@ -1662,12 +1681,12 @@ impl SourceMessageCache {
         let mut state = self.state();
         self.ensure_namespace_loaded(&mut state, identity.namespace);
         let retains_history = retained_history_key_filter(identity.namespace).is_some();
-        let pinned = retains_history || state.dirty_keys.contains(&key);
+        let dirty = state.dirty_keys.contains(&key);
         let entry = state.entries.get_mut(&key)?;
         if !entry.matches_identity(identity) {
             return None;
         }
-        if pinned {
+        if dirty || (retains_history && entry.holds_retained_history()) {
             return Some(entry.clone());
         }
         Some(entry.take_payload())
@@ -4101,31 +4120,105 @@ mod tests {
         );
     }
 
-    /// Claude's entries hold turns the live transcript no longer contains, and
+    /// A Claude entry holds turns the live transcript no longer contains, and
     /// the cache is the only copy (#994). Draining one would make a second
-    /// lookup look like a cold source and retire that history for good, so
-    /// retention namespaces are served by clone instead.
+    /// lookup look like a cold source and retire that history for good, so an
+    /// entry that is carrying retained rows is served by clone instead.
     #[test]
     #[serial_test::serial]
-    fn take_keeps_the_payload_for_namespaces_that_retain_history() {
+    fn take_keeps_the_payload_of_an_entry_carrying_retained_history() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let identity = CacheIdentity::for_client(ClientId::Claude);
+        let source = write_temp_file(b"claude\n");
+
+        let live = keyed_message(identity.namespace, "claude-session", "live:req_live");
+        let retained = keyed_message(identity.namespace, "claude-session", "old:req_old");
+        let mut seed = SourceMessageCache::default();
+        seed.insert(CachedSourceEntry::new_with_retained_message_keys(
+            identity,
+            source.path(),
+            SourceFingerprint::from_path(source.path()).unwrap(),
+            vec![live, retained],
+            &HashSet::from(["old:req_old".to_string()]),
+        ));
+        seed.save_if_dirty();
+
+        let cache = SourceMessageCache::load();
+        let first = cache.take(identity, source.path()).expect("warm entry");
+        assert_eq!(first.messages.len(), 2);
+        assert_eq!(
+            cache
+                .take(identity, source.path())
+                .expect("a retained-history entry must survive being read")
+                .messages
+                .len(),
+            2,
+            "the only copy of a compacted turn must not leave the cache"
+        );
+    }
+
+    /// The same namespace, but nothing was retained: the live file reproduces
+    /// every row, so the entry drains like any other and Claude-heavy machines
+    /// still get the memory back.
+    #[test]
+    #[serial_test::serial]
+    fn take_drains_a_claude_entry_with_no_retained_history() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let identity = CacheIdentity::for_client(ClientId::Claude);
+        let source = write_temp_file(b"claude\n");
+
+        let live = keyed_message(identity.namespace, "claude-session", "live:req_live");
+        let mut seed = SourceMessageCache::default();
+        seed.insert(CachedSourceEntry::new_with_retained_message_keys(
+            identity,
+            source.path(),
+            SourceFingerprint::from_path(source.path()).unwrap(),
+            vec![live],
+            &HashSet::new(),
+        ));
+        seed.save_if_dirty();
+
+        let cache = SourceMessageCache::load();
+        assert_eq!(
+            cache
+                .take(identity, source.path())
+                .expect("warm entry")
+                .messages
+                .len(),
+            1
+        );
+        assert!(
+            cache.entry_messages_released(identity, source.path()),
+            "an entry with an empty retained set is reproducible from the live \
+             file, so it must not keep a second copy"
+        );
+    }
+
+    /// An entry written before retention provenance existed cannot say which of
+    /// its rows the live file already dropped, so it has to be treated as
+    /// carrying history even though its retained set reads as empty.
+    #[test]
+    #[serial_test::serial]
+    fn take_keeps_the_payload_of_a_pre_provenance_claude_entry() {
         let temp_home = TempDir::new().unwrap();
         let _cache_env = sandbox_cache_env(temp_home.path());
         let identity = CacheIdentity::for_client(ClientId::Claude);
         let source = write_temp_file(b"claude\n");
 
         let mut seed = SourceMessageCache::default();
-        seed.insert(test_entry(identity, source.path(), "claude-session"));
+        // `test_entry` builds the legacy shape: messages, no provenance marker.
+        let legacy = test_entry(identity, source.path(), "claude-session");
+        assert!(legacy.needs_retention_provenance_migration());
+        seed.insert(legacy);
         seed.save_if_dirty();
 
         let cache = SourceMessageCache::load();
         assert!(cache.take(identity, source.path()).is_some());
-        assert_eq!(
-            cache
-                .take(identity, source.path())
-                .expect("a retained-history entry must survive being read")
-                .messages[0]
-                .session_id,
-            "claude-session"
+        assert!(
+            !cache.entry_messages_released(identity, source.path()),
+            "a legacy entry may be hiding retained rows it cannot identify"
         );
     }
 

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -934,6 +934,7 @@ impl CacheIdentity {
         ClientId::from_str(namespace).map(Self::for_client)
     }
 
+    #[cfg(test)]
     fn all() -> impl Iterator<Item = Self> {
         ClientId::iter()
             .map(Self::for_client)
@@ -1213,6 +1214,32 @@ impl CachedSourceEntry {
             .is_some_and(|identity| identity.parser_version == self.parser_version)
     }
 
+    fn matches_identity(&self, identity: CacheIdentity) -> bool {
+        self.parser_namespace == identity.namespace
+            && self.parser_version == identity.parser_version
+    }
+
+    /// Moves everything that scales with the transcript out of this entry,
+    /// leaving the metadata a later `remove` or shard rewrite still needs.
+    ///
+    /// The husk left behind reports no messages, which every warm-hit check
+    /// already treats as "not usable" — so a second lookup degrades to a
+    /// re-parse rather than serving a truncated entry. See
+    /// [`SourceMessageCache::take`] for why that second lookup cannot happen
+    /// for the namespaces where a re-parse would lose history.
+    fn take_payload(&mut self) -> Self {
+        Self {
+            parser_namespace: self.parser_namespace.clone(),
+            parser_version: self.parser_version,
+            path: self.path.clone(),
+            fingerprint: self.fingerprint.clone(),
+            messages: std::mem::take(&mut self.messages),
+            fallback_timestamp_indices: std::mem::take(&mut self.fallback_timestamp_indices),
+            codex_incremental: self.codex_incremental.take(),
+            prime_accounting: self.prime_accounting.take(),
+        }
+    }
+
     pub(crate) fn is_claude_namespace(&self) -> bool {
         self.parser_namespace == ClientId::Claude.as_str()
     }
@@ -1397,22 +1424,79 @@ enum DeletionReason {
     Missing,
 }
 
+/// The mutable half of [`SourceMessageCache`].
+///
+/// It lives behind one mutex because the parse lanes hold the cache by shared
+/// reference from inside `rayon` closures, and both of the memory properties
+/// this type is responsible for need to mutate through that shared reference:
+/// a namespace's shards are read on first use, and an entry's message payload
+/// is handed to its one consumer instead of being cloned out from under a copy
+/// the cache keeps forever. Every critical section is a hash lookup plus a
+/// couple of `mem::take`s, except the once-per-namespace shard read.
 #[derive(Default)]
-pub(crate) struct SourceMessageCache {
-    pub entries: HashMap<CacheKey, CachedSourceEntry>,
+struct CacheState {
+    entries: HashMap<CacheKey, CachedSourceEntry>,
+    /// Namespaces whose shards were already read (or attempted). Recorded even
+    /// when the read fails so a broken cache directory cannot make every file
+    /// in a lane retry the same I/O.
+    loaded_namespaces: HashSet<&'static str>,
     dirty: bool,
     dirty_keys: HashSet<CacheKey>,
     deleted_keys: HashMap<CacheKey, DeletionReason>,
     rewrite_shards: HashSet<CacheShardKey>,
 }
 
+/// The persisted parse cache, read lazily and drained as it is consumed.
+///
+/// Both behaviours exist for one reason: a scan's memory must be proportional
+/// to what it actually reads, not to everything the machine has ever cached.
+/// Loading every namespace up front and keeping every entry alive for the
+/// whole scan made a `tokscale` run cost the size of the entire cache plus the
+/// size of its own output — a single-message `-c droid` scan peaked at 1.16 GB
+/// against a 358 MB cache, and the TUI paid that peak again on every
+/// auto-refresh until the process was killed (#1100).
+#[derive(Default)]
+pub(crate) struct SourceMessageCache {
+    state: Mutex<CacheState>,
+    /// `false` for [`SourceCachePolicy::InMemory`] callers, who must never
+    /// touch the on-disk shards.
+    persistent: bool,
+}
+
 impl SourceMessageCache {
+    /// Opens the persistent cache without reading any shard.
+    ///
+    /// Shards are read per namespace on first access, so a scan that only
+    /// looks at one client never deserializes another client's history.
     pub(crate) fn load() -> Self {
+        Self {
+            state: Mutex::new(CacheState::default()),
+            persistent: true,
+        }
+    }
+
+    fn state(&self) -> std::sync::MutexGuard<'_, CacheState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Reads `namespace`'s shards into `state` the first time it is needed.
+    ///
+    /// Missing-source pruning happens here rather than in one pass over the
+    /// whole cache, so it stays scoped to the namespaces this scan touched.
+    fn ensure_namespace_loaded(&self, state: &mut CacheState, namespace: &'static str) {
+        if !self.persistent || !state.loaded_namespaces.insert(namespace) {
+            return;
+        }
+        let Some(identity) = CacheIdentity::current_for_namespace(namespace) else {
+            return;
+        };
         let Some(shard_root) = cache_shard_dir() else {
-            return Self::default();
+            return;
         };
         let Some(lock_path) = cache_lock_path() else {
-            return Self::default();
+            return;
         };
         if let Err(error) = ensure_cache_dir(&shard_root) {
             warn_cache_failure_once(
@@ -1420,7 +1504,7 @@ impl SourceMessageCache {
                 &shard_root,
                 &error,
             );
-            return Self::default();
+            return;
         }
         let lock_file = match OpenOptions::new()
             .read(true)
@@ -1436,110 +1520,238 @@ impl SourceMessageCache {
                     &lock_path,
                     &error,
                 );
-                return Self::default();
+                return;
             }
         };
         if let Err(error) = fs2::FileExt::lock_shared(&lock_file) {
             warn_cache_failure_once("source message cache lock failed", &lock_path, &error);
-            return Self::default();
+            return;
         }
 
-        let mut cache = Self::default();
-        for identity in CacheIdentity::all() {
-            let parser_dir = shard_root.join(identity.namespace);
-            let read_dir = match fs::read_dir(&parser_dir) {
-                Ok(read_dir) => read_dir,
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
-                Err(error) => {
-                    warn_cache_failure_once(
-                        "source message cache parser directory is unreadable",
-                        &parser_dir,
-                        &error,
-                    );
+        let parser_dir = shard_root.join(namespace);
+        let read_dir = match fs::read_dir(&parser_dir) {
+            Ok(read_dir) => read_dir,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+            Err(error) => {
+                warn_cache_failure_once(
+                    "source message cache parser directory is unreadable",
+                    &parser_dir,
+                    &error,
+                );
+                return;
+            }
+        };
+
+        for dir_entry in read_dir.filter_map(Result::ok) {
+            let Some(index) = parse_shard_filename(&dir_entry.file_name()) else {
+                continue;
+            };
+            let shard_key = CacheShardKey {
+                namespace: namespace.to_string(),
+                index,
+            };
+            let path = dir_entry.path();
+            let (entries, migrated) = match read_shard(&path, identity) {
+                ShardReadStatus::Loaded(entries) => (entries, false),
+                ShardReadStatus::Migrated(entries) => (entries, true),
+                ShardReadStatus::Missing => continue,
+                ShardReadStatus::Stale => {
+                    state.rewrite_shards.insert(shard_key);
+                    state.dirty = true;
+                    continue;
+                }
+                ShardReadStatus::Invalid(error) => {
+                    warn_cache_failure_once("source message cache shard is invalid", &path, &error);
+                    state.rewrite_shards.insert(shard_key);
+                    state.dirty = true;
                     continue;
                 }
             };
-
-            for dir_entry in read_dir.filter_map(Result::ok) {
-                let Some(index) = parse_shard_filename(&dir_entry.file_name()) else {
+            if migrated {
+                state.rewrite_shards.insert(shard_key.clone());
+                state.dirty = true;
+            }
+            for mut entry in entries {
+                let key = CacheKey::from_entry(&entry);
+                if key.shard() != shard_key || !entry.identity_is_current() {
+                    state.rewrite_shards.insert(shard_key.clone());
+                    state.dirty = true;
                     continue;
-                };
-                let shard_key = CacheShardKey {
-                    namespace: identity.namespace.to_string(),
-                    index,
-                };
-                let path = dir_entry.path();
-                let (entries, migrated) = match read_shard(&path, identity) {
-                    ShardReadStatus::Loaded(entries) => (entries, false),
-                    ShardReadStatus::Migrated(entries) => (entries, true),
-                    ShardReadStatus::Missing => continue,
-                    ShardReadStatus::Stale => {
-                        cache.rewrite_shards.insert(shard_key);
-                        continue;
-                    }
-                    ShardReadStatus::Invalid(error) => {
-                        warn_cache_failure_once(
-                            "source message cache shard is invalid",
-                            &path,
-                            &error,
-                        );
-                        cache.rewrite_shards.insert(shard_key);
-                        continue;
-                    }
-                };
-                if migrated {
-                    cache.rewrite_shards.insert(shard_key.clone());
                 }
-                for mut entry in entries {
-                    let key = CacheKey::from_entry(&entry);
-                    if key.shard() == shard_key && entry.identity_is_current() {
-                        if entry.remove_claude_synthetic_placeholders() {
-                            // Do not bump Claude's parser version here: compacted
-                            // transcripts rely on cached assistant history that a
-                            // full invalidation cannot recover. Repair only the bad
-                            // `<synthetic>` rows and persist that narrow migration.
-                            cache.dirty_keys.insert(key.clone());
-                        }
-                        cache.entries.insert(key, entry);
-                    } else {
-                        cache.rewrite_shards.insert(shard_key.clone());
-                    }
+                // A source that no longer exists can never be scanned again,
+                // so its entry is dead weight in memory and on disk.
+                if !key.path.to_path_buf().exists() {
+                    state.deleted_keys.insert(key, DeletionReason::Missing);
+                    state.dirty = true;
+                    continue;
                 }
+                // This scan already produced (or deleted) something for this
+                // source, and that is newer than the bytes on disk.
+                if state.entries.contains_key(&key)
+                    || state.dirty_keys.contains(&key)
+                    || state.deleted_keys.contains_key(&key)
+                {
+                    continue;
+                }
+                if entry.remove_claude_synthetic_placeholders() {
+                    // Do not bump Claude's parser version here: compacted
+                    // transcripts rely on cached assistant history that a
+                    // full invalidation cannot recover. Repair only the bad
+                    // `<synthetic>` rows and persist that narrow migration.
+                    state.dirty_keys.insert(key.clone());
+                    state.dirty = true;
+                }
+                state.entries.insert(key, entry);
             }
         }
+    }
 
-        cache.dirty = !(cache.rewrite_shards.is_empty() && cache.dirty_keys.is_empty());
-        cache
+    #[cfg(test)]
+    fn load_all_namespaces(&self, state: &mut CacheState) {
+        for identity in CacheIdentity::all() {
+            self.ensure_namespace_loaded(state, identity.namespace);
+        }
     }
 
     pub(crate) fn insert(&mut self, entry: CachedSourceEntry) {
         let key = CacheKey::from_entry(&entry);
-        self.entries.insert(key.clone(), entry);
-        self.deleted_keys.remove(&key);
-        self.dirty_keys.insert(key);
-        self.dirty = true;
+        let state = self.state.get_mut().unwrap_or_else(|p| p.into_inner());
+        state.entries.insert(key.clone(), entry);
+        state.deleted_keys.remove(&key);
+        state.dirty_keys.insert(key);
+        state.dirty = true;
     }
 
-    pub(crate) fn get(&self, identity: CacheIdentity, path: &Path) -> Option<&CachedSourceEntry> {
+    /// Reads an entry without disturbing the cache's copy.
+    ///
+    /// Production scans use [`Self::take`]; this exists so tests can assert on
+    /// what a load produced without consuming it.
+    #[cfg(test)]
+    pub(crate) fn get(&self, identity: CacheIdentity, path: &Path) -> Option<CachedSourceEntry> {
         let key = CacheKey::new(identity, path);
-        self.entries.get(&key).filter(|entry| {
-            entry.parser_namespace == identity.namespace
-                && entry.parser_version == identity.parser_version
-        })
+        let mut state = self.state();
+        self.ensure_namespace_loaded(&mut state, identity.namespace);
+        state
+            .entries
+            .get(&key)
+            .filter(|entry| entry.matches_identity(identity))
+            .cloned()
+    }
+
+    /// Hands the entry for `path` to its one consumer, moving the message
+    /// payload out of the cache and leaving the entry's metadata behind.
+    ///
+    /// Every source is looked up at most once per scan, and
+    /// [`Self::save_if_dirty`] re-reads each shard it rewrites from disk and
+    /// only overlays the entries this scan marked dirty — so a clean entry's
+    /// messages are never needed again in memory, and releasing them here is
+    /// what keeps a scan from holding the whole cache and its own output at
+    /// the same time.
+    ///
+    /// Two cases keep their payload:
+    ///
+    /// * A namespace that retains history (see [`retained_history_key_filter`])
+    ///   holds messages the live file no longer contains, and the cache is the
+    ///   only copy. A second lookup of a drained entry would look like a cold
+    ///   source and re-derive history from the live bytes alone, retiring rows
+    ///   that can never come back (#994).
+    /// * An entry already marked dirty is written back from memory by
+    ///   `save_if_dirty`, so its payload has to still be there.
+    pub(crate) fn take(&self, identity: CacheIdentity, path: &Path) -> Option<CachedSourceEntry> {
+        let key = CacheKey::new(identity, path);
+        let mut state = self.state();
+        self.ensure_namespace_loaded(&mut state, identity.namespace);
+        let retains_history = retained_history_key_filter(identity.namespace).is_some();
+        let pinned = retains_history || state.dirty_keys.contains(&key);
+        let entry = state.entries.get_mut(&key)?;
+        if !entry.matches_identity(identity) {
+            return None;
+        }
+        if pinned {
+            return Some(entry.clone());
+        }
+        Some(entry.take_payload())
     }
 
     pub(crate) fn remove(&mut self, identity: CacheIdentity, path: &Path) {
         let key = CacheKey::new(identity, path);
-        if let Some(entry) = self.entries.remove(&key) {
-            self.dirty_keys.remove(&key);
-            self.deleted_keys
+        // Load first: an invalidation has to record the fingerprint it is
+        // replacing, and an unread namespace holds no entry to record.
+        let mut state = self.state();
+        self.ensure_namespace_loaded(&mut state, identity.namespace);
+        if let Some(entry) = state.entries.remove(&key) {
+            state.dirty_keys.remove(&key);
+            state
+                .deleted_keys
                 .insert(key, DeletionReason::Invalidated(entry.fingerprint));
-            self.dirty = true;
+            state.dirty = true;
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn loaded_namespace_count(&self) -> usize {
+        self.state().loaded_namespaces.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn namespace_is_loaded(&self, namespace: &str) -> bool {
+        self.state().loaded_namespaces.contains(namespace)
+    }
+
+    /// Whether the cache is holding a husk: an entry it still knows about
+    /// whose messages were handed to their consumer.
+    #[cfg(test)]
+    pub(crate) fn entry_messages_released(&self, identity: CacheIdentity, path: &Path) -> bool {
+        let state = self.state();
+        state
+            .entries
+            .get(&CacheKey::new(identity, path))
+            .is_some_and(|entry| entry.messages.is_empty())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn entry_fingerprint(
+        &self,
+        identity: CacheIdentity,
+        path: &Path,
+    ) -> Option<SourceFingerprint> {
+        let state = self.state();
+        state
+            .entries
+            .get(&CacheKey::new(identity, path))
+            .map(|entry| entry.fingerprint.clone())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn entry_count(&self) -> usize {
+        self.all_entries().len()
+    }
+
+    #[cfg(test)]
+    fn is_dirty(&self) -> bool {
+        self.state().dirty
+    }
+
+    #[cfg(test)]
+    fn has_rewrite_shard(&self, shard: &CacheShardKey) -> bool {
+        let mut state = self.state();
+        self.load_all_namespaces(&mut state);
+        state.rewrite_shards.contains(shard)
+    }
+
+    /// Every entry this cache currently holds, loading every namespace first.
+    #[cfg(test)]
+    pub(crate) fn all_entries(&self) -> Vec<CachedSourceEntry> {
+        let mut state = self.state();
+        self.load_all_namespaces(&mut state);
+        state.entries.values().cloned().collect()
+    }
+
+    #[cfg(test)]
     pub(crate) fn prune_missing_files(&mut self) {
-        let removed_keys: Vec<CacheKey> = self
+        let mut state = self.state();
+        self.load_all_namespaces(&mut state);
+        let removed_keys: Vec<CacheKey> = state
             .entries
             .keys()
             .filter(|key| !key.path.to_path_buf().exists())
@@ -1547,10 +1759,10 @@ impl SourceMessageCache {
             .collect();
 
         for key in removed_keys {
-            self.entries.remove(&key);
-            self.dirty_keys.remove(&key);
-            self.deleted_keys.insert(key, DeletionReason::Missing);
-            self.dirty = true;
+            state.entries.remove(&key);
+            state.dirty_keys.remove(&key);
+            state.deleted_keys.insert(key, DeletionReason::Missing);
+            state.dirty = true;
         }
     }
 
@@ -1559,7 +1771,8 @@ impl SourceMessageCache {
     }
 
     fn save_if_dirty_with_limit(&mut self, max_shard_bytes: u64) {
-        if !self.dirty {
+        let state = self.state.get_mut().unwrap_or_else(|p| p.into_inner());
+        if !state.dirty {
             return;
         }
 
@@ -1606,7 +1819,7 @@ impl SourceMessageCache {
         // dominated cold-cache builds (hundreds of shards * tens of thousands of
         // files re-hashed).
         let mut dirty_by_shard: HashMap<CacheShardKey, Vec<CacheKey>> = HashMap::new();
-        for key in &self.dirty_keys {
+        for key in &state.dirty_keys {
             dirty_by_shard
                 .entry(key.shard())
                 .or_default()
@@ -1614,14 +1827,14 @@ impl SourceMessageCache {
         }
         let mut deleted_by_shard: HashMap<CacheShardKey, Vec<(CacheKey, DeletionReason)>> =
             HashMap::new();
-        for (key, reason) in &self.deleted_keys {
+        for (key, reason) in &state.deleted_keys {
             deleted_by_shard
                 .entry(key.shard())
                 .or_default()
                 .push((key.clone(), reason.clone()));
         }
 
-        let mut affected_shards = self.rewrite_shards.clone();
+        let mut affected_shards = state.rewrite_shards.clone();
         affected_shards.extend(dirty_by_shard.keys().cloned());
         affected_shards.extend(deleted_by_shard.keys().cloned());
 
@@ -1677,7 +1890,7 @@ impl SourceMessageCache {
             }
             if let Some(dirty) = dirty_by_shard.get(&shard_key) {
                 for key in dirty {
-                    if let Some(entry) = self.entries.get(key) {
+                    if let Some(entry) = state.entries.get(key) {
                         let mut entry = entry.clone();
                         // Another process holding the lock before us may have
                         // stored history for this same path that our in-memory
@@ -1708,15 +1921,18 @@ impl SourceMessageCache {
             }
         }
 
-        self.dirty_keys
+        state
+            .dirty_keys
             .retain(|key| !successful_shards.contains(&key.shard()));
-        self.deleted_keys
+        state
+            .deleted_keys
             .retain(|key, _| !successful_shards.contains(&key.shard()));
-        self.rewrite_shards
+        state
+            .rewrite_shards
             .retain(|shard| !successful_shards.contains(shard));
-        self.dirty = !(self.dirty_keys.is_empty()
-            && self.deleted_keys.is_empty()
-            && self.rewrite_shards.is_empty());
+        state.dirty = !(state.dirty_keys.is_empty()
+            && state.deleted_keys.is_empty()
+            && state.rewrite_shards.is_empty());
     }
 }
 
@@ -3422,7 +3638,7 @@ mod tests {
         assert!(shard_one.is_file());
         assert!(shard_two.is_file());
         let loaded = SourceMessageCache::load();
-        assert_eq!(loaded.entries.len(), 2);
+        assert_eq!(loaded.entry_count(), 2);
         assert!(loaded.get(identity, &path_one).is_some());
         assert!(loaded.get(identity, &path_two).is_some());
     }
@@ -3448,7 +3664,7 @@ mod tests {
         cache.insert(entry_two);
         cache.save_if_dirty_with_limit(TEST_SHARD_LIMIT);
         assert!(
-            !cache.dirty,
+            !cache.is_dirty(),
             "both independently bounded shards should save"
         );
 
@@ -3493,7 +3709,7 @@ mod tests {
             "valid-session"
         );
         assert!(
-            loaded.dirty,
+            loaded.is_dirty(),
             "the corrupt shard should be scheduled for rewrite"
         );
     }
@@ -3541,9 +3757,9 @@ mod tests {
             ShardReadStatus::Stale
         ));
         let mut loaded = SourceMessageCache::load();
-        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entry_count(), 1);
         assert!(loaded.get(claude, source.path()).is_some());
-        assert!(loaded.rewrite_shards.contains(&stale_key));
+        assert!(loaded.has_rewrite_shard(&stale_key));
 
         loaded.save_if_dirty();
         assert!(matches!(
@@ -3632,7 +3848,7 @@ mod tests {
             cache.get(identity, source.path()).unwrap().messages[0].session_id,
             "legacy-prime"
         );
-        assert!(cache.rewrite_shards.contains(&shard_key));
+        assert!(cache.has_rewrite_shard(&shard_key));
         cache.save_if_dirty();
         assert!(matches!(
             read_shard(&legacy_path, identity),
@@ -3728,7 +3944,7 @@ mod tests {
             loaded.get(current_identity, &source_path).is_none(),
             "a stale Copilot cache entry must not be served after the parser output change"
         );
-        assert!(loaded.rewrite_shards.contains(&shard_key));
+        assert!(loaded.has_rewrite_shard(&shard_key));
         assert_eq!(
             SourceFingerprint::from_path(&source_path).unwrap(),
             fingerprint,
@@ -3772,6 +3988,219 @@ mod tests {
                     && entries[0].messages[0].agent.as_deref()
                         == Some("github.copilot.default")
         ));
+    }
+
+    /// #1100: a scan must not deserialize namespaces it never reads.
+    ///
+    /// Before this was lazy, `load` read every shard of every client up front,
+    /// so a one-file `-c droid` scan paid for the whole machine's history —
+    /// 1.16 GB against a 358 MB cache on the reporter's class of machine — and
+    /// the TUI paid it again on every auto-refresh.
+    #[test]
+    #[serial_test::serial]
+    fn load_reads_only_the_namespaces_a_scan_touches() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let claude = CacheIdentity::for_client(ClientId::Claude);
+        let codex = CacheIdentity::for_client(ClientId::Codex);
+        let claude_source = write_temp_file(b"claude\n");
+        let codex_source = write_temp_file(b"codex\n");
+
+        let mut seed = SourceMessageCache::default();
+        seed.insert(test_entry(claude, claude_source.path(), "claude-session"));
+        seed.insert(test_entry(codex, codex_source.path(), "codex-session"));
+        seed.save_if_dirty();
+
+        let cache = SourceMessageCache::load();
+        assert_eq!(
+            cache.loaded_namespace_count(),
+            0,
+            "opening the cache must not read a single shard"
+        );
+
+        assert!(cache.take(codex, codex_source.path()).is_some());
+        assert_eq!(
+            cache.loaded_namespace_count(),
+            1,
+            "only the namespace that was asked for may be deserialized"
+        );
+        assert!(
+            !cache.namespace_is_loaded(claude.namespace),
+            "an untouched client's history must stay on disk"
+        );
+    }
+
+    /// #1100: the payload handed to a scan must leave the cache, not be copied
+    /// out of it. Holding both made a run cost the whole cache plus its own
+    /// output at the same time.
+    #[test]
+    #[serial_test::serial]
+    fn take_releases_the_entry_payload_but_keeps_its_metadata() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let identity = CacheIdentity::for_client(ClientId::Codex);
+        let source = write_temp_file(b"codex\n");
+
+        let mut seed = SourceMessageCache::default();
+        seed.insert(test_entry(identity, source.path(), "codex-session"));
+        seed.save_if_dirty();
+
+        let cache = SourceMessageCache::load();
+        let taken = cache.take(identity, source.path()).expect("warm entry");
+        assert_eq!(taken.messages.len(), 1);
+        assert_eq!(taken.messages[0].session_id, "codex-session");
+
+        assert!(
+            cache.entry_messages_released(identity, source.path()),
+            "the cache must not keep a second copy of a payload it handed out"
+        );
+        assert_eq!(
+            cache.entry_fingerprint(identity, source.path()),
+            Some(taken.fingerprint.clone()),
+            "the husk still has to answer fingerprint and invalidation lookups"
+        );
+    }
+
+    /// A drained clean entry is still on disk, so a shard rewrite driven by a
+    /// different file must carry it forward untouched. If `save_if_dirty` ever
+    /// starts writing shards from memory alone, this is the test that fails.
+    #[test]
+    #[serial_test::serial]
+    fn saving_after_a_take_keeps_the_drained_entry_on_disk() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let identity = CacheIdentity::for_client(ClientId::Codex);
+        let untouched = write_temp_file(b"untouched\n");
+        let rewritten = write_temp_file(b"rewritten\n");
+
+        let mut seed = SourceMessageCache::default();
+        seed.insert(test_entry(identity, untouched.path(), "kept-session"));
+        seed.save_if_dirty();
+
+        let mut cache = SourceMessageCache::load();
+        assert!(cache.take(identity, untouched.path()).is_some());
+        cache.insert(test_entry(identity, rewritten.path(), "new-session"));
+        cache.save_if_dirty();
+
+        let reloaded = SourceMessageCache::load();
+        assert_eq!(
+            reloaded
+                .get(identity, untouched.path())
+                .expect("the drained entry must survive the save")
+                .messages[0]
+                .session_id,
+            "kept-session"
+        );
+        assert_eq!(
+            reloaded
+                .get(identity, rewritten.path())
+                .expect("the newly cached entry must be saved")
+                .messages[0]
+                .session_id,
+            "new-session"
+        );
+    }
+
+    /// Claude's entries hold turns the live transcript no longer contains, and
+    /// the cache is the only copy (#994). Draining one would make a second
+    /// lookup look like a cold source and retire that history for good, so
+    /// retention namespaces are served by clone instead.
+    #[test]
+    #[serial_test::serial]
+    fn take_keeps_the_payload_for_namespaces_that_retain_history() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let identity = CacheIdentity::for_client(ClientId::Claude);
+        let source = write_temp_file(b"claude\n");
+
+        let mut seed = SourceMessageCache::default();
+        seed.insert(test_entry(identity, source.path(), "claude-session"));
+        seed.save_if_dirty();
+
+        let cache = SourceMessageCache::load();
+        assert!(cache.take(identity, source.path()).is_some());
+        assert_eq!(
+            cache
+                .take(identity, source.path())
+                .expect("a retained-history entry must survive being read")
+                .messages[0]
+                .session_id,
+            "claude-session"
+        );
+    }
+
+    /// Invalidating a source the current process never read still has to
+    /// record the fingerprint it replaces, so the stale shard row is dropped.
+    #[test]
+    #[serial_test::serial]
+    fn remove_loads_the_namespace_it_invalidates() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let identity = CacheIdentity::for_client(ClientId::Codex);
+        let source = write_temp_file(b"codex\n");
+
+        let mut seed = SourceMessageCache::default();
+        seed.insert(test_entry(identity, source.path(), "codex-session"));
+        seed.save_if_dirty();
+
+        let mut cache = SourceMessageCache::load();
+        cache.remove(identity, source.path());
+        cache.save_if_dirty();
+
+        assert!(SourceMessageCache::load()
+            .get(identity, source.path())
+            .is_none());
+    }
+
+    /// A source that vanished is dropped as its namespace loads, which is the
+    /// only pruning pass left now that nothing reads the whole cache.
+    #[test]
+    #[serial_test::serial]
+    fn loading_a_namespace_prunes_entries_whose_source_is_gone() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let identity = CacheIdentity::for_client(ClientId::Codex);
+        let source = write_temp_file(b"codex\n");
+        let path = source.path().to_path_buf();
+
+        let mut seed = SourceMessageCache::default();
+        seed.insert(test_entry(identity, &path, "codex-session"));
+        seed.save_if_dirty();
+        drop(source);
+        assert!(!path.exists());
+
+        let mut cache = SourceMessageCache::load();
+        assert!(cache.take(identity, &path).is_none());
+        cache.save_if_dirty();
+
+        assert!(SourceMessageCache::load().get(identity, &path).is_none());
+    }
+
+    /// The shard on disk is older than what this scan produced, so loading the
+    /// namespace afterwards must not resurrect the stale row.
+    #[test]
+    #[serial_test::serial]
+    fn a_lazy_namespace_load_does_not_overwrite_this_scan_s_entries() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let identity = CacheIdentity::for_client(ClientId::Codex);
+        let source = write_temp_file(b"codex\n");
+
+        let mut seed = SourceMessageCache::default();
+        seed.insert(test_entry(identity, source.path(), "stale-session"));
+        seed.save_if_dirty();
+
+        let mut cache = SourceMessageCache::load();
+        cache.insert(test_entry(identity, source.path(), "fresh-session"));
+        assert_eq!(
+            cache
+                .get(identity, source.path())
+                .expect("the freshly inserted entry")
+                .messages[0]
+                .session_id,
+            "fresh-session",
+            "a later shard read must not clobber what this scan just produced"
+        );
     }
 
     #[test]
@@ -3845,7 +4274,7 @@ mod tests {
         std::fs::remove_file(&path).unwrap();
         cache.prune_missing_files();
 
-        assert!(cache.entries.is_empty());
+        assert!(cache.all_entries().is_empty());
     }
 
     #[test]
@@ -3872,16 +4301,16 @@ mod tests {
         let _cache_env = sandbox_cache_env(temp_home.path());
 
         let mut cache = SourceMessageCache::default();
-        assert!(!cache.dirty);
+        assert!(!cache.is_dirty());
 
         {
             let file = write_temp_file(b"{}\n");
             let identity = CacheIdentity::for_client(ClientId::Claude);
             cache.insert(test_entry(identity, file.path(), "session-1"));
-            assert!(cache.dirty);
+            assert!(cache.is_dirty());
 
             cache.save_if_dirty();
-            assert!(!cache.dirty);
+            assert!(!cache.is_dirty());
         }
     }
 


### PR DESCRIPTION
Fixes #1100.

## Diagnosis

`npx -y tokscale@4` is not leaking in the Rust sense — a tracking-allocator probe over four repeated in-process scans of a ~1M-message home shows the live heap returning to the same 6.2 MB baseline every time (`retained_delta=0.0MB`). What grows is the *peak* of each scan, and the TUI pays that peak again on every auto-refresh (the reporter's footer shows `R:auto 60s`).

The peak was proportional to the entire persisted source-message cache rather than to what the scan actually reads, because `SourceMessageCache::load` eagerly deserialized every client namespace and every shard, then kept every entry alive for the whole scan while the scan's own output accumulated on top of it. Measured against a real 358 MB on-disk cache, a scan that produces a *single* message peaked at 1164.7 MB; the same scan against an empty cache peaked at 12.9 MB. A live-heap timeline of a full scan shows 1215 MB allocated in the first 8 seconds (the cache load) and held flat as a floor for the remaining 76 seconds while the output grew to ~2.1 GB. That is why v3 is fine and v4 is not: v3 has no source-message cache, so it never paid this floor, and the floor grows for the life of the install as the cache accumulates.

## Change

- Read a namespace's shards the first time a lane asks for one of its sources instead of reading every namespace up front. Missing-source pruning moves into that per-namespace load, since nothing reads the whole cache any more.
- Hand a clean entry's message payload to its one consumer (`SourceMessageCache::take`) instead of cloning it out of a copy the cache keeps for the rest of the scan. A metadata husk stays behind so invalidation and shard rewrites still see the entry's path and fingerprint.
- Two cases keep their payload: an entry actually carrying retained history (a Claude entry with a non-empty retained set, or a pre-provenance entry that cannot say which of its rows are retained), where the cache is the only copy and a second lookup of a drained entry would retire those turns (#994); and entries already marked dirty, which `save_if_dirty` writes back from memory. A Claude entry whose retained set is empty is fully reproducible from the live file, so it drains like any other.

`save_if_dirty` already re-reads each shard it rewrites from disk and only overlays the entries a scan marked dirty, so a drained clean entry is never needed in memory again — that is what makes releasing it safe, and `saving_after_a_take_keeps_the_drained_entry_on_disk` pins it.

## Measured before/after

Peak heap per scan, tracking global allocator, same machine, same 368 MB cache snapshot restored before each run, real ~1M-message home:

| scan | before | after | change |
| --- | --- | --- | --- |
| `-c droid` (1 message) | 1164.7 MB | 6.3 MB | −99.5% |
| `-c codex` (334k messages) | 1477.0 MB | 328.3 MB | −77.8% |
| `-c claude` (254k messages) | 1839.6 MB | 757.2 MB | −58.8% |
| all clients (993k messages) | 2252.5 MB | 1473.2 MB | −34.6% |

Warm-scan wall clock over the same runs: `-c codex` 15.4 s → 1.9 s, `-c droid` 15.2 s → 0.0 s, `-c claude` 67.3 s → 38.1 s. A full all-clients scan is unchanged within run-to-run noise (85.6 s → 89.8 s against a 75.9–91.7 s spread across repeats), since it still reads every namespace.

End-to-end TUI (`tokscale --refresh 20`, 5.5 minutes, same cache snapshot), macOS `vmmap` physical footprint: peak 1843 MB → 1638 MB, and the between-refresh floor drops from ~1126 MB to ~300–900 MB.

The all-clients row is the smallest win because the TUI does read every namespace; the floor now decays as the scan's output grows instead of being held whole.

## Output equality

Byte-identical `tokscale --json -c claude` output between `main` and this branch, cold and warm, over an 800k-message synthetic Claude corpus (only `processingTimeMs` differs). A live-corpus probe that appends to five transcripts and compacts one between eight successive scans returns the identical message sequence (900/1800/…/7200) on both, so retention across compaction is unchanged.

## Tests

Seven new regression tests in `message_cache`:

- `load_reads_only_the_namespaces_a_scan_touches`
- `take_releases_the_entry_payload_but_keeps_its_metadata`
- `saving_after_a_take_keeps_the_drained_entry_on_disk`
- `take_keeps_the_payload_of_an_entry_carrying_retained_history`
- `take_keeps_the_payload_of_a_pre_provenance_claude_entry`
- `take_drains_a_claude_entry_with_no_retained_history`
- `remove_loads_the_namespace_it_invalidates`
- `loading_a_namespace_prunes_entries_whose_source_is_gone`
- `a_lazy_namespace_load_does_not_overwrite_this_scan_s_entries`

## Validation

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings` — exit 0
- `cargo test --workspace` — 2871 passed, 0 failed

## Known limitations

- Stale entries in a namespace this machine never scans again are no longer pruned, because nothing reads that namespace. They cost disk, not memory.
- A source looked up twice in one scan sees a drained husk and re-parses it: output is unchanged, the scan is slower. Retention namespaces are exempt, so this can never lose history.
- This does not make the TUI's refresh incremental. A full all-clients refresh still materializes every message, so a large enough history can still spike; the reporter's own cache was not available to verify the absolute numbers on their machine.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read source-message cache shards lazily per client and hand cached payloads to parsers instead of cloning them. Fixes #1100 memory spikes by only deserializing what a scan needs and not keeping a second in-memory copy; Claude entries now drain unless they actually carry retained history.

- Bug Fixes
  - Load shards on first access per namespace; prune missing sources during that load. Load a namespace on `remove` to record the replaced fingerprint.
  - Added `SourceMessageCache::take(...)` to move an entry’s messages to its consumer while keeping lightweight metadata for invalidation and shard rewrites; parser paths now use `take` and stop cloning payloads.
  - Keep payloads only when needed: entries already marked dirty, or entries that actually hold retained history (non-empty retained set or pre-provenance Claude). Drained clean entries are preserved via on-disk shard reads during saves.
  - Further reduced peak heap: `-c claude` 890.7 → 757.2 MB; all clients 1617.5 → 1473.2 MB.

<sup>Written for commit 615d24cfaadd868d4e31ad097eaf730839796ead. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

