### PR TITLE
test: make the #1092 tiebreak regression non-vacuous and de-flake the TUI cache tests

### DIFF
--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -6,7 +6,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fs::{self, File};
 use std::io::{BufReader, BufWriter};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -759,23 +759,22 @@ pub fn load_cache(
     let Some(cache_path) = cache_file() else {
         return CacheResult::Miss;
     };
-    let cached: Option<CachedTUIData> = match File::open(&cache_path) {
-        Ok(file) => {
-            let reader = BufReader::new(file);
-            serde_json::from_reader(reader).ok()
-        }
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            legacy_cache_files().into_iter().find_map(|path| {
-                let file = File::open(path).ok()?;
-                let reader = BufReader::new(file);
-                serde_json::from_reader(reader).ok()
-            })
-        }
-        Err(_) => None,
-    };
-    let Some(cached) = cached else {
+    let Some(cached) = read_cached_payload(&cache_path, &legacy_cache_files()) else {
         return CacheResult::Miss;
     };
+    classify_cached_payload(cached, enabled_clients, group_by, report_scope)
+}
+
+/// Decide whether a payload that was already read off disk is usable, and how
+/// stale it is. Pure given its inputs apart from the current clock, so the
+/// freshness contract can be asserted without redirecting process-global
+/// paths.
+fn classify_cached_payload(
+    cached: CachedTUIData,
+    enabled_clients: &HashSet<ClientFilter>,
+    group_by: &GroupBy,
+    report_scope: &CacheReportScope,
+) -> CacheResult {
     if cached.schema_version > CACHE_SCHEMA_VERSION {
         return CacheResult::Miss;
     }
@@ -825,6 +824,30 @@ pub fn load_cache(
         CacheResult::Stale(data)
     } else {
         CacheResult::Fresh(data)
+    }
+}
+
+/// Read the cache payload, preferring the canonical path and falling back to
+/// the pre-#470 locations only when the canonical file does not exist.
+///
+/// Split out of [`load_cache`] because the canonical path is not redirectable
+/// in a test: on Windows `get_config_dir()` resolves through
+/// `dirs::config_dir()` (`%APPDATA%`), which no environment variable can move,
+/// while `legacy_dot_cache_tokscale_dir()` follows `$HOME`. A test that drove
+/// this precedence through the environment therefore depended on whatever the
+/// rest of the suite had left in the real `%APPDATA%\tokscale\cache`. Taking
+/// both paths as arguments makes the ordering testable directly.
+///
+/// A canonical file that exists but fails to parse is NOT a reason to read a
+/// legacy file: only `NotFound` opens the fallback.
+fn read_cached_payload(primary: &Path, legacy: &[PathBuf]) -> Option<CachedTUIData> {
+    match File::open(primary) {
+        Ok(file) => serde_json::from_reader(BufReader::new(file)).ok(),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => legacy.iter().find_map(|path| {
+            let file = File::open(path).ok()?;
+            serde_json::from_reader(BufReader::new(file)).ok()
+        }),
+        Err(_) => None,
     }
 }
 
