### PR TITLE
fix(senpi): discover OmO child sessions without duplicate scans

### DIFF
--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -2164,11 +2164,15 @@ fn scan_all_clients_with_env_strategy_inner(
         })
         .collect();
 
-    // Aggregate results, deduplicating file paths across overlapping directories
-    let mut seen: HashSet<PathBuf> = HashSet::new();
+    // Aggregate results, deduplicating canonical file paths across overlapping
+    // roots while preserving one copy per client. Canonical keys collapse a
+    // symlinked root onto its real path; keeping the client in the key avoids
+    // suppressing an independent client that intentionally scans the same file.
+    let mut seen: HashSet<(ClientId, PathBuf)> = HashSet::new();
     for (client_id, files) in scan_results {
         for file in files {
-            if seen.insert(file.clone()) {
+            let key = std::fs::canonicalize(&file).unwrap_or_else(|_| file.clone());
+            if seen.insert((client_id, key)) {
                 result.get_mut(client_id).push(file);
             }
         }
@@ -2183,7 +2187,8 @@ fn scan_all_clients_with_env_strategy_inner(
         result.copilot_vscode_sessions = discover_copilot_vscode_sessions(home_dir, use_env_roots);
 
         if let Some(path) = copilot_exporter_path_with_env_strategy(use_env_roots) {
-            if path.is_file() && seen.insert(path.clone()) {
+            let key = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+            if path.is_file() && seen.insert((ClientId::Copilot, key)) {
                 let copilot_files = result.get_mut(ClientId::Copilot);
                 copilot_files.push(path);
                 copilot_files.sort_unstable();
@@ -2319,6 +2324,37 @@ mod tests {
         let result = ScanResult::default();
         assert_eq!(result.total_files(), 0);
         assert!(result.all_files().is_empty());
+    }
+
+    #[test]
+    fn test_overlapping_roots_do_not_suppress_independent_clients() {
+        let dir = TempDir::new().unwrap();
+        let session = dir.path().join("shared.jsonl");
+        File::create(&session).unwrap();
+        let mut settings = ScannerSettings::default();
+        settings
+            .extra_scan_paths
+            .insert("pi".to_string(), vec![dir.path().to_path_buf()]);
+        settings
+            .extra_scan_paths
+            .insert("senpi".to_string(), vec![dir.path().to_path_buf()]);
+
+        let result = scan_all_clients_with_scanner_settings(
+            dir.path().to_str().unwrap(),
+            &["pi".to_string(), "senpi".to_string()],
+            false,
+            &settings,
+        );
+
+        assert_eq!(
+            result.get(ClientId::Pi).as_slice(),
+            std::slice::from_ref(&session)
+        );
+        assert_eq!(
+            result.get(ClientId::Senpi).as_slice(),
+            std::slice::from_ref(&session)
+        );
+        assert_eq!(result.all_files().len(), 2);
     }
 
     #[test]
@@ -6351,44 +6387,113 @@ mod tests {
         restore_env("XDG_DATA_HOME", prev_xdg);
     }
 
+    fn setup_mock_senpi_omo_child(project_dir: &Path) -> PathBuf {
+        let child_session = project_dir
+            .join(".omo/senpi-task/children/task-123/sessions/task-123")
+            .join("child.jsonl");
+        fs::create_dir_all(child_session.parent().unwrap()).unwrap();
+        File::create(&child_session).unwrap();
+        child_session.canonicalize().unwrap()
+    }
+
     #[test]
     #[serial]
     fn test_senpi_discovers_omo_task_children_in_current_project() {
         let home_dir = TempDir::new().unwrap();
         let project_dir = TempDir::new().unwrap();
-        let child_sessions = project_dir
-            .path()
-            .join(".omo/senpi-task/children/task-123/sessions/encoded-cwd");
-        fs::create_dir_all(&child_sessions).unwrap();
-        let child_session = child_sessions.join("child.jsonl");
-        File::create(&child_session).unwrap();
+        let child_session = setup_mock_senpi_omo_child(project_dir.path());
+        let mut env = EnvGuard::capture(&["SENPI_CODING_AGENT_SESSION_DIR"]);
+        env.remove("SENPI_CODING_AGENT_SESSION_DIR");
         let _current_dir = CurrentDirGuard::set(project_dir.path());
 
         let result =
             scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
 
-        assert!(
-            result.get(ClientId::Senpi).contains(&child_session),
+        assert_eq!(
+            result.get(ClientId::Senpi).as_slice(),
+            std::slice::from_ref(&child_session),
             "current-project OmO child sessions must be auto-discovered"
         );
     }
 
     #[test]
     #[serial]
-    fn test_senpi_honors_coding_agent_session_dir() {
+    fn test_senpi_honors_independent_coding_agent_session_dir() {
         let home_dir = TempDir::new().unwrap();
+        let project_dir = TempDir::new().unwrap();
+        let child_session = setup_mock_senpi_omo_child(project_dir.path());
         let redirected_sessions = TempDir::new().unwrap();
         let redirected_session = redirected_sessions.path().join("redirected.jsonl");
         File::create(&redirected_session).unwrap();
         let mut env = EnvGuard::capture(&["SENPI_CODING_AGENT_SESSION_DIR"]);
         env.set("SENPI_CODING_AGENT_SESSION_DIR", redirected_sessions.path());
+        let _current_dir = CurrentDirGuard::set(project_dir.path());
 
         let result =
             scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
 
-        assert!(
-            result.get(ClientId::Senpi).contains(&redirected_session),
-            "SENPI_CODING_AGENT_SESSION_DIR must be scanned"
-        );
+        assert_eq!(result.get(ClientId::Senpi).len(), 2);
+        assert!(result.get(ClientId::Senpi).contains(&child_session));
+        assert!(result.get(ClientId::Senpi).contains(&redirected_session));
+    }
+
+    #[test]
+    #[serial]
+    fn test_senpi_overlapping_session_roots_return_each_file_once() {
+        let home_dir = TempDir::new().unwrap();
+        let project_dir = TempDir::new().unwrap();
+        let child_session = setup_mock_senpi_omo_child(project_dir.path());
+        let children_dir = project_dir.path().join(".omo/senpi-task/children");
+        let task_dir = children_dir.join("task-123");
+        let exact_session_dir = task_dir.join("sessions/task-123");
+        let mut env = EnvGuard::capture(&["SENPI_CODING_AGENT_SESSION_DIR"]);
+        let _current_dir = CurrentDirGuard::set(project_dir.path());
+
+        for env_root in [
+            project_dir.path(),
+            children_dir.as_path(),
+            task_dir.as_path(),
+            exact_session_dir.as_path(),
+            child_session.as_path(),
+        ] {
+            env.set("SENPI_CODING_AGENT_SESSION_DIR", env_root);
+            let result =
+                scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
+            let files = result.get(ClientId::Senpi);
+            assert_eq!(
+                files.len(),
+                1,
+                "overlapping env root {} must not duplicate the child session",
+                env_root.display()
+            );
+            assert_eq!(files[0].canonicalize().unwrap(), child_session);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn test_senpi_symlinked_overlapping_session_root_returns_each_file_once() {
+        use std::os::unix::fs::symlink;
+
+        let home_dir = TempDir::new().unwrap();
+        let project_dir = TempDir::new().unwrap();
+        let child_session = setup_mock_senpi_omo_child(project_dir.path());
+        let symlink_root = project_dir.path().join("redirected-sessions");
+        symlink(
+            project_dir.path().join(".omo/senpi-task/children"),
+            &symlink_root,
+        )
+        .unwrap();
+        let mut env = EnvGuard::capture(&["SENPI_CODING_AGENT_SESSION_DIR"]);
+        env.set("SENPI_CODING_AGENT_SESSION_DIR", &symlink_root);
+        let _current_dir = CurrentDirGuard::set(project_dir.path());
+
+        let result =
+            scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
+
+        let files = result.get(ClientId::Senpi);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].canonicalize().unwrap(), child_session);
     }
 }

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -6440,11 +6440,13 @@ mod tests {
         let result =
             scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
 
+        let files = result.get(ClientId::Senpi);
         assert_eq!(
-            result.get(ClientId::Senpi).as_slice(),
-            std::slice::from_ref(&child_session),
+            files.len(),
+            1,
             "current-project OmO child sessions must be auto-discovered"
         );
+        assert_eq!(files[0].canonicalize().unwrap(), child_session);
     }
 
     #[test]
@@ -6463,9 +6465,14 @@ mod tests {
         let result =
             scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
 
-        assert_eq!(result.get(ClientId::Senpi).len(), 2);
-        assert!(result.get(ClientId::Senpi).contains(&child_session));
-        assert!(result.get(ClientId::Senpi).contains(&redirected_session));
+        let canonical_files: HashSet<PathBuf> = result
+            .get(ClientId::Senpi)
+            .iter()
+            .map(|path| path.canonicalize().unwrap())
+            .collect();
+        assert_eq!(canonical_files.len(), 2);
+        assert!(canonical_files.contains(&child_session));
+        assert!(canonical_files.contains(&redirected_session.canonicalize().unwrap()));
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -624,6 +624,21 @@ pub fn built_in_extra_scan_paths_for(
         );
     }
 
+    if enabled.contains(&ClientId::Senpi) && use_env_roots {
+        if let Some(path) =
+            std::env::var_os("SENPI_CODING_AGENT_SESSION_DIR").filter(|path| !path.is_empty())
+        {
+            paths.push((ClientId::Senpi, PathBuf::from(path)));
+        }
+
+        if let Ok(current_dir) = std::env::current_dir() {
+            paths.push((
+                ClientId::Senpi,
+                current_dir.join(".omo/senpi-task/children"),
+            ));
+        }
+    }
+
     paths
 }
 
@@ -6334,5 +6349,46 @@ mod tests {
         restore_env("GJC_CONFIG_DIR", prev_config);
         restore_env("PI_CONFIG_DIR", prev_pi);
         restore_env("XDG_DATA_HOME", prev_xdg);
+    }
+
+    #[test]
+    #[serial]
+    fn test_senpi_discovers_omo_task_children_in_current_project() {
+        let home_dir = TempDir::new().unwrap();
+        let project_dir = TempDir::new().unwrap();
+        let child_sessions = project_dir
+            .path()
+            .join(".omo/senpi-task/children/task-123/sessions/encoded-cwd");
+        fs::create_dir_all(&child_sessions).unwrap();
+        let child_session = child_sessions.join("child.jsonl");
+        File::create(&child_session).unwrap();
+        let _current_dir = CurrentDirGuard::set(project_dir.path());
+
+        let result =
+            scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
+
+        assert!(
+            result.get(ClientId::Senpi).contains(&child_session),
+            "current-project OmO child sessions must be auto-discovered"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_senpi_honors_coding_agent_session_dir() {
+        let home_dir = TempDir::new().unwrap();
+        let redirected_sessions = TempDir::new().unwrap();
+        let redirected_session = redirected_sessions.path().join("redirected.jsonl");
+        File::create(&redirected_session).unwrap();
+        let mut env = EnvGuard::capture(&["SENPI_CODING_AGENT_SESSION_DIR"]);
+        env.set("SENPI_CODING_AGENT_SESSION_DIR", redirected_sessions.path());
+
+        let result =
+            scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
+
+        assert!(
+            result.get(ClientId::Senpi).contains(&redirected_session),
+            "SENPI_CODING_AGENT_SESSION_DIR must be scanned"
+        );
     }
 }

--- a/crates/tokscale-core/src/sessions/senpi.rs
+++ b/crates/tokscale-core/src/sessions/senpi.rs
@@ -8,9 +8,9 @@
 //! `session_info.name` carries a human session title rather than Pi's
 //! `subagent-<name>-<id>` marker.
 //!
-//! OmO task children are senpi sessions too, but `SENPI_CODING_AGENT_SESSION_DIR`
-//! redirects them to `<project>/.omo/senpi-task/children/<taskId>/sessions/`, so
-//! they need an explicit `scanner.extraScanPaths.senpi` entry to be counted.
+//! OmO task children are senpi sessions too. The scanner honors
+//! `SENPI_CODING_AGENT_SESSION_DIR` and discovers the current project's
+//! `.omo/senpi-task/children` tree so their redirected sessions are counted.
 
 use super::pi::parse_pi_format_file;
 use super::UnifiedMessage;


### PR DESCRIPTION
## Summary

- carries the Senpi OmO child-session discovery from #1113 in a maintainer-owned branch while preserving the contributor's authorship
- deduplicates discovered files by canonical path per client, covering exact, ancestor, descendant, file, and symlinked overlaps between `SENPI_CODING_AGENT_SESSION_DIR` and `.omo/senpi-task/children`
- preserves independent roots and preserves the same physical file when separate clients intentionally scan it

Closes #1112.

Follow-up to #1113; this does not modify or merge the contributor branch.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-features --all-targets -- -D warnings`
- `cargo test --locked --workspace --all-features --no-fail-fast`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically discovers Senpi OmO task child-session files and deduplicates results per client using canonical paths. Previously, children were only found via extra paths and dedup could drop files across overlapping or symlinked roots; now we honor SENPI_CODING_AGENT_SESSION_DIR and .omo/senpi-task/children and return each physical file once per client without suppressing other clients.

- Registers Senpi roots when env roots are enabled: SENPI_CODING_AGENT_SESSION_DIR and cwd/.omo/senpi-task/children (uses native separators on Windows).
- Aggregates with a dedup key of (ClientId, canonical_path) for scan results and Copilot exporter files, so overlaps don’t duplicate within a client while different clients keep their own entries.
- Adds tests for OmO child discovery, env-root overlap (ancestor/descendant/exact/file), symlinked roots, Windows native separators and canonical path comparisons, and independent clients scanning the same file.

<sup>Written for commit 39e6a0f1be6597ecf13c98a8fc517e961761dc8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

