### PR TITLE
fix(droid): attribute session usage to the replies that spent it, and bound it server-side

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -8232,6 +8232,21 @@ mod tests {
         );
     }
 
+    /// Droid is bounded by the server's device/client lifetime high-water
+    /// (`SUPPORTED_VERSIONED_PARSERS` in packages/frontend/src/lib/db/parserHighWater.ts),
+    /// which accepts generation 1 for it. The submission generation is not the
+    /// cache `parser_version`: re-attribution changes which day a token lands
+    /// on, never the lifetime total, so no installed generation has to be
+    /// frozen out. Declaring anything else here freezes every Droid submission
+    /// server-side until the registry is bumped in lockstep.
+    #[test]
+    fn submit_scan_scope_declares_the_droid_generation_the_server_registers() {
+        let clients = vec!["droid".to_string()];
+        let scope = submit_scan_scope(Some(&clients), true).expect("droid scope");
+
+        assert_eq!(scope.parser_versions.get("droid"), Some(&1));
+    }
+
     #[test]
     #[cfg(target_os = "macos")]
     #[serial_test::serial]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1063,6 +1063,13 @@ fn parser_version(client: ClientId) -> u32 {
         // v2->v3: duplicate merging now upgrades the retained row when a later
         // copy carries an explicit cost, including zero.
         ClientId::MiMoCode => 3,
+        // Droid's cumulative session totals now anchor on the settings file's
+        // mtime (floored at providerLockTimestamp) instead of the lock
+        // timestamp alone, so a long-running session stops reporting every
+        // token it ever spent against the day it was started. A session that
+        // has since ended never changes its bytes again, so its fingerprint
+        // stays valid forever and only this bump discards the v1 anchor.
+        ClientId::Droid => 2,
         _ => 1,
     }
 }
@@ -2946,6 +2953,14 @@ mod tests {
         // fingerprint forever, so only the version bump discards the truncated
         // v6 parse and forces a cold reparse.
         assert_eq!(parser_version(ClientId::Grok), 7);
+    }
+
+    #[test]
+    fn test_droid_usage_anchor_parser_version_invalidates_v1_entries() {
+        // A finished Droid session's settings.json is never rewritten again, so
+        // its fingerprint keeps matching and only the version bump discards the
+        // v1 lock-timestamp anchor.
+        assert_eq!(parser_version(ClientId::Droid), 2);
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1073,7 +1073,12 @@ fn parser_version(client: ClientId) -> u32 {
         // instant. It is now apportioned across the assistant replies in the
         // sibling transcript, weighted by the context each reply read, so a
         // multi-day session reports against the days it actually ran.
-        ClientId::Droid => 3,
+        // v3->v4: a reply is weighted by the context standing before it rather
+        // than including its own bytes, so a long answer no longer charges
+        // itself for its own output. Versions 2 and 3 only ever existed in
+        // pre-release builds of this change; the bump past them keeps anyone
+        // who ran one from holding the superseded weighting.
+        ClientId::Droid => 4,
         _ => 1,
     }
 }
@@ -2964,7 +2969,7 @@ mod tests {
         // A finished Droid session's settings.json is never rewritten again, so
         // its fingerprint keeps matching and only the version bump discards the
         // v1 lock-timestamp anchor.
-        assert_eq!(parser_version(ClientId::Droid), 3);
+        assert_eq!(parser_version(ClientId::Droid), 4);
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1087,7 +1087,11 @@ fn parser_version(client: ClientId) -> u32 {
         // the transcript ceiling, and a transcript that could not be read whole
         // takes the single-record path rather than apportioning the session
         // over the prefix that was read.
-        ClientId::Droid => 6,
+        // v6->v7: the apportioned records are attribution fragments of one
+        // session, so the session's reply count now rides on exactly one of
+        // them. v6 entries carry a count on every record, which `sessionize`
+        // reads as one session per record.
+        ClientId::Droid => 7,
         _ => 1,
     }
 }
@@ -2978,7 +2982,7 @@ mod tests {
         // A finished Droid session's settings.json is never rewritten again, so
         // its fingerprint keeps matching and only the version bump discards the
         // v1 lock-timestamp anchor.
-        assert_eq!(parser_version(ClientId::Droid), 6);
+        assert_eq!(parser_version(ClientId::Droid), 7);
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1082,7 +1082,12 @@ fn parser_version(client: ClientId) -> u32 {
         // takes the single-record path. Versions 2 through 4 only ever existed
         // in pre-release builds of this change; the bump past them keeps anyone
         // who ran one from holding a superseded split.
-        ClientId::Droid => 5,
+        // v5->v6: a coalesced run of replies now reports how many calls it
+        // stands for instead of one, an unreadable file size no longer waives
+        // the transcript ceiling, and a transcript that could not be read whole
+        // takes the single-record path rather than apportioning the session
+        // over the prefix that was read.
+        ClientId::Droid => 6,
         _ => 1,
     }
 }
@@ -2973,7 +2978,7 @@ mod tests {
         // A finished Droid session's settings.json is never rewritten again, so
         // its fingerprint keeps matching and only the version bump discards the
         // v1 lock-timestamp anchor.
-        assert_eq!(parser_version(ClientId::Droid), 5);
+        assert_eq!(parser_version(ClientId::Droid), 6);
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1069,7 +1069,11 @@ fn parser_version(client: ClientId) -> u32 {
         // token it ever spent against the day it was started. A session that
         // has since ended never changes its bytes again, so its fingerprint
         // stays valid forever and only this bump discards the v1 anchor.
-        ClientId::Droid => 2,
+        // v2->v3: a session's cumulative total is no longer one record at one
+        // instant. It is now apportioned across the assistant replies in the
+        // sibling transcript, weighted by the context each reply read, so a
+        // multi-day session reports against the days it actually ran.
+        ClientId::Droid => 3,
         _ => 1,
     }
 }
@@ -2960,7 +2964,7 @@ mod tests {
         // A finished Droid session's settings.json is never rewritten again, so
         // its fingerprint keeps matching and only the version bump discards the
         // v1 lock-timestamp anchor.
-        assert_eq!(parser_version(ClientId::Droid), 2);
+        assert_eq!(parser_version(ClientId::Droid), 3);
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1075,10 +1075,14 @@ fn parser_version(client: ClientId) -> u32 {
         // multi-day session reports against the days it actually ran.
         // v3->v4: a reply is weighted by the context standing before it rather
         // than including its own bytes, so a long answer no longer charges
-        // itself for its own output. Versions 2 and 3 only ever existed in
-        // pre-release builds of this change; the bump past them keeps anyone
-        // who ran one from holding the superseded weighting.
-        ClientId::Droid => 4,
+        // itself for its own output.
+        // v4->v5: output and reasoning follow the reply's own size instead of
+        // the context it read, a pre-epoch transcript timestamp no longer
+        // anchors a share of the session in 1969, and an oversized transcript
+        // takes the single-record path. Versions 2 through 4 only ever existed
+        // in pre-release builds of this change; the bump past them keeps anyone
+        // who ran one from holding a superseded split.
+        ClientId::Droid => 5,
         _ => 1,
     }
 }
