### PR TITLE
feat(clients): add DeepSeek Harness support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -103,6 +103,7 @@
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP イベント：macOS `~/Library/Application Support/Devin/User/acp-events/`、Linux `~/.config/Devin/User/acp-events/`、Windows `%APPDATA%\Devin\User\acp-events\` |
 | <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/)（Auggie CLI） | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | `hf:`モデルや`synthetic`プロバイダを検出して他ソースから再帰属（+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`） |
+| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd`（zstd 圧縮 JSONL セッション転写、`DSH_HOME` で上書き可） |
 
 [🚅 LiteLLMの価格データ](https://github.com/BerriAI/litellm)を使用してリアルタイム価格計算を提供し、階層型価格モデルとキャッシュトークン割引をサポートしています。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -103,6 +103,7 @@
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP 이벤트: macOS `~/Library/Application Support/Devin/User/acp-events/`; Linux `~/.config/Devin/User/acp-events/`; Windows `%APPDATA%\Devin\User\acp-events\` |
 | <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/) (Auggie CLI) | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | `hf:` 모델/`synthetic` provider 감지로 다른 소스에서 재귀속 (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) |
+| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd`（zstd 압축 JSONL 세션 트랜스크립트, `DSH_HOME`으로 재정의 가능） |
 
 [🚅 LiteLLM의 가격 데이터](https://github.com/BerriAI/litellm)를 사용해 **실시간 비용 계산**을 제공합니다. 구간별 가격 모델(대용량 컨텍스트 등)과 **캐시 토큰 할인**도 지원합니다.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP events: macOS `~/Library/Application Support/Devin/User/acp-events/`; Linux `~/.config/Devin/User/acp-events/`; Windows `%APPDATA%\Devin\User\acp-events\` |
 | <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/) (Auggie CLI) | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | Re-attributed from other sources via `hf:` model prefix or `synthetic` provider (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) |
+| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd` (zstd-compressed JSONL transcripts; override via `DSH_HOME`) |
 
 Get real-time pricing calculations using [🚅 LiteLLM's pricing data](https://github.com/BerriAI/litellm), with support for tiered pricing models and cache token discounts.
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -104,6 +104,7 @@
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP 事件：macOS `~/Library/Application Support/Devin/User/acp-events/`；Linux `~/.config/Devin/User/acp-events/`；Windows `%APPDATA%\Devin\User\acp-events\` |
 | <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/)（Auggie CLI） | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | 通过 `hf:` 模型前缀或 `synthetic` provider 从其他来源重归属（+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`） |
+| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd`（zstd 压缩的 JSONL 会话转录；可通过 `DSH_HOME` 覆盖） |
 
 使用 [🚅 LiteLLM 的价格数据](https://github.com/BerriAI/litellm)提供实时价格计算，支持分层定价模型和缓存 Token 折扣。
 

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1067,6 +1067,7 @@ pub enum ClientFilter {
     PrimeAgent,
     Freebuff,
     CherryStudio,
+    Dsh,
     Synthetic,
 }
 
@@ -1123,6 +1124,7 @@ impl ClientFilter {
             Self::PrimeAgent => "prime-agent",
             Self::Freebuff => "freebuff",
             Self::CherryStudio => "cherrystudio",
+            Self::Dsh => "dsh",
             Self::Synthetic => "synthetic",
         }
     }
@@ -1182,6 +1184,7 @@ impl ClientFilter {
             Self::PrimeAgent => Some(ClientId::PrimeAgent),
             Self::Freebuff => Some(ClientId::Freebuff),
             Self::CherryStudio => Some(ClientId::CherryStudio),
+            Self::Dsh => Some(ClientId::Dsh),
             Self::Synthetic => None,
         }
     }
@@ -1237,6 +1240,7 @@ impl ClientFilter {
             ClientId::PrimeAgent => Self::PrimeAgent,
             ClientId::Freebuff => Self::Freebuff,
             ClientId::CherryStudio => Self::CherryStudio,
+            ClientId::Dsh => Self::Dsh,
         }
     }
 

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -51,6 +51,7 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
     ClientUi { hotkey: 'P' },
     ClientUi { hotkey: 'F' },
     ClientUi { hotkey: 'G' },
+    ClientUi { hotkey: 't' },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {
@@ -62,6 +63,8 @@ pub fn display_name(client: ClientId) -> &'static str {
 pub fn compact_display_name(client: ClientId) -> &'static str {
     match client {
         ClientId::Senpi => "Senpi",
+        // "DeepSeek Harness" (16 cells) overflows the 15-cell Client column.
+        ClientId::Dsh => "DeepSeek",
         _ => display_name(client),
     }
 }

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1617,6 +1617,8 @@ mod tests {
         assert_eq!(clients[42], ClientId::Reasonix);
         assert_eq!(clients[43], ClientId::PrimeAgent);
         assert_eq!(clients[44], ClientId::Freebuff);
+        assert_eq!(clients[45], ClientId::CherryStudio);
+        assert_eq!(clients[46], ClientId::Dsh);
     }
 
     #[test]
@@ -1668,6 +1670,7 @@ mod tests {
             "Prime Agent",
             "Freebuff",
             "Cherry Studio",
+            "DeepSeek Harness",
         ];
 
         assert_eq!(expected.len(), ClientId::COUNT);

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -864,6 +864,26 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    // DeepSeek Harness (DSH) writes one zstd-compressed JSONL transcript per
+    // session under `<DSH_HOME>/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd`
+    // (`DSH_HOME` defaults to `~/.dsh`). Each `assistant/message` event carries
+    // authoritative per-call usage (`inputTokens`/`outputTokens`/`cacheReadTokens`)
+    // plus the model/provider it was served by; the `session` event supplies the
+    // workspace (`cwd`) and session id. See `sessions::dsh`.
+    Dsh = 46 => {
+        id: "dsh",
+        display: "DeepSeek Harness",
+        logo: None,
+        root: PathRoot::EnvVar {
+            var: "DSH_HOME",
+            fallback_relative: ".dsh",
+        },
+        relative: "sessions",
+        pattern: "session.jsonl.zstd",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -979,7 +999,7 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 46);
+        assert_eq!(ClientId::COUNT, 47);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2264,6 +2264,19 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         }
     }
 
+    // DeepSeek Harness (DSH) zstd JSONL transcripts. Every `assistant/message`
+    // carries authoritative usage but never a cost, so pricing is the only cost
+    // source — the generic source cache (which reprices unconditionally) is
+    // safe here, same as opencodereview.
+    parse_cached_lane(
+        &scan_result,
+        &mut source_cache,
+        pricing,
+        &mut all_messages,
+        ClientId::Dsh,
+        sessions::dsh::parse_dsh_file,
+    );
+
     // ZCode (Z.ai GLM-5.2 ADE) JSONL sessions. Token usage may be embedded
     // from the API response; otherwise estimated from content.
     let zcode_messages: Vec<UnifiedMessage> = scan_result
@@ -4359,6 +4372,21 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let cherrystudio_count = summed_parsed_message_count(&cherrystudio_msgs);
     counts.set(ClientId::CherryStudio, cherrystudio_count);
     messages.extend(cherrystudio_msgs);
+
+    // DeepSeek Harness zstd JSONL transcripts.
+    let dsh_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Dsh)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::dsh::parse_dsh_file(path)
+                .into_iter()
+                .map(|message| unified_to_parsed(&message))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let dsh_count = summed_parsed_message_count(&dsh_msgs);
+    counts.set(ClientId::Dsh, dsh_count);
+    messages.extend(dsh_msgs);
 
     let opencodereview_msgs: Vec<ParsedMessage> = scan_result
         .get(ClientId::OpenCodeReview)

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -500,6 +500,10 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                             .unwrap_or(false)
                 }
                 "sessions.json" => file_name == "sessions.json",
+                // DeepSeek Harness: one zstd-compressed JSONL transcript per
+                // session, always named `session.jsonl.zstd` at any depth under
+                // `~/.dsh/sessions/`.
+                "session.jsonl.zstd" => file_name == "session.jsonl.zstd",
                 "wire.jsonl" => file_name == "wire.jsonl",
                 "updates.jsonl" => file_name == "updates.jsonl",
                 "unified.jsonl" => file_name == "unified.jsonl",
@@ -2582,6 +2586,33 @@ mod tests {
                 .unwrap_or_default()
                 == "ui_messages.json"
         }));
+    }
+
+    #[test]
+    fn test_scan_directory_dsh_session_jsonl_zstd() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        // DeepSeek Harness layout: sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd
+        let session_dir = path
+            .join("sessions")
+            .join("--E-Code-proj--")
+            .join("session-abc-123");
+        fs::create_dir_all(&session_dir).unwrap();
+        File::create(session_dir.join("session.jsonl.zstd")).unwrap();
+
+        // Non-matching siblings must be excluded: other zstd files, plain
+        // jsonl transcripts, and any file outside a session dir.
+        File::create(path.join("sessions").join("other.jsonl.zstd")).unwrap();
+        File::create(session_dir.join("session.jsonl")).unwrap();
+        File::create(path.join("sessions").join("unrelated.txt")).unwrap();
+
+        let files = scan_directory(path.to_str().unwrap(), "session.jsonl.zstd");
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].file_name().and_then(|n| n.to_str()),
+            Some("session.jsonl.zstd")
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/dsh.rs
+++ b/crates/tokscale-core/src/sessions/dsh.rs
@@ -1,0 +1,318 @@
+//! DeepSeek Harness (DSH) session parser
+//!
+//! DSH persists one zstd-compressed JSONL transcript per session under
+//! `<DSH_HOME>/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd`
+//! (`DSH_HOME` defaults to `~/.dsh`). The transcript is an append-only event
+//! stream; the rows Tokscale needs are:
+//!
+//! - `session`: session id, `createdAt` (ms), `cwd` (workspace root).
+//! - `request/header`: the provider/model the request was routed to (fallback
+//!   for messages whose `source` is absent).
+//! - `assistant/message`: authoritative per-call usage on `data.usage`
+//!   (`inputTokens`, `outputTokens`, `cacheReadTokens`, ...) plus the serving
+//!   provider/model on `data.message.source`.
+//!
+//! DSH never embeds a cost, so every message leaves the parser at `0.0` and
+//! pricing is its only cost source — the generic source cache is safe here.
+
+use super::utils::lossy_lines;
+use super::{workspace_label_from_key, UnifiedMessage};
+use crate::TokenBreakdown;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Parse one DSH `session.jsonl.zstd` transcript into unified messages.
+///
+/// Each `assistant/message` event with a non-zero `data.usage` becomes one
+/// [`UnifiedMessage`]. Messages without usable timestamps are skipped; usage
+/// with a zero total is skipped so noise rows (e.g. echoed tool-call-only
+/// messages) do not produce zero-token contributions.
+pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(_) => return Vec::new(),
+    };
+    let decoded = match zstd::stream::decode_all(file) {
+        Ok(decoded) => decoded,
+        // A truncated/foreign `.zstd` payload must not abort the whole scan.
+        Err(_) => return Vec::new(),
+    };
+
+    // The transcript directory is named after the session id; it is the
+    // fallback when the leading `session` event is missing.
+    let session_id_from_path = path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let mut session_id: Option<String> = None;
+    let mut workspace_key: Option<String> = None;
+    // Most recent request routing, used when a message lacks its own `source`.
+    let mut fallback_provider: Option<String> = None;
+    let mut fallback_model: Option<String> = None;
+
+    let mut messages = Vec::new();
+    let mut seen = HashSet::new();
+    // Turn numbers that already emitted a turn-start message.
+    let mut turn_started: HashSet<i64> = HashSet::new();
+    // Fallback turn-start marker for transcripts without turn numbers: a
+    // `user/message` arms the next assistant message as a turn start.
+    let mut pending_user_turn = false;
+
+    for line in lossy_lines(decoded.as_slice()) {
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        let Some(event_type) = value.get("type").and_then(Value::as_str) else {
+            continue;
+        };
+        match event_type {
+            "session" => {
+                session_id = value.get("id").and_then(Value::as_str).map(str::to_string);
+                workspace_key = value.get("cwd").and_then(Value::as_str).map(str::to_string);
+            }
+            "request/header" => {
+                let config = value.pointer("/data/header/config");
+                fallback_provider = config
+                    .and_then(|c| c.get("provider"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                fallback_model = config
+                    .and_then(|c| c.get("model"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+            }
+            "user/message" => {
+                pending_user_turn = true;
+            }
+            "assistant/message" => {
+                let Some(usage) = value.pointer("/data/usage") else {
+                    continue;
+                };
+                let tokens = tokens_from_usage(usage);
+                if tokens.total() == 0 {
+                    continue;
+                }
+                let Some(timestamp) = value.get("time").and_then(Value::as_i64) else {
+                    continue;
+                };
+                if timestamp <= 0 {
+                    continue;
+                }
+
+                let source = value.pointer("/data/message/source");
+                let model_id = source
+                    .and_then(|s| s.get("model"))
+                    .and_then(Value::as_str)
+                    .or(fallback_model.as_deref())
+                    .unwrap_or("unknown")
+                    .to_string();
+                let provider_id = source
+                    .and_then(|s| s.get("provider"))
+                    .and_then(Value::as_str)
+                    .or(fallback_provider.as_deref())
+                    .unwrap_or("unknown")
+                    .to_string();
+
+                let sid = session_id
+                    .clone()
+                    .unwrap_or_else(|| session_id_from_path.clone());
+
+                let turn = value.pointer("/data/turn").and_then(Value::as_i64);
+                let is_turn_start = match turn {
+                    Some(turn) => turn_started.insert(turn),
+                    None => std::mem::take(&mut pending_user_turn),
+                };
+
+                let dedup_key = format!(
+                    "dsh:{sid}:{timestamp}:{provider_id}:{model_id}:{}:{}:{}:{}:{}",
+                    tokens.input,
+                    tokens.output,
+                    tokens.cache_read,
+                    tokens.cache_write,
+                    tokens.reasoning
+                );
+                if !seen.insert(dedup_key.clone()) {
+                    continue;
+                }
+
+                let mut message = UnifiedMessage::new_with_dedup(
+                    "dsh",
+                    model_id,
+                    provider_id,
+                    &sid,
+                    timestamp,
+                    tokens,
+                    0.0,
+                    Some(dedup_key),
+                );
+                message.is_turn_start = is_turn_start;
+                if let Some(cwd) = &workspace_key {
+                    if let Some(key) = super::normalize_workspace_key(cwd) {
+                        let label = workspace_label_from_key(&key);
+                        message.set_workspace(Some(key), label);
+                    }
+                }
+                messages.push(message);
+            }
+            _ => {}
+        }
+    }
+
+    messages
+}
+
+fn tokens_from_usage(usage: &Value) -> TokenBreakdown {
+    TokenBreakdown {
+        input: int_field(usage, "inputTokens"),
+        output: int_field(usage, "outputTokens"),
+        cache_read: int_field(usage, "cacheReadTokens"),
+        cache_write: int_field(usage, "cacheWriteTokens"),
+        reasoning: int_field(usage, "reasoningTokens"),
+    }
+}
+
+fn int_field(value: &Value, key: &str) -> i64 {
+    value.get(key).and_then(Value::as_i64).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_zstd_session(lines: &[&str]) -> tempfile::NamedTempFile {
+        let payload = lines.join("\n");
+        let compressed = zstd::encode_all(payload.as_bytes(), 3).unwrap();
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut file, &compressed).unwrap();
+        file
+    }
+
+    #[test]
+    fn parses_assistant_messages_with_usage() {
+        let file = write_zstd_session(&[
+            r#"{"type":"session","version":0,"id":"session-abc","createdAt":1786669406484,"cwd":"E:\\repo\\proj","delegationDepth":0,"agentPreset":"cordis"}"#,
+            r#"{"type":"turn/start","seq":4,"time":1786669450000,"data":{"turn":1}}"#,
+            r#"{"type":"user/message","seq":7,"time":1786669450001,"data":{"turn":1}}"#,
+            r#"{"type":"assistant/message","seq":301,"time":1786669454772,"data":{"turn":1,"step":1,"message":{"role":"assistant","content":[],"source":{"kind":"model","provider":"irix","model":"deepseek-v4-flash"}},"usage":{"inputTokens":130,"outputTokens":159,"cacheReadTokens":13824}}}"#,
+            r#"{"type":"assistant/message","seq":414,"time":1786669459063,"data":{"turn":1,"step":2,"message":{"role":"assistant","content":[],"source":{"kind":"model","provider":"irix","model":"deepseek-v4-flash"}},"usage":{"inputTokens":130,"outputTokens":159,"cacheReadTokens":13824}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert_eq!(messages.len(), 2);
+
+        let first = &messages[0];
+        assert_eq!(first.client, "dsh");
+        assert_eq!(first.model_id, "deepseek-v4-flash");
+        assert_eq!(first.provider_id, "irix");
+        assert_eq!(first.session_id, "session-abc");
+        assert_eq!(first.timestamp, 1786669454772);
+        assert_eq!(first.tokens.input, 130);
+        assert_eq!(first.tokens.output, 159);
+        assert_eq!(first.tokens.cache_read, 13824);
+        assert_eq!(first.tokens.cache_write, 0);
+        assert_eq!(first.tokens.reasoning, 0);
+        assert_eq!(first.cost, 0.0);
+        assert!(first.is_turn_start);
+        assert_eq!(first.workspace_key.as_deref(), Some("E:/repo/proj"));
+        assert_eq!(first.workspace_label.as_deref(), Some("proj"));
+        assert!(first.dedup_key.as_deref().unwrap().starts_with("dsh:session-abc:"));
+
+        // Same turn, later step: not a turn start.
+        assert!(!messages[1].is_turn_start);
+    }
+
+    #[test]
+    fn supports_cache_write_and_reasoning_buckets() {
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-xyz","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"assistant/message","time":1786669454772,"data":{"turn":1,"message":{"source":{"provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":10,"outputTokens":20,"cacheReadTokens":30,"cacheWriteTokens":40,"reasoningTokens":50}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert_eq!(messages.len(), 1);
+        let msg = &messages[0];
+        assert_eq!(msg.tokens.input, 10);
+        assert_eq!(msg.tokens.output, 20);
+        assert_eq!(msg.tokens.cache_read, 30);
+        assert_eq!(msg.tokens.cache_write, 40);
+        assert_eq!(msg.tokens.reasoning, 50);
+        assert_eq!(msg.model_id, "deepseek-reasoner");
+        assert_eq!(msg.provider_id, "deepseek");
+    }
+
+    #[test]
+    fn falls_back_to_request_header_routing_and_folder_session_id() {
+        let file = write_zstd_session(&[
+            r#"{"type":"request/header","seq":11,"time":1786669450062,"data":{"header":{"config":{"provider":"irix","model":"deepseek-v4-flash"}}}}"#,
+            // No `session` event and no `source` on the message: session id
+            // comes from the folder, model/provider from the header.
+            r#"{"type":"assistant/message","time":1786669454772,"data":{"turn":1,"message":{"role":"assistant","content":[]},"usage":{"inputTokens":5,"outputTokens":7}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert_eq!(messages.len(), 1);
+        let msg = &messages[0];
+        let folder = file
+            .path()
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|n| n.to_str())
+            .unwrap();
+        assert_eq!(msg.session_id, folder);
+        assert_eq!(msg.model_id, "deepseek-v4-flash");
+        assert_eq!(msg.provider_id, "irix");
+    }
+
+    #[test]
+    fn skips_zero_usage_and_missing_timestamp() {
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-zero","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"assistant/message","time":1786669454772,"data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":0,"outputTokens":0}}}"#,
+            r#"{"type":"assistant/message","data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":1,"outputTokens":1}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn dedups_identical_replayed_rows_within_a_file() {
+        let line = r#"{"type":"assistant/message","time":1786669454772,"data":{"turn":1,"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20}}}"#;
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-dedup","createdAt":1,"cwd":"/work"}"#,
+            line,
+            line,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert_eq!(messages.len(), 1);
+    }
+
+    #[test]
+    fn missing_or_corrupt_files_yield_no_messages() {
+        assert!(parse_dsh_file(Path::new("/nonexistent/dsh/session.jsonl.zstd")).is_empty());
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut file, b"this is not zstd").unwrap();
+        assert!(parse_dsh_file(file.path()).is_empty());
+    }
+
+    #[test]
+    fn marks_turn_start_when_no_turn_numbers_are_present() {
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-noturn","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"user/message","time":1,"data":{}}"#,
+            r#"{"type":"assistant/message","time":1786669454772,"data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20}}}"#,
+            r#"{"type":"assistant/message","time":1786669455000,"data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":11,"outputTokens":21}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert_eq!(messages.len(), 2);
+        assert!(messages[0].is_turn_start);
+        assert!(!messages[1].is_turn_start);
+    }
+}

--- a/crates/tokscale-core/src/sessions/dsh.rs
+++ b/crates/tokscale-core/src/sessions/dsh.rs
@@ -220,7 +220,11 @@ mod tests {
         assert!(first.is_turn_start);
         assert_eq!(first.workspace_key.as_deref(), Some("E:/repo/proj"));
         assert_eq!(first.workspace_label.as_deref(), Some("proj"));
-        assert!(first.dedup_key.as_deref().unwrap().starts_with("dsh:session-abc:"));
+        assert!(first
+            .dedup_key
+            .as_deref()
+            .unwrap()
+            .starts_with("dsh:session-abc:"));
 
         // Same turn, later step: not a turn start.
         assert!(!messages[1].is_turn_start);

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -20,6 +20,7 @@ pub mod crush;
 pub mod cursor;
 pub mod devin;
 pub mod droid;
+pub mod dsh;
 pub mod freebuff;
 pub mod gemini;
 pub mod gjc;

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -75,6 +75,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   reasonix: "Reasonix",
   "prime-agent": "Prime Agent",
   cherrystudio: "Cherry Studio",
+  dsh: "DeepSeek Harness",
 };
 
 // Client logos from GitHub CDN (public repo)
@@ -133,6 +134,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
   reasonix: `${GITHUB_CDN_BASE}/client-synthetic.png`,
   "prime-agent": "https://github.com/PrimeIntellect-ai.png",
   cherrystudio: `${GITHUB_CDN_BASE}/client-cherrystudio.png`,
+  dsh: "https://github.com/deepseek-ai.png",
 };
 
 export const SOURCE_COLORS: Record<ClientType, string> = {
@@ -184,6 +186,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   reasonix: "#6366F1",
   "prime-agent": "#6C63FF",
   cherrystudio: "#FA7298",
+  dsh: "#4D6BFE",
 };
 
 // Derived values

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -47,6 +47,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "reasonix",
   "prime-agent",
   "cherrystudio",
+  "dsh",
 ] as const;
 
 export type CcMirrorClientType = `cc-mirror/${string}`;


### PR DESCRIPTION
## What

Adds **DeepSeek Harness (DSH)** as a supported client so `tokscale` can track token usage and cost from DSH session transcripts.

## Data source

DSH persists one zstd-compressed JSONL transcript per session under `~/.dsh/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd` (home overridable via `DSH_HOME`). Each `assistant/message` event carries authoritative per-call usage (`inputTokens`/`outputTokens`/`cacheReadTokens`/`cacheWriteTokens`/`reasoningTokens`) plus the serving provider/model; the `session` event supplies the session id and workspace (`cwd`).

## Changes

- **`sessions::dsh` parser**: zstd-decompresses each transcript, emits one `UnifiedMessage` per `assistant/message` with non-zero usage, falls back to the most recent `request/header` routing when a message lacks its own `source`, marks the first message of each turn as a turn start, normalizes the workspace key, and dedups replayed rows within a file.
- **Client registry**: registers `dsh` (display "DeepSeek Harness") at index 46 with `DSH_HOME` env-var root and `session.jsonl.zstd` pattern.
- **Scanner**: matches `session.jsonl.zstd` at any depth under the sessions root.
- **Pipeline**: wires DSH through the generic cached parse lane in `collect_all_messages` and through `parse_local_clients` so `tokscale clients` reports message counts.
- **CLI/TUI**: adds `dsh` to the `ClientFilter` (`-c dsh`), the TUI hotkey map (`t`), and a compact display name ("DeepSeek") that fits the 15-cell Client column.
- **Docs**: adds the DeepSeek Harness row to all four READMEs.

## Tests

- New parser unit tests (usage buckets, header fallback, dedup, turn-start, corrupt/missing files) and a scanner discovery test.
- `cargo test -p tokscale-core --lib` → 1672 passed.
- `cargo test -p tokscale-cli --bin tokscale` → 1038 passed; the one failure (`tui::cache::tests::load_cache_falls_back_to_legacy_dot_cache_path`) also fails on `main` and is unrelated.
- Verified end-to-end against real DSH data: `tokscale models --client dsh` reports 500+ messages with tokens and cost resolved through the existing pricing pipeline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DeepSeek Harness (DSH) as a first-class client so `tokscale` discovers, tracks, and prices token usage from DSH session transcripts. Previously DSH sessions were ignored; now zstd-compressed JSONL transcripts are scanned and priced like other local clients.

- Client registry/scanner: registers `dsh` (display "DeepSeek Harness") at index 46 with root `DSH_HOME` (default `~/.dsh`), scanning `~/.dsh/sessions/**/session.jsonl.zstd`; bumps `ClientId::COUNT` to 47.
- Parser (`sessions::dsh`): emits one `UnifiedMessage` per `assistant/message` with non-zero usage (input/output/cache-read/cache-write/reasoning), falls back to latest `request/header` for model/provider, marks turn starts, normalizes workspace, dedups replayed rows, and skips corrupt/missing files.
- Pipeline wiring: adds DSH to the cached parse lane in `collect_all_messages` and to `parse_local_clients`; DSH messages carry no cost and are priced via existing pricing data.
- CLI/TUI: adds `-c dsh` filter and TUI hotkey `t`; compact client name "DeepSeek".
- Frontend: registers `dsh` display name, logo, and color in `packages/frontend` so the UI renders DeepSeek Harness correctly.
- Docs/Tests: adds DeepSeek Harness to all READMEs; tests cover parser, scanner, and client ordering.
- Migration: no breaking changes. To ingest DSH data, ensure transcripts exist under `DSH_HOME` and run `tokscale models --client dsh` (or use `-c dsh` elsewhere).

<sup>Written for commit fce70cf1a38219cd2d726def49f693c8993739b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

