### PR TITLE
fix(pricing): reject cross-provider model-part submissions

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3478,6 +3478,8 @@ const AMBIGUOUS_MODEL_PRICING_REASON: &str =
     "model price lookup is ambiguous across non-equivalent candidates";
 const UNVERIFIED_MODEL_IDENTITY_REASON: &str =
     "model price match does not exactly name the requested model";
+const UNVERIFIED_PROVIDER_IDENTITY_REASON: &str =
+    "model price match does not establish the requested provider";
 
 /// Routing labels name the router that served the request, never the model
 /// that answered it, so they have no authoritative model-to-price mapping.
@@ -3555,6 +3557,9 @@ fn exclude_unpriced_submission_messages(
                     SubmissionSafetyGap::PriceDisagreement => AMBIGUOUS_MODEL_PRICING_REASON,
                     SubmissionSafetyGap::UnverifiedModelIdentity => {
                         UNVERIFIED_MODEL_IDENTITY_REASON
+                    }
+                    SubmissionSafetyGap::UnverifiedProviderIdentity => {
+                        UNVERIFIED_PROVIDER_IDENTITY_REASON
                     }
                 }
             } else if resolution.is_some() {
@@ -4969,7 +4974,7 @@ mod tests {
         TokenBreakdown, UnifiedMessage, UnpricedSubmissionExclusion,
         AMBIGUOUS_MODEL_PRICING_REASON, INCOMPLETE_MODEL_PRICING_REASON,
         MISSING_MODEL_PRICING_REASON, ROUTING_LABEL_UNPRICED_REASON, UNKNOWN_WORKSPACE_LABEL,
-        UNVERIFIED_MODEL_IDENTITY_REASON,
+        UNVERIFIED_MODEL_IDENTITY_REASON, UNVERIFIED_PROVIDER_IDENTITY_REASON,
     };
     use serial_test::serial;
     use std::collections::{HashMap, HashSet};
@@ -9796,6 +9801,60 @@ mod tests {
                 total_tokens: 1,
                 reason: MISSING_MODEL_PRICING_REASON,
             }]
+        );
+    }
+
+    /// An unscoped model-part fallback proves only the model spelling, not
+    /// which provider served it. The estimate remains available locally, while
+    /// submission excludes it with the provider-specific evidence gap.
+    #[test]
+    fn submission_excludes_cross_provider_model_part_estimate() {
+        let openrouter = HashMap::from([(
+            "vendor/atlas-chat".to_string(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(1e-6),
+                output_cost_per_token: Some(2e-6),
+                ..Default::default()
+            },
+        )]);
+        let pricing = pricing::PricingService::new(HashMap::new(), openrouter);
+        let message = UnifiedMessage::new(
+            "synthetic",
+            "atlas-chat",
+            "unknown",
+            "cross-provider-model-part",
+            1_736_510_400_000,
+            TokenBreakdown {
+                input: 100,
+                output: 50,
+                ..Default::default()
+            },
+            0.0,
+        );
+
+        let estimate = pricing
+            .lookup_with_source("atlas-chat", None)
+            .expect("the model-part estimate remains available for reporting");
+        assert_eq!(estimate.matched_key, "vendor/atlas-chat");
+        assert_eq!(
+            estimate.evidence.kind,
+            pricing::lookup::ResolutionKind::ModelPart
+        );
+
+        let graph = build_graph_from_messages(
+            vec![message],
+            Some(&pricing),
+            GraphPricingRequirement::Submission,
+            std::time::Instant::now(),
+            &crate::bucket_tz::BucketTimezone::Local,
+        )
+        .expect("the unsafe estimate must be excluded, not abort the graph");
+
+        assert!(graph.contributions.is_empty());
+        assert_eq!(graph.unpriced_submission_exclusions.len(), 1);
+        assert_eq!(
+            graph.unpriced_submission_exclusions[0].reason,
+            UNVERIFIED_PROVIDER_IDENTITY_REASON
         );
     }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -9858,6 +9858,129 @@ mod tests {
         );
     }
 