@@ -2969,7 +2973,7 @@ mod tests {
         // A finished Droid session's settings.json is never rewritten again, so
         // its fingerprint keeps matching and only the version bump discards the
         // v1 lock-timestamp anchor.
-        assert_eq!(parser_version(ClientId::Droid), 4);
+        assert_eq!(parser_version(ClientId::Droid), 5);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/droid.rs
+++ b/crates/tokscale-core/src/sessions/droid.rs
@@ -165,6 +165,22 @@ pub(crate) fn droid_jsonl_path(path: &Path) -> Option<PathBuf> {
 /// When the filesystem reports no mtime at all, fall back to the lock
 /// timestamp, then to now() — a record with real token usage is never dropped
 /// just because its timestamp could not be resolved.
+/// Parse `providerLockTimestamp` into epoch milliseconds, rejecting values that
+/// cannot describe a real provider lock.
+///
+/// Zero is Droid's unset sentinel, and a negative value is a clock or
+/// corruption artifact — neither is a usable anchor. Both collapse to `None` so
+/// the resolver treats them as absent, which keeps this anchor's validity rule
+/// symmetric with the mtime one: `file_modified_timestamp_ms_opt` already
+/// reports `None` for a pre-epoch mtime. Without that symmetry a negative lock
+/// would survive as the resolved anchor whenever mtime was unavailable, and the
+/// record would land in a 1969 bucket that no date filter can reach.
+fn parse_lock_timestamp(raw: Option<&str>) -> Option<i64> {
+    raw.and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
+        .map(|dt| dt.timestamp_millis())
+        .filter(|&ts| ts > 0)
+}
+
 fn resolve_usage_timestamp(lock_timestamp: Option<i64>, modified: Option<i64>) -> i64 {
     match (modified, lock_timestamp) {
         (Some(modified), Some(lock)) => modified.max(lock),
@@ -230,12 +246,7 @@ pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
         }
     };
 
-    let lock_timestamp = settings
-        .provider_lock_timestamp
-        .as_deref()
-        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
-        .map(|dt| dt.timestamp_millis())
-        .filter(|&ts| ts != 0);
+    let lock_timestamp = parse_lock_timestamp(settings.provider_lock_timestamp.as_deref());
 
     let timestamp = resolve_usage_timestamp(lock_timestamp, file_modified_timestamp_ms_opt(path));
 
@@ -308,6 +319,33 @@ mod tests {
         assert_eq!(get_default_model_from_provider("google"), "gemini-unknown");
         assert_eq!(get_default_model_from_provider("xai"), "grok-unknown");
         assert_eq!(get_default_model_from_provider("custom"), "custom-unknown");
+    }
+
+    #[test]
+    fn test_parse_lock_timestamp_rejects_unusable_anchors() {
+        // Zero is Droid's unset sentinel.
+        assert_eq!(parse_lock_timestamp(Some("1970-01-01T00:00:00Z")), None);
+        // A pre-epoch lock is a clock/corruption artifact. Keeping it would
+        // outlive the mtime fallback and bucket the record in 1969, where no
+        // date filter can reach it.
+        assert_eq!(parse_lock_timestamp(Some("1969-07-20T20:17:00Z")), None);
+        assert_eq!(parse_lock_timestamp(Some("not-a-timestamp")), None);
+        assert_eq!(parse_lock_timestamp(None), None);
+
+        assert_eq!(
+            parse_lock_timestamp(Some("2026-08-07T03:32:46.663Z")),
+            Some(1_786_073_566_663)
+        );
+    }
+
+    #[test]
+    fn test_pre_epoch_lock_falls_through_to_now_without_mtime() {
+        // The resolver only reaches its now() fallback if the rejected lock
+        // arrives as None, so this pins the two halves together: an unusable
+        // lock plus an unavailable mtime must not yield a pre-epoch anchor.
+        let lock = parse_lock_timestamp(Some("1969-07-20T20:17:00Z"));
+
+        assert!(resolve_usage_timestamp(lock, None) > 1_700_000_000_000);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/droid.rs
+++ b/crates/tokscale-core/src/sessions/droid.rs
@@ -208,9 +208,11 @@ struct TranscriptTurn {
 /// another, which is all the apportioning below needs.
 ///
 /// Only assistant replies are counted, since one reply corresponds to one API
-/// call; user and tool records ride along inside the call that reads them.
-/// Compaction resets the running context because it discards the transcript
-/// the following calls would otherwise re-read.
+/// call; user and tool records ride along inside the call that reads them. Each
+/// reply is weighted by the context standing *before* it, since its own bytes
+/// are output rather than something it paid to read. Compaction resets the
+/// running context because it discards the transcript the following calls would
+/// otherwise re-read.
 fn transcript_turns(jsonl: &Path) -> Vec<TranscriptTurn> {
     let Ok(file) = std::fs::File::open(jsonl) else {
         return Vec::new();
@@ -232,6 +234,12 @@ fn transcript_turns(jsonl: &Path) -> Vec<TranscriptTurn> {
             context_bytes = line_bytes;
             continue;
         }
+
+        // What the call read is the conversation as it stood *before* this
+        // record. A reply's own bytes are its output; charging them back to the
+        // same reply would let a long answer inflate its own share of the
+        // input and cache-read totals. They join the context for later calls.
+        let context_read = context_bytes;
         context_bytes = context_bytes.saturating_add(line_bytes);
 
         if record_type != Some("message") {
@@ -252,7 +260,9 @@ fn transcript_turns(jsonl: &Path) -> Vec<TranscriptTurn> {
 
         turns.push(TranscriptTurn {
             timestamp,
-            weight: context_bytes.max(1),
+            // The first reply in a session reads a context of zero bytes but
+            // still cost something, so every turn carries at least one unit.
+            weight: context_read.max(1),
         });
     }
 
@@ -470,6 +480,13 @@ mod tests {
         )
     }
 
+    fn user(timestamp: &str, filler: usize) -> String {
+        format!(
+            r#"{{"type":"message","timestamp":"{timestamp}","message":{{"role":"user","content":"{}"}}}}"#,
+            "x".repeat(filler)
+        )
+    }
+
     #[test]
     fn test_apportion_parts_sum_to_the_original_total() {
         // Truncation must never lose or invent tokens: the daily figures have to
@@ -518,6 +535,38 @@ mod tests {
     }
 
     #[test]
+    fn test_a_long_reply_does_not_charge_itself_for_its_own_output() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        // Two replies on an identical context, one of them enormously long.
+        // What each call *read* is the same, so the split must be even: the
+        // long answer's own bytes are output, not context it paid to read.
+        let settings = write_session(
+            temp_dir.path(),
+            "44444444-4444-4444-4444-444444444444",
+            r#"{"inputTokens":1000}"#,
+            &[
+                r#"{"type":"message","timestamp":"2026-08-07T11:00:00Z","message":{"role":"user","content":"seed"}}"#,
+                &assistant("2026-08-07T12:00:00Z", 50_000),
+                &assistant("2026-08-07T13:00:00Z", 10),
+            ],
+        );
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 1000);
+        // The first reply read only the short seed; the second read that plus a
+        // 50KB answer, so it should carry overwhelmingly more. Charging a reply
+        // for its own output would instead hand the first one that same 50KB
+        // and leave the two nearly equal, so the ratio is what discriminates.
+        assert!(
+            messages[1].tokens.input > messages[0].tokens.input * 10,
+            "a long reply inflated its own share: {:?}",
+            messages.iter().map(|m| m.tokens.input).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn test_compaction_resets_the_context_weighting() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         // A big conversation, compacted, then one short reply afterwards. The
@@ -527,7 +576,11 @@ mod tests {
             "11111111-1111-1111-1111-111111111111",
             r#"{"inputTokens":1000}"#,
             &[
-                &assistant("2026-08-07T12:00:00Z", 2000),
+                // A long conversation the first reply had to read...
+                &user("2026-08-07T11:00:00Z", 4000),
+                &assistant("2026-08-07T12:00:00Z", 10),
+                // ...then compaction discards it, so the reply after it reads
+                // only the compacted summary.
                 r#"{"type":"compaction_state","timestamp":"2026-08-08T12:00:00Z"}"#,
                 &assistant("2026-08-09T12:00:00Z", 10),
             ],
@@ -539,7 +592,8 @@ mod tests {
         assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 1000);
         assert!(
             messages[0].tokens.input > messages[1].tokens.input,
-            "the compacted-away context should not keep charging later replies"
+            "the compacted-away context should not keep charging later replies: {:?}",
+            messages.iter().map(|m| m.tokens.input).collect::<Vec<_>>()
         );
     }
 

--- a/crates/tokscale-core/src/sessions/droid.rs
+++ b/crates/tokscale-core/src/sessions/droid.rs
@@ -2,7 +2,7 @@
 //!
 //! Parses JSON files from ~/.factory/sessions/
 
-use super::utils::{file_modified_timestamp_ms, read_file_or_none};
+use super::utils::{file_modified_timestamp_ms_opt, read_file_or_none};
 use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
@@ -142,6 +142,38 @@ pub(crate) fn droid_jsonl_path(path: &Path) -> Option<PathBuf> {
     Some(path.with_file_name(format!("{stem}.jsonl")))
 }
 
+/// Pick the instant a Droid session's cumulative `tokenUsage` is attributed to.
+///
+/// A Droid `*.settings.json` holds one running total for the whole session and
+/// is rewritten every time the agent spends tokens, so the parser emits a
+/// single record and has to anchor it somewhere.
+///
+/// `providerLockTimestamp` is the wrong anchor: it records when the provider
+/// was *selected*, not when the tokens were spent. Droid rewrites the totals
+/// in place without touching that field, so a session left running across days
+/// (a `/loop`, a long autonomous run) keeps reporting its very first instant
+/// while the totals climb. Every token it has ever spent lands in the bucket
+/// for the day it started, and the session reads as silent in `--today` and
+/// `--yesterday` even while it is actively burning tokens.
+///
+/// The file's mtime is when the totals being read were written, which is the
+/// closest available marker for when they were last accrued, so it wins. The
+/// lock timestamp becomes a floor rather than the answer: usage cannot predate
+/// provider selection, so a stale mtime (a restore or copy that rewound it)
+/// cannot drag the record earlier than the session could possibly have run.
+///
+/// When the filesystem reports no mtime at all, fall back to the lock
+/// timestamp, then to now() — a record with real token usage is never dropped
+/// just because its timestamp could not be resolved.
+fn resolve_usage_timestamp(lock_timestamp: Option<i64>, modified: Option<i64>) -> i64 {
+    match (modified, lock_timestamp) {
+        (Some(modified), Some(lock)) => modified.max(lock),
+        (Some(modified), None) => modified,
+        (None, Some(lock)) => lock,
+        (None, None) => chrono::Utc::now().timestamp_millis(),
+    }
+}
+
 /// Parse a Droid settings.json file
 pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
     let Some(data) = read_file_or_none(path) else {
@@ -198,15 +230,14 @@ pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
         }
     };
 
-    // Get timestamp from providerLockTimestamp, falling back to file mtime
-    // (which itself falls back to now()). Never drop a record with real token
-    // usage just because the timestamp could not be resolved.
-    let timestamp = settings
+    let lock_timestamp = settings
         .provider_lock_timestamp
-        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
+        .as_deref()
+        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
         .map(|dt| dt.timestamp_millis())
-        .filter(|&ts| ts != 0)
-        .unwrap_or_else(|| file_modified_timestamp_ms(path));
+        .filter(|&ts| ts != 0);
+
+    let timestamp = resolve_usage_timestamp(lock_timestamp, file_modified_timestamp_ms_opt(path));
 
     vec![UnifiedMessage::new(
         "droid",
@@ -277,6 +308,84 @@ mod tests {
         assert_eq!(get_default_model_from_provider("google"), "gemini-unknown");
         assert_eq!(get_default_model_from_provider("xai"), "grok-unknown");
         assert_eq!(get_default_model_from_provider("custom"), "custom-unknown");
+    }
+
+    #[test]
+    fn test_resolve_usage_timestamp_prefers_mtime_over_stale_lock() {
+        // The regression: a session locked its provider on day 1 and was still
+        // spending tokens on day 4. Anchoring on the lock timestamp reported
+        // all of it against day 1 and left the session invisible in --today.
+        let lock = 1_700_000_000_000;
+        let modified = lock + 3 * 86_400_000;
+
+        assert_eq!(
+            resolve_usage_timestamp(Some(lock), Some(modified)),
+            modified
+        );
+    }
+
+    #[test]
+    fn test_resolve_usage_timestamp_floors_stale_mtime_at_lock() {
+        // A copy or restore can rewind mtime below the instant the provider was
+        // locked. Usage cannot predate provider selection, so the lock wins.
+        let lock = 1_700_000_000_000;
+        let modified = lock - 86_400_000;
+
+        assert_eq!(resolve_usage_timestamp(Some(lock), Some(modified)), lock);
+    }
+
+    #[test]
+    fn test_resolve_usage_timestamp_falls_back_across_missing_inputs() {
+        let lock = 1_700_000_000_000;
+        let modified = 1_700_000_500_000;
+
+        // Droid omits providerLockTimestamp on plenty of sessions.
+        assert_eq!(resolve_usage_timestamp(None, Some(modified)), modified);
+        // Filesystem reported no mtime: the lock is still better than now().
+        assert_eq!(resolve_usage_timestamp(Some(lock), None), lock);
+    }
+
+    #[test]
+    fn test_resolve_usage_timestamp_without_any_anchor_is_not_pre_epoch() {
+        // Neither anchor available: the record still carries real token usage,
+        // so it must land in a present-day bucket rather than at the epoch.
+        assert!(resolve_usage_timestamp(None, None) > 1_700_000_000_000);
+    }
+
+    #[test]
+    fn test_parse_droid_file_anchors_long_running_session_at_last_write() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir
+            .path()
+            .join("11111111-2222-3333-4444-555555555555.settings.json");
+
+        // providerLockTimestamp far in the past, totals written just now —
+        // the shape of a session that has been looping for days.
+        let lock_ms = chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+            .unwrap()
+            .timestamp_millis();
+        std::fs::write(
+            &path,
+            r#"{
+                "model": "custom:Kimi-K3-(free)-0",
+                "providerLockTimestamp": "2024-01-01T00:00:00Z",
+                "tokenUsage": { "inputTokens": 1000, "outputTokens": 200 }
+            }"#,
+        )
+        .unwrap();
+
+        let messages = parse_droid_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].session_id,
+            "11111111-2222-3333-4444-555555555555"
+        );
+        assert!(
+            messages[0].timestamp > lock_ms,
+            "cumulative usage anchored on the stale lock timestamp ({lock_ms}), \
+             got {}",
+            messages[0].timestamp
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/droid.rs
+++ b/crates/tokscale-core/src/sessions/droid.rs
@@ -2,10 +2,13 @@
 //!
 //! Parses JSON files from ~/.factory/sessions/
 
-use super::utils::{file_modified_timestamp_ms_opt, read_file_or_none};
+use super::utils::{
+    file_modified_timestamp_ms_opt, lossy_lines, parse_timestamp_value, read_file_or_none,
+};
 use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
+use serde_json::Value;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
@@ -142,29 +145,6 @@ pub(crate) fn droid_jsonl_path(path: &Path) -> Option<PathBuf> {
     Some(path.with_file_name(format!("{stem}.jsonl")))
 }
 
-/// Pick the instant a Droid session's cumulative `tokenUsage` is attributed to.
-///
-/// A Droid `*.settings.json` holds one running total for the whole session and
-/// is rewritten every time the agent spends tokens, so the parser emits a
-/// single record and has to anchor it somewhere.
-///
-/// `providerLockTimestamp` is the wrong anchor: it records when the provider
-/// was *selected*, not when the tokens were spent. Droid rewrites the totals
-/// in place without touching that field, so a session left running across days
-/// (a `/loop`, a long autonomous run) keeps reporting its very first instant
-/// while the totals climb. Every token it has ever spent lands in the bucket
-/// for the day it started, and the session reads as silent in `--today` and
-/// `--yesterday` even while it is actively burning tokens.
-///
-/// The file's mtime is when the totals being read were written, which is the
-/// closest available marker for when they were last accrued, so it wins. The
-/// lock timestamp becomes a floor rather than the answer: usage cannot predate
-/// provider selection, so a stale mtime (a restore or copy that rewound it)
-/// cannot drag the record earlier than the session could possibly have run.
-///
-/// When the filesystem reports no mtime at all, fall back to the lock
-/// timestamp, then to now() — a record with real token usage is never dropped
-/// just because its timestamp could not be resolved.
 /// Parse `providerLockTimestamp` into epoch milliseconds, rejecting values that
 /// cannot describe a real provider lock.
 ///
@@ -181,6 +161,25 @@ fn parse_lock_timestamp(raw: Option<&str>) -> Option<i64> {
         .filter(|&ts| ts > 0)
 }
 
+/// Pick the single instant a session's cumulative `tokenUsage` is attributed
+/// to, for the sessions whose transcript cannot spread it across the calls that
+/// spent it.
+///
+/// `providerLockTimestamp` is the wrong anchor: it records when the provider
+/// was *selected*, not when the tokens were spent. Droid rewrites the totals in
+/// place without touching that field, so a session left running across days
+/// keeps reporting its very first instant while the totals climb, and reads as
+/// silent in `--today` even while it is actively burning tokens.
+///
+/// The file's mtime is when the totals being read were written, which is the
+/// closest available marker for when they were last accrued, so it wins. The
+/// lock timestamp becomes a floor rather than the answer: usage cannot predate
+/// provider selection, so a stale mtime (a restore or copy that rewound it)
+/// cannot drag the record earlier than the session could possibly have run.
+///
+/// When the filesystem reports no mtime at all, fall back to the lock
+/// timestamp, then to now() — a record with real token usage is never dropped
+/// just because its timestamp could not be resolved.
 fn resolve_usage_timestamp(lock_timestamp: Option<i64>, modified: Option<i64>) -> i64 {
     match (modified, lock_timestamp) {
         (Some(modified), Some(lock)) => modified.max(lock),
@@ -188,6 +187,103 @@ fn resolve_usage_timestamp(lock_timestamp: Option<i64>, modified: Option<i64>) -
         (None, Some(lock)) => lock,
         (None, None) => chrono::Utc::now().timestamp_millis(),
     }
+}
+
+/// One assistant reply in a Droid transcript: when it was written, and how
+/// expensive it plausibly was relative to the session's other replies.
+struct TranscriptTurn {
+    timestamp: i64,
+    weight: u128,
+}
+
+/// Recover the shape of a session's spend from its transcript.
+///
+/// Droid records no token counts anywhere in the `*.jsonl` — only the
+/// cumulative total in `*.settings.json` — so the transcript cannot say what a
+/// reply cost. It can say *when* each reply happened and how much context was
+/// live at the time, and cost per call tracks context length closely: nearly
+/// every token in these sessions is a cache read of the conversation so far.
+/// Weighting each assistant reply by the bytes accumulated since the last
+/// compaction therefore recovers the relative cost of one reply against
+/// another, which is all the apportioning below needs.
+///
+/// Only assistant replies are counted, since one reply corresponds to one API
+/// call; user and tool records ride along inside the call that reads them.
+/// Compaction resets the running context because it discards the transcript
+/// the following calls would otherwise re-read.
+fn transcript_turns(jsonl: &Path) -> Vec<TranscriptTurn> {
+    let Ok(file) = std::fs::File::open(jsonl) else {
+        return Vec::new();
+    };
+
+    let mut turns = Vec::new();
+    let mut context_bytes: u128 = 0;
+
+    for line in lossy_lines(BufReader::new(file)) {
+        let line_bytes = line.len() as u128;
+        let Ok(record) = serde_json::from_str::<Value>(&line) else {
+            // A malformed line still occupied context in the real conversation.
+            context_bytes = context_bytes.saturating_add(line_bytes);
+            continue;
+        };
+
+        let record_type = record.get("type").and_then(|v| v.as_str());
+        if record_type == Some("compaction_state") {
+            context_bytes = line_bytes;
+            continue;
+        }
+        context_bytes = context_bytes.saturating_add(line_bytes);
+
+        if record_type != Some("message") {
+            continue;
+        }
+        if record
+            .get("message")
+            .and_then(|message| message.get("role"))
+            .and_then(|role| role.as_str())
+            != Some("assistant")
+        {
+            continue;
+        }
+
+        let Some(timestamp) = record.get("timestamp").and_then(parse_timestamp_value) else {
+            continue;
+        };
+
+        turns.push(TranscriptTurn {
+            timestamp,
+            weight: context_bytes.max(1),
+        });
+    }
+
+    turns
+}
+
+/// Split `total` across `weights` so the parts sum back to exactly `total`.
+///
+/// Allocates on the running total rather than rounding each share on its own:
+/// each part is the difference between two cumulative shares, so truncation
+/// error is carried forward instead of accumulating, and the final cumulative
+/// share is `total` by construction. That exactness is what lets a session be
+/// split across days without the daily figures drifting from the cumulative
+/// number Droid actually recorded.
+fn apportion(total: i64, weights: &[u128], total_weight: u128) -> Vec<i64> {
+    if total_weight == 0 {
+        return vec![0; weights.len()];
+    }
+
+    let mut parts = Vec::with_capacity(weights.len());
+    let mut consumed_weight: u128 = 0;
+    let mut allocated: i64 = 0;
+
+    for weight in weights {
+        consumed_weight += weight;
+        let up_to = ((total as i128 * consumed_weight as i128) / total_weight as i128) as i64;
+        parts.push(up_to - allocated);
+        allocated = up_to;
+    }
+
+    parts
 }
 
 /// Parse a Droid settings.json file
@@ -246,24 +342,59 @@ pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
         }
     };
 
-    let lock_timestamp = parse_lock_timestamp(settings.provider_lock_timestamp.as_deref());
+    let totals = TokenBreakdown {
+        input: usage.input_tokens.unwrap_or(0).max(0),
+        output: usage.output_tokens.unwrap_or(0).max(0),
+        cache_read: usage.cache_read_tokens.unwrap_or(0).max(0),
+        cache_write: usage.cache_creation_tokens.unwrap_or(0).max(0),
+        reasoning: usage.thinking_tokens.unwrap_or(0).max(0),
+    };
 
+    let turns = droid_jsonl_path(path)
+        .map(|jsonl| transcript_turns(&jsonl))
+        .unwrap_or_default();
+    let total_weight: u128 = turns.iter().map(|turn| turn.weight).sum();
+
+    if !turns.is_empty() && total_weight > 0 {
+        let weights: Vec<u128> = turns.iter().map(|turn| turn.weight).collect();
+        let input = apportion(totals.input, &weights, total_weight);
+        let output = apportion(totals.output, &weights, total_weight);
+        let cache_read = apportion(totals.cache_read, &weights, total_weight);
+        let cache_write = apportion(totals.cache_write, &weights, total_weight);
+        let reasoning = apportion(totals.reasoning, &weights, total_weight);
+
+        return turns
+            .iter()
+            .enumerate()
+            .map(|(index, turn)| {
+                UnifiedMessage::new(
+                    "droid",
+                    model.clone(),
+                    provider.clone(),
+                    session_id.clone(),
+                    turn.timestamp,
+                    TokenBreakdown {
+                        input: input[index],
+                        output: output[index],
+                        cache_read: cache_read[index],
+                        cache_write: cache_write[index],
+                        reasoning: reasoning[index],
+                    },
+                    0.0,
+                )
+            })
+            .collect();
+    }
+
+    // No usable transcript (missing, unreadable, or no assistant replies yet).
+    // Fall back to one record for the whole session, anchored at the last write
+    // so an active session still lands in the present rather than at the
+    // instant its provider was locked.
+    let lock_timestamp = parse_lock_timestamp(settings.provider_lock_timestamp.as_deref());
     let timestamp = resolve_usage_timestamp(lock_timestamp, file_modified_timestamp_ms_opt(path));
 
     vec![UnifiedMessage::new(
-        "droid",
-        model,
-        provider,
-        session_id,
-        timestamp,
-        TokenBreakdown {
-            input: usage.input_tokens.unwrap_or(0).max(0),
-            output: usage.output_tokens.unwrap_or(0).max(0),
-            cache_read: usage.cache_read_tokens.unwrap_or(0).max(0),
-            cache_write: usage.cache_creation_tokens.unwrap_or(0).max(0),
-            reasoning: usage.thinking_tokens.unwrap_or(0).max(0),
-        },
-        0.0,
+        "droid", model, provider, session_id, timestamp, totals, 0.0,
     )]
 }
 
@@ -319,6 +450,134 @@ mod tests {
         assert_eq!(get_default_model_from_provider("google"), "gemini-unknown");
         assert_eq!(get_default_model_from_provider("xai"), "grok-unknown");
         assert_eq!(get_default_model_from_provider("custom"), "custom-unknown");
+    }
+
+    fn write_session(dir: &Path, id: &str, usage: &str, transcript: &[&str]) -> PathBuf {
+        let settings = dir.join(format!("{id}.settings.json"));
+        std::fs::write(
+            &settings,
+            format!(r#"{{"model":"custom:Kimi-K3-0","tokenUsage":{usage}}}"#),
+        )
+        .unwrap();
+        std::fs::write(dir.join(format!("{id}.jsonl")), transcript.join("\n")).unwrap();
+        settings
+    }
+
+    fn assistant(timestamp: &str, filler: usize) -> String {
+        format!(
+            r#"{{"type":"message","timestamp":"{timestamp}","message":{{"role":"assistant","content":"{}"}}}}"#,
+            "x".repeat(filler)
+        )
+    }
+
+    #[test]
+    fn test_apportion_parts_sum_to_the_original_total() {
+        // Truncation must never lose or invent tokens: the daily figures have to
+        // add back up to the cumulative number Droid recorded.
+        let weights = vec![3u128, 1, 1, 1, 1];
+        let parts = apportion(1_000_003, &weights, weights.iter().sum());
+
+        assert_eq!(parts.len(), 5);
+        assert_eq!(parts.iter().sum::<i64>(), 1_000_003);
+        assert!(parts.iter().all(|&p| p >= 0));
+        // The heaviest turn gets the largest share.
+        assert!(parts[0] > parts[1]);
+    }
+
+    #[test]
+    fn test_apportion_without_weight_yields_no_tokens() {
+        assert_eq!(apportion(500, &[0, 0], 0), vec![0, 0]);
+    }
+
+    #[test]
+    fn test_usage_spreads_across_the_days_the_session_ran() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        // Two assistant replies a day apart, the second on a larger context.
+        let settings = write_session(
+            temp_dir.path(),
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            r#"{"inputTokens":900,"outputTokens":100}"#,
+            &[
+                r#"{"type":"session_start","id":"s"}"#,
+                &assistant("2026-08-07T12:00:00Z", 10),
+                &assistant("2026-08-09T12:00:00Z", 400),
+            ],
+        );
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(messages.len(), 2, "one record per assistant reply");
+        // Nothing is lost or invented by the split.
+        assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 900);
+        assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 100);
+        // Each record lands on the reply that earned it, not on one anchor.
+        assert!(messages[0].timestamp < messages[1].timestamp);
+        assert_ne!(messages[0].date, messages[1].date);
+        // The later reply read a longer conversation, so it carries more.
+        assert!(messages[1].tokens.input > messages[0].tokens.input);
+    }
+
+    #[test]
+    fn test_compaction_resets_the_context_weighting() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        // A big conversation, compacted, then one short reply afterwards. The
+        // post-compaction reply must not inherit the discarded context's weight.
+        let settings = write_session(
+            temp_dir.path(),
+            "11111111-1111-1111-1111-111111111111",
+            r#"{"inputTokens":1000}"#,
+            &[
+                &assistant("2026-08-07T12:00:00Z", 2000),
+                r#"{"type":"compaction_state","timestamp":"2026-08-08T12:00:00Z"}"#,
+                &assistant("2026-08-09T12:00:00Z", 10),
+            ],
+        );
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 1000);
+        assert!(
+            messages[0].tokens.input > messages[1].tokens.input,
+            "the compacted-away context should not keep charging later replies"
+        );
+    }
+
+    #[test]
+    fn test_session_without_assistant_replies_falls_back_to_one_record() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        // Usage recorded but the transcript has no assistant reply to hang it
+        // on — the record must still be emitted rather than silently dropped.
+        let settings = write_session(
+            temp_dir.path(),
+            "22222222-2222-2222-2222-222222222222",
+            r#"{"inputTokens":700,"outputTokens":7}"#,
+            &[r#"{"type":"session_start","id":"s"}"#],
+        );
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 700);
+        assert_eq!(messages[0].tokens.output, 7);
+    }
+
+    #[test]
+    fn test_missing_transcript_falls_back_to_one_record() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let settings = temp_dir
+            .path()
+            .join("33333333-3333-3333-3333-333333333333.settings.json");
+        std::fs::write(
+            &settings,
+            r#"{"model":"custom:Kimi-K3-0","tokenUsage":{"inputTokens":42}}"#,
+        )
+        .unwrap();
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 42);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/droid.rs
+++ b/crates/tokscale-core/src/sessions/droid.rs
@@ -198,8 +198,9 @@ fn resolve_usage_timestamp(lock_timestamp: Option<i64>, modified: Option<i64>) -
 /// bytes, which is what the call produced.
 ///
 /// `replies` is how many assistant replies the turn stands for. It is 1 until