@@ -961,9 +984,65 @@ pub fn save_cached_data(
 mod tests {
     use super::*;
     use serial_test::serial;
+    use std::ffi::OsString;
     use std::time::{SystemTime, UNIX_EPOCH};
     use std::{env, fs};
     use tempfile::TempDir;
+
+    /// Redirect `$HOME` **and** the canonical cache dir at a scratch root.
+    ///
+    /// `$HOME` alone is not enough. `legacy_dot_cache_tokscale_dir()` follows
+    /// `$HOME` on every platform, but `get_config_dir()` only does so on
+    /// macOS/Linux; on Windows it resolves through `dirs::config_dir()`
+    /// (`%APPDATA%`), which no environment variable can move. Every test here
+    /// that writes `cache_file()` was therefore writing the runner's real
+    /// `%APPDATA%\tokscale\cache\tui-data-cache.json` and leaking it into
+    /// whichever test ran next. `TOKSCALE_CONFIG_DIR` is the one knob that
+    /// moves the canonical path on all three platforms.
+    ///
+    /// Restoring on `Drop` rather than at the end of the test body matters for
+    /// the same reason it does in `tokscale_core::paths::test_env`: a failing
+    /// assertion panics before a manual restore runs and leaves `$HOME`
+    /// pointing at a deleted `TempDir` for every later test in the process.
+    /// That helper is `#[cfg(test)] pub(crate)` inside tokscale-core and is not
+    /// reachable from this crate, hence the local copy.
+    struct CacheEnv {
+        home: Option<OsString>,
+        config_dir: Option<OsString>,
+    }
+
+    impl CacheEnv {
+        fn capture() -> Self {
+            Self {
+                home: env::var_os("HOME"),
+                config_dir: env::var_os("TOKSCALE_CONFIG_DIR"),
+            }
+        }
+
+        fn redirect(root: &Path) -> Self {
+            let saved = Self::capture();
+            unsafe {
+                env::set_var("HOME", root);
+                env::set_var("TOKSCALE_CONFIG_DIR", root.join("config"));
+            }
+            saved
+        }
+    }
+
+    impl Drop for CacheEnv {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.home {
+                    Some(value) => env::set_var("HOME", value),
+                    None => env::remove_var("HOME"),
+                }
+                match &self.config_dir {
+                    Some(value) => env::set_var("TOKSCALE_CONFIG_DIR", value),
+                    None => env::remove_var("TOKSCALE_CONFIG_DIR"),
+                }
+            }
+        }
+    }
 
     /// Build a unified filter set. Pass `synthetic=true` to include
     /// `ClientFilter::Synthetic` as a set member (the new way to express
@@ -1151,10 +1230,7 @@ mod tests {
     #[serial]
     fn load_cache_misses_when_report_scope_differs() {
         let temp_dir = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        unsafe {
-            env::set_var("HOME", temp_dir.path());
-        }
+        let _env = CacheEnv::redirect(temp_dir.path());
 
         let cache_path = cache_file().unwrap();
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
@@ -1202,23 +1278,13 @@ mod tests {
             load_cache(&clients, &GroupBy::Model, &filtered_scope),
             CacheResult::Fresh(_)
         ));
-
-        match previous_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
-        }
     }
 
     #[test]
     #[serial]
     fn save_cached_data_writes_report_scope() {
         let temp_dir = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        let previous_override = env::var_os("TOKSCALE_CONFIG_DIR");
-        unsafe {
-            env::set_var("HOME", temp_dir.path());
-            env::remove_var("TOKSCALE_CONFIG_DIR");
-        }
+        let _env = CacheEnv::redirect(temp_dir.path());
 
         let clients = make_filters(&[ClientFilter::Claude], false);
         let scope = CacheReportScope::new(
@@ -1240,25 +1306,13 @@ mod tests {
             load_cache(&clients, &GroupBy::Model, &CacheReportScope::default()),
             CacheResult::Miss
         ));
-
-        match previous_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
-        }
-        match previous_override {
-            Some(value) => unsafe { env::set_var("TOKSCALE_CONFIG_DIR", value) },
-            None => unsafe { env::remove_var("TOKSCALE_CONFIG_DIR") },
-        }
     }
 
     #[test]
     #[serial]
     fn old_cache_without_report_scope_is_stale_for_unfiltered_scope() {
         let temp_dir = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        unsafe {
-            env::set_var("HOME", temp_dir.path());
-        }
+        let _env = CacheEnv::redirect(temp_dir.path());
 
         let cache_path = cache_file().unwrap();
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
@@ -1296,21 +1350,13 @@ mod tests {
             load_cache(&clients, &GroupBy::Model, &filtered_scope),
             CacheResult::Miss
         ));
-
-        match previous_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
-        }
     }
 
     #[test]
     #[serial]
     fn test_load_cache_misses_for_legacy_schema_without_group_by() {
         let temp_dir = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        unsafe {
-            env::set_var("HOME", temp_dir.path());
-        }
+        let _env = CacheEnv::redirect(temp_dir.path());
 
         let cache_path = cache_file().unwrap();
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
@@ -1338,21 +1384,13 @@ mod tests {
             load_cache(&clients, &GroupBy::Model, &CacheReportScope::default()),
             CacheResult::Miss
         ));
-
-        match previous_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
-        }
     }
 
     #[test]
     #[serial]
     fn test_load_cache_misses_when_group_by_differs() {
         let temp_dir = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        unsafe {
-            env::set_var("HOME", temp_dir.path());
-        }
+        let _env = CacheEnv::redirect(temp_dir.path());
 
         let cache_path = cache_file().unwrap();
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
@@ -1386,21 +1424,13 @@ mod tests {
             ),
             CacheResult::Miss
         ));
