### PR TITLE
fix(claude): select model-scoped weekly limits by kind, not is_active

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -787,7 +787,7 @@ TUI では **Usage** タブに移動するとサブスクリプションデー�
 
 | プロバイダー | 認証方法 | メトリクス | セットアップ |
 |----------|-------------|---------|-------|
-| **Claude** | OAuth（資格情報ファイルまたは macOS Keychain） | Session（5時間）、Weekly、Opus クォータ | `claude` を実行してログイン |
+| **Claude** | OAuth（資格情報ファイルまたは macOS Keychain） | Session（5時間）、Weekly、モデル別クォータ | `claude` を実行してログイン |
 | **Codex**（OpenAI） | OAuth（Codex 認証、保存済み Tokscale アカウント、または OpenCode の `$XDG_DATA_HOME/opencode/auth.json`） | Session、Weekly クォータ | `[Add Codex]`、`codex`、`tokscale codex import --name work`、または OpenCode で OpenAI の ChatGPT Plus/Pro に接続 |
 | **Z.ai** | API キー（環境変数） | トークン上限、Web 検索 | `ZAI_API_KEY` または `GLM_API_KEY` を設定 |
 | **Amp** | API キー（`~/.local/share/amp/secrets.json`） | 無料枠残高、クレジット | `amp` を実行してログイン |

--- a/README.ko.md
+++ b/README.ko.md
@@ -784,7 +784,7 @@ TUI에서는 **Usage** 탭으로 이동해 구독 데이터를 확인하세요. 
 
 | 프로바이더 | 인증 방식 | 지표 | 설정 |
 |----------|-------------|---------|-------|
-| **Claude** | OAuth (자격 증명 파일 또는 macOS Keychain) | 세션(5시간), 주간, Opus 할당량 | `claude`를 실행해 로그인 |
+| **Claude** | OAuth (자격 증명 파일 또는 macOS Keychain) | 세션(5시간), 주간, 모델별 할당량 | `claude`를 실행해 로그인 |
 | **Codex** (OpenAI) | OAuth (Codex 인증, 저장된 Tokscale 계정 또는 OpenCode의 `$XDG_DATA_HOME/opencode/auth.json`) | 세션, 주간 할당량 | `[Add Codex]`, `codex`, `tokscale codex import --name work` 또는 OpenCode에서 OpenAI ChatGPT Plus/Pro 연결 사용 |
 | **Z.ai** | API 키 (환경 변수) | 토큰 한도, 웹 검색 | `ZAI_API_KEY` 또는 `GLM_API_KEY` 설정 |
 | **Amp** | API 키 (`~/.local/share/amp/secrets.json`) | 무료 티어 잔액, 크레딧 | `amp`를 실행해 로그인 |