-/// `coalesce_turns` folds a run together, and the emitted record carries it as
-/// its message count so the session still reports the number of calls it made.
+/// `coalesce_turns` folds a run together. The session's replies are summed and
+/// carried on a single emitted record, so the session reports the number of
+/// calls it made without its apportioned records counting as separate sessions.
 struct TranscriptTurn {
     timestamp: i64,
     context_weight: u128,
@@ -489,12 +490,20 @@ pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
     let total_context: u128 = context_weights.iter().sum();
     let total_output: u128 = output_weights.iter().sum();
 
-    if !turns.is_empty() && total_context > 0 && total_output > 0 {
+    // Every weight is `.max(1)`, so a non-empty turn list always has positive
+    // weight in both columns and the apportioning below is well defined.
+    if !turns.is_empty() {
         let input = apportion(totals.input, &context_weights, total_context);
         let cache_read = apportion(totals.cache_read, &context_weights, total_context);
         let cache_write = apportion(totals.cache_write, &context_weights, total_context);
         let output = apportion(totals.output, &output_weights, total_output);
         let reasoning = apportion(totals.reasoning, &output_weights, total_output);
+
+        // One Droid session made this many API calls, however many records its
+        // spend is spread over.
+        let session_replies = turns
+            .iter()
+            .fold(0i32, |sum, turn| sum.saturating_add(turn.replies.max(1)));
 
         return turns
             .iter()
@@ -515,10 +524,17 @@ pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
                     },
                     0.0,
                 );
-                // One record per API call, except where coalescing folded a run
-                // of them into one. Counting a run as a single message would
-                // understate a long session's calls by the coalescing factor.
-                message.message_count = turn.replies.max(1);
+                // These records are attribution fragments of one session, not
+                // separate sessions. `sessionize` opens a new interval whenever
+                // two records sit more than the idle gap apart and counts every
+                // interval that reports messages, so a count on each fragment
+                // would turn one Droid session into one session per apportioned
+                // record. Carry the session's authoritative reply total on
+                // exactly one record and make the rest count-neutral, the same
+                // split `copilot_desktop` applies to its shutdown fragments:
+                // the total number of calls stays exact, the session count
+                // stays one.
+                message.message_count = if index == 0 { session_replies } else { 0 };
                 message
             })
             .collect();
