### PR TITLE
fix(senpi): discover OmO task child sessions

### DIFF
--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -624,6 +624,21 @@ pub fn built_in_extra_scan_paths_for(
         );
     }
 
+    if enabled.contains(&ClientId::Senpi) && use_env_roots {
+        if let Some(path) =
+            std::env::var_os("SENPI_CODING_AGENT_SESSION_DIR").filter(|path| !path.is_empty())
+        {
+            paths.push((ClientId::Senpi, PathBuf::from(path)));
+        }
+
+        if let Ok(current_dir) = std::env::current_dir() {
+            paths.push((
+                ClientId::Senpi,
+                current_dir.join(".omo/senpi-task/children"),
+            ));
+        }
+    }
+
     paths
 }
 
@@ -6334,5 +6349,46 @@ mod tests {
         restore_env("GJC_CONFIG_DIR", prev_config);
         restore_env("PI_CONFIG_DIR", prev_pi);
         restore_env("XDG_DATA_HOME", prev_xdg);
+    }
+
+    #[test]
+    #[serial]
+    fn test_senpi_discovers_omo_task_children_in_current_project() {
+        let home_dir = TempDir::new().unwrap();
+        let project_dir = TempDir::new().unwrap();
+        let child_sessions = project_dir
+            .path()
+            .join(".omo/senpi-task/children/task-123/sessions/encoded-cwd");
+        fs::create_dir_all(&child_sessions).unwrap();
+        let child_session = child_sessions.join("child.jsonl");
+        File::create(&child_session).unwrap();
+        let _current_dir = CurrentDirGuard::set(project_dir.path());
+
+        let result =
+            scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
+
+        assert!(
+            result.get(ClientId::Senpi).contains(&child_session),
+            "current-project OmO child sessions must be auto-discovered"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_senpi_honors_coding_agent_session_dir() {
+        let home_dir = TempDir::new().unwrap();
+        let redirected_sessions = TempDir::new().unwrap();
+        let redirected_session = redirected_sessions.path().join("redirected.jsonl");
+        File::create(&redirected_session).unwrap();
+        let mut env = EnvGuard::capture(&["SENPI_CODING_AGENT_SESSION_DIR"]);
+        env.set("SENPI_CODING_AGENT_SESSION_DIR", redirected_sessions.path());
+
+        let result =
+            scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
+
+        assert!(
+            result.get(ClientId::Senpi).contains(&redirected_session),
+            "SENPI_CODING_AGENT_SESSION_DIR must be scanned"
+        );
     }
 }

--- a/crates/tokscale-core/src/sessions/senpi.rs
+++ b/crates/tokscale-core/src/sessions/senpi.rs
@@ -8,9 +8,9 @@
 //! `session_info.name` carries a human session title rather than Pi's
 //! `subagent-<name>-<id>` marker.
 //!
-//! OmO task children are senpi sessions too, but `SENPI_CODING_AGENT_SESSION_DIR`
-//! redirects them to `<project>/.omo/senpi-task/children/<taskId>/sessions/`, so
-//! they need an explicit `scanner.extraScanPaths.senpi` entry to be counted.
+//! OmO task children are senpi sessions too. The scanner honors
+//! `SENPI_CODING_AGENT_SESSION_DIR` and discovers the current project's
+//! `.omo/senpi-task/children` tree so their redirected sessions are counted.
 
 use super::pi::parse_pi_format_file;
 use super::UnifiedMessage;


### PR DESCRIPTION
## Summary

- honor `SENPI_CODING_AGENT_SESSION_DIR` as a built-in Senpi scan root
- auto-discover `.omo/senpi-task/children` under the current project
- keep overlapping roots deduplicated through the existing scanner path handling
- update the Senpi parser documentation to describe automatic child-session discovery

## Testing

- `cargo fmt --manifest-path Cargo.toml --all -- --check`
- `cargo check --manifest-path Cargo.toml -p tokscale-core`
- `cargo test --manifest-path Cargo.toml -p tokscale-core scanner::tests::test_senpi_`
- `cargo test --manifest-path Cargo.toml -p tokscale-core` (1,619 passed; one pre-existing Windows symlink test could not create a symlink without elevated privileges)
- manual `tokscale report --client senpi --today --json --no-spinner` against a project with OmO child sessions

Closes #1112


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically discovers Senpi OmO child sessions by honoring `SENPI_CODING_AGENT_SESSION_DIR` and scanning `.omo/senpi-task/children` in the current project. Senpi reports now include redirected child sessions without extra config.

- **Bug Fixes**
  - Add built-in Senpi scan roots: `SENPI_CODING_AGENT_SESSION_DIR` and `.omo/senpi-task/children`.
  - Deduplicate overlapping roots via existing scanner logic.
  - Add tests and update inline docs to reflect auto-discovery.

<sup>Written for commit a398fa312f2d503eeaeddfda5992d491c33eda8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

