### PR TITLE
fix(claude): resolve diagnostics cache from config root

### DIFF
--- a/crates/tokscale-cli/src/claude_diagnostics.rs
+++ b/crates/tokscale-cli/src/claude_diagnostics.rs
@@ -53,6 +53,7 @@ fn claude_diagnostics(
     include_info: bool,
 ) -> Vec<ClientDiagnostic> {
     let mut diagnostics = Vec::new();
+    let claude_root = resolved_claude_root(home_dir, use_env_roots);
 
     let desktop_paths: Vec<PathBuf> = claude_desktop_storage_paths(home_dir)
         .into_iter()
@@ -65,11 +66,11 @@ fn claude_diagnostics(
             severity: "warning",
             message: CLAUDE_DESKTOP_MESSAGE,
             help: CLAUDE_DESKTOP_HELP,
-            paths: diagnostic_paths(home_dir, use_env_roots, desktop_paths),
+            paths: diagnostic_paths(&claude_root, desktop_paths),
         });
     }
 
-    let stats_cache = home_dir.join(".claude").join("stats-cache.json");
+    let stats_cache = claude_root.join("stats-cache.json");
     if include_info && stats_cache.exists() {
         diagnostics.push(ClientDiagnostic {
             code: "claude_stats_cache_not_imported",
@@ -98,11 +99,16 @@ fn claude_desktop_storage_paths(home_dir: &Path) -> Vec<PathBuf> {
     ]
 }
 
-fn diagnostic_paths(
-    home_dir: &Path,
-    use_env_roots: bool,
-    desktop_paths: Vec<PathBuf>,
-) -> Vec<DiagnosticPath> {
+fn resolved_claude_root(home_dir: &Path, use_env_roots: bool) -> PathBuf {
+    PathBuf::from(
+        tokscale_core::ClientId::Claude
+            .data()
+            .root
+            .resolve_with_env_strategy(&home_dir.to_string_lossy(), use_env_roots),
+    )
+}
+
+fn diagnostic_paths(claude_root: &Path, desktop_paths: Vec<PathBuf>) -> Vec<DiagnosticPath> {
     let mut paths: Vec<DiagnosticPath> = desktop_paths
         .into_iter()
         .map(|path| DiagnosticPath {
@@ -112,17 +118,6 @@ fn diagnostic_paths(
         })
         .collect();
 
-    // Resolve through the client registry (CLAUDE_CONFIG_DIR-aware) instead of
-    // a fixed `.claude` offset from home, so this diagnostic reports the same
-    // paths the scanner actually reads — and respect `use_env_roots` so a
-    // `--home` override keeps its documented ignore-conflicting-env-vars
-    // semantics instead of always following CLAUDE_CONFIG_DIR.
-    let claude_root = PathBuf::from(
-        tokscale_core::ClientId::Claude
-            .data()
-            .root
-            .resolve_with_env_strategy(&home_dir.to_string_lossy(), use_env_roots),
-    );
     for (label, path) in [
         ("claudeCodeProjects", claude_root.join("projects")),
         ("claudeCodeTranscripts", claude_root.join("transcripts")),

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3608,6 +3608,95 @@ fn test_clients_json_includes_claude_desktop_diagnostic() {
 }
 
 #[test]
+fn test_clients_json_finds_stats_cache_under_claude_config_dir() {
+    let home = create_empty_fixture_dir();
+    let default_cache = home.path().join(".claude/stats-cache.json");
+    fs::create_dir_all(default_cache.parent().unwrap()).unwrap();
+    fs::write(&default_cache, "{}").unwrap();
+
+    let claude_config_dir = TempDir::new().expect("failed to create Claude config dir");
+    let configured_cache = claude_config_dir.path().join("stats-cache.json");
+    fs::write(&configured_cache, "{}").unwrap();
+
+    let output = cmd_with_home(home.path())
+        .env("CLAUDE_CONFIG_DIR", claude_config_dir.path())
+        .args(["clients", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let claude = json["clients"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["client"] == "claude")
+        .unwrap();
+    let stats_cache = claude["diagnostics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["code"] == "claude_stats_cache_not_imported")
+        .expect("configured stats-cache.json should produce a diagnostic");
+
+    assert_eq!(
+        stats_cache["paths"][0]["path"],
+        configured_cache.to_string_lossy().as_ref()
+    );
+}
+
+#[test]
+fn test_clients_home_override_ignores_claude_config_dir_for_stats_cache() {
+    let explicit_home = create_empty_fixture_dir();
+    let expected_cache = explicit_home.path().join(".claude/stats-cache.json");
+    fs::create_dir_all(expected_cache.parent().unwrap()).unwrap();
+    fs::write(&expected_cache, "{}").unwrap();
+
+    let process_home = TempDir::new().expect("failed to create process home");
+    let conflicting_claude_dir = TempDir::new().expect("failed to create Claude config dir");
+    fs::write(conflicting_claude_dir.path().join("stats-cache.json"), "{}").unwrap();
+
+    let output = cmd_with_conflicting_env(process_home.path())
+        .env("CLAUDE_CONFIG_DIR", conflicting_claude_dir.path())
+        .args([
+            "clients",
+            "--json",
+            "--home",
+            explicit_home.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let claude = json["clients"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["client"] == "claude")
+        .unwrap();
+    let stats_cache = claude["diagnostics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["code"] == "claude_stats_cache_not_imported")
+        .expect("the --home stats-cache.json should produce a diagnostic");
+
+    assert_eq!(
+        stats_cache["paths"][0]["path"],
+        expected_cache.to_string_lossy().as_ref()
+    );
+}
+
+#[test]
 fn test_clients_home_override_ignores_conflicting_claude_config_dir_env() {
     let real_home = create_empty_fixture_dir();
     fs::create_dir_all(real_home.path().join("Library/Application Support/Claude")).unwrap();

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3652,7 +3652,10 @@ fn test_clients_json_finds_stats_cache_under_claude_config_dir() {
 #[test]
 fn test_clients_home_override_ignores_claude_config_dir_for_stats_cache() {
     let explicit_home = create_empty_fixture_dir();
-    let expected_cache = explicit_home.path().join(".claude/stats-cache.json");
+    let expected_cache = explicit_home
+        .path()
+        .join(".claude")
+        .join("stats-cache.json");
     fs::create_dir_all(expected_cache.parent().unwrap()).unwrap();
     fs::write(&expected_cache, "{}").unwrap();
 


### PR DESCRIPTION
## Summary

- resolve Claude's `stats-cache.json` diagnostic from the same client-registry root used for projects and transcripts
- honor `CLAUDE_CONFIG_DIR` during normal environment-root discovery
- preserve explicit `--home` isolation from a conflicting `CLAUDE_CONFIG_DIR`

Follow-up to #1102 for the Claude path-discovery work tracked in #1101.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p tokscale-cli --test cli_tests stats_cache -- --nocapture`
- `cargo test -p tokscale-cli --test cli_tests`
- `cargo test --locked -p tokscale-cli --all-features`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Claude diagnostics to read `stats-cache.json` from the client-registry root, matching the scanner. Honors `CLAUDE_CONFIG_DIR`, keeps `--home` overrides isolated from env vars, and updates tests (override uses native path).

<sup>Written for commit 6469c235ab6bb9a5d7df6331c6358b45cc1dded1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