@@ -923,7 +939,7 @@ mod tests {
     }
 
     #[test]
-    fn test_uncoalesced_replies_each_count_as_one_message() {
+    fn test_reply_count_rides_on_exactly_one_record() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let settings = write_session(
             temp_dir.path(),
@@ -938,7 +954,55 @@ mod tests {
         let messages = parse_droid_file(&settings);
 
         assert_eq!(messages.len(), 2);
-        assert!(messages.iter().all(|m| m.message_count == 1));
+        // Both calls are counted, but only one record is countable: the second
+        // is an attribution fragment of the same session, not a new session.
+        assert_eq!(messages.iter().map(|m| m.message_count).sum::<i32>(), 2);
+        assert_eq!(messages.iter().filter(|m| m.message_count > 0).count(), 1);
+    }
+
+    #[test]
+    fn test_apportioned_session_still_sessionizes_as_one_session() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        // 40 replies ten minutes apart: every gap exceeds the idle threshold,
+        // so each apportioned record would open its own session interval. The
+        // session count must stay 1 while all 40 calls are still reported.
+        let replies = 40;
+        let transcript: Vec<String> = (0..replies)
+            .map(|i| {
+                assistant(
+                    &format!(
+                        "2026-08-07T{:02}:{:02}:00Z",
+                        6 + (i * 10) / 60,
+                        (i * 10) % 60
+                    ),
+                    10,
+                )
+            })
+            .collect();
+        let settings = write_session(
+            temp_dir.path(),
+            "aaaaaaaa-3333-3333-3333-333333333333",
+            r#"{"inputTokens":4000,"outputTokens":400}"#,
+            &transcript.iter().map(String::as_str).collect::<Vec<_>>(),
+        );
+
+        let messages = parse_droid_file(&settings);
+        assert_eq!(messages.len(), replies as usize);
+        assert_eq!(
+            messages.iter().map(|m| m.message_count).sum::<i32>(),
+            replies
+        );
+
+        let intervals =
+            crate::sessionize::sessionize(&messages, crate::sessionize::DEFAULT_IDLE_GAP_MS);
+        let metrics = crate::sessionize::compute_time_metrics(
+            &intervals,
+            crate::sessionize::DEFAULT_IDLE_GAP_MS,
+        );
+        assert_eq!(metrics.session_count, 1);
+        // The totals the session actually recorded are untouched by the split.
+        assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 4000);
+        assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 400);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/droid.rs
+++ b/crates/tokscale-core/src/sessions/droid.rs
@@ -191,10 +191,36 @@ fn resolve_usage_timestamp(lock_timestamp: Option<i64>, modified: Option<i64>) -
 
 /// One assistant reply in a Droid transcript: when it was written, and how
 /// expensive it plausibly was relative to the session's other replies.
+///
+/// Two weights, because a reply's read cost and its write cost do not move
+/// together. `context_weight` is the conversation standing before the reply,
+/// which is what the call had to read; `output_weight` is the reply's own
+/// bytes, which is what the call produced.
 struct TranscriptTurn {
     timestamp: i64,
-    weight: u128,
+    context_weight: u128,
+    output_weight: u128,
 }
+
+/// Ceiling on the transcript bytes read to shape one session's spend.
+///
+/// Apportioning is a refinement, not a correctness requirement: the fallback
+/// emits one record carrying the identical total, so declining to read an
+/// oversized transcript costs attribution detail and nothing else. Cost grows
+/// linearly with transcript size and is paid again on every scan while the
+/// session is live, because the growing transcript keeps invalidating the
+/// cached parse (measured on a 104.7 MB transcript: 148 ms per parse in
+/// release, 1.28 s in debug, ~1.4 ms/MB). This ceiling bounds that per-session
+/// work at roughly 45 ms in release.
+const MAX_TRANSCRIPT_BYTES: u64 = 32 * 1024 * 1024;
+
+/// Ceiling on the records one session contributes.
+///
+/// One record per assistant reply is unbounded in the session's length, and
+/// every record is retained in the message cache. Past this many replies the
+/// turns are coalesced into runs rather than truncated, so the apportioned
+/// total is unchanged and only the resolution of the attribution drops.
+const MAX_TURNS_PER_SESSION: usize = 1024;
 
 /// Recover the shape of a session's spend from its transcript.
 ///