-
-        match previous_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
-        }
     }
 
     #[test]
     #[serial]
     fn test_load_cache_stale_legacy_daily_models_without_display_fields() {
         let temp_dir = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        unsafe {
-            env::set_var("HOME", temp_dir.path());
-        }
+        let _env = CacheEnv::redirect(temp_dir.path());
 
         let cache_path = cache_file().unwrap();
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
@@ -1463,21 +1493,13 @@ mod tests {
                 other_variant_name(&other)
             ),
         }
-
-        match previous_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
-        }
     }
 
     #[test]
     #[serial]
     fn test_load_cache_reads_source_breakdown_from_current_schema() {
         let temp_dir = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        unsafe {
-            env::set_var("HOME", temp_dir.path());
-        }
+        let _env = CacheEnv::redirect(temp_dir.path());
 
         let cache_path = cache_file().unwrap();
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
@@ -1584,21 +1606,13 @@ mod tests {
                 other_variant_name(&other)
             ),
         }
-
-        match previous_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
-        }
     }
 
     #[test]
     #[serial]
     fn test_load_cache_stale_legacy_hourly_models_without_display_fields() {
         let temp_dir = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        unsafe {
-            env::set_var("HOME", temp_dir.path());
-        }
+        let _env = CacheEnv::redirect(temp_dir.path());
 
         let cache_path = cache_file().unwrap();
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
@@ -1660,21 +1674,13 @@ mod tests {
             }
             other => panic!("expected cache data, got {:?}", other_variant_name(&other)),
         }
-
-        match previous_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
-        }
     }
 
     #[test]
     #[serial]
     fn test_load_cache_legacy_empty_client_falls_back_to_unknown() {
         let temp_dir = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        unsafe {
-            env::set_var("HOME", temp_dir.path());
-        }
+        let _env = CacheEnv::redirect(temp_dir.path());
 
         let cache_path = cache_file().unwrap();
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
@@ -1741,31 +1747,9 @@ mod tests {
                 other_variant_name(&other)
             ),
         }
-
-        match previous_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
-        }
     }
 