--- a/README.md
+++ b/README.md
@@ -788,7 +788,7 @@ In the TUI, navigate to the **Usage** tab to see subscription data. Use `[Refres
 
 | Provider | Auth Method | Metrics | Setup |
 |----------|-------------|---------|-------|
-| **Claude** | OAuth (credentials file or macOS Keychain) | Session (5hr), Weekly, Opus quotas | Run `claude` to log in |
+| **Claude** | OAuth (credentials file or macOS Keychain) | Session (5hr), Weekly, model-scoped quotas | Run `claude` to log in |
 | **Codex** (OpenAI) | OAuth (Codex auth, saved Tokscale accounts, or OpenCode's `$XDG_DATA_HOME/opencode/auth.json`) | Session, Weekly quotas | Use `[Add Codex]`, run `codex`, import with `tokscale codex import --name work`, or connect OpenAI with ChatGPT Plus/Pro in OpenCode |
 | **Z.ai** | API key (env var) | Token limits, Web Searches | Set `ZAI_API_KEY` or `GLM_API_KEY` |
 | **Amp** | API key (`~/.local/share/amp/secrets.json`) | Free tier balance, Credits | Run `amp` to log in |

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -786,7 +786,7 @@ tokscale usage --light
 
 | 提供商 | 认证方式 | 指标 | 设置 |
 |----------|-------------|---------|-------|
-| **Claude** | OAuth（凭据文件或 macOS 钥匙串） | Session（5 小时）、Weekly、Opus 配额 | 运行 `claude` 登录 |
+| **Claude** | OAuth（凭据文件或 macOS 钥匙串） | Session（5 小时）、Weekly、模型专属配额 | 运行 `claude` 登录 |
 | **Codex**（OpenAI） | OAuth（Codex 认证、已保存的 Tokscale 账号，或 OpenCode 的 `$XDG_DATA_HOME/opencode/auth.json`） | Session、Weekly 配额 | 使用 `[Add Codex]`、运行 `codex`、通过 `tokscale codex import --name work` 导入，或在 OpenCode 中连接 OpenAI ChatGPT Plus/Pro |
 | **Z.ai** | API key（环境变量） | Token 限额、Web Searches | 设置 `ZAI_API_KEY` 或 `GLM_API_KEY` |
 | **Amp** | API key（`~/.local/share/amp/secrets.json`） | 免费额度余额、Credits | 运行 `amp` 登录 |

--- a/crates/tokscale-cli/src/commands/usage/claude.rs
+++ b/crates/tokscale-cli/src/commands/usage/claude.rs
@@ -39,12 +39,33 @@ struct UsageResponse {
     five_hour: Option<Window>,
     seven_day: Option<Window>,
     seven_day_opus: Option<Window>,
+    limits: Option<Vec<PlanLimit>>,
 }
 
 #[derive(Debug, Deserialize)]
 struct Window {
     utilization: f64,
     resets_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlanLimit {
+    kind: Option<String>,
+    percent: Option<f64>,
+    resets_at: Option<String>,
+    scope: Option<LimitScope>,
+    #[serde(default)]
+    is_active: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct LimitScope {
+    model: Option<ScopedModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ScopedModel {
+    display_name: Option<String>,
 }
 
 fn credentials_path() -> std::path::PathBuf {
@@ -116,6 +137,65 @@ fn window_metric(label: &str, w: &Window) -> UsageMetric {
     }
 }
 
+fn scoped_limit_metric(limit: &PlanLimit) -> Option<UsageMetric> {
+    if limit.kind.as_deref() != Some("weekly_scoped") || !limit.is_active {
+        return None;
+    }
+
+    let label = limit
+        .scope
+        .as_ref()?
+        .model
+        .as_ref()?
+        .display_name
+        .as_deref()?
+        .trim();
+    if label.is_empty() {
+        return None;
+    }
+
+    let used = limit.percent?.clamp(0.0, 100.0);
+    Some(UsageMetric {
+        label: label.to_string(),
+        used_percent: used,
+        remaining_percent: 100.0 - used,
+        remaining_label: None,
+        resets_at: limit.resets_at.clone(),
+    })
+}
+
+fn usage_metrics(resp: &UsageResponse) -> Vec<UsageMetric> {
+    let mut metrics = Vec::new();
+    if let Some(ref w) = resp.five_hour {
+        metrics.push(window_metric("Session", w));
+    }
+    if let Some(ref w) = resp.seven_day {
+        metrics.push(window_metric("Weekly", w));
+    }
+    if let Some(ref w) = resp.seven_day_opus {
+        metrics.push(window_metric("Opus", w));
+    }
+
+    for metric in resp
+        .limits
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(scoped_limit_metric)
+    {
+        if let Some(existing) = metrics
+            .iter_mut()
+            .find(|existing| existing.label.eq_ignore_ascii_case(&metric.label))
+        {
+            *existing = metric;
+        } else {
+            metrics.push(metric);
+        }
+    }
+
+    metrics
+}
+
 /// The whole Claude usage path, with the only two things a test cannot supply
 /// for real -- the usage endpoint and the credential source -- as parameters.
 /// The destructive refresh-and-write this module was fixed for lived in exactly
@@ -148,16 +228,7 @@ fn fetch_blocking(usage_url: &str, read: CredentialReader) -> Result<UsageOutput
         let client = reqwest::Client::new();
         let resp = fetch_usage(&client, usage_url, access_token).await?;
 
-        let mut metrics = Vec::new();
-        if let Some(ref w) = resp.five_hour {
-            metrics.push(window_metric("Session", w));
-        }
-        if let Some(ref w) = resp.seven_day {
-            metrics.push(window_metric("Weekly", w));
-        }
-        if let Some(ref w) = resp.seven_day_opus {
-            metrics.push(window_metric("Opus", w));
-        }
+        let metrics = usage_metrics(&resp);
 
         Ok(UsageOutput {
             provider: "Claude".into(),
@@ -202,6 +273,32 @@ mod tests {
 
     const USAGE_BODY: &str =
         r#"{"five_hour":{"utilization":12.5,"resets_at":"2026-08-03T12:00:00Z"}}"#;
+
+    const SCOPED_USAGE_BODY: &str = r#"{
+  "five_hour": { "utilization": 0, "resets_at": "2026-08-12T05:30:00Z" },
+  "seven_day": { "utilization": 30, "resets_at": "2026-08-17T04:00:00Z" },
+  "seven_day_opus": null,
+  "limits": [
+    { "kind": "session", "group": "session", "percent": 0, "is_active": false },
+    { "kind": "weekly_all", "group": "weekly", "percent": 30, "is_active": false },
+    {
+      "kind": "weekly_scoped",
+      "group": "weekly",
+      "percent": 47,
+      "resets_at": "2026-08-17T04:00:00Z",
+      "scope": { "model": { "id": null, "display_name": "Fable" } },
+      "is_active": true
+    },
+    {
+      "kind": "weekly_scoped",
+      "group": "weekly",
+      "percent": 90,
+      "scope": { "model": { "display_name": "Retired model" } },
+      "is_active": false
+    },
+    { "kind": "weekly_scoped", "percent": 99, "is_active": true }
+  ]
+}"#;
 
     /// Mirrors the path component of [`USAGE_URL`] so the recorded request line
     /// is the same string production would produce.
@@ -381,6 +478,50 @@ mod tests {
             "tokscale rewrote Claude Code's credential file"
         );
         assert_only_usage_request(&log);
+    }
+
+    #[test]
+    fn exposes_active_model_scoped_weekly_limit() {
+        let response: UsageResponse =
+            serde_json::from_str(SCOPED_USAGE_BODY).expect("scoped usage response parses");
+
+        let metrics = usage_metrics(&response);
+
+        assert_eq!(
+            metrics
+                .iter()
+                .map(|metric| metric.label.as_str())
+                .collect::<Vec<_>>(),
+            ["Session", "Weekly", "Fable"]
+        );
+        let fable = &metrics[2];
+        assert!((fable.used_percent - 47.0).abs() < f64::EPSILON);
+        assert!((fable.remaining_percent - 53.0).abs() < f64::EPSILON);
+        assert_eq!(fable.resets_at.as_deref(), Some("2026-08-17T04:00:00Z"));
+    }
+
+    #[test]
+    fn scoped_limit_replaces_matching_legacy_model_window() {
+        let response: UsageResponse = serde_json::from_str(
+            r#"{
+  "seven_day_opus": { "utilization": 60, "resets_at": "legacy" },
+  "limits": [{
+    "kind": "weekly_scoped",
+    "percent": 25,
+    "resets_at": "current",
+    "scope": { "model": { "display_name": "Opus" } },
+    "is_active": true
+  }]
+}"#,
+        )
+        .expect("legacy and scoped usage response parses");
+
+        let metrics = usage_metrics(&response);
+
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].label, "Opus");
+        assert!((metrics[0].used_percent - 25.0).abs() < f64::EPSILON);
+        assert_eq!(metrics[0].resets_at.as_deref(), Some("current"));
     }
 
     /// `read_credentials()` is the source of truth for what tokscale parses.

--- a/crates/tokscale-cli/src/commands/usage/claude.rs
+++ b/crates/tokscale-cli/src/commands/usage/claude.rs
@@ -235,7 +235,11 @@ fn scoped_limit_metric(limit: &PlanLimit) -> Option<ScopedLimit> {
 }
 
 /// Two entries describe the same quota when their model ids match; the display
-/// name is the fallback for entries the server sends without an id.
+/// name is the fallback for entries the server sends without an id. Name
+/// matching is only reachable while one side is still id-less, because folding
+/// sharpens a bucket's id (see [`usage_metrics`]), so an entry that arrives
+/// without an id joins the first bucket wearing its label and every later entry
+/// is then compared against a known id.
 fn same_scoped_model(a: &ScopedLimit, b: &ScopedLimit) -> bool {
     match (a.id.as_deref(), b.id.as_deref()) {
         (Some(a_id), Some(b_id)) => a_id == b_id,
@@ -261,11 +265,24 @@ fn usage_metrics(resp: &UsageResponse) -> Vec<UsageMetric> {
             .iter_mut()
             .find(|existing| same_scoped_model(existing, &candidate))
         {
-            // The binding window is the authoritative reading when the same
-            // model is reported twice; otherwise the first entry wins, so the
-            // order the server sent is what renders.
-            Some(existing) if candidate.is_active && !existing.is_active => *existing = candidate,
-            Some(_) => {}
+            Some(existing) => {
+                // Every fold sharpens the bucket's identity, including the one
+                // that replaces the reading: an id-less bucket adopts the first
+                // id folded into it, and a bucket that has an id keeps it when
+                // an id-less entry folds in. Without this, `same_scoped_model`
+                // is not transitive -- an id-less "Opus" bucket would swallow
+                // both `claude-opus-4-5` and `claude-opus-4-6` by name, dropping
+                // a distinct quota, and which of the two survived depended on
+                // whichever entry happened to carry `is_active`.
+                let id = existing.id.take().or_else(|| candidate.id.clone());
+                // The binding window is the authoritative reading when the same
+                // model is reported twice; otherwise the first entry wins, so
+                // the order the server sent is what renders.
+                if candidate.is_active && !existing.is_active {
+                    *existing = candidate;
+                }
+                existing.id = id;
+            }
             None => scoped.push(candidate),
         }
     }
@@ -826,6 +843,112 @@ mod tests {
         assert_eq!(labels(&metrics), ["Opus", "Opus"]);
         assert!((metrics[0].used_percent - 12.0).abs() < f64::EPSILON);
         assert!((metrics[1].used_percent - 38.0).abs() < f64::EPSILON);
+    }
+
+    /// An entry the server sent without an id must not swallow the models that
+    /// do carry one. Name matching is the only identity an id-less entry has, so
+    /// it folds into the first bucket wearing its label -- and that fold has to
+    /// sharpen the bucket's id, or the bucket keeps matching every later id by
+    /// name and the third entry's distinct quota is silently dropped.
+    #[test]
+    fn id_less_entry_does_not_swallow_distinct_model_ids() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "limits": [
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 10,
+      "scope": { "model": { "id": null, "display_name": "Opus" } },
+      "is_active": false },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 20,
+      "scope": { "model": { "id": "claude-opus-4-5", "display_name": "Opus" } },
+      "is_active": false },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 30,
+      "scope": { "model": { "id": "claude-opus-4-6", "display_name": "Opus" } },
+      "is_active": false }
+  ]
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Opus", "Opus"]);
+        assert!((metrics[0].used_percent - 10.0).abs() < f64::EPSILON);
+        assert!((metrics[1].used_percent - 30.0).abs() < f64::EPSILON);
+    }
+
+    /// The same three entries with the binding flag on the middle one. Which
+    /// entry happens to be active decides which reading survives the fold, and
+    /// it must not decide how many quotas the account has.
+    #[test]
+    fn active_entry_does_not_change_how_many_scoped_rows_survive() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "limits": [
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 10,
+      "scope": { "model": { "id": null, "display_name": "Opus" } },
+      "is_active": false },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 20,
+      "scope": { "model": { "id": "claude-opus-4-5", "display_name": "Opus" } },
+      "is_active": true },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 30,
+      "scope": { "model": { "id": "claude-opus-4-6", "display_name": "Opus" } },
+      "is_active": false }
+  ]
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Opus", "Opus"]);
+        assert!((metrics[0].used_percent - 20.0).abs() < f64::EPSILON);
+        assert!((metrics[1].used_percent - 30.0).abs() < f64::EPSILON);
+    }
+
+    /// Taking the binding entry's reading must not cost the bucket the id it
+    /// already knew: the active entry here has none, and a bucket reset to
+    /// id-less would go on to swallow the distinct model that follows.
+    #[test]
+    fn active_id_less_entry_keeps_the_bucket_model_id() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "limits": [
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 20,
+      "scope": { "model": { "id": "claude-opus-4-5", "display_name": "Opus" } },
+      "is_active": false },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 40,
+      "scope": { "model": { "display_name": "Opus" } },
+      "is_active": true },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 30,
+      "scope": { "model": { "id": "claude-opus-4-6", "display_name": "Opus" } },
+      "is_active": false }
+  ]
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Opus", "Opus"]);
+        assert!((metrics[0].used_percent - 40.0).abs() < f64::EPSILON);
+        assert!((metrics[1].used_percent - 30.0).abs() < f64::EPSILON);
+    }
+
+    /// Sharpening the bucket id must not hand the same model two rows: an entry
+    /// that arrives without an id still folds into the bucket its label names.
+    #[test]
+    fn id_less_entries_still_fold_into_an_identified_bucket() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "limits": [
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 12,
+      "scope": { "model": { "id": null, "display_name": "Opus" } },
+      "is_active": false },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 38,
+      "resets_at": "binding-reset",
+      "scope": { "model": { "id": "claude-opus-4-6", "display_name": "Opus" } },
+      "is_active": true },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 99,
+      "scope": { "model": { "display_name": "opus" } },
+      "is_active": false }
+  ]
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Opus"]);
+        assert!((metrics[0].used_percent - 38.0).abs() < f64::EPSILON);
+        assert_eq!(metrics[0].resets_at.as_deref(), Some("binding-reset"));
     }
 
     /// A scoped entry outside the weekly group is not a weekly quota row.

--- a/crates/tokscale-cli/src/commands/usage/claude.rs
+++ b/crates/tokscale-cli/src/commands/usage/claude.rs
@@ -48,14 +48,23 @@ struct Window {
     resets_at: Option<String>,
 }
 
+/// One entry of the `limits` array Anthropic returns alongside the legacy
+/// `five_hour`/`seven_day` windows. Model-scoped weekly caps arrive only here,
+/// as `kind: "weekly_scoped"` with the model under `scope.model`.
 #[derive(Debug, Deserialize)]
 struct PlanLimit {
     kind: Option<String>,
+    group: Option<String>,
     percent: Option<f64>,
     resets_at: Option<String>,
     scope: Option<LimitScope>,
-    #[serde(default)]
-    is_active: bool,
+    /// Marks the single window that is currently binding for the account, not
+    /// whether a cap exists: in captured responses exactly one entry across all
+    /// kinds is active, and it is the most-consumed one. Gating the scoped rows
+    /// on it hides a model quota whenever another window happens to be the
+    /// hottest, so it is only used as a tiebreak between duplicate entries.
+    /// Optional because Claude Code's own schema does not model the field.
+    is_active: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -65,7 +74,17 @@ struct LimitScope {
 
 #[derive(Debug, Deserialize)]
 struct ScopedModel {
+    id: Option<String>,
     display_name: Option<String>,
+}
+
+/// A `weekly_scoped` entry that survived selection, kept with the identity
+/// needed to dedup it before it reaches the metric list.
+struct ScopedLimit {
+    /// `scope.model.id`, lowercased. Authoritative when both sides have one.
+    id: Option<String>,
+    is_active: bool,
+    metric: UsageMetric,
 }
 
 fn credentials_path() -> std::path::PathBuf {
@@ -137,31 +156,75 @@ fn window_metric(label: &str, w: &Window) -> UsageMetric {
     }
 }
 
-fn scoped_limit_metric(limit: &PlanLimit) -> Option<UsageMetric> {
-    if limit.kind.as_deref() != Some("weekly_scoped") || !limit.is_active {
+/// The account-wide weekly cap is also reported as a scope in some responses;
+/// `seven_day` already renders it, so a scope that names every model is not a
+/// separate row. `all-models`, `all_models` and `All models` are the spellings
+/// observed.
+fn is_all_models_scope(value: &str) -> bool {
+    let normalized = value
+        .trim()
+        .to_ascii_lowercase()
+        .replace(['-', '_'], " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    normalized == "all models"
+}
+
+/// Selects on what identifies a model-scoped weekly cap -- `kind`, the weekly
+/// group, and a named model -- which is what Claude Code itself selects on.
+/// Anything the entry does not carry (a percent, a display name, a reset time)
+/// makes it unrenderable rather than fatal, so a partial entry is skipped and
+/// the rest of the response still reports.
+fn scoped_limit_metric(limit: &PlanLimit) -> Option<ScopedLimit> {
+    if limit.kind.as_deref() != Some("weekly_scoped") {
+        return None;
+    }
+    // `group` is absent from some entries; only an explicitly non-weekly group
+    // disqualifies one, so a response that omits the field still reports.
+    if limit
+        .group
+        .as_deref()
+        .is_some_and(|group| group != "weekly")
+    {
         return None;
     }
 
-    let label = limit
-        .scope
-        .as_ref()?
-        .model
-        .as_ref()?
-        .display_name
-        .as_deref()?
-        .trim();
+    let model = limit.scope.as_ref()?.model.as_ref()?;
+    let id = model
+        .id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty());
+    let label = model.display_name.as_deref()?.trim();
     if label.is_empty() {
+        return None;
+    }
+    if is_all_models_scope(label) || id.is_some_and(is_all_models_scope) {
         return None;
     }
 
     let used = limit.percent?.clamp(0.0, 100.0);
-    Some(UsageMetric {
-        label: label.to_string(),
-        used_percent: used,
-        remaining_percent: 100.0 - used,
-        remaining_label: None,
-        resets_at: limit.resets_at.clone(),
+    Some(ScopedLimit {
+        id: id.map(str::to_ascii_lowercase),
+        is_active: limit.is_active.unwrap_or(false),
+        metric: UsageMetric {
+            label: label.to_string(),
+            used_percent: used,
+            remaining_percent: 100.0 - used,
+            remaining_label: None,
+            resets_at: limit.resets_at.clone(),
+        },
     })
+}
+
+/// Two entries describe the same quota when their model ids match; the display
+/// name is the fallback for entries the server sends without an id.
+fn same_scoped_model(a: &ScopedLimit, b: &ScopedLimit) -> bool {
+    match (a.id.as_deref(), b.id.as_deref()) {
+        (Some(a_id), Some(b_id)) => a_id == b_id,
+        _ => a.metric.label.eq_ignore_ascii_case(&b.metric.label),
+    }
 }
 
 fn usage_metrics(resp: &UsageResponse) -> Vec<UsageMetric> {
@@ -176,20 +239,53 @@ fn usage_metrics(resp: &UsageResponse) -> Vec<UsageMetric> {
         metrics.push(window_metric("Opus", w));
     }
 
-    for metric in resp
+    let mut scoped: Vec<ScopedLimit> = Vec::new();
+    for candidate in resp
         .limits
         .as_deref()
         .unwrap_or_default()
         .iter()
         .filter_map(scoped_limit_metric)
     {
-        if let Some(existing) = metrics
+        match scoped
             .iter_mut()
-            .find(|existing| existing.label.eq_ignore_ascii_case(&metric.label))
+            .find(|existing| same_scoped_model(existing, &candidate))
         {
-            *existing = metric;
-        } else {
-            metrics.push(metric);
+            // The binding window is the authoritative reading when the same
+            // model is reported twice; otherwise the first entry wins, so the
+            // order the server sent is what renders.
+            Some(existing) if candidate.is_active && !existing.is_active => *existing = candidate,
+            Some(_) => {}
+            None => scoped.push(candidate),
+        }
+    }
+
+    // Only the legacy windows are merge targets: a scoped entry that names the
+    // same model as `seven_day_opus` is the current reading of that quota, not a
+    // second row. Identity between two scoped entries is already settled above,
+    // so they are never folded into each other here.
+    let legacy_count = metrics.len();
+    let mut replaced = vec![false; legacy_count];
+    for candidate in scoped {
+        let mut metric = candidate.metric;
+        let legacy_slot = metrics[..legacy_count]
+            .iter()
+            .enumerate()
+            .find(|(index, existing)| {
+                !replaced[*index] && existing.label.eq_ignore_ascii_case(&metric.label)
+            })
+            .map(|(index, _)| index);
+        match legacy_slot {
+            Some(index) => {
+                // `resets_at` is nullable in the scoped entry; the legacy
+                // window's reset time is better than a blank reset column.
+                if metric.resets_at.is_none() {
+                    metric.resets_at = metrics[index].resets_at.clone();
+                }
+                metrics[index] = metric;
+                replaced[index] = true;
+            }
+            None => metrics.push(metric),
         }
     }
 
@@ -274,6 +370,10 @@ mod tests {
     const USAGE_BODY: &str =
         r#"{"five_hour":{"utilization":12.5,"resets_at":"2026-08-03T12:00:00Z"}}"#;
 
+    /// A response carrying both the legacy windows and the `limits` array, with
+    /// the entry shapes that must not reach the metric list: a non-weekly kind,
+    /// the account-wide weekly entry `seven_day` already reports, and a scoped
+    /// entry with no model to name.
     const SCOPED_USAGE_BODY: &str = r#"{
   "five_hour": { "utilization": 0, "resets_at": "2026-08-12T05:30:00Z" },
   "seven_day": { "utilization": 30, "resets_at": "2026-08-17T04:00:00Z" },
@@ -293,12 +393,40 @@ mod tests {
       "kind": "weekly_scoped",
       "group": "weekly",
       "percent": 90,
-      "scope": { "model": { "display_name": "Retired model" } },
+      "scope": { "model": { "display_name": "Sonnet" } },
       "is_active": false
     },
     { "kind": "weekly_scoped", "percent": 99, "is_active": true }
   ]
 }"#;
+
+    /// Trimmed from a live Anthropic response captured on 2026-08-07 (published
+    /// verbatim in egoist/waku `src/usage.rs`). It is the ordinary case this
+    /// module has to handle: the session window is the binding one, so the Fable
+    /// weekly cap the user is being metered against carries `is_active: false`.
+    const LIVE_USAGE_BODY: &str = r#"{
+  "five_hour": {"utilization": 41.0, "resets_at": "2026-08-07T14:59:59.729061+00:00"},
+  "seven_day": {"utilization": 20.0, "resets_at": "2026-08-13T11:59:59.729091+00:00"},
+  "seven_day_opus": null,
+  "limits": [
+    {"kind": "session", "group": "session", "percent": 41, "severity": "normal",
+     "resets_at": "2026-08-07T14:59:59.729061+00:00", "scope": null, "is_active": true},
+    {"kind": "weekly_all", "group": "weekly", "percent": 20, "severity": "normal",
+     "resets_at": "2026-08-13T11:59:59.729091+00:00", "scope": null, "is_active": false},
+    {"kind": "weekly_scoped", "group": "weekly", "percent": 38, "severity": "normal",
+     "resets_at": "2026-08-13T11:59:59.729307+00:00",
+     "scope": {"model": {"id": null, "display_name": "Fable"}, "surface": null},
+     "is_active": false}
+  ]
+}"#;
+
+    fn labels(metrics: &[UsageMetric]) -> Vec<&str> {
+        metrics.iter().map(|m| m.label.as_str()).collect()
+    }
+
+    fn parse(body: &str) -> UsageResponse {
+        serde_json::from_str(body).expect("usage response parses")
+    }
 
     /// Mirrors the path component of [`USAGE_URL`] so the recorded request line
     /// is the same string production would produce.
@@ -481,28 +609,105 @@ mod tests {
     }
 
     #[test]
-    fn exposes_active_model_scoped_weekly_limit() {
-        let response: UsageResponse =
-            serde_json::from_str(SCOPED_USAGE_BODY).expect("scoped usage response parses");
+    fn exposes_model_scoped_weekly_limits() {
+        let metrics = usage_metrics(&parse(SCOPED_USAGE_BODY));
 
-        let metrics = usage_metrics(&response);
-
-        assert_eq!(
-            metrics
-                .iter()
-                .map(|metric| metric.label.as_str())
-                .collect::<Vec<_>>(),
-            ["Session", "Weekly", "Fable"]
-        );
+        assert_eq!(labels(&metrics), ["Session", "Weekly", "Fable", "Sonnet"]);
         let fable = &metrics[2];
         assert!((fable.used_percent - 47.0).abs() < f64::EPSILON);
         assert!((fable.remaining_percent - 53.0).abs() < f64::EPSILON);
         assert_eq!(fable.resets_at.as_deref(), Some("2026-08-17T04:00:00Z"));
     }
 
+    /// The regression this module was carrying: `is_active` marks the single
+    /// binding window, so gating the scoped row on it hid the model quota
+    /// whenever the session window happened to be the hottest -- which is what
+    /// this captured response shows.
+    #[test]
+    fn inactive_scoped_limit_is_still_reported() {
+        let metrics = usage_metrics(&parse(LIVE_USAGE_BODY));
+
+        assert_eq!(labels(&metrics), ["Session", "Weekly", "Fable"]);
+        let fable = &metrics[2];
+        assert!((fable.used_percent - 38.0).abs() < f64::EPSILON);
+        assert!((fable.remaining_percent - 62.0).abs() < f64::EPSILON);
+        assert_eq!(
+            fable.resets_at.as_deref(),
+            Some("2026-08-13T11:59:59.729307+00:00")
+        );
+    }
+
+    /// `is_active` is absent from Claude Code's own schema for this array, so a
+    /// response that omits it must not lose its scoped rows.
+    #[test]
+    fn scoped_limit_without_is_active_is_reported() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "limits": [{
+    "kind": "weekly_scoped",
+    "group": "weekly",
+    "percent": 23,
+    "resets_at": "2026-08-17T04:00:00Z",
+    "scope": { "model": { "display_name": "Fable" } }
+  }]
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Fable"]);
+        assert!((metrics[0].used_percent - 23.0).abs() < f64::EPSILON);
+    }
+
+    /// A fresh week reports the cap at 0%; it is still a cap, and it is exactly
+    /// the reading a user refreshes to see.
+    #[test]
+    fn scoped_limit_at_zero_percent_is_reported() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "limits": [{
+    "kind": "weekly_scoped",
+    "group": "weekly",
+    "percent": 0,
+    "scope": { "model": { "display_name": "Fable" } },
+    "is_active": false
+  }]
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Fable"]);
+        assert_eq!(metrics[0].used_percent, 0.0);
+        assert_eq!(metrics[0].remaining_percent, 100.0);
+    }
+
+    #[test]
+    fn every_scoped_model_gets_its_own_row() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "five_hour": { "utilization": 10, "resets_at": "session-reset" },
+  "seven_day": { "utilization": 20, "resets_at": "weekly-reset" },
+  "limits": [
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 38,
+      "scope": { "model": { "id": "claude-fable-1", "display_name": "Fable" } },
+      "is_active": false },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 61,
+      "scope": { "model": { "id": "claude-opus-4-6", "display_name": "Opus" } },
+      "is_active": true },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 4,
+      "scope": { "model": { "id": "claude-sonnet-4-6", "display_name": "Sonnet" } },
+      "is_active": false }
+  ]
+}"#,
+        ));
+
+        assert_eq!(
+            labels(&metrics),
+            ["Session", "Weekly", "Fable", "Opus", "Sonnet"]
+        );
+        assert!((metrics[3].used_percent - 61.0).abs() < f64::EPSILON);
+    }
+
     #[test]
     fn scoped_limit_replaces_matching_legacy_model_window() {
-        let response: UsageResponse = serde_json::from_str(
+        let metrics = usage_metrics(&parse(
             r#"{
   "seven_day_opus": { "utilization": 60, "resets_at": "legacy" },
   "limits": [{
@@ -513,15 +718,191 @@ mod tests {
     "is_active": true
   }]
 }"#,
-        )
-        .expect("legacy and scoped usage response parses");
+        ));
 
-        let metrics = usage_metrics(&response);
-
-        assert_eq!(metrics.len(), 1);
-        assert_eq!(metrics[0].label, "Opus");
+        assert_eq!(labels(&metrics), ["Opus"]);
         assert!((metrics[0].used_percent - 25.0).abs() < f64::EPSILON);
         assert_eq!(metrics[0].resets_at.as_deref(), Some("current"));
+    }
+
+    /// `resets_at` is nullable on a scoped entry. Replacing the legacy window
+    /// wholesale would blank the reset column the legacy window did carry.
+    #[test]
+    fn replacing_a_legacy_window_keeps_its_reset_time() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "seven_day_opus": { "utilization": 60, "resets_at": "2026-08-17T04:00:00Z" },
+  "limits": [{
+    "kind": "weekly_scoped",
+    "group": "weekly",
+    "percent": 25,
+    "resets_at": null,
+    "scope": { "model": { "display_name": "Opus" } },
+    "is_active": false
+  }]
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Opus"]);
+        assert!((metrics[0].used_percent - 25.0).abs() < f64::EPSILON);
+        assert_eq!(
+            metrics[0].resets_at.as_deref(),
+            Some("2026-08-17T04:00:00Z")
+        );
+    }
+
+    /// The account-wide weekly cap is `seven_day`; a scope naming every model is
+    /// the same number under another label.
+    #[test]
+    fn all_models_scope_does_not_duplicate_the_weekly_row() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "seven_day": { "utilization": 20, "resets_at": "weekly-reset" },
+  "limits": [
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 20,
+      "scope": { "model": { "id": "all-models", "display_name": "All models" } },
+      "is_active": true },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 20,
+      "scope": { "model": { "display_name": "all_models" } },
+      "is_active": false }
+  ]
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Weekly"]);
+    }
+
+    /// Same model reported twice: one row, and the binding entry is the reading
+    /// that survives. The ids match, so the differing display names do not make
+    /// them two models.
+    #[test]
+    fn duplicate_scoped_models_dedupe_on_model_id() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "limits": [
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 12,
+      "scope": { "model": { "id": "claude-fable-1", "display_name": "Fable 1" } },
+      "is_active": false },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 38,
+      "resets_at": "binding-reset",
+      "scope": { "model": { "id": "claude-fable-1", "display_name": "Fable" } },
+      "is_active": true }
+  ]
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Fable"]);
+        assert!((metrics[0].used_percent - 38.0).abs() < f64::EPSILON);
+        assert_eq!(metrics[0].resets_at.as_deref(), Some("binding-reset"));
+    }
+
+    /// Distinct ids are distinct quotas even when the server sends the same
+    /// display name for both.
+    #[test]
+    fn distinct_model_ids_are_not_deduped_by_display_name() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "limits": [
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 12,
+      "scope": { "model": { "id": "claude-opus-4-5", "display_name": "Opus" } },
+      "is_active": false },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 38,
+      "scope": { "model": { "id": "claude-opus-4-6", "display_name": "Opus" } },
+      "is_active": false }
+  ]
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Opus", "Opus"]);
+        assert!((metrics[0].used_percent - 12.0).abs() < f64::EPSILON);
+        assert!((metrics[1].used_percent - 38.0).abs() < f64::EPSILON);
+    }
+
+    /// A scoped entry outside the weekly group is not a weekly quota row.
+    #[test]
+    fn non_weekly_group_scoped_entry_is_ignored() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "seven_day": { "utilization": 20, "resets_at": "weekly-reset" },
+  "limits": [{
+    "kind": "weekly_scoped",
+    "group": "session",
+    "percent": 99,
+    "scope": { "model": { "display_name": "Fable" } },
+    "is_active": true
+  }]
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Weekly"]);
+    }
+
+    /// Entries the server sends without the parts a row needs are skipped one by
+    /// one; they must not take the rest of the response down with them, and must
+    /// not overwrite a legacy window with a blank reading.
+    #[test]
+    fn unrenderable_scoped_entries_are_skipped_individually() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "five_hour": { "utilization": 10, "resets_at": "session-reset" },
+  "seven_day_opus": { "utilization": 60, "resets_at": "legacy-reset" },
+  "limits": [
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 50, "is_active": true },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 50, "scope": {}, "is_active": true },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 50,
+      "scope": { "model": { "id": "claude-opus-4-6" } }, "is_active": true },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 50,
+      "scope": { "model": { "display_name": "   " } }, "is_active": true },
+    { "kind": "weekly_scoped", "group": "weekly",
+      "scope": { "model": { "display_name": "Opus" } }, "is_active": true },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 38,
+      "resets_at": "fable-reset",
+      "scope": { "model": { "display_name": "Fable" } }, "is_active": false }
+  ]
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Session", "Opus", "Fable"]);
+        assert!((metrics[1].used_percent - 60.0).abs() < f64::EPSILON);
+        assert_eq!(metrics[1].resets_at.as_deref(), Some("legacy-reset"));
+        assert!((metrics[2].used_percent - 38.0).abs() < f64::EPSILON);
+    }
+
+    /// A response with no `limits` array at all is the old shape, and still has
+    /// to report its legacy windows.
+    #[test]
+    fn response_without_limits_reports_legacy_windows() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "five_hour": { "utilization": 12.5, "resets_at": "session-reset" },
+  "seven_day": { "utilization": 30, "resets_at": "weekly-reset" },
+  "seven_day_opus": { "utilization": 60, "resets_at": "opus-reset" }
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Session", "Weekly", "Opus"]);
+    }
+
+    /// Out-of-range percents are clamped to the same 0-100 scale the legacy
+    /// `utilization` windows use, so the remaining half of the bar stays sane.
+    #[test]
+    fn scoped_percent_is_clamped_to_the_utilization_scale() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "limits": [
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 140,
+      "scope": { "model": { "display_name": "Fable" } }, "is_active": true },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": -3,
+      "scope": { "model": { "display_name": "Sonnet" } }, "is_active": false }
+  ]
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Fable", "Sonnet"]);
+        assert_eq!(metrics[0].used_percent, 100.0);
+        assert_eq!(metrics[0].remaining_percent, 0.0);
+        assert_eq!(metrics[1].used_percent, 0.0);
+        assert_eq!(metrics[1].remaining_percent, 100.0);
     }
 
     /// `read_credentials()` is the source of truth for what tokscale parses.

--- a/crates/tokscale-cli/src/commands/usage/claude.rs
+++ b/crates/tokscale-cli/src/commands/usage/claude.rs
@@ -39,7 +39,23 @@ struct UsageResponse {
     five_hour: Option<Window>,
     seven_day: Option<Window>,
     seven_day_opus: Option<Window>,
-    limits: Option<Vec<PlanLimit>>,
+    #[serde(default, deserialize_with = "lenient_limits")]
+    limits: Vec<PlanLimit>,
+}
+
+/// A limits entry tokscale cannot parse must not cost the whole response: the
+/// legacy windows and every other entry still report. The array is a moving
+/// server-side schema, and this module only reads a handful of its fields.
+fn lenient_limits<'de, D>(deserializer: D) -> Result<Vec<PlanLimit>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let entries = Option::<Vec<serde_json::Value>>::deserialize(deserializer)?;
+    Ok(entries
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|entry| serde_json::from_value(entry).ok())
+        .collect())
 }
 
 #[derive(Debug, Deserialize)]
@@ -240,13 +256,7 @@ fn usage_metrics(resp: &UsageResponse) -> Vec<UsageMetric> {
     }
 
     let mut scoped: Vec<ScopedLimit> = Vec::new();
-    for candidate in resp
-        .limits
-        .as_deref()
-        .unwrap_or_default()
-        .iter()
-        .filter_map(scoped_limit_metric)
-    {
+    for candidate in resp.limits.iter().filter_map(scoped_limit_metric) {
         match scoped
             .iter_mut()
             .find(|existing| same_scoped_model(existing, &candidate))
@@ -866,6 +876,28 @@ mod tests {
         assert!((metrics[1].used_percent - 60.0).abs() < f64::EPSILON);
         assert_eq!(metrics[1].resets_at.as_deref(), Some("legacy-reset"));
         assert!((metrics[2].used_percent - 38.0).abs() < f64::EPSILON);
+    }
+
+    /// The `limits` array is a server-side schema this module reads a few fields
+    /// of. An entry it cannot parse is dropped on its own; the legacy windows
+    /// and the entries it can parse still report.
+    #[test]
+    fn unparseable_limit_entry_does_not_sink_the_response() {
+        let metrics = usage_metrics(&parse(
+            r#"{
+  "five_hour": { "utilization": 41, "resets_at": "session-reset" },
+  "limits": [
+    { "kind": 7, "group": "weekly", "percent": 50 },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": "38",
+      "scope": { "model": { "display_name": "Sonnet" } } },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 38,
+      "scope": { "model": { "display_name": "Fable" } }, "is_active": false }
+  ]
+}"#,
+        ));
+
+        assert_eq!(labels(&metrics), ["Session", "Fable"]);
+        assert!((metrics[1].used_percent - 38.0).abs() < f64::EPSILON);
     }
 
     /// A response with no `limits` array at all is the old shape, and still has

--- a/crates/tokscale-cli/src/commands/usage/claude.rs
+++ b/crates/tokscale-cli/src/commands/usage/claude.rs
@@ -46,16 +46,27 @@ struct UsageResponse {
 /// A limits entry tokscale cannot parse must not cost the whole response: the
 /// legacy windows and every other entry still report. The array is a moving
 /// server-side schema, and this module only reads a handful of its fields.
+///
+/// The field is read as an untyped value rather than as a sequence for the same
+/// reason: if `limits` ever stops being an array, the strongly-typed form fails
+/// the whole document ("invalid type: map, expected a sequence") and takes the
+/// legacy Session/Weekly windows down with it. A shape this module cannot walk
+/// degrades to no scoped rows.
 fn lenient_limits<'de, D>(deserializer: D) -> Result<Vec<PlanLimit>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let entries = Option::<Vec<serde_json::Value>>::deserialize(deserializer)?;
-    Ok(entries
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|entry| serde_json::from_value(entry).ok())
-        .collect())
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value
+        .as_ref()
+        .and_then(serde_json::Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| PlanLimit::deserialize(entry).ok())
+                .collect()
+        })
+        .unwrap_or_default())
 }
 
 #[derive(Debug, Deserialize)]
@@ -949,6 +960,37 @@ mod tests {
         assert_eq!(labels(&metrics), ["Opus"]);
         assert!((metrics[0].used_percent - 38.0).abs() < f64::EPSILON);
         assert_eq!(metrics[0].resets_at.as_deref(), Some("binding-reset"));
+    }
+
+    /// `limits` is a server-side schema, and its container type is as much a
+    /// moving part as its entries. A `limits` that stops being an array must
+    /// cost the scoped rows only -- a strongly-typed sequence fails the whole
+    /// document ("invalid type: map, expected a sequence") and the user sees
+    /// "Claude usage unavailable" instead of Session and Weekly.
+    #[test]
+    fn non_array_limits_does_not_sink_the_response() {
+        for limits in [
+            r#"{ "weekly_scoped": [] }"#,
+            r#""weekly_scoped""#,
+            "7",
+            "true",
+        ] {
+            let body = format!(
+                r#"{{
+  "five_hour": {{ "utilization": 41, "resets_at": "session-reset" }},
+  "seven_day": {{ "utilization": 20, "resets_at": "weekly-reset" }},
+  "limits": {limits}
+}}"#
+            );
+
+            let metrics = usage_metrics(&parse(&body));
+
+            assert_eq!(
+                labels(&metrics),
+                ["Session", "Weekly"],
+                "legacy windows lost to a `limits` of {limits}"
+            );
+        }
     }
 
     /// A scoped entry outside the weekly group is not a weekly quota row.


### PR DESCRIPTION
Supersedes #1104 (thanks @Luzivog). The contributor's two commits are preserved here; the fix is the selection predicate on top.

## What was wrong

#1104 gated the scoped row on `is_active`:

```rust
if limit.kind.as_deref() != Some("weekly_scoped") || !limit.is_active {
    return None;
}
```

`is_active` marks the single window that is currently *binding* for the account, not whether a cap exists. In captured responses exactly one entry across all kinds carries `is_active: true`, and it is always the most-consumed one. So the model-scoped row only rendered while that model happened to be the hottest window, appearing and disappearing between refreshes, and a fresh-week cap sitting at 0% never rendered at all. Claude Code itself selects on `kind === "weekly_scoped"` and the presence of `scope.model`, and does not model `is_active`. A response captured on 2026-08-07 (now a fixture in this PR) shows the ordinary case: the session window is the active one, and the Fable weekly cap the user is metered against carries `is_active: false`.

## What this changes

- Select scoped caps on `kind == "weekly_scoped"` plus a weekly group. `is_active` is now only a tiebreak between duplicate entries for the same model.
- `group` and `is_active` are optional: only an explicitly non-weekly group disqualifies an entry, so a response that omits either field still reports. A `weekly_scoped` entry in the `session` group is no longer rendered as a weekly quota row.
- Skip scopes that name every model (`all-models` / `All models`), which otherwise duplicate the account-wide `seven_day` row.
- Dedup on `scope.model.id` before the display name, so the same model reported twice collapses to one row and the binding entry wins.
- Keep the legacy window's `resets_at` when the scoped entry carries `resets_at: null`; the previous wholesale replacement blanked the reset column.
- Confine legacy-window replacement to the legacy rows, so two distinct scoped models are never folded into each other by a shared display name.
- Partial entries stay non-fatal: a missing percent, missing `scope.model`, or blank display name skips that entry only, and `limits` is now deserialized entry by entry so one entry whose types tokscale does not model no longer fails the whole response and takes the legacy windows with it.
- Sharpen a scoped bucket's model id on every fold, replacement arm included. An id-less entry can only be matched by display name, so it folds into the first bucket wearing its label; leaving that bucket id-less made `same_scoped_model` non-transitive, and the active-replacement arm overwrote the bucket's id with the incoming entry's. Three entries all named "Opus" (`null` 10%, `claude-opus-4-5` 20%, `claude-opus-4-6` 30%) collapsed to two rows or one depending on which carried `is_active`, and the one-row case dropped a distinct quota. Ids are now unioned on each fold, so the row count no longer depends on which window is binding, and an id-less entry still folds into the bucket its label names rather than earning a second identically-labelled row.
- Read `limits` as an untyped value and walk it only when it is an array. Entry-level leniency did not cover the container: a `limits` that stops being an array fails the whole document with `invalid type: map, expected a sequence`, so the user got "Claude usage unavailable" with Session and Weekly included. An unrecognised shape now costs the scoped rows only.

Unchanged from #1104: the READMEs (EN/JA/KO/ZH) documenting model-scoped quotas, and the `percent` -> `used_percent` mapping on the same 0-100 scale as `utilization`.

## Tests

`crates/tokscale-cli/src/commands/usage/claude.rs` gains regressions over realistic payloads: the 2026-08-07 live capture with `is_active: false`, an entry with no `is_active` field, a 0% cap, three scoped models at once, `resets_at: null` over a legacy window, an all-models scope alongside `seven_day`, duplicate and distinct model ids, a `session`-group scoped entry, unrenderable entries mixed with a good one, a response with no `limits` array, out-of-range percents, an unparseable entry mixed in with good ones, an id-less entry ahead of two distinct model ids under one display name (with and without the middle entry binding), an id-less *binding* entry that must not cost the bucket its id, id-less entries folding into an identified bucket, and a `limits` that is an object, a string, a number, or a bool.

## Gates

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-features --no-fail-fast`