@@ -209,14 +235,20 @@ struct TranscriptTurn {
 ///
 /// Only assistant replies are counted, since one reply corresponds to one API
 /// call; user and tool records ride along inside the call that reads them. Each
-/// reply is weighted by the context standing *before* it, since its own bytes
-/// are output rather than something it paid to read. Compaction resets the
-/// running context because it discards the transcript the following calls would
-/// otherwise re-read.
-fn transcript_turns(jsonl: &Path) -> Vec<TranscriptTurn> {
+/// reply carries two weights: the context standing *before* it, which is what
+/// the call read, and its own bytes, which is what the call wrote. Compaction
+/// resets the running context because it discards the transcript the following
+/// calls would otherwise re-read.
+///
+/// Returns no turns for a transcript past `max_bytes`, which sends the session
+/// down the single-record fallback rather than paying an unbounded read.
+fn transcript_turns_bounded(jsonl: &Path, max_bytes: u64, max_turns: usize) -> Vec<TranscriptTurn> {
     let Ok(file) = std::fs::File::open(jsonl) else {
         return Vec::new();
     };
+    if file.metadata().map(|meta| meta.len()).unwrap_or(0) > max_bytes {
+        return Vec::new();
+    }
 
     let mut turns = Vec::new();
     let mut context_bytes: u128 = 0;
@@ -254,7 +286,17 @@ fn transcript_turns(jsonl: &Path) -> Vec<TranscriptTurn> {
             continue;
         }
 
-        let Some(timestamp) = record.get("timestamp").and_then(parse_timestamp_value) else {
+        // A non-positive timestamp is the parsers' "no usable time" sentinel,
+        // not an instant before 1970 — `rebucket_date` refuses to re-key one.
+        // The RFC3339 path has no such floor of its own, so a pre-epoch
+        // transcript timestamp would otherwise anchor a share of the session in
+        // 1969, where no date filter reaches it. Skipping the turn keeps its
+        // tokens in the session: apportioning runs over the turns that remain.
+        let Some(timestamp) = record
+            .get("timestamp")
+            .and_then(parse_timestamp_value)
+            .filter(|&ts| ts > 0)
+        else {
             continue;
         };
 
@@ -262,11 +304,49 @@ fn transcript_turns(jsonl: &Path) -> Vec<TranscriptTurn> {
             timestamp,
             // The first reply in a session reads a context of zero bytes but
             // still cost something, so every turn carries at least one unit.
-            weight: context_read.max(1),
+            context_weight: context_read.max(1),
+            output_weight: line_bytes.max(1),
         });
     }
 
+    coalesce_turns(turns, max_turns)
+}
+
+fn transcript_turns(jsonl: &Path) -> Vec<TranscriptTurn> {
+    transcript_turns_bounded(jsonl, MAX_TRANSCRIPT_BYTES, MAX_TURNS_PER_SESSION)
+}
+
+/// Fold consecutive turns into at most `max_turns` runs, summing their weights.
+///
+/// Coalescing rather than truncating keeps the apportioned total intact: every
+/// turn's weight still competes for the session's tokens, so no usage is
+/// dropped and the parts still sum to what Droid recorded. A run reports at its
+/// latest reply, which is where most of its weight sits — context grows
+/// monotonically within a run, so the last reply of the run is the heaviest.
+/// The parser cannot bucket by day itself: the day key is re-derived later
+/// under the user's pinned timezone, which is not known here.
+fn coalesce_turns(turns: Vec<TranscriptTurn>, max_turns: usize) -> Vec<TranscriptTurn> {
+    if max_turns == 0 || turns.len() <= max_turns {
+        return turns;
+    }
+
+    let run = turns.len().div_ceil(max_turns);
     turns
+        .chunks(run)
+        .map(|chunk| TranscriptTurn {
+            timestamp: chunk
+                .iter()
+                .map(|turn| turn.timestamp)
+                .max()
+                .unwrap_or_default(),
+            context_weight: chunk
+                .iter()
+                .fold(0u128, |sum, turn| sum.saturating_add(turn.context_weight)),
+            output_weight: chunk
+                .iter()
+                .fold(0u128, |sum, turn| sum.saturating_add(turn.output_weight)),
+        })
+        .collect()
 }
 
 /// Split `total` across `weights` so the parts sum back to exactly `total`.
@@ -363,15 +443,23 @@ pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
     let turns = droid_jsonl_path(path)
         .map(|jsonl| transcript_turns(&jsonl))
         .unwrap_or_default();
-    let total_weight: u128 = turns.iter().map(|turn| turn.weight).sum();
+    // Read cost and write cost are apportioned on different weights. Input,
+    // cache reads and cache writes are all charged for the conversation the
+    // call had to send, so they follow the context standing before the reply.
+    // Output and reasoning are what the call produced, so they follow the
+    // reply's own size — a verbose answer on a short context earns its output
+    // share without also claiming the input share of the replies around it.
+    let context_weights: Vec<u128> = turns.iter().map(|turn| turn.context_weight).collect();
+    let output_weights: Vec<u128> = turns.iter().map(|turn| turn.output_weight).collect();
+    let total_context: u128 = context_weights.iter().sum();
+    let total_output: u128 = output_weights.iter().sum();
 
-    if !turns.is_empty() && total_weight > 0 {
-        let weights: Vec<u128> = turns.iter().map(|turn| turn.weight).collect();
-        let input = apportion(totals.input, &weights, total_weight);
-        let output = apportion(totals.output, &weights, total_weight);
-        let cache_read = apportion(totals.cache_read, &weights, total_weight);
-        let cache_write = apportion(totals.cache_write, &weights, total_weight);
-        let reasoning = apportion(totals.reasoning, &weights, total_weight);
+    if !turns.is_empty() && total_context > 0 && total_output > 0 {
+        let input = apportion(totals.input, &context_weights, total_context);
+        let cache_read = apportion(totals.cache_read, &context_weights, total_context);
+        let cache_write = apportion(totals.cache_write, &context_weights, total_context);
+        let output = apportion(totals.output, &output_weights, total_output);
+        let reasoning = apportion(totals.reasoning, &output_weights, total_output);
 
         return turns
             .iter()
@@ -564,6 +652,195 @@ mod tests {
             "a long reply inflated its own share: {:?}",
             messages.iter().map(|m| m.tokens.input).collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn test_output_follows_the_replys_own_size_not_the_context_it_read() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        // Two replies reading the same conversation, one of them far longer.
+        // They read the same bytes, so the input split is even; the long one
+        // produced far more, so it must carry far more of the output total.
+        let settings = write_session(
+            temp_dir.path(),
+            "55555555-5555-5555-5555-555555555555",
+            r#"{"inputTokens":1000,"outputTokens":1000,"thinkingTokens":1000}"#,
+            &[
+                &user("2026-08-07T11:00:00Z", 4000),
+                &assistant("2026-08-07T12:00:00Z", 10),
+                &assistant("2026-08-07T13:00:00Z", 10),
+            ],
+        );
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 1000);
+        // The second reply reads the first one's bytes too, but 10 bytes on top
+        // of a 4KB context barely moves the input split.
+        let input_ratio = messages[1].tokens.input as f64 / messages[0].tokens.input as f64;
+        assert!(
+            input_ratio < 1.1,
+            "identical context should split input evenly, got {:?}",
+            messages.iter().map(|m| m.tokens.input).collect::<Vec<_>>()
+        );
+        // Same-length replies split output evenly here; the discriminating case
+        // is below, where one reply is much longer than the other.
+        assert_eq!(messages[0].tokens.output, messages[1].tokens.output);
+
+        let settings = write_session(
+            temp_dir.path(),
+            "66666666-6666-6666-6666-666666666666",
+            r#"{"inputTokens":1000,"outputTokens":1000,"thinkingTokens":1000}"#,
+            &[
+                &user("2026-08-07T11:00:00Z", 4000),
+                &assistant("2026-08-07T12:00:00Z", 50_000),
+                &assistant("2026-08-07T13:00:00Z", 10),
+            ],
+        );
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 1000);
+        assert_eq!(
+            messages.iter().map(|m| m.tokens.reasoning).sum::<i64>(),
+            1000
+        );
+        assert!(
+            messages[0].tokens.output > messages[1].tokens.output * 10,
+            "the long reply should carry the output it produced: {:?}",
+            messages.iter().map(|m| m.tokens.output).collect::<Vec<_>>()
+        );
+        assert!(
+            messages[0].tokens.reasoning > messages[1].tokens.reasoning * 10,
+            "reasoning is produced alongside output: {:?}",
+            messages
+                .iter()
+                .map(|m| m.tokens.reasoning)
+                .collect::<Vec<_>>()
+        );
+        // ...while the input split still follows what each call read, so the
+        // long reply does not also take the other's input share.
+        assert!(
+            messages[1].tokens.input > messages[0].tokens.input,
+            "input must still follow the context each call read: {:?}",
+            messages.iter().map(|m| m.tokens.input).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_pre_epoch_transcript_timestamp_is_not_an_attribution_anchor() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        // A clock artifact in the transcript. Anchoring a share of the session
+        // on it buckets those tokens in 1969, past every date filter.
+        let settings = write_session(
+            temp_dir.path(),
+            "77777777-7777-7777-7777-777777777777",
+            r#"{"inputTokens":900,"outputTokens":100}"#,
+            &[
+                &assistant("1969-07-20T20:17:00Z", 10),
+                &assistant("2026-08-09T12:00:00Z", 10),
+            ],
+        );
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(
+            messages.len(),
+            1,
+            "the pre-epoch reply is not a usable turn"
+        );
+        assert!(messages.iter().all(|m| m.timestamp > 0));
+        // Nothing is dropped: the surviving turn carries the whole session.
+        assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 900);
+        assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 100);
+    }
+
+    #[test]
+    fn test_transcript_of_only_pre_epoch_replies_falls_back_to_one_record() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let settings = write_session(
+            temp_dir.path(),
+            "88888888-8888-8888-8888-888888888888",
+            r#"{"inputTokens":900}"#,
+            &[&assistant("1969-07-20T20:17:00Z", 10)],
+        );
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 900);
+        assert!(
+            messages[0].timestamp > 0,
+            "the fallback anchor must stay in a reachable bucket"
+        );
+    }
+
+    #[test]
+    fn test_oversized_transcript_takes_the_single_record_path() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let settings = write_session(
+            temp_dir.path(),
+            "99999999-9999-9999-9999-999999999999",
+            r#"{"inputTokens":900}"#,
+            &[
+                &assistant("2026-08-07T12:00:00Z", 200),
+                &assistant("2026-08-09T12:00:00Z", 200),
+            ],
+        );
+        let jsonl = droid_jsonl_path(&settings).unwrap();
+        let size = std::fs::metadata(&jsonl).unwrap().len();
+
+        // Under the ceiling the transcript still shapes the session.
+        assert_eq!(
+            transcript_turns_bounded(&jsonl, size, MAX_TURNS_PER_SESSION).len(),
+            2
+        );
+        // Past it, no turns — which is what routes the session to the
+        // mtime-anchored single record instead of an unbounded read.
+        assert!(transcript_turns_bounded(&jsonl, size - 1, MAX_TURNS_PER_SESSION).is_empty());
+    }
+
+    #[test]
+    fn test_turn_count_is_capped_without_losing_usage() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let transcript: Vec<String> = (0..50)
+            .map(|i| {
+                assistant(
+                    &format!("2026-08-{:02}T{:02}:00:00Z", 1 + i / 24, i % 24),
+                    10,
+                )
+            })
+            .collect();
+        let settings = write_session(
+            temp_dir.path(),
+            "aaaaaaaa-0000-0000-0000-000000000000",
+            r#"{"inputTokens":1000}"#,
+            &transcript.iter().map(String::as_str).collect::<Vec<_>>(),
+        );
+        let jsonl = droid_jsonl_path(&settings).unwrap();
+
+        let uncapped = transcript_turns_bounded(&jsonl, MAX_TRANSCRIPT_BYTES, usize::MAX);
+        assert_eq!(uncapped.len(), 50);
+
+        let capped = transcript_turns_bounded(&jsonl, MAX_TRANSCRIPT_BYTES, 7);
+        assert!(capped.len() <= 7, "cap not honoured: {}", capped.len());
+        // Coalescing folds weight rather than discarding it, so the session
+        // still apportions the same total across the runs that remain.
+        assert_eq!(
+            capped.iter().map(|turn| turn.context_weight).sum::<u128>(),
+            uncapped
+                .iter()
+                .map(|turn| turn.context_weight)
+                .sum::<u128>()
+        );
+        assert_eq!(
+            capped.iter().map(|turn| turn.output_weight).sum::<u128>(),
+            uncapped.iter().map(|turn| turn.output_weight).sum::<u128>()
+        );
+        // Every run reports at a real reply instant inside the session.
+        assert!(capped.iter().all(|turn| turn.timestamp > 0));
+        assert!(capped.windows(2).all(|w| w[0].timestamp <= w[1].timestamp));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/droid.rs
+++ b/crates/tokscale-core/src/sessions/droid.rs
@@ -9,7 +9,7 @@ use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
 use serde_json::Value;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Seek};
 use std::path::{Path, PathBuf};
 
 /// Droid settings.json structure
@@ -196,10 +196,15 @@ fn resolve_usage_timestamp(lock_timestamp: Option<i64>, modified: Option<i64>) -
 /// together. `context_weight` is the conversation standing before the reply,
 /// which is what the call had to read; `output_weight` is the reply's own
 /// bytes, which is what the call produced.