-    #[test]
-    #[serial]
-    fn load_cache_falls_back_to_legacy_dot_cache_path() {
-        let temp_dir = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        let previous_override = env::var_os("TOKSCALE_CONFIG_DIR");
-        let previous_xdg_config_home = env::var_os("XDG_CONFIG_HOME");
-        unsafe {
-            env::set_var("HOME", temp_dir.path());
-            env::remove_var("TOKSCALE_CONFIG_DIR");
-            env::set_var("XDG_CONFIG_HOME", temp_dir.path().join(".xdg-config"));
-        }
-
-        let legacy_path = temp_dir.path().join(".cache/tokscale/tui-data-cache.json");
-        fs::create_dir_all(legacy_path.parent().unwrap()).unwrap();
-        fs::write(
-            &legacy_path,
-            r#"{
+    const LEGACY_FALLBACK_PAYLOAD: &str = r#"{
   "schemaVersion": 10,
   "timestamp": 9999999999999,
   "enabledClients": ["claude"],
@@ -1782,28 +1766,86 @@ mod tests {
     "currentStreak": 0,
     "longestStreak": 0
   }
-}"#,
-        )
-        .unwrap();
+}"#;
+
+    /// The canonical cache path and the legacy `~/.cache/tokscale` path are
+    /// asserted separately on purpose.
+    ///
+    /// Driving this contract through `load_cache` was order-dependent on
+    /// Windows and flaked in CI (run 31772032073). `HOME` moves
+    /// `legacy_dot_cache_tokscale_dir()` on every platform, but it does not
+    /// move `get_config_dir()` on Windows, where it resolves through
+    /// `dirs::config_dir()` (`%APPDATA%`) and no environment variable can
+    /// redirect it. Every sibling test that writes `cache_file()` therefore
+    /// wrote the same real `%APPDATA%\tokscale\cache\tui-data-cache.json`,
+    /// and this test only reached the legacy probe when it happened to run
+    /// before all of them: `load_cache` reads a legacy file only when the
+    /// canonical one is `NotFound`. That precedence is correct and stays
+    /// unchanged — the test was the broken part.
+    #[test]
+    fn read_cached_payload_reads_legacy_only_when_canonical_is_absent() {
+        let temp_dir = TempDir::new().unwrap();
+        let canonical = temp_dir.path().join("canonical/tui-data-cache.json");
+        let legacy = temp_dir.path().join(".cache/tokscale/tui-data-cache.json");
+        fs::create_dir_all(canonical.parent().unwrap()).unwrap();
+        fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+        fs::write(&legacy, LEGACY_FALLBACK_PAYLOAD).unwrap();
 
         let clients = make_filters(&[ClientFilter::Claude], false);
-        assert!(matches!(
-            load_cache(&clients, &GroupBy::Model, &CacheReportScope::default()),
-            CacheResult::Fresh(_)
-        ));
+        let scope = CacheReportScope::default();
 
-        match previous_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
+        let fallback = read_cached_payload(&canonical, std::slice::from_ref(&legacy))
+            .expect("legacy file must be read when the canonical file is absent");
+        let result = classify_cached_payload(fallback, &clients, &GroupBy::Model, &scope);
+        assert!(
+            matches!(result, CacheResult::Fresh(_)),
+            "legacy fallback must classify as Fresh, got {}",
+            other_variant_name(&result)
+        );
+
+        // Canonical present: the legacy file must not be consulted at all,
+        // even though it is the newer/valid one here.
+        fs::write(
+            &canonical,
+            LEGACY_FALLBACK_PAYLOAD
+                .replace(r#""groupBy": "model""#, r#""groupBy": "client,model""#),
+        )
+        .unwrap();
+        let preferred = read_cached_payload(&canonical, std::slice::from_ref(&legacy))
+            .expect("canonical file must be read when present");
+        assert_eq!(preferred.group_by.as_deref(), Some("client,model"));
+
+        // Canonical present but unparseable is a miss, not a legacy read:
+        // falling back would resurrect data the canonical write superseded.
+        fs::write(&canonical, "{ not json").unwrap();
+        assert!(read_cached_payload(&canonical, std::slice::from_ref(&legacy)).is_none());
+    }
+
+    /// Pins the other half of the fallback: the legacy candidate list itself.
+    /// `home_dir()` honors `$HOME` on Windows too (#997), so this assertion is
+    /// deterministic on every platform.
+    #[test]
+    #[serial]
+    fn legacy_cache_files_resolve_under_home_and_vanish_when_overridden() {
+        let temp_dir = TempDir::new().unwrap();
+        let _env = CacheEnv::capture();
+        unsafe {
+            env::set_var("HOME", temp_dir.path());
+            env::remove_var("TOKSCALE_CONFIG_DIR");
         }
-        match previous_override {
-            Some(value) => unsafe { env::set_var("TOKSCALE_CONFIG_DIR", value) },
-            None => unsafe { env::remove_var("TOKSCALE_CONFIG_DIR") },
+
+        assert_eq!(
+            legacy_cache_files(),
+            vec![temp_dir.path().join(".cache/tokscale/tui-data-cache.json")]
+        );
+
+        unsafe {
+            env::set_var("TOKSCALE_CONFIG_DIR", temp_dir.path().join("explicit"));
         }
-        match previous_xdg_config_home {
-            Some(value) => unsafe { env::set_var("XDG_CONFIG_HOME", value) },
-            None => unsafe { env::remove_var("XDG_CONFIG_HOME") },
-        }
+        assert!(
+            legacy_cache_files().is_empty(),
+            "an explicit config dir must stay hermetic"
+        );
     }
 
     #[test]
@@ -1811,8 +1853,7 @@ mod tests {
     fn load_cache_skips_legacy_when_overridden() {
         let temp_dir = TempDir::new().unwrap();
         let override_dir = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        let previous_override = env::var_os("TOKSCALE_CONFIG_DIR");
+        let _env = CacheEnv::capture();
         unsafe {
             env::set_var("HOME", temp_dir.path());
             env::set_var("TOKSCALE_CONFIG_DIR", override_dir.path());
@@ -1848,27 +1889,13 @@ mod tests {
             load_cache(&clients, &GroupBy::Model, &CacheReportScope::default()),
             CacheResult::Miss
         ));
-
-        match previous_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
-        }
-        match previous_override {
-            Some(value) => unsafe { env::set_var("TOKSCALE_CONFIG_DIR", value) },
-            None => unsafe { env::remove_var("TOKSCALE_CONFIG_DIR") },
-        }
     }
 
     #[test]
     #[serial]
     fn save_cached_data_does_not_delete_destination() {
         let temp_dir = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        let previous_override = env::var_os("TOKSCALE_CONFIG_DIR");
-        unsafe {
-            env::set_var("HOME", temp_dir.path());
-            env::remove_var("TOKSCALE_CONFIG_DIR");
-        }
+        let _env = CacheEnv::redirect(temp_dir.path());
 
         let cache_path = cache_file().unwrap();
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
@@ -1914,15 +1941,6 @@ mod tests {
         assert!(metadata.is_file());
         let saved: CachedTUIData = serde_json::from_slice(&fs::read(&cache_path).unwrap()).unwrap();
         assert!(saved.timestamp >= old_timestamp);
-
-        match previous_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
-        }
-        match previous_override {
-            Some(value) => unsafe { env::set_var("TOKSCALE_CONFIG_DIR", value) },
-            None => unsafe { env::remove_var("TOKSCALE_CONFIG_DIR") },
-        }
     }
 
     fn other_variant_name(result: &CacheResult) -> &'static str {
@@ -1957,12 +1975,7 @@ mod tests {
     #[serial]
     fn warm_cache_round_trip_under_canonical_key_is_fresh() {
         let temp_dir = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        let previous_override = env::var_os("TOKSCALE_CONFIG_DIR");
-        unsafe {
-            env::set_var("HOME", temp_dir.path());
-            env::remove_var("TOKSCALE_CONFIG_DIR");
-        }
+        let _env = CacheEnv::redirect(temp_dir.path());
 
         let enabled = ClientFilter::default_set();
         let scope = CacheReportScope::default();
@@ -1986,15 +1999,6 @@ mod tests {
             "expected Fresh after writing with TUI_DEFAULT_GROUP_BY, got {}",
             other_variant_name(&result)
         );
-
-        match previous_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
-        }
-        match previous_override {
-            Some(value) => unsafe { env::set_var("TOKSCALE_CONFIG_DIR", value) },
-            None => unsafe { env::remove_var("TOKSCALE_CONFIG_DIR") },
-        }
     }
 
     /// Documents the historical bug as a frozen regression: writing with
@@ -2006,12 +2010,7 @@ mod tests {
     #[serial]
     fn pre_fix_writer_key_misses_under_canonical_reader_key() {
         let temp_dir = TempDir::new().unwrap();
-        let previous_home = env::var_os("HOME");
-        let previous_override = env::var_os("TOKSCALE_CONFIG_DIR");
-        unsafe {
-            env::set_var("HOME", temp_dir.path());
-            env::remove_var("TOKSCALE_CONFIG_DIR");
-        }
+        let _env = CacheEnv::redirect(temp_dir.path());
 
         let enabled = ClientFilter::default_set();
         let scope = CacheReportScope::default();
@@ -2031,14 +2030,5 @@ mod tests {
             "expected Miss when reader uses TUI_DEFAULT_GROUP_BY and writer used GroupBy::default(), got {}",
             other_variant_name(&result)
         );
-
-        match previous_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
-        }
-        match previous_override {
-            Some(value) => unsafe { env::set_var("TOKSCALE_CONFIG_DIR", value) },
-            None => unsafe { env::remove_var("TOKSCALE_CONFIG_DIR") },
-        }
     }
 }

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -333,6 +333,10 @@ impl PricingLookup {
         sakana: HashMap<String, ModelPricing>,
         models_dev: HashMap<String, ModelPricing>,
     ) -> Self {
+        // Longest key first, then alphabetical. The alphabetical leg only pins
+        // equal-length ties so a run is reproducible; it carries no pricing
+        // meaning, and the cheaper or more authoritative row does not win by
+        // being sorted earlier.
         let mut litellm_keys: Vec<String> = litellm.keys().cloned().collect();
         litellm_keys.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
 
@@ -7197,64 +7201,49 @@ mod tests {
         );
     }
 
+    /// Regression (#1092): equal-length candidate keys must be ordered by the
+    /// index, not by `HashMap` iteration order. This exercises the ordered
+    /// candidate list consumed by `select_best_match` — two litellm keys of the
+    /// same length, no models.dev entries, so the only thing that can decide the
+    /// winner is the tiebreak in the key sort. Without it the lookup returns
+    /// whichever key the hasher happened to yield first, and the reported rate
+    /// flips between $0.01 and $0.02 across processes.
     #[test]
     fn test_pricing_index_deterministic_key_sorting_equal_length() {
-        // Equal length keys inserted in different orders must produce identical candidate key ordering
-        let mut map_a = HashMap::new();
-        map_a.insert(
-            "bedrock/us-east-1/zai.glm-5".to_string(),
-            ModelPricing {
-                input_cost_per_token: Some(0.01),
-                ..Default::default()
-            },
-        );
-        map_a.insert(
-            "bedrock/us-west-2/zai.glm-5".to_string(),
-            ModelPricing {
-                input_cost_per_token: Some(0.02),
-                ..Default::default()
-            },
-        );
+        let build = |first: (&str, f64), second: (&str, f64)| {
+            let mut litellm = HashMap::new();
+            for (key, input_cost) in [first, second] {
+                litellm.insert(
+                    key.to_string(),
+                    ModelPricing {
+                        input_cost_per_token: Some(input_cost),
+                        ..Default::default()
+                    },
+                );
+            }
+            PricingLookup::new_with_models_dev(
+                litellm,
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::new(),
+            )
+        };
 
-        let mut map_b = HashMap::new();
-        map_b.insert(
-            "bedrock/us-west-2/zai.glm-5".to_string(),
-            ModelPricing {
-                input_cost_per_token: Some(0.02),
-                ..Default::default()
-            },
-        );
-        map_b.insert(
-            "bedrock/us-east-1/zai.glm-5".to_string(),
-            ModelPricing {
-                input_cost_per_token: Some(0.01),
-                ..Default::default()
-            },
-        );
+        let east = ("bedrock/us-east-1/zai.glm-5", 0.01);
+        let west = ("bedrock/us-west-2/zai.glm-5", 0.02);
+        assert_eq!(east.0.len(), west.0.len());
 
-        let index_a = PricingLookup::new_with_models_dev(
-            map_a.clone(),
-            HashMap::new(),
-            HashMap::new(),
-            HashMap::new(),
-            map_a,
-        );
-        let index_b = PricingLookup::new_with_models_dev(
-            map_b.clone(),
-            HashMap::new(),
-            HashMap::new(),
-            HashMap::new(),
-            map_b,
-        );
-
-        let res_a = index_a.lookup("zai.glm-5").unwrap();
-        let res_b = index_b.lookup("zai.glm-5").unwrap();
-
-        assert_eq!(
-            res_a.matched_key, res_b.matched_key,
-            "Pricing lookup for equal length keys must be deterministic regardless of insertion order"
-        );
-        assert_eq!(res_a.matched_key, "bedrock/us-east-1/zai.glm-5");
+        for (order, index) in [build(east, west), build(west, east)].iter().enumerate() {
+            let result = index
+                .lookup_with_provider("zai.glm-5", Some("bedrock"))
+                .unwrap_or_else(|| panic!("insertion order {order} must resolve zai.glm-5"));
+            assert_eq!(
+                result.matched_key, "bedrock/us-east-1/zai.glm-5",
+                "equal-length candidates must resolve to the alphabetically first key regardless of insertion order (order {order})"
+            );
+            assert_eq!(result.pricing.input_cost_per_token, Some(0.01));
+        }
     }
 
     /// Regression (#1062): a bare router label must not be priced from a


### PR DESCRIPTION
Two test-only follow-ups. Separate commits, no production behavior change.

## 1. The #1092 regression test was vacuous

`test_pricing_index_deterministic_key_sorting_equal_length` seeded the same map into both the litellm and models.dev arguments of `new_with_models_dev`, so `lookup("zai.glm-5")` resolved through the `models_dev_model_part` index. That index's tiebreak is `prefers_model_part_key`, which was already deterministic before #1092 and never touches the sorted candidate list the PR changed. With `new_with_models_dev`'s sort reverted to `sort_by_key(|k| Reverse(k.len()))`, the test passes 40/40 processes.

The replacement uses two equal-length litellm keys, no models.dev entries, and `lookup_with_provider("zai.glm-5", Some("bedrock"))`, so the ordered candidate list feeding `select_best_match` is the only thing that can elect a winner. Both insertion orders are asserted, and so is the resulting rate, because the failure mode is a $0.01/$0.02 flip rather than a lookup miss.

Non-vacuity, same binary, one process per run:

| sort | result |
| --- | --- |
| reverted to `sort_by_key(Reverse(len))` | 41/60 fail |
| `main` as merged | 60/60 pass |
| old test, reverted sort (control) | 60/60 pass |

The comment at the sort now records that the alphabetical leg only pins equal-length ties for reproducibility and is not a price signal.

## 2. `load_cache_falls_back_to_legacy_dot_cache_path` flaked on windows-latest

Run 31772032073, job 94679768460, passed on rerun. Not a race, and not a bug in the legacy fallback: it is order dependence on a path no test can redirect.

`legacy_dot_cache_tokscale_dir()` resolves through `home_dir()`, which honors `$HOME` on Windows too (#997). `get_config_dir()` does not — on Windows it goes to `dirs::config_dir()` (`%APPDATA%`), which no environment variable can move. Every test in the module that writes `cache_file()` was therefore writing the runner's real `%APPDATA%\tokscale\cache\tui-data-cache.json`, and this test only reached its legacy probe when it happened to run before all of them, since `load_cache` reads a legacy file only when the canonical one is `NotFound`. In the failing attempt `load_cache_misses_when_report_scope_differs` completed immediately before it and left a canonical file whose `reportScope` does not match the requested one, so `load_cache` returned `Miss` at the scope check and the legacy file was never opened. Test ordering on the reruns confirms it: the legacy test completed first in the passing attempt and second in the failing one.

The precedence (canonical first, legacy only on `NotFound`) is correct and is unchanged.

Changes:

- Split the two decisions out of `load_cache`. `read_cached_payload(primary, legacy)` takes both paths as arguments; `classify_cached_payload` grades a payload already read off disk.
- Replace the flaky test with one that drives those directly and needs no process-global state: legacy read when the canonical path is absent, legacy ignored when the canonical path is present, and `None` rather than a legacy read when the canonical file exists but does not parse (falling back there would resurrect data the canonical write superseded). A separate serial test pins the other half — `legacy_cache_files()` follows `$HOME` and is empty under `TOKSCALE_CONFIG_DIR`.
- Point the remaining cache tests at a scratch `TOKSCALE_CONFIG_DIR` via a `CacheEnv` guard, so the suite stops writing the developer's or runner's real `%APPDATA%\tokscale\cache`, and restore the environment on `Drop` instead of at the end of the body, which a failing assertion skips.

Verification: temporarily forcing `get_config_dir()` to a fixed non-`$HOME` directory (simulating Windows) and pre-seeding it with the canonical file `load_cache_misses_when_report_scope_differs` leaves behind reproduces the CI failure exactly — same assertion, same line. Under the same condition the new tests pass, and after the whole cache module runs, that directory is empty.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`, and `cargo test --locked --workspace --all-features --no-fail-fast` (2974 passed, 0 failed, 6 ignored) all clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the #1092 regression by exercising the real tiebreak and de-flakes TUI cache tests on Windows. No production behavior changes; cache precedence stays canonical-first and only falls back to legacy on NotFound.

- Pricing lookup: replace the vacuous equal-length key test with one that uses only litellm keys and `lookup_with_provider("zai.glm-5", Some("bedrock"))`, asserting the alphabetical tiebreak and resulting $0.01 rate regardless of insertion order. Add a comment clarifying the alphabetical leg is for reproducibility only.

- TUI cache tests: split `load_cache` into `read_cached_payload` (I/O, canonical vs. legacy) and `classify_cached_payload` (pure classification) to test precedence directly; behavior unchanged. Replace the flaky legacy-fallback test with focused unit tests and a serial check that `legacy_cache_files()` follows `$HOME` and is empty under `TOKSCALE_CONFIG_DIR`. Introduce a `CacheEnv` guard to redirect and restore `HOME`/`TOKSCALE_CONFIG_DIR`, stopping tests from writing to the runner’s real `%APPDATA%\tokscale\cache`.

<sup>Written for commit ea18563e1eec35d56cd5ea7c42b3b1cdb9afc612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