+    /// Prefix probing and provider-tag aliases are useful lookup fallbacks,
+    /// not proof that the recorded provider used the candidate's billing
+    /// endpoint. Both stay estimate-only at the submission boundary.
+    #[test]
+    fn submission_excludes_provider_prefix_and_cross_endpoint_alias_estimates() {
+        let litellm = HashMap::from([
+            (
+                "anthropic/atlas-chat".to_string(),
+                pricing::ModelPricing {
+                    input_cost_per_token: Some(1e-6),
+                    output_cost_per_token: Some(2e-6),
+                    ..Default::default()
+                },
+            ),
+            (
+                "vertex_ai/vertex-chat".to_string(),
+                pricing::ModelPricing {
+                    input_cost_per_token: Some(3e-6),
+                    output_cost_per_token: Some(6e-6),
+                    ..Default::default()
+                },
+            ),
+            (
+                "vertex_ai/accounts/anthropic/models/vertex-chat".to_string(),
+                pricing::ModelPricing {
+                    input_cost_per_token: Some(3e-6),
+                    output_cost_per_token: Some(6e-6),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let pricing = pricing::PricingService::new(litellm, HashMap::new());
+        let usage = TokenBreakdown {
+            input: 100,
+            output: 50,
+            ..Default::default()
+        };
+        let messages = vec![
+            UnifiedMessage::new(
+                "synthetic",
+                "atlas-chat",
+                "synthetic",
+                "provider-prefix",
+                1_736_510_400_000,
+                usage.clone(),
+                0.0,
+            ),
+            UnifiedMessage::new(
+                "synthetic",
+                "vertex-chat",
+                "anthropic",
+                "cross-endpoint-alias",
+                1_736_510_400_001,
+                usage.clone(),
+                0.0,
+            ),
+            UnifiedMessage::new(
+                "synthetic",
+                "accounts/anthropic/models/vertex-chat",
+                "anthropic",
+                "scoped-cross-endpoint-alias",
+                1_736_510_400_002,
+                usage,
+                0.0,
+            ),
+        ];
+
+        let graph = build_graph_from_messages(
+            messages,
+            Some(&pricing),
+            GraphPricingRequirement::Submission,
+            std::time::Instant::now(),
+            &crate::bucket_tz::BucketTimezone::Local,
+        )
+        .expect("unsafe estimates must be excluded, not abort the graph");
+
+        assert!(graph.contributions.is_empty());
+        assert_eq!(graph.unpriced_submission_exclusions.len(), 3);
+        for exclusion in graph.unpriced_submission_exclusions {
+            assert_eq!(exclusion.reason, UNVERIFIED_PROVIDER_IDENTITY_REASON);
+        }
+
+        // Source-constrained OpenRouter uses a separate scoped wrapper. Keep a
+        // graph-level guard with only that source loaded so it cannot regress
+        // independently from the auto/LiteLLM path above.
+        let openrouter_pricing = pricing::PricingService::new(
+            HashMap::new(),
+            HashMap::from([(
+                "vertex_ai/accounts/anthropic/models/vertex-chat".to_string(),
+                pricing::ModelPricing {
+                    input_cost_per_token: Some(3e-6),
+                    output_cost_per_token: Some(6e-6),
+                    ..Default::default()
+                },
+            )]),
+        );
+        let openrouter_graph = build_graph_from_messages(
+            vec![UnifiedMessage::new(
+                "synthetic",
+                "accounts/anthropic/models/vertex-chat",
+                "anthropic",
+                "openrouter-scoped-cross-endpoint-alias",
+                1_736_510_400_003,
+                TokenBreakdown {
+                    input: 100,
+                    output: 50,
+                    ..Default::default()
+                },
+                0.0,
+            )],
+            Some(&openrouter_pricing),
+            GraphPricingRequirement::Submission,
+            std::time::Instant::now(),
+            &crate::bucket_tz::BucketTimezone::Local,
+        )
+        .expect("the OpenRouter alias estimate must be excluded");
+        assert!(openrouter_graph.contributions.is_empty());
+        assert_eq!(
+            openrouter_graph.unpriced_submission_exclusions[0].reason,
+            UNVERIFIED_PROVIDER_IDENTITY_REASON
+        );
+    }
+
     /// A fuzzy lookup with one candidate is excluded because nothing proves
     /// the priced key names the model that was used — not because candidates
     /// disagreed. There is only one candidate, so it cannot disagree with

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -208,10 +208,10 @@ impl ResolutionEvidence {
     /// disagreed when the lookup only ever saw one.
     pub fn submission_safety_gap(&self) -> Option<SubmissionSafetyGap> {
         match self.kind {
-            // A model-part fallback starts from a bare id and borrows a
-            // provider-qualified row. Matching the terminal model spelling
-            // does not establish that the request used that provider's price.
-            ResolutionKind::ModelPart => {
+            // These fallbacks start from a bare id and add or borrow a
+            // provider-qualified row. Matching the model spelling alone does
+            // not establish that the request used that provider's price.
+            ResolutionKind::ModelPart | ResolutionKind::ProviderPrefix => {
                 return Some(SubmissionSafetyGap::UnverifiedProviderIdentity);
             }
             ResolutionKind::Fuzzy | ResolutionKind::ProviderScoped => {}
@@ -652,7 +652,7 @@ impl PricingLookup {
 
     fn lookup_auto(&self, model_id: &str, provider_id: Option<&str>) -> Option<LookupResult> {
         if let Some(result) = self.lookup_provider_scoped_path(model_id, provider_id) {
-            return Some(result.with_kind(ResolutionKind::ProviderScoped));
+            return Some(scope_resolution_to_provider(result, model_id));
         }
         if parse_provider_scoped_model_path(model_id).is_some() {
             return None;
@@ -976,7 +976,7 @@ impl PricingLookup {
         provider_id: Option<&str>,
     ) -> Option<LookupResult> {
         if let Some(result) = self.lookup_provider_scoped_path_litellm(model_id, provider_id) {
-            return Some(result.with_kind(ResolutionKind::ProviderScoped));
+            return Some(scope_resolution_to_provider(result, model_id));
         }
         if parse_provider_scoped_model_path(model_id).is_some() {
             return None;
@@ -1012,7 +1012,7 @@ impl PricingLookup {
         provider_id: Option<&str>,
     ) -> Option<LookupResult> {
         if let Some(result) = self.lookup_provider_scoped_path_openrouter(model_id, provider_id) {
-            return Some(result.with_kind(ResolutionKind::ProviderScoped));
+            return Some(scope_resolution_to_provider(result, model_id));
         }
         if parse_provider_scoped_model_path(model_id).is_some() {
             return None;
@@ -2794,6 +2794,22 @@ fn model_prefix_matches_provider(model_id: &str, provider_id: Option<&str>) -> b
     }
 }
 
+fn scope_resolution_to_provider(mut result: LookupResult, model_id: &str) -> LookupResult {
+    let Some(scoped) = parse_provider_scoped_model_path(model_id) else {
+        return result;
+    };
+
+    // The scoped path asserts an endpoint, but a canonical-tag alias can still
+    // make its terminal fallback land on another endpoint's root. Preserve the
+    // weaker evidence in that case instead of laundering it as provider-scoped.
+    result.evidence.kind = if key_root_matches_provider_hint(&result.matched_key, scoped.provider) {
+        ResolutionKind::ProviderScoped
+    } else {
+        ResolutionKind::ModelPart
+    };
+    result
+}
+
 fn parse_provider_scoped_model_path(model_id: &str) -> Option<ProviderScopedModelPath<'_>> {
     let rest = model_id.strip_prefix("accounts/")?;
     let (provider, rest) = rest.split_once('/')?;
@@ -2946,9 +2962,9 @@ fn choose_best_source_result_with_models_dev(
     }
 }
 
-/// Resolve an exact model part only among keys matched by the explicit
-/// provider hint. This is provider-scoped evidence, unlike the unhinted
-/// cross-provider model-part indexes.
+/// Resolve an exact model part among keys matched by the provider hint.
+/// Canonical tag aliases keep endpoint-related candidates reachable for
+/// estimates, but only a raw root match is provider-scoped evidence.
 fn exact_match_with_provider_prefixes(
     model_id: &str,
     provider_id: Option<&str>,
@@ -2972,14 +2988,25 @@ fn exact_match_with_provider_prefixes(
         return None;
     }
 
-    select_best_match(
+    let result = select_best_match(
         &matches,
         dataset,
         source,
         Some(provider_id),
-        ResolutionKind::ProviderScoped,
+        ResolutionKind::ModelPart,
         model_id,
-    )
+    )?;
+
+    // Canonical provider tags deliberately keep endpoint aliases reachable for
+    // estimates (notably `anthropic` <-> `vertex_ai`). Only a candidate whose
+    // top-level endpoint actually matches the hint proves provider identity.
+    // Otherwise this remains the same estimate-only ModelPart evidence as an
+    // unhinted cross-provider fallback.
+    if key_root_matches_provider_hint(&result.matched_key, provider_id) {
+        Some(result.with_kind(ResolutionKind::ProviderScoped))
+    } else {
+        Some(result)
+    }
 }
 
 #[cfg(test)]
@@ -4101,6 +4128,8 @@ mod tests {
             "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro"
         );
         assert_eq!(result.source, "LiteLLM");
+        assert_eq!(result.evidence.kind, ResolutionKind::ProviderScoped);
+        assert!(result.evidence.is_submission_safe());
     }
 
     #[test]
@@ -4122,6 +4151,8 @@ mod tests {
 
         assert_eq!(result.matched_key, "fireworks_ai/deepseek-v4-pro");
         assert_eq!(result.source, "LiteLLM");
+        assert_eq!(result.evidence.kind, ResolutionKind::ProviderScoped);
+        assert!(result.evidence.is_submission_safe());
     }
 
     #[test]
@@ -4209,6 +4240,98 @@ mod tests {
             Some(SubmissionSafetyGap::UnverifiedProviderIdentity)
         );
         assert!(!result.evidence.is_submission_safe());
+    }
+
+    #[test]
+    fn unhinted_provider_prefix_remains_visible_but_is_not_submission_safe() {
+        let litellm = HashMap::from([(
+            "anthropic/atlas-chat".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(1e-6),
+                output_cost_per_token: Some(2e-6),
+                ..Default::default()
+            },
+        )]);
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        let result = lookup
+            .lookup_with_provider("atlas-chat", Some("synthetic"))
+            .expect("reporting should retain the provider-prefix estimate");
+
+        assert_eq!(result.matched_key, "anthropic/atlas-chat");
+        assert_eq!(result.evidence.kind, ResolutionKind::ProviderPrefix);
+        assert_eq!(
+            result.evidence.submission_safety_gap(),
+            Some(SubmissionSafetyGap::UnverifiedProviderIdentity)
+        );
+        assert!(!result.evidence.is_submission_safe());
+    }
+
+    #[test]
+    fn provider_hint_alias_does_not_verify_another_endpoint_root() {
+        let litellm = HashMap::from([(
+            "vertex_ai/atlas-chat".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(1e-6),
+                output_cost_per_token: Some(2e-6),
+                ..Default::default()
+            },
+        )]);
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        let anthropic = lookup
+            .lookup_with_provider("atlas-chat", Some("anthropic"))
+            .expect("the Vertex alias remains available as an estimate");
+        assert_eq!(anthropic.matched_key, "vertex_ai/atlas-chat");
+        assert_eq!(anthropic.evidence.kind, ResolutionKind::ModelPart);
+        assert!(!anthropic.evidence.is_submission_safe());
+
+        let vertex = lookup
+            .lookup_with_provider("atlas-chat", Some("vertex_ai"))
+            .expect("the literal Vertex endpoint should resolve");
+        assert_eq!(vertex.matched_key, "vertex_ai/atlas-chat");
+        assert_eq!(vertex.evidence.kind, ResolutionKind::ProviderScoped);
+        assert!(vertex.evidence.is_submission_safe());
+    }
+
+    #[test]
+    fn scoped_provider_path_does_not_verify_another_endpoint_root() {
+        let vertex_row = ModelPricing {
+            input_cost_per_token: Some(1e-6),
+            output_cost_per_token: Some(2e-6),
+            ..Default::default()
+        };
+        let litellm = HashMap::from([
+            ("vertex_ai/atlas-chat".to_string(), vertex_row.clone()),
+            (
+                "vertex_ai/accounts/anthropic/models/atlas-chat".to_string(),
+                vertex_row.clone(),
+            ),
+        ]);
+        let openrouter = HashMap::from([(
+            "vertex_ai/accounts/anthropic/models/atlas-chat".to_string(),
+            vertex_row,
+        )]);
+        let lookup = PricingLookup::new(litellm, openrouter, HashMap::new());
+
+        for source in [None, Some("litellm"), Some("openrouter")] {
+            let result = lookup
+                .lookup_with_source_and_provider(
+                    "accounts/anthropic/models/atlas-chat",
+                    source,
+                    Some("anthropic"),
+                )
+                .unwrap_or_else(|| {
+                    panic!("the {source:?} cross-endpoint row remains available as an estimate")
+                });
+
+            assert_eq!(
+                result.matched_key,
+                "vertex_ai/accounts/anthropic/models/atlas-chat"
+            );
+            assert_eq!(result.evidence.kind, ResolutionKind::ModelPart);
+            assert!(!result.evidence.is_submission_safe());
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -146,6 +146,8 @@ pub enum ResolutionKind {
     Exact,
     ModelPart,
     ProviderPrefix,
+    /// The provider was established by an explicit scoped path or a provider
+    /// hint matched against the qualified catalog candidates.
     ProviderScoped,
     BuiltIn,
     Fuzzy,
@@ -205,8 +207,15 @@ impl ResolutionEvidence {
     /// that decides safety is what keeps a diagnostic from claiming candidates
     /// disagreed when the lookup only ever saw one.
     pub fn submission_safety_gap(&self) -> Option<SubmissionSafetyGap> {
-        if self.kind != ResolutionKind::Fuzzy {
-            return None;
+        match self.kind {
+            // A model-part fallback starts from a bare id and borrows a
+            // provider-qualified row. Matching the terminal model spelling
+            // does not establish that the request used that provider's price.
+            ResolutionKind::ModelPart => {
+                return Some(SubmissionSafetyGap::UnverifiedProviderIdentity);
+            }
+            ResolutionKind::Fuzzy | ResolutionKind::ProviderScoped => {}
+            _ => return None,
         }
         if !self.price_consensus {
             return Some(SubmissionSafetyGap::PriceDisagreement);
@@ -259,6 +268,9 @@ pub enum SubmissionSafetyGap {
     /// No candidate names the requested model exactly, so the price belongs to
     /// a model that merely resembles the one that was used.
     UnverifiedModelIdentity,
+    /// A bare model id resolved through another provider's qualified catalog
+    /// key, without evidence that the request used that provider's price.
+    UnverifiedProviderIdentity,
 }
 
 #[derive(Debug, Clone)]
@@ -2934,6 +2946,9 @@ fn choose_best_source_result_with_models_dev(
     }
 }
 
+/// Resolve an exact model part only among keys matched by the explicit
+/// provider hint. This is provider-scoped evidence, unlike the unhinted
+/// cross-provider model-part indexes.
 fn exact_match_with_provider_prefixes(
     model_id: &str,
     provider_id: Option<&str>,
@@ -2962,7 +2977,7 @@ fn exact_match_with_provider_prefixes(
         dataset,
         source,
         Some(provider_id),
-        ResolutionKind::ModelPart,
+        ResolutionKind::ProviderScoped,
         model_id,
     )
 }
@@ -4167,6 +4182,35 @@ mod tests {
         assert_eq!(result.source, "OpenRouter");
     }
 
+    /// A bare model id only proves the terminal model spelling. Resolving it to
+    /// another provider's qualified catalog row remains useful as an estimate,
+    /// but must not authorize publishing that provider's price.
+    #[test]
+    fn cross_provider_model_part_remains_visible_but_is_not_submission_safe() {
+        let openrouter = HashMap::from([(
+            "vendor/atlas-chat".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(1e-6),
+                output_cost_per_token: Some(2e-6),
+                ..Default::default()
+            },
+        )]);
+        let lookup = PricingLookup::new(HashMap::new(), openrouter, HashMap::new());
+
+        let result = lookup
+            .lookup("atlas-chat")
+            .expect("reporting should retain the model-part estimate");
+
+        assert_eq!(result.matched_key, "vendor/atlas-chat");
+        assert_eq!(result.evidence.kind, ResolutionKind::ModelPart);
+        assert!(result.evidence.exact_model_identity);
+        assert_eq!(
+            result.evidence.submission_safety_gap(),
+            Some(SubmissionSafetyGap::UnverifiedProviderIdentity)
+        );
+        assert!(!result.evidence.is_submission_safe());
+    }
+
     #[test]
     fn test_tier_suffix_low() {
         let lookup = create_lookup();
@@ -5140,6 +5184,8 @@ mod tests {
             .unwrap();
         assert_eq!(hinted.matched_key, "venice/claude-opus-4.6-fast");
         assert_eq!(hinted.pricing.input_cost_per_token, Some(36e-6));
+        assert_eq!(hinted.evidence.kind, ResolutionKind::ProviderScoped);
+        assert!(hinted.evidence.is_submission_safe());
 
         // Unhinted dotted lookup keeps the canonical OpenRouter resolution.
         let unhinted = lookup.lookup("claude-opus-4.6-fast").unwrap();

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -1758,6 +1758,33 @@ mod tests {
     }
 
     #[test]
+    fn cross_provider_model_part_price_remains_an_estimate_only() {
+        let service = PricingService::new(
+            HashMap::new(),
+            HashMap::from([(
+                "vendor/atlas-chat".to_string(),
+                model_pricing(0.000001, 0.000002),
+            )]),
+        );
+        let usage = TokenBreakdown {
+            input: 100,
+            output: 50,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        };
+
+        let resolution = service
+            .lookup_with_source("atlas-chat", None)
+            .expect("lenient reporting keeps the model-part estimate visible");
+        assert_eq!(resolution.matched_key, "vendor/atlas-chat");
+        assert_eq!(resolution.evidence.kind, ResolutionKind::ModelPart);
+        assert!(!resolution.evidence.is_submission_safe());
+        assert!(service.calculate_cost_with_provider("atlas-chat", None, &usage) > 0.0);
+        assert!(!service.covers_usage_with_provider("atlas-chat", None, &usage));
+    }
+
+    #[test]
     fn ambiguous_fuzzy_price_remains_visible_but_does_not_cover_submission() {
         let litellm = HashMap::from([
             (

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -1785,6 +1785,77 @@ mod tests {
     }
 
     #[test]
+    fn provider_prefix_and_cross_endpoint_aliases_remain_estimates_only() {
+        let service = PricingService::new(
+            HashMap::from([
+                (
+                    "anthropic/atlas-chat".to_string(),
+                    model_pricing(0.000001, 0.000002),
+                ),
+                (
+                    "vertex_ai/vertex-chat".to_string(),
+                    model_pricing(0.000003, 0.000006),
+                ),
+                (
+                    "vertex_ai/accounts/anthropic/models/vertex-chat".to_string(),
+                    model_pricing(0.000003, 0.000006),
+                ),
+            ]),
+            HashMap::from([(
+                "vertex_ai/accounts/anthropic/models/vertex-chat".to_string(),
+                model_pricing(0.000003, 0.000006),
+            )]),
+        );
+        let usage = TokenBreakdown {
+            input: 100,
+            output: 50,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        };
+
+        let prefixed = service
+            .lookup_with_source_and_provider("atlas-chat", None, Some("synthetic"))
+            .expect("the provider-prefix estimate remains visible");
+        assert_eq!(prefixed.evidence.kind, ResolutionKind::ProviderPrefix);
+        assert!(!prefixed.evidence.is_submission_safe());
+        assert!(!service.covers_usage_with_provider("atlas-chat", Some("synthetic"), &usage));
+
+        let aliased = service
+            .lookup_with_source_and_provider("vertex-chat", None, Some("anthropic"))
+            .expect("the cross-endpoint alias estimate remains visible");
+        assert_eq!(aliased.evidence.kind, ResolutionKind::ModelPart);
+        assert!(!aliased.evidence.is_submission_safe());
+        assert!(!service.covers_usage_with_provider("vertex-chat", Some("anthropic"), &usage));
+
+        assert!(
+            service.calculate_cost_with_provider("atlas-chat", Some("synthetic"), &usage) > 0.0
+        );
+        assert!(
+            service.calculate_cost_with_provider("vertex-chat", Some("anthropic"), &usage) > 0.0
+        );
+
+        for source in [None, Some("litellm"), Some("openrouter")] {
+            let scoped = service
+                .lookup_with_source_and_provider(
+                    "accounts/anthropic/models/vertex-chat",
+                    source,
+                    Some("anthropic"),
+                )
+                .unwrap_or_else(|| {
+                    panic!("the {source:?} scoped cross-endpoint alias remains visible")
+                });
+            assert_eq!(scoped.evidence.kind, ResolutionKind::ModelPart);
+            assert!(!scoped.evidence.is_submission_safe());
+        }
+        assert!(!service.covers_usage_with_provider(
+            "accounts/anthropic/models/vertex-chat",
+            Some("anthropic"),
+            &usage,
+        ));
+    }
+
+    #[test]
     fn ambiguous_fuzzy_price_remains_visible_but_does_not_cover_submission() {
         let litellm = HashMap::from([
             (


### PR DESCRIPTION
## Summary

- mark unscoped cross-provider model-part fallbacks as estimate-only
- retain provider-hinted exact model-part matches as submission-safe provider-scoped evidence when identity and pricing checks pass
- report unverified provider identity when submission excludes one of these estimates
- add resolver, service, and end-to-end submission regression coverage for bare `atlas-chat` resolving to `vendor/atlas-chat`

## Diagnosis

#1084 introduced resolution evidence but `submission_safety_gap()` only scrutinized `ResolutionKind::Fuzzy`. The OpenRouter and models.dev model-part indexes classify a bare model ID resolved through another provider's qualified catalog key as `ResolutionKind::ModelPart`, so that path was treated as safe by default even though its own resolver comments place it in the same cross-provider fallback trust class as fuzzy resolution.

The fix keeps the local price estimate visible while preventing it from satisfying submission coverage. Provider-hinted matches are separately classified as `ProviderScoped`, because the hint and qualified candidate establish provider identity; their existing price-consensus and exact-model checks still apply.

Follow-up to #1084.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-features --all-targets -- -D warnings`
- `cargo test --locked -p tokscale-core --no-fail-fast` (1621 passed, 1 ignored)
- focused ModelPart resolver/service/submission regressions
- independent GPT-5.6 Terra adversarial review: approved; its test-strength caveat was addressed with the end-to-end exclusion-reason assertion

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cross-provider model-part and provider-prefix fallbacks from counting as submission-safe while keeping their price estimates visible. Requires an endpoint-root match before provider-hinted or scoped lookups are considered provider-scoped.

- **Bug Fixes**
  - Treat `ResolutionKind::ModelPart` and `ResolutionKind::ProviderPrefix` as estimate-only for submissions by flagging `SubmissionSafetyGap::UnverifiedProviderIdentity`; expose `UNVERIFIED_PROVIDER_IDENTITY_REASON`.
  - Only mark hinted or scoped lookups as `ResolutionKind::ProviderScoped` when the matched key’s endpoint root matches the hinted provider; otherwise keep them as `ModelPart`.
  - Add resolver, service, and end-to-end tests for provider-prefix and cross-endpoint alias paths (e.g., hinted `anthropic` resolving to `vertex_ai/...`) and bare `atlas-chat` -> `vendor/atlas-chat` to ensure estimates stay visible but are excluded from submission.

<sup>Written for commit e9d3042702083f8cc201b888684ffa69366acb86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