+///
+/// `replies` is how many assistant replies the turn stands for. It is 1 until
+/// `coalesce_turns` folds a run together, and the emitted record carries it as
+/// its message count so the session still reports the number of calls it made.
 struct TranscriptTurn {
     timestamp: i64,
     context_weight: u128,
     output_weight: u128,
+    replies: i32,
 }
 
 /// Ceiling on the transcript bytes read to shape one session's spend.
@@ -240,20 +245,29 @@ const MAX_TURNS_PER_SESSION: usize = 1024;
 /// resets the running context because it discards the transcript the following
 /// calls would otherwise re-read.
 ///
-/// Returns no turns for a transcript past `max_bytes`, which sends the session
-/// down the single-record fallback rather than paying an unbounded read.
+/// Returns no turns for a transcript past `max_bytes`, or for one that could
+/// not be read whole, which sends the session down the single-record fallback
+/// rather than paying an unbounded read or splitting on partial evidence.
 fn transcript_turns_bounded(jsonl: &Path, max_bytes: u64, max_turns: usize) -> Vec<TranscriptTurn> {
     let Ok(file) = std::fs::File::open(jsonl) else {
         return Vec::new();
     };
-    if file.metadata().map(|meta| meta.len()).unwrap_or(0) > max_bytes {
+    // Fail closed. A metadata call that does not answer says nothing about the
+    // size of what follows, and treating that silence as zero would license
+    // exactly the unbounded read this ceiling exists to prevent. The session
+    // still reports its identical total through the single-record fallback.
+    let Ok(declared_bytes) = file.metadata().map(|meta| meta.len()) else {
+        return Vec::new();
+    };
+    if declared_bytes > max_bytes {
         return Vec::new();
     }
 
     let mut turns = Vec::new();
     let mut context_bytes: u128 = 0;
+    let mut reader = BufReader::new(file);
 
-    for line in lossy_lines(BufReader::new(file)) {
+    for line in lossy_lines(&mut reader) {
         let line_bytes = line.len() as u128;
         let Ok(record) = serde_json::from_str::<Value>(&line) else {
             // A malformed line still occupied context in the real conversation.
@@ -306,7 +320,21 @@ fn transcript_turns_bounded(jsonl: &Path, max_bytes: u64, max_turns: usize) -> V
             // still cost something, so every turn carries at least one unit.
             context_weight: context_read.max(1),
             output_weight: line_bytes.max(1),
+            replies: 1,
         });
+    }
+
+    // `lossy_lines` ends silently on a hard I/O failure (vanished network
+    // mount, EIO), so a prefix of the transcript is indistinguishable from the
+    // whole of it by the turn list alone. Apportioning the session's total over
+    // that prefix would move every token the unread tail earned onto the days
+    // the prefix covers, and the parse is cached under a fingerprint that a
+    // finished session never invalidates again, so the misattribution would
+    // stick. A short read is therefore no evidence at all: fall back.
+    // Reading past `declared_bytes` is normal — a live session appends while
+    // this runs — and only a read that stopped early disqualifies the split.
+    if reader.stream_position().unwrap_or(0) < declared_bytes {
+        return Vec::new();
     }
 
     coalesce_turns(turns, max_turns)
@@ -325,6 +353,10 @@ fn transcript_turns(jsonl: &Path) -> Vec<TranscriptTurn> {
 /// monotonically within a run, so the last reply of the run is the heaviest.
 /// The parser cannot bucket by day itself: the day key is re-derived later
 /// under the user's pinned timezone, which is not known here.
+///
+/// A run also carries the number of replies it folded, so the session's message
+/// count survives coalescing: the resolution of *when* the calls happened
+/// drops, but not *how many* there were.
 fn coalesce_turns(turns: Vec<TranscriptTurn>, max_turns: usize) -> Vec<TranscriptTurn> {
     if max_turns == 0 || turns.len() <= max_turns {
         return turns;
@@ -345,6 +377,9 @@ fn coalesce_turns(turns: Vec<TranscriptTurn>, max_turns: usize) -> Vec<Transcrip
             output_weight: chunk
                 .iter()
                 .fold(0u128, |sum, turn| sum.saturating_add(turn.output_weight)),
+            replies: chunk
+                .iter()
+                .fold(0i32, |sum, turn| sum.saturating_add(turn.replies)),
         })
         .collect()
 }
@@ -465,7 +500,7 @@ pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
             .iter()
             .enumerate()
             .map(|(index, turn)| {
-                UnifiedMessage::new(
+                let mut message = UnifiedMessage::new(
                     "droid",
                     model.clone(),
                     provider.clone(),
@@ -479,7 +514,12 @@ pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
                         reasoning: reasoning[index],
                     },
                     0.0,
-                )
+                );
+                // One record per API call, except where coalescing folded a run
+                // of them into one. Counting a run as a single message would
+                // understate a long session's calls by the coalescing factor.
+                message.message_count = turn.replies.max(1);
+                message
             })
             .collect();
     }
@@ -841,6 +881,64 @@ mod tests {
         // Every run reports at a real reply instant inside the session.
         assert!(capped.iter().all(|turn| turn.timestamp > 0));
         assert!(capped.windows(2).all(|w| w[0].timestamp <= w[1].timestamp));
+        // A run also remembers how many calls it stands for, so the cap costs
+        // attribution resolution and not the session's message count.
+        assert_eq!(capped.iter().map(|turn| turn.replies).sum::<i32>(), 50);
+        assert_eq!(uncapped.iter().map(|turn| turn.replies).sum::<i32>(), 50);
+    }
+
+    #[test]
+    fn test_coalesced_session_still_reports_every_reply_it_made() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        // More replies than the cap, so the emitted records are runs rather
+        // than calls. Counting a run as one message would report this session
+        // as having made 1024 calls instead of the 1200 it made.
+        let replies = MAX_TURNS_PER_SESSION + 176;
+        let transcript: Vec<String> = (0..replies)
+            .map(|i| assistant(&format!("2026-08-07T12:00:{:02}Z", i % 60), 10))
+            .collect();
+        let settings = write_session(
+            temp_dir.path(),
+            "aaaaaaaa-1111-1111-1111-111111111111",
+            r#"{"inputTokens":1000}"#,
+            &transcript.iter().map(String::as_str).collect::<Vec<_>>(),
+        );
+
+        let messages = parse_droid_file(&settings);
+
+        assert!(
+            messages.len() <= MAX_TURNS_PER_SESSION,
+            "record count not capped: {}",
+            messages.len()
+        );
+        assert_eq!(
+            messages
+                .iter()
+                .map(|m| m.message_count as usize)
+                .sum::<usize>(),
+            replies
+        );
+        // The cap changes resolution, never the total it splits.
+        assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 1000);
+    }
+
+    #[test]
+    fn test_uncoalesced_replies_each_count_as_one_message() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let settings = write_session(
+            temp_dir.path(),
+            "aaaaaaaa-2222-2222-2222-222222222222",
+            r#"{"inputTokens":1000}"#,
+            &[
+                &assistant("2026-08-07T12:00:00Z", 10),
+                &assistant("2026-08-08T12:00:00Z", 10),
+            ],
+        );
+
+        let messages = parse_droid_file(&settings);
+
+        assert_eq!(messages.len(), 2);
+        assert!(messages.iter().all(|m| m.message_count == 1));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -135,13 +135,27 @@ pub(crate) fn parse_timestamp_str(value: &str) -> Option<i64> {
     None
 }
 
-pub(crate) fn file_modified_timestamp_ms(path: &Path) -> i64 {
+/// Modification time in epoch milliseconds, or `None` when the filesystem does
+/// not report one.
+///
+/// `SystemTime::modified` is the one timestamp every tier-1 target supports
+/// (unlike `created`, which is absent on many Linux filesystems), so callers
+/// that need a portable "when was this last written" anchor use this.
+///
+/// Returns `None` rather than substituting a value so a caller with its own
+/// fallback can reach for it instead of silently anchoring on the wrong
+/// instant. Pre-epoch mtimes also collapse to `None`: `duration_since` fails
+/// for them, and a negative anchor would bucket the record before 1970.
+pub(crate) fn file_modified_timestamp_ms_opt(path: &Path) -> Option<i64> {
     std::fs::metadata(path)
         .and_then(|meta| meta.modified())
         .ok()
         .and_then(|time| time.duration_since(SystemTime::UNIX_EPOCH).ok())
         .map(|duration| duration.as_millis() as i64)
-        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis())
+}
+
+pub(crate) fn file_modified_timestamp_ms(path: &Path) -> i64 {
+    file_modified_timestamp_ms_opt(path).unwrap_or_else(|| chrono::Utc::now().timestamp_millis())
 }
 
 /// Open a SQLite file for read-only access with no mutex (single-threaded parser use).

--- a/packages/frontend/__tests__/lib/parserHighWater.test.ts
+++ b/packages/frontend/__tests__/lib/parserHighWater.test.ts
@@ -3,9 +3,14 @@ import {
   addClientBreakdownIncrement,
   foldParserClientSnapshot,
   planParserHighWaterSubmission,
+  SUPPORTED_VERSIONED_PARSERS,
   type ParserClientHighWaterState,
 } from "../../src/lib/db/parserHighWater";
