### PR TITLE
fix(clients): follow a redirected home for the AppData scan root

### DIFF
--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -1187,26 +1187,36 @@ fn write_codex_token_session(dir: &Path, name: &str, model: &str, input: i64, ou
     .unwrap();
 }
 
+/// The V1 Cherry Studio transcript root under a sandboxed home, spelled the
+/// way `PathRoot::AppData` resolves it per platform.
+///
+/// Built component-by-component rather than from a single `/`-joined literal:
+/// `Path::join` only normalizes the junction, so a `"AppData/Roaming/..."`
+/// literal keeps its own forward slashes on Windows and the fixture would not
+/// exercise the real `AppData\Roaming\CherryStudio\.claude\projects`
+/// layout the scanner walks (#1048).
 fn cherrystudio_projects_root(base: &Path) -> std::path::PathBuf {
     #[cfg(target_os = "windows")]
-    {
-        base.join("AppData/Roaming/CherryStudio/.claude/projects")
-    }
+    let relative = "AppData/Roaming/CherryStudio/.claude/projects";
     #[cfg(target_os = "macos")]
-    {
-        base.join("Library/Application Support/CherryStudio/.claude/projects")
-    }
+    let relative = "Library/Application Support/CherryStudio/.claude/projects";
     #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
-    {
-        base.join(".config/CherryStudio/.claude/projects")
+    let relative = ".config/CherryStudio/.claude/projects";
+
+    let mut path = base.to_path_buf();
+    for component in relative.split('/') {
+        path.push(component);
     }
+    path
 }
 
 /// Four snapshots of one streamed Cherry Studio API call. The final snapshot
 /// connects the UUID-only, message-only, and request-only partial records and
 /// carries the final streamed output count.
 fn write_cherrystudio_connected_alias_transcript(base: &Path) {
-    let path = cherrystudio_projects_root(base).join("workspace/session.jsonl");
+    let path = cherrystudio_projects_root(base)
+        .join("workspace")
+        .join("session.jsonl");
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     fs::write(
         path,
@@ -1228,7 +1238,9 @@ fn write_cherrystudio_connected_alias_transcript(base: &Path) {
 /// replay. The replay grows output usage but must not take the transcript mtime
 /// as the call timestamp when its component has a valid event timestamp.
 fn write_cherrystudio_historical_replay_without_timestamp(base: &Path) {
-    let path = cherrystudio_projects_root(base).join("workspace/historical.jsonl");
+    let path = cherrystudio_projects_root(base)
+        .join("workspace")
+        .join("historical.jsonl");
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     fs::write(
         path,
@@ -1997,6 +2009,40 @@ fn test_models_with_client_filter_jcode() {
     assert_eq!(entry["cacheWrite"].as_i64().unwrap(), 50);
     assert_eq!(entry["output"].as_i64().unwrap(), 250);
     assert_eq!(entry["reasoning"].as_i64().unwrap(), 25);
+}
+
+/// The Windows regression guard for the two tests below.
+///
+/// Both of them assert on parsed totals, so when discovery silently reads the
+/// wrong root they fail as `Some(0)` vs `Some(1)` with nothing pointing at the
+/// path. `PathRoot::AppData` used to resolve to the `FOLDERID_RoamingAppData`
+/// known folder under env roots, which no environment variable can redirect,
+/// so on Windows the scan walked the live profile instead of this sandbox and
+/// the fixture was never seen. Assert the emitted scan root directly.
+#[test]
+fn test_clients_json_cherrystudio_scan_root_stays_inside_the_sandboxed_home() {
+    let tmp = create_empty_fixture_dir();
+    write_cherrystudio_connected_alias_transcript(tmp.path());
+
+    let output = cmd_with_home(tmp.path())
+        .args(["clients", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let cherry = json["clients"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["client"] == "cherrystudio")
+        .expect("cherrystudio must appear in `clients --json`");
+
+    assert_eq!(
+        cherry["sessionsPath"],
+        serde_json::json!(cherrystudio_projects_root(tmp.path()).to_string_lossy()),
+        "Cherry Studio's scan root must follow the sandboxed home, not the machine's app-data folder"
+    );
 }
 
 #[test]

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -55,12 +55,42 @@ fn app_data_follows_home(home_dir: &str) -> bool {
     #[cfg(target_os = "windows")]
     {
         let home = std::path::Path::new(home_dir);
-        home.is_absolute() && dirs::home_dir().is_none_or(|profile| profile != home)
+        if !home.is_absolute() {
+            return false;
+        }
+        match dirs::home_dir() {
+            Some(profile) => !same_windows_dir(home, &profile),
+            None => true,
+        }
     }
     #[cfg(not(target_os = "windows"))]
     {
         let _ = home_dir;
         false
+    }
+}
+
+/// Whether two absolute Windows paths name the same directory.
+///
+/// A lexical comparison is not enough here, and getting it wrong is not
+/// symmetric: a home that merely *spells* the profile differently would be
+/// misread as a redirect, and on a machine whose `FOLDERID_RoamingAppData` is
+/// itself redirected that would move the scan to `<profile>\AppData\Roaming`
+/// and lose the user's transcripts. Windows offers at least three such
+/// spellings — different casing (`c:\users\me`), the 8.3 alias
+/// (`C:\Users\RUNNER~1`), and a junction or symlink pointing at the profile —
+/// and `Path`'s component comparison treats all three as different paths.
+///
+/// `canonicalize` resolves every one of them to the same `\\?\`-verbatim
+/// path. It touches the filesystem and fails on a path that does not exist, so
+/// fall back to the lexical comparison when either side cannot be
+/// canonicalized: a home that is not on disk cannot be the live profile under
+/// another spelling, and the fallback then correctly reports a redirect.
+#[cfg(target_os = "windows")]
+fn same_windows_dir(home: &std::path::Path, profile: &std::path::Path) -> bool {
+    match (std::fs::canonicalize(home), std::fs::canonicalize(profile)) {
+        (Ok(home_real), Ok(profile_real)) => home_real == profile_real,
+        _ => home == profile,
     }
 }
 
@@ -1149,6 +1179,40 @@ mod tests {
             !app_data_follows_home(&profile.to_string_lossy()),
             "the machine profile is not a redirect and must not override the platform lookup"
         );
+    }
+
+    /// A home that only *spells* the profile differently is not a redirect.
+    ///
+    /// Windows reaches the same directory through different casing, through the
+    /// 8.3 alias (`C:\Users\RUNNER~1`), and through junctions, and `Path`
+    /// compares all of those as distinct. Reading one as a redirect would pull
+    /// the app-data root off the known folder, and on a machine whose
+    /// `FOLDERID_RoamingAppData` is itself redirected that loses the user's
+    /// transcripts. Both assertions are skipped rather than inverted if
+    /// `canonicalize` cannot resolve the spelling, since a case-sensitive
+    /// volume would legitimately make them different directories.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_env_roots_app_data_sees_through_windows_spellings_of_the_profile() {
+        let Some(profile) = dirs::home_dir() else {
+            return;
+        };
+        let Ok(canonical_profile) = std::fs::canonicalize(&profile) else {
+            return;
+        };
+
+        assert!(
+            !app_data_follows_home(&canonical_profile.to_string_lossy()),
+            "the verbatim spelling of the profile is the profile, not a redirect"
+        );
+
+        let shouted = profile.to_string_lossy().to_uppercase();
+        if std::fs::canonicalize(&shouted).is_ok_and(|resolved| resolved == canonical_profile) {
+            assert!(
+                !app_data_follows_home(&shouted),
+                "a case variant of the profile must not read as a redirect"
+            );
+        }
     }
 
     /// A POSIX-shaped `HOME` (Git Bash, MSYS2, Cygwin) is not a redirect.

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -6,8 +6,10 @@ pub enum PathRoot {
     Config,
     /// The per-user application data directory, resolved via the `dirs` crate:
     /// `%APPDATA%` on Windows, `~/Library/Application Support` on macOS, and
-    /// the XDG config home on Linux. When an explicit home is supplied, this
-    /// root is derived from that home using the matching platform convention.
+    /// the XDG config home on Linux. When an explicit home is supplied — or,
+    /// on Windows, when the resolved home is not the Win32 profile — this root
+    /// is derived from that home using the matching platform convention; see
+    /// [`app_data_follows_home`].
     AppData,
     EnvVar {
         var: &'static str,
@@ -24,6 +26,42 @@ fn join_home(home_dir: &str, relative: &str) -> String {
         path.push(component.as_os_str());
     }
     path.to_string_lossy().into_owned()
+}
+
+/// Whether an [`PathRoot::AppData`] scan must be derived from `home_dir`
+/// rather than from the platform's own app-data lookup, even under env roots.
+///
+/// Only Windows can disagree with `home_dir`. `dirs::config_dir()` is
+/// `SHGetKnownFolderPath(FOLDERID_RoamingAppData)` there — a Win32 known
+/// folder that no environment variable can redirect, not even `%APPDATA%`.
+/// macOS and Linux resolve it from `$HOME` / `$XDG_CONFIG_HOME`, so they
+/// already follow whatever home `paths::home_dir()` handed this call.
+///
+/// That asymmetry is the one `paths::home_dir` was written to close for
+/// `dirs::home_dir()` in #997: every home-rooted scan target obeys a
+/// redirected `HOME`, so an AppData-rooted client must not be the single
+/// target that keeps reading the machine's real profile. Cherry Studio is
+/// currently that client, and on Windows its transcripts were discovered
+/// under the live profile no matter where the caller pointed the home.
+///
+/// The known-folder answer still wins when `home_dir` *is* the Win32 profile,
+/// because folder redirection and roaming profiles can legitimately place
+/// `%APPDATA%` outside the profile directory; only a home that actually names
+/// somewhere else overrides it. A non-absolute `home_dir` (a POSIX-shaped
+/// `HOME` from Git Bash, a drive-relative `C:temp`) is never treated as a
+/// redirect, matching `paths::home_dir`, which rejects those same shapes
+/// because `Path` resolves them against ambient state.
+fn app_data_follows_home(home_dir: &str) -> bool {
+    #[cfg(target_os = "windows")]
+    {
+        let home = std::path::Path::new(home_dir);
+        home.is_absolute() && dirs::home_dir().is_none_or(|profile| profile != home)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = home_dir;
+        false
+    }
 }
 
 impl PathRoot {
@@ -100,7 +138,7 @@ impl PathRoot {
                 join_home(home_dir, ".config/tokscale")
             }
             PathRoot::AppData => {
-                if use_env_roots {
+                if use_env_roots && !app_data_follows_home(home_dir) {
                     if let Some(dir) = dirs::config_dir() {
                         return dir.to_string_lossy().into_owned();
                     }
@@ -1062,6 +1100,86 @@ mod tests {
         assert_eq!(
             PathRoot::AppData.resolve_with_env_strategy(home.to_str().unwrap(), false),
             expected.to_string_lossy()
+        );
+    }
+
+    /// Under env roots the AppData root must still land under the home it was
+    /// handed once that home is not the machine profile.
+    ///
+    /// `dirs::config_dir()` on Windows is the `FOLDERID_RoamingAppData` known
+    /// folder, which ignores every environment variable, so this root was the
+    /// one scan target that kept reading the live profile after
+    /// `paths::home_dir()` had been redirected. Cherry Studio — the only
+    /// AppData-rooted client — was therefore never discovered under a
+    /// redirected home on Windows, while macOS and Linux resolved it correctly
+    /// because their `dirs::config_dir()` is `$HOME`/`$XDG_CONFIG_HOME`-derived
+    /// and so already follows the redirect.
+    ///
+    /// The assertions read the known-folder API but no environment variable, so
+    /// this test does not need to serialize against the `EnvGuard` tests above.
+    #[test]
+    fn test_env_roots_app_data_follows_a_redirected_home() {
+        let home = absolute_test_path("redirected-home");
+
+        assert_eq!(
+            app_data_follows_home(home.to_str().unwrap()),
+            cfg!(target_os = "windows"),
+            "only Windows has an app-data lookup that a redirected home cannot reach"
+        );
+
+        #[cfg(target_os = "windows")]
+        assert_eq!(
+            PathRoot::AppData.resolve_with_env_strategy(home.to_str().unwrap(), true),
+            native_join(&home, "AppData/Roaming"),
+            "a redirected Windows home must win over the roaming-app-data known folder"
+        );
+    }
+
+    /// The known-folder answer stays authoritative when the home *is* the real
+    /// profile: folder redirection and roaming profiles can legitimately place
+    /// `%APPDATA%` outside the profile directory, and deriving it from the home
+    /// would silently relocate those users' scans.
+    #[test]
+    fn test_env_roots_app_data_keeps_the_platform_lookup_for_the_real_profile() {
+        let Some(profile) = dirs::home_dir() else {
+            return;
+        };
+
+        assert!(
+            !app_data_follows_home(&profile.to_string_lossy()),
+            "the machine profile is not a redirect and must not override the platform lookup"
+        );
+    }
+
+    /// A POSIX-shaped `HOME` (Git Bash, MSYS2, Cygwin) is not a redirect.
+    /// `paths::home_dir` rejects those because `Path` reads the leading `/` as
+    /// "root of the current drive"; the AppData root must agree rather than
+    /// relocating every Unix-shell user's scan to `C:\home\user\AppData`. The
+    /// same holds for a drive-relative `C:temp`, which Windows resolves against
+    /// the per-drive current directory.
+    #[test]
+    fn test_env_roots_app_data_ignores_non_absolute_windows_homes() {
+        for home in ["/home/user", "C:temp", ""] {
+            assert!(
+                !app_data_follows_home(home),
+                "{home:?} is not a usable native home and must not override the platform lookup"
+            );
+        }
+    }
+
+    /// The end-to-end claim the Windows CLI regression turns on: Cherry Studio
+    /// is the only AppData-rooted client, and under env roots its transcript
+    /// root must sit under a redirected home.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_cherrystudio_transcript_root_follows_a_redirected_home_under_env_roots() {
+        let home = absolute_test_path("cherry-home");
+
+        assert_eq!(
+            ClientId::CherryStudio
+                .data()
+                .resolve_path_with_env_strategy(home.to_str().unwrap(), true),
+            native_join(&home, "AppData/Roaming/CherryStudio/.claude/projects")
         );
     }
 


### PR DESCRIPTION
Fixes the two Cherry Studio CLI tests that fail on `Test & Coverage / Tests (windows-latest)` at current `main` (5777ad9c, the #1105 merge):

```
crates/tokscale-cli/tests/cli_tests.rs:2027 test_cherrystudio_connected_aliases_count_once_cold_and_warm_cache
crates/tokscale-cli/tests/cli_tests.rs:2080 test_cherrystudio_historical_timestamp_survives_timestampless_replay_cold_and_warm
```

Both report `left: Some(0), right: Some(1)`. `main` itself has no post-#1105 Windows run; #1118 and #1119 both build on 5777ad9c and both reproduce exactly these two.

## Cause

Production bug, not a fixture bug.

`PathRoot::AppData` resolved through `dirs::config_dir()` whenever env roots were in play, discarding the `home_dir` argument entirely. On Windows `dirs::config_dir()` is `dirs_sys::known_folder_roaming_app_data()`, i.e. `SHGetKnownFolderPath(FOLDERID_RoamingAppData)` — a Win32 known folder that no environment variable can redirect, not even `%APPDATA%`. So an AppData-rooted client kept scanning the machine's live profile no matter where the caller pointed the home.

Every other root in the client table follows `paths::home_dir()`, which honors a native absolute `$HOME` on Windows for exactly this reason; its own doc comment states the invariant ("Every home-rooted path in the workspace must resolve through here ... otherwise the redirect holds for some roots and not others"). `PathRoot::AppData` was the one violation, and it is the same asymmetry #997 closed for `dirs::home_dir()`.

Cherry Studio is the only `PathRoot::AppData` client, so it was the only scan target affected — which is why the regression arrived with #1105 rather than earlier. It stayed invisible on the other platforms because `dirs::config_dir()` is `$HOME`-derived on macOS and `$HOME`/`$XDG_CONFIG_HOME`-derived on Linux, so both already follow a redirected home.

The two failing tests do not pass `--home`, so `use_env_roots(&None) == true` and they take the env-root branch; the fixture written under the sandboxed `TempDir` home was never scanned. The scanner's own Cherry Studio tests pass on Windows because they call `scan_all_clients_with_env_strategy(..., false)`.

The V1/V2 root classification and the temp-path canonicalization were both ruled out: `is_cherrystudio_v2_root` walks `Path::components()` in reverse and is separator- and case-agnostic, and the dedup keys come from the walker rather than from fixture strings.

## Fix

Derive the AppData root from `home_dir` when that home is an absolute native path other than the Win32 profile.

The known-folder lookup stays authoritative when the home *is* the real profile, because folder redirection and roaming profiles can legitimately place `%APPDATA%` outside the profile directory and deriving it from the home would silently relocate those users' scans. That comparison is on filesystem identity, not on `Path` components: Windows reaches the profile through different casing, through the 8.3 alias (`C:\Users\RUNNER~1`), and through junctions, and treating any of those as a redirect would break exactly the folder-redirection users the check exists to protect. `canonicalize` collapses all three; the lexical comparison is the fallback for a home that is not on disk, which cannot be the live profile under another spelling.

A non-absolute `HOME` — Git Bash's `/home/user`, a drive-relative `C:temp` — is never treated as a redirect, matching `paths::home_dir`, which rejects those same shapes because `Path` resolves them against ambient state.

macOS and Linux behavior is unchanged: `app_data_follows_home` is a compile-time `false` there.

Test-side changes:

- `cherrystudio_projects_root` builds `AppData\Roaming\CherryStudio\.claude\projects` component-by-component instead of from one `/`-joined literal, so the fixture exercises the real Windows layout rather than relying on Win32 accepting forward slashes (#1048).
- New `test_clients_json_cherrystudio_scan_root_stays_inside_the_sandboxed_home` asserts the emitted `clients --json` scan root. The two existing tests only assert parsed totals, so a discovery failure surfaced as a zero-token report with nothing naming the path.
- Five unit tests in `clients.rs` cover the redirect, the real-profile case, alternative spellings of the profile, non-absolute homes, and the end-to-end Cherry Studio root.

## Gates

Run at 18d983df on macOS (aarch64-apple-darwin):

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings` | pass |
| `cargo test --locked --workspace --all-features --no-fail-fast` | pass, 2926 tests, 0 failed |
| `cargo check --locked --workspace --all-features --all-targets --target x86_64-pc-windows-gnu` | pass |

GitHub Actions at 18d983df: 21/21 checks green, including `Test & Coverage / Tests (windows-latest)` (run 31756126993). Both previously failing tests and all five new ones pass there:

```
test test_cherrystudio_connected_aliases_count_once_cold_and_warm_cache ... ok
test test_cherrystudio_historical_timestamp_survives_timestampless_replay_cold_and_warm ... ok
test test_clients_json_cherrystudio_scan_root_stays_inside_the_sandboxed_home ... ok
test clients::tests::test_env_roots_app_data_follows_a_redirected_home ... ok
test clients::tests::test_env_roots_app_data_keeps_the_platform_lookup_for_the_real_profile ... ok
test clients::tests::test_env_roots_app_data_sees_through_windows_spellings_of_the_profile ... ok
test clients::tests::test_env_roots_app_data_ignores_non_absolute_windows_homes ... ok
test clients::tests::test_cherrystudio_transcript_root_follows_a_redirected_home_under_env_roots ... ok
```