-import { recalculateDayTotals, type ClientBreakdownData } from "../../src/lib/db/helpers";
+import {
+  mergeClientBreakdownsWithRegressionGuard,
+  recalculateDayTotals,
+  type ClientBreakdownData,
+} from "../../src/lib/db/helpers";
 
 function contribution(
   date: string,
@@ -964,5 +969,140 @@ describe("non-destructive parser generation high-water", () => {
 
     expect(plan.mode).toBe("baseline-new");
     expect(plan.nextState?.aggregate.tokens).toBe(100);
+  });
+});
+
+describe("droid parser high-water", () => {
+  function droidContribution(date: string, tokens: number, modelId = "kimi-k3-0") {
+    return {
+      date,
+      clients: [
+        {
+          client: "droid",
+          modelId,
+          tokens: {
+            input: tokens,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            reasoning: 0,
+          },
+          cost: 0,
+          messages: 1,
+        },
+      ],
+    };
+  }
+
+  function droidSnapshot(...rows: ReturnType<typeof droidContribution>[]) {
+    return foldParserClientSnapshot(rows, "droid");
+  }
+
+  function droidPlan(
+    existingLegacyDays: Record<string, ClientBreakdownData>,
+    incomingDays: Record<string, ClientBreakdownData>,
+    state?: ParserClientHighWaterState
+  ) {
+    return planParserHighWaterSubmission({
+      client: "droid",
+      incomingVersion: SUPPORTED_VERSIONED_PARSERS.droid,
+      fullHistory: true,
+      existingLegacyDays,
+      incomingDays,
+      state,
+    });
+  }
+
+  // One 321,000-token session that ran across three days. The old parser put
+  // the whole session on one day; the transcript-weighted parser splits it
+  // across the days it actually ran. The lifetime total is identical.
+  const wholeSessionOnOneDay = droidSnapshot(droidContribution("2026-08-07", 321_000));
+  const sessionSplitAcrossDays = droidSnapshot(
+    droidContribution("2026-08-07", 21_000),
+    droidContribution("2026-08-08", 152_000),
+    droidContribution("2026-08-09", 148_000)
+  );
+
+  it("is registered at the generation every CLI already declares", () => {
+    // The two Droid shapes disagree about which day a token lands on, never
+    // about the lifetime total, so no generation has to be frozen out. A
+    // registered version above 1 would instead freeze every installed CLI.
+    expect(SUPPORTED_VERSIONED_PARSERS.droid).toBe(1);
+  });
+
+  it("shows why the day-by-day merge alone inflates a re-attributed session", () => {
+    // Without the high-water this is what the submit route stores: the merge
+    // guard refuses the decrease on 2026-08-07 and accepts the two days that
+    // rose, so the device's stored total gains everything that moved.
+    let stored = 0;
+    for (const date of Object.keys(sessionSplitAcrossDays)) {
+      const merged = mergeClientBreakdownsWithRegressionGuard(
+        wholeSessionOnOneDay[date] ? { droid: wholeSessionOnOneDay[date] } : {},
+        { droid: sessionSplitAcrossDays[date] },
+        new Set(["droid"]),
+        undefined,
+        true
+      );
+      stored += merged.merged.droid?.tokens ?? 0;
+    }
+
+    expect(stored).toBe(621_000);
+  });
+
+  it("credits nothing for a pure re-attribution of the same lifetime total", () => {
+    const plan = droidPlan(wholeSessionOnOneDay, sessionSplitAcrossDays);
+
+    expect(plan.mode).toBe("baseline-legacy");
+    const credited = Object.values(plan.increments).reduce(
+      (sum, day) => sum + day.tokens,
+      0
+    );
+    expect(credited).toBe(0);
+
+    // The stored rows are preserved untouched, so the device's total is the
+    // 321,000 it always was rather than the 621,000 the merge alone stores.
+    const stored = Object.keys(sessionSplitAcrossDays).reduce((sum, date) => {
+      const existing = wholeSessionOnOneDay[date];
+      const increment = plan.increments[date];
+      const merged = increment
+        ? addClientBreakdownIncrement(existing, increment)
+        : existing;
+      return sum + (merged?.tokens ?? 0);
+    }, 0);
+    expect(stored).toBe(321_000);
+  });
+
+  it("still credits real usage that arrives after the re-attribution", () => {
+    const state = droidPlan(wholeSessionOnOneDay, sessionSplitAcrossDays).nextState!;
+    const grown = droidSnapshot(
+      droidContribution("2026-08-07", 21_000),
+      droidContribution("2026-08-08", 152_000),
+      droidContribution("2026-08-09", 148_000),
+      droidContribution("2026-08-10", 79_000)
+    );
+
+    const plan = droidPlan({}, grown, state);
+
+    expect(plan.mode).toBe("incremental");
+    expect(plan.increments["2026-08-10"]?.tokens).toBe(79_000);
+    expect(
+      Object.values(plan.increments).reduce((sum, day) => sum + day.tokens, 0)
+    ).toBe(79_000);
+  });
+
+  it("does not let a date-filtered rescan advance the high-water", () => {
+    const state = droidPlan(wholeSessionOnOneDay, sessionSplitAcrossDays).nextState!;
+
+    const plan = planParserHighWaterSubmission({
+      client: "droid",
+      incomingVersion: SUPPORTED_VERSIONED_PARSERS.droid,
+      fullHistory: false,
+      existingLegacyDays: {},
+      incomingDays: droidSnapshot(droidContribution("2026-08-10", 500_000)),
+      state,
+    });
+
+    expect(plan.mode).toBe("freeze");
+    expect(plan.increments).toEqual({});
   });
 });

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -35,8 +35,11 @@ import {
   addClientBreakdownIncrement,
   foldParserClientSnapshot,
   planParserHighWaterSubmission,
+  SUPPORTED_VERSIONED_PARSERS,
   type DeviceParserStates,
+  type ParserHighWaterPlan,
 } from "@/lib/db/parserHighWater";
+import { SOURCE_DISPLAY_NAMES } from "@/lib/constants";
 import { normalizeUsernameCacheKey, revalidateUsernamePaths } from "@/lib/db/usernameLookup";
 import { revalidateUserGroupLeaderboards } from "@/lib/groups/cache";
 import { LEGACY_DEVICE_KEY } from "@/lib/devices/shared";
@@ -694,51 +697,72 @@ export async function POST(request: Request) {
       }
 
       const deviceParserStates = (submittedDevice.parserStates ?? {}) as DeviceParserStates;
-      const copilotIncomingDays = foldParserClientSnapshot(
-        data.contributions,
-        "copilot"
-      );
-      const existingCopilotDays = Object.fromEntries(
-        existingDeviceDays.flatMap((day) => {
-          const breakdown = day.sourceBreakdown as Record<string, ClientBreakdownData> | null;
-          return breakdown?.copilot ? [[day.date, breakdown.copilot] as const] : [];
-        })
-      );
-      const copilotWasScanned =
-        submittedClients.has("copilot") ||
-        Boolean(
-          data.scanScope &&
-            Object.prototype.hasOwnProperty.call(
-              data.scanScope.parserVersions,
-              "copilot"
-            )
-        );
-      const copilotPlan = copilotWasScanned
-        ? planParserHighWaterSubmission({
-            client: "copilot",
-            incomingVersion: isBackfill
-              ? undefined
-              : data.scanScope?.parserVersions.copilot,
-            fullHistory: data.scanScope?.fullHistory === true,
-            existingLegacyDays: existingCopilotDays,
-            incomingDays: copilotIncomingDays,
-            state: deviceParserStates.copilot,
-            persistedVersion: submittedDevice.parserVersions?.copilot,
+      // Every client whose parser can re-attribute already-submitted history
+      // runs through the high-water path, not just Copilot. A re-attribution
+      // moves a day's tokens without changing the lifetime total, and the
+      // per-day merge guard defends each stored day against a decrease, so the
+      // days that fall are pinned while the days that rise are written: the
+      // device's stored total inflates by exactly what moved. Bounding each
+      // submission by the device/client lifetime high-water makes a pure
+      // reshuffle contribute nothing, which is the only reading of it that is
+      // both non-destructive and non-inflating.
+      const parserPlans = new Map<string, ParserHighWaterPlan>();
+      for (const [client, supportedVersion] of Object.entries(
+        SUPPORTED_VERSIONED_PARSERS
+      )) {
+        const wasScanned =
+          submittedClients.has(client) ||
+          Boolean(
+            data.scanScope &&
+              Object.prototype.hasOwnProperty.call(
+                data.scanScope.parserVersions,
+                client
+              )
+          );
+        if (!wasScanned) continue;
+        const existingClientDays = Object.fromEntries(
+          existingDeviceDays.flatMap((day) => {
+            const breakdown = day.sourceBreakdown as Record<string, ClientBreakdownData> | null;
+            const stored = breakdown ? ownValue(breakdown, client) : undefined;
+            return stored ? [[day.date, stored] as const] : [];
           })
-        : { mode: "status-quo" as const, increments: {} };
-      const freezeCopilot = copilotPlan.mode === "freeze";
-      const applyCopilotIncrements =
-        copilotPlan.mode === "incremental" ||
-        copilotPlan.mode === "baseline-legacy";
-      if (copilotPlan.mode === "baseline-legacy") {
-        warnings.push(
-          "Established the Copilot parser generation 2 baseline; existing same-device history was preserved and only bounded lifetime growth was added."
         );
-      } else if (copilotPlan.mode === "freeze") {
-        warnings.push(
-          "Ignored Copilot changes because this parser generation or partial snapshot cannot safely advance the device high-water."
-        );
+        const plan = planParserHighWaterSubmission({
+          client,
+          incomingVersion: isBackfill
+            ? undefined
+            : ownValue(
+                data.scanScope?.parserVersions as
+                  | Record<string, number>
+                  | undefined,
+                client
+              ),
+          fullHistory: data.scanScope?.fullHistory === true,
+          existingLegacyDays: existingClientDays,
+          incomingDays: foldParserClientSnapshot(data.contributions, client),
+          state: ownValue(deviceParserStates, client),
+          persistedVersion: ownValue(
+            submittedDevice.parserVersions as Record<string, number> | undefined,
+            client
+          ),
+        });
+        if (plan.mode === "status-quo") continue;
+        parserPlans.set(client, plan);
+        const label = ownValue(SOURCE_DISPLAY_NAMES, client) ?? client;
+        if (plan.mode === "baseline-legacy") {
+          warnings.push(
+            `Established the ${label} parser generation ${supportedVersion} baseline; existing same-device history was preserved and only bounded lifetime growth was added.`
+          );
+        } else if (plan.mode === "freeze") {
+          warnings.push(
+            `Ignored ${label} changes because this parser generation or partial snapshot cannot safely advance the device high-water.`
+          );
+        }
       }
+      const plannedIncrementClients = [...parserPlans].filter(
+        ([, plan]) =>
+          plan.mode === "incremental" || plan.mode === "baseline-legacy"
+      );
 
       const existingDaysMap = new Map(
         existingDeviceDays.map((d) => [d.date, d])
@@ -792,27 +816,35 @@ export async function POST(request: Request) {
           }
         }
 
-        if (freezeCopilot) {
-          delete incomingClientBreakdown.copilot;
-        } else if (applyCopilotIncrements) {
-          // The full snapshot itself is never merged. Only the bounded growth
-          // calculated against the persisted generation high-water is eligible.
-          const increment = copilotPlan.increments[incomingDay.date];
-          if (increment) {
-            incomingClientBreakdown.copilot = increment;
-          } else {
-            delete incomingClientBreakdown.copilot;
+        for (const [client, plan] of parserPlans) {
+          if (plan.mode === "freeze") {
+            delete incomingClientBreakdown[client];
+          } else if (
+            plan.mode === "incremental" ||
+            plan.mode === "baseline-legacy"
+          ) {
+            // The full snapshot itself is never merged. Only the bounded growth
+            // calculated against the persisted generation high-water is eligible.
+            const increment = ownValue(plan.increments, incomingDay.date);
+            if (increment) {
+              incomingClientBreakdown[client] = increment;
+            } else {
+              delete incomingClientBreakdown[client];
+            }
           }
         }
 
         const clientsToMerge = new Set(submittedClients);
-        if (
-          (freezeCopilot || applyCopilotIncrements) &&
-          !incomingClientBreakdown.copilot
-        ) {
-          // A frozen/zero-increment Copilot plan is a no-op for that client,
-          // not a request to delete its stored row from this day.
-          clientsToMerge.delete("copilot");
+        for (const [client, plan] of parserPlans) {
+          const planRewroteClient =
+            plan.mode === "freeze" ||
+            plan.mode === "incremental" ||
+            plan.mode === "baseline-legacy";
+          if (planRewroteClient && !incomingClientBreakdown[client]) {
+            // A frozen/zero-increment plan is a no-op for that client, not a
+            // request to delete its stored row from this day.
+            clientsToMerge.delete(client);
+          }
         }
 
         const existingDay = existingDaysMap.get(incomingDay.date);
@@ -824,13 +856,14 @@ export async function POST(request: Request) {
           >;
           const { breakdown: existingClientBreakdown, foldedClientFloors } =
             normalizeClientBreakdownAliases(rawExistingBreakdown);
-          if (
-            applyCopilotIncrements && incomingClientBreakdown.copilot
-          ) {
-            incomingClientBreakdown.copilot = addClientBreakdownIncrement(
-              existingClientBreakdown.copilot,
-              incomingClientBreakdown.copilot
-            );
+          for (const [client] of plannedIncrementClients) {
+            const increment = incomingClientBreakdown[client];
+            if (increment) {
+              incomingClientBreakdown[client] = addClientBreakdownIncrement(
+                ownValue(existingClientBreakdown, client),
+                increment
+              );
+            }
           }
           const mergeResult = mergeClientBreakdownsWithRegressionGuard(
             existingClientBreakdown,
@@ -852,15 +885,18 @@ export async function POST(request: Request) {
             );
           }
           const mergedClientBreakdown = mergeResult.merged;
-          if (
-            applyCopilotIncrements &&
-            existingClientBreakdown.copilot?.provenance?.costIsComplete === false &&
-            mergedClientBreakdown.copilot
-          ) {
-            mergedClientBreakdown.copilot.provenance = {
-              ...deriveClientBreakdownProvenance(mergedClientBreakdown.copilot),
-              costIsComplete: false,
-            };
+          for (const [client] of plannedIncrementClients) {
+            const merged = mergedClientBreakdown[client];
+            if (
+              merged &&
+              ownValue(existingClientBreakdown, client)?.provenance
+                ?.costIsComplete === false
+            ) {
+              merged.provenance = {
+                ...deriveClientBreakdownProvenance(merged),
+                costIsComplete: false,
+              };
+            }
           }
           // A preserved fold must keep its ORIGINAL raw alias keys in storage
           // (e.g. both "kilocode" and "kilo"), not the collapsed sum: the
@@ -920,17 +956,25 @@ export async function POST(request: Request) {
         }
       }
 
-      if (copilotPlan.nextState) {
+      const advancedParserStates = [...parserPlans].flatMap(([client, plan]) =>
+        plan.nextState ? [[client, plan.nextState] as const] : []
+      );
+      if (advancedParserStates.length > 0) {
         await tx
           .update(submittedDevices)
           .set({
             parserVersions: {
               ...(submittedDevice.parserVersions ?? {}),
-              copilot: copilotPlan.nextState.version,
+              ...Object.fromEntries(
+                advancedParserStates.map(([client, state]) => [
+                  client,
+                  state.version,
+                ])
+              ),
             },
             parserStates: {
               ...deviceParserStates,
-              copilot: copilotPlan.nextState,
+              ...Object.fromEntries(advancedParserStates),
             },
           })
           .where(eq(submittedDevices.id, submittedDevice.id));

--- a/packages/frontend/src/lib/db/parserHighWater.ts
+++ b/packages/frontend/src/lib/db/parserHighWater.ts
@@ -5,8 +5,26 @@ import {
 } from "./helpers";
 import { createSafeRecord, ownValue } from "../safeRecord";
 
+/**
+ * Clients whose submissions are bounded by a device/client lifetime
+ * high-water instead of being merged day by day, mapped to the parser
+ * generation the server accepts.
+ *
+ * A client belongs here when its parser can re-attribute usage it has already
+ * submitted. The per-day merge guard refuses a decrease per (day, client), so
+ * a re-attribution that moves tokens between days pins the days that fall and
+ * writes the days that rise, inflating the stored total by exactly what moved.
+ *
+ * Copilot is pinned at generation 2 because generation 1 counted differently
+ * and must not advance the high-water. Droid is registered at generation 1,
+ * the generation every CLI already declares: its shapes differ in *where*
+ * tokens land, never in the lifetime total, so no generation needs freezing —
+ * bounding every Droid submission by the lifetime high-water is what makes a
+ * re-attribution contribute nothing.
+ */
 export const SUPPORTED_VERSIONED_PARSERS: Readonly<Record<string, number>> = {
   copilot: 2,
+  droid: 1,
 };
 
 const TOKEN_FIELDS = [


### PR DESCRIPTION
Maintainer follow-up to #1090 by @Jackson57279. Their two commits are carried here with authorship intact; the rest are the corrections and the hosted-side guard the change needs before it can ship.

## What #1090 does

Droid records only a cumulative `tokenUsage` per session. Anchoring that total at a single instant cannot describe a session that ran for days: one day absorbs everything the session ever spent. Against a provider dashboard, a machine with three multi-day sessions reported 517M tokens for a day that had actually spent 24M. #1090 splits the session total across its assistant replies, weighted by the conversation each reply read, so a multi-day session reports against the days it actually ran.

## Commits

1. `fix(droid): anchor session usage at last write instead of provider lock` (@Jackson57279's original direction, rebased)
2. `fix(droid): treat a pre-epoch provider lock as an unusable anchor`
3. `fix(droid): attribute session usage to the replies that spent it` (@Jackson57279)
4. `fix(droid): weight a reply by the context it read, not its own output` (@Jackson57279)
5. `fix(droid): correct and bound the transcript-weighted usage split` - three defects in the apportioning: a pre-epoch transcript timestamp anchored a share of the session in a 1969 bucket no date filter reaches; output and reasoning were apportioned on the context each reply *read* rather than what it *produced*; and the transcript read was unbounded (measured 148ms per parse in release, 1.28s in debug, on a 104.7MB transcript with 10,000 replies, paid again on every scan while the session is live). Caps the read at 32 MiB and coalesces the turn list to 1024 runs. Droid parser version to 5.
6. `fix(frontend): bound every re-attributing parser by the device high-water` - the hosted guard, below.
7. `test(cli): pin the Droid submission generation to the server registry`
8. `fix(droid): keep the reply count, and fail closed on an unreadable transcript` - three review findings on the bounded read: a coalesced run reported one message instead of the calls it stands for; a failing `metadata()` mapped to length 0 and so waived the ceiling in exactly the case where the size was unknown; and a transcript whose read stopped early (`lossy_lines` ends silently on EIO) was apportioned as if it were whole, moving the unread tail's tokens onto the days the prefix covers. Droid parser version to 6.
9. `fix(droid): count one session, not one per apportioned record` - review finding. The split emits one record per assistant reply, and each carried its own message count. `sessionize` opens a new interval whenever two records sit more than the idle gap (3 min) apart and counts every interval that reports messages, so a session whose replies are minutes apart became one session per record: 40 replies ten minutes apart reported `sessionCount` 40, and a 1200-reply session coalesced to 1024 runs reported 600. `timeMetrics.sessionCount` is computed before `parserPlans` in the submit route and ratcheted with `GREATEST`, so the inflated figure bypasses the device high-water and sticks on a public profile. The session's authoritative reply total now rides on exactly one record and the rest are count-neutral, the same split `copilot_desktop` applies to its shutdown fragments: the number of calls stays exact, the session count returns to one. Also drops the unreachable `total_context > 0 && total_output > 0` guard - both weights are `.max(1)`.
10. `fix(droid): invalidate caches holding a count on every apportioned record` - a v6 entry carries a count on every record, and a finished session never rewrites its `settings.json`, so only a version bump discards it. Droid parser version to 7.

## The hosted hazard, and why commit 6 is not optional

Re-attribution moves tokens between days without changing the lifetime total, and the hosted merge cannot read it as a move. `mergeClientBreakdownsWithRegressionGuard` defends each stored `(day, client)` cell against a decrease, so the days that fall keep their old figure while the days that rise are written. The device's stored total gains exactly what moved, permanently, and again on every resubmit.

A single 321,000-token session re-attributed across three days stores 621,000. That is a regression test in this PR (`shows why the day-by-day merge alone inflates a re-attributed session`), not a hypothetical.

The device/client lifetime high-water added for Copilot already answers this: credit only growth bounded by both the per-cell delta and the cumulative aggregate, so a pure reshuffle contributes nothing while genuinely new usage still lands. The submit route hardcoded it to one client. Commit 6 drives it from `SUPPORTED_VERSIONED_PARSERS` and registers Droid there; Copilot behaviour is unchanged, including the `baseline-new` case that still merges its snapshot directly.

Droid is registered at **generation 1** - the generation every installed CLI already declares (`SUBMISSION_PARSER_VERSION`), not the message-cache `parser_version` this branch bumps to 7. The two Droid shapes differ in *where* a token lands, never in the lifetime total, so no installed generation has to be frozen out; registering above 1 would freeze every CLI in the field instead. Commit 7 pins that cross-language contract with a test, because the value comes from a shared default that a bump made for any other client would silently change.

### Two behaviour changes that follow, both shared with Copilot

- A CLI old enough to send no `scanScope` has its Droid rows ignored once the device holds a Droid high-water. An undeclared generation cannot be trusted to advance one.
- A date-filtered scan (`--since`/`--until`/`--year`) cannot establish or advance the high-water, so it freezes Droid rather than crediting a partial snapshot. The next unfiltered submit re-credits everything it covered.

Both are the existing Copilot rollout's tradeoff, applied to a second client. Flagging them explicitly since they are user-visible.

### Two limits this change does not remove

Both are stated rather than fixed; changing either needs its own decision.

- **The 32 MiB transcript ceiling routes the largest sessions back to the single mtime-anchored record.** That is the exact misattribution this PR exists to fix, and it survives for any session whose `*.jsonl` exceeds the cap - a long-running multi-day session is precisely the shape most likely to cross it. The alternative was an unbounded per-scan read that a live session pays again on every scan (measured 148 ms per parse in release, 1.28 s in debug, on a 104.7 MB transcript). The fallback total is still exact; only the day it lands on is wrong.
- **The per-cell high-water can permanently withhold credit for later genuine usage.** The guard bounds each `(day, client)` cell by growth, so a re-attribution that moves a day's share *down* leaves that cell's stored figure above what the device now reports for it. Real usage on that day afterwards is credited only once it exceeds the old stored figure. The direction is undercount, not inflation, and it is the same tradeoff the Copilot rollout already carries - but it is a real, silent loss for the affected days, not a transient one.

### What this does not fix

The high-water is per `(device, client)`. Rows already inflated by a re-attribution submitted *before* this deploys are not rolled back - the baseline preserves them and only bounds future growth. If any such submissions exist in production, they need a separate repair pass; nothing in this PR can distinguish them from real usage after the fact.

## Gates

Run at `4a0b4b30`, which merges current `main` (including the `windows-latest` `PathRoot::AppData` fix from #1121):

```
cargo fmt --all -- --check                                                      exit 0
cargo clippy --locked --workspace --all-targets --all-features -- -D warnings   exit 0
cargo test --locked --workspace --all-features --no-fail-fast                   exit 0  (2952 passed, 0 failed, 12 suites)
packages/frontend: npx vitest run                                               exit 0  (910 passed, 6 skipped, 88 files)
packages/frontend: npx tsc --noEmit                                             exit 0
packages/frontend: npx eslint .                                                 exit 0  (17 pre-existing warnings, none in touched files)
```

### Session-count evidence, from the built binary

Fixture: one Droid session, 40 assistant replies ten minutes apart, `inputTokens` 4000 / `outputTokens` 400.

```
# built at 3559a092 (before commit 9)
tokscale time-metrics --json --home $H --client droid   ->  session_count 40
tokscale models --json --home $H --client droid         ->  totalMessages 40, input 4000, output 400

# built at 4a0b4b30
tokscale time-metrics --json --home $H --client droid   ->  session_count 1
tokscale models --json --home $H --client droid         ->  totalMessages 40, input 4000, output 400

# same home, old binary first (writes a v6 cache), then the new one
old -> session_count 40 ; new over that cache -> session_count 1   (parser version 7 discards it)
```

Covered by `test_apportioned_session_still_sessionizes_as_one_session` and `test_reply_count_rides_on_exactly_one_record`.

The `Test & Coverage / Tests (windows-latest)` failure reported earlier came from `main`, not this branch; #1121 fixed it and this branch now carries that merge.

Refs #1090.
