### PR TITLE
feat(clients): add DeepSeek Harness support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3503,6 +3503,7 @@ dependencies = [
  "unicode-width 0.2.0",
  "usvg",
  "uuid",
+ "zstd",
 ]
 
 [[package]]

--- a/README.ja.md
+++ b/README.ja.md
@@ -103,6 +103,7 @@
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP イベント：macOS `~/Library/Application Support/Devin/User/acp-events/`、Linux `~/.config/Devin/User/acp-events/`、Windows `%APPDATA%\Devin\User\acp-events\` |
 | <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/)（Auggie CLI） | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | `hf:`モデルや`synthetic`プロバイダを検出して他ソースから再帰属（+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`） |
+| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd`（zstd 圧縮 JSONL セッション転写、`DSH_HOME` で上書き可） |
 
 [🚅 LiteLLMの価格データ](https://github.com/BerriAI/litellm)を使用してリアルタイム価格計算を提供し、階層型価格モデルとキャッシュトークン割引をサポートしています。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -103,7 +103,7 @@
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP イベント：macOS `~/Library/Application Support/Devin/User/acp-events/`、Linux `~/.config/Devin/User/acp-events/`、Windows `%APPDATA%\Devin\User\acp-events\` |
 | <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/)（Auggie CLI） | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | `hf:`モデルや`synthetic`プロバイダを検出して他ソースから再帰属（+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`） |
-| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd`（zstd 圧縮 JSONL セッション転写、`DSH_HOME` で上書き可） |
+| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd`（非圧縮で書き出された場合は `session.jsonl`、`DSH_HOME` で上書き可） |
 
 [🚅 LiteLLMの価格データ](https://github.com/BerriAI/litellm)を使用してリアルタイム価格計算を提供し、階層型価格モデルとキャッシュトークン割引をサポートしています。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -103,6 +103,7 @@
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP 이벤트: macOS `~/Library/Application Support/Devin/User/acp-events/`; Linux `~/.config/Devin/User/acp-events/`; Windows `%APPDATA%\Devin\User\acp-events\` |
 | <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/) (Auggie CLI) | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | `hf:` 모델/`synthetic` provider 감지로 다른 소스에서 재귀속 (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) |
+| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd`（zstd 압축 JSONL 세션 트랜스크립트, `DSH_HOME`으로 재정의 가능） |
 
 [🚅 LiteLLM의 가격 데이터](https://github.com/BerriAI/litellm)를 사용해 **실시간 비용 계산**을 제공합니다. 구간별 가격 모델(대용량 컨텍스트 등)과 **캐시 토큰 할인**도 지원합니다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -103,7 +103,7 @@
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP 이벤트: macOS `~/Library/Application Support/Devin/User/acp-events/`; Linux `~/.config/Devin/User/acp-events/`; Windows `%APPDATA%\Devin\User\acp-events\` |
 | <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/) (Auggie CLI) | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | `hf:` 모델/`synthetic` provider 감지로 다른 소스에서 재귀속 (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) |
-| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd`（zstd 압축 JSONL 세션 트랜스크립트, `DSH_HOME`으로 재정의 가능） |
+| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd`（압축 없이 기록된 경우 `session.jsonl`, `DSH_HOME`으로 재정의 가능） |
 
 [🚅 LiteLLM의 가격 데이터](https://github.com/BerriAI/litellm)를 사용해 **실시간 비용 계산**을 제공합니다. 구간별 가격 모델(대용량 컨텍스트 등)과 **캐시 토큰 할인**도 지원합니다.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP events: macOS `~/Library/Application Support/Devin/User/acp-events/`; Linux `~/.config/Devin/User/acp-events/`; Windows `%APPDATA%\Devin\User\acp-events\` |
 | <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/) (Auggie CLI) | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | Re-attributed from other sources via `hf:` model prefix or `synthetic` provider (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) |
+| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd` (zstd-compressed JSONL transcripts; override via `DSH_HOME`) |
 
 Get real-time pricing calculations using [🚅 LiteLLM's pricing data](https://github.com/BerriAI/litellm), with support for tiered pricing models and cache token discounts.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP events: macOS `~/Library/Application Support/Devin/User/acp-events/`; Linux `~/.config/Devin/User/acp-events/`; Windows `%APPDATA%\Devin\User\acp-events\` |
 | <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/) (Auggie CLI) | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | Re-attributed from other sources via `hf:` model prefix or `synthetic` provider (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) |
-| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd` (zstd-compressed JSONL transcripts; override via `DSH_HOME`) |
+| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd` (or `session.jsonl` when written uncompressed; override via `DSH_HOME`) |
 
 Get real-time pricing calculations using [🚅 LiteLLM's pricing data](https://github.com/BerriAI/litellm), with support for tiered pricing models and cache token discounts.
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -104,6 +104,7 @@
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP 事件：macOS `~/Library/Application Support/Devin/User/acp-events/`；Linux `~/.config/Devin/User/acp-events/`；Windows `%APPDATA%\Devin\User\acp-events\` |
 | <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/)（Auggie CLI） | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | 通过 `hf:` 模型前缀或 `synthetic` provider 从其他来源重归属（+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`） |
+| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd`（zstd 压缩的 JSONL 会话转录；可通过 `DSH_HOME` 覆盖） |
 
 使用 [🚅 LiteLLM 的价格数据](https://github.com/BerriAI/litellm)提供实时价格计算，支持分层定价模型和缓存 Token 折扣。
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -104,7 +104,7 @@
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP 事件：macOS `~/Library/Application Support/Devin/User/acp-events/`；Linux `~/.config/Devin/User/acp-events/`；Windows `%APPDATA%\Devin\User\acp-events\` |
 | <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/)（Auggie CLI） | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | 通过 `hf:` 模型前缀或 `synthetic` provider 从其他来源重归属（+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`） |
-| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd`（zstd 压缩的 JSONL 会话转录；可通过 `DSH_HOME` 覆盖） |
+| <img width="48px" src="https://github.com/deepseek-ai.png" alt="DeepSeek Harness" /> | [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | `~/.dsh/sessions/**/session.jsonl.zstd`（未压缩写出时为 `session.jsonl`；可通过 `DSH_HOME` 覆盖） |
 
 使用 [🚅 LiteLLM 的价格数据](https://github.com/BerriAI/litellm)提供实时价格计算，支持分层定价模型和缓存 Token 折扣。
 

--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -79,3 +79,5 @@ assert_cmd = "2.0"
 predicates = "3.0"
 tempfile = "3.0"
 serial_test = "3.0"
+# DSH transcript fixtures are zstd frames; the CLI tests write them directly.
+zstd = { workspace = true }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1067,6 +1067,7 @@ pub enum ClientFilter {
     PrimeAgent,
     Freebuff,
     CherryStudio,
+    Dsh,
     Synthetic,
 }
 
@@ -1123,6 +1124,7 @@ impl ClientFilter {
             Self::PrimeAgent => "prime-agent",
             Self::Freebuff => "freebuff",
             Self::CherryStudio => "cherrystudio",
+            Self::Dsh => "dsh",
             Self::Synthetic => "synthetic",
         }
     }
@@ -1182,6 +1184,7 @@ impl ClientFilter {
             Self::PrimeAgent => Some(ClientId::PrimeAgent),
             Self::Freebuff => Some(ClientId::Freebuff),
             Self::CherryStudio => Some(ClientId::CherryStudio),
+            Self::Dsh => Some(ClientId::Dsh),
             Self::Synthetic => None,
         }
     }
@@ -1237,6 +1240,7 @@ impl ClientFilter {
             ClientId::PrimeAgent => Self::PrimeAgent,
             ClientId::Freebuff => Self::Freebuff,
             ClientId::CherryStudio => Self::CherryStudio,
+            ClientId::Dsh => Self::Dsh,
         }
     }
 

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -51,6 +51,7 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
     ClientUi { hotkey: 'P' },
     ClientUi { hotkey: 'F' },
     ClientUi { hotkey: 'G' },
+    ClientUi { hotkey: 't' },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {
@@ -62,6 +63,8 @@ pub fn display_name(client: ClientId) -> &'static str {
 pub fn compact_display_name(client: ClientId) -> &'static str {
     match client {
         ClientId::Senpi => "Senpi",
+        // "DeepSeek Harness" (16 cells) overflows the 15-cell Client column.
+        ClientId::Dsh => "DeepSeek",
         _ => display_name(client),
     }
 }

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1617,6 +1617,8 @@ mod tests {
         assert_eq!(clients[42], ClientId::Reasonix);
         assert_eq!(clients[43], ClientId::PrimeAgent);
         assert_eq!(clients[44], ClientId::Freebuff);
+        assert_eq!(clients[45], ClientId::CherryStudio);
+        assert_eq!(clients[46], ClientId::Dsh);
     }
 
     #[test]
@@ -1668,6 +1670,7 @@ mod tests {
             "Prime Agent",
             "Freebuff",
             "Cherry Studio",
+            "DeepSeek Harness",
         ];
 
         assert_eq!(expected.len(), ClientId::COUNT);

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -873,7 +873,8 @@ fn cmd_with_home(tmp: &Path) -> Command {
         .env_remove("HERMES_HOME")
         .env_remove("PRIME_AGENT_CODING_AGENT_DIR")
         .env_remove("PRIME_AGENT_SESSION_DIR")
-        .env_remove("PRIME_AGENT_CODING_AGENT_SESSION_DIR");
+        .env_remove("PRIME_AGENT_CODING_AGENT_SESSION_DIR")
+        .env_remove("DSH_HOME");
     cmd
 }
 
@@ -1252,6 +1253,104 @@ fn write_cherrystudio_historical_replay_without_timestamp(base: &Path) {
         ),
     )
     .unwrap();
+}
+
+/// The DSH transcript root under a sandboxed home: `<home>/.dsh/sessions`.
+///
+/// DSH keeps all user data under one root, resolved as an explicit config
+/// path, then `$DSH_HOME`, then `~/.dsh` (`util/home-paths`, `resolveDshHome`);
+/// the shipped base composition pins the session store to `sessions` beneath
+/// it. `cmd_with_home` clears `DSH_HOME` so this test reads the sandbox.
+fn dsh_sessions_root(base: &Path) -> std::path::PathBuf {
+    base.join(".dsh").join("sessions")
+}
+
+/// One zstd DSH transcript with a reasoning-bearing call, written to
+/// `<home>/.dsh/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd`.
+///
+/// Usage numbers are the committed vendor pair from
+/// `examples/acp-agent/tests/snapshots/subagent-fork-in-process`.
+fn write_dsh_zstd_session(base: &Path) {
+    let dir = dsh_sessions_root(base)
+        .join("-tmp-dsh-workspace")
+        .join("96cf59c9-b347-48b9-b234-a5200913ad05");
+    fs::create_dir_all(&dir).unwrap();
+    let payload = concat!(
+        r#"{"type":"session","version":0,"id":"96cf59c9-b347-48b9-b234-a5200913ad05","createdAt":1783352134832,"cwd":"/tmp/dsh-workspace","delegationDepth":0}"#,
+        "
+",
+        r#"{"type":"assistant/message","seq":39,"time":1785730448979,"data":{"turn":1,"message":{"id":"7ac2e3d7-d558-4b24-b71e-40fc2f42216d","source":{"kind":"model","provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":2885,"outputTokens":25,"cacheReadTokens":0,"reasoningTokens":23}}}"#,
+        "
+"
+    );
+    fs::write(
+        dir.join("session.jsonl.zstd"),
+        zstd::encode_all(payload.as_bytes(), 3).unwrap(),
+    )
+    .unwrap();
+}
+
+/// A DSH fork pair: the parent transcript plus the child whose seeded prefix
+/// repeats the parent's seq-39 call verbatim under a different session id.
+fn write_dsh_fork_pair(base: &Path) {
+    write_dsh_zstd_session(base);
+
+    let dir = dsh_sessions_root(base)
+        .join("-tmp-dsh-workspace")
+        .join("ada8966c-9fa3-441b-8721-37ff1e795e6a");
+    fs::create_dir_all(&dir).unwrap();
+    let payload = concat!(
+        r#"{"type":"session","version":0,"id":"ada8966c-9fa3-441b-8721-37ff1e795e6a","createdAt":1783352137161,"cwd":"/tmp/dsh-workspace","parentSession":"96cf59c9-b347-48b9-b234-a5200913ad05","seedLength":42,"origin":"subagent","delegationDepth":1}"#,
+        "
+",
+        r#"{"type":"assistant/message","seq":39,"time":1785730448979,"data":{"turn":1,"message":{"id":"7ac2e3d7-d558-4b24-b71e-40fc2f42216d","source":{"kind":"model","provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":2885,"outputTokens":25,"cacheReadTokens":0,"reasoningTokens":23}}}"#,
+        "
+",
+        r#"{"type":"assistant/message","seq":96,"time":1786358035361,"data":{"turn":2,"message":{"id":"cdc56e00-c648-4669-92b2-7299e41cb743","source":{"kind":"model","provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":97,"outputTokens":39,"cacheReadTokens":2816,"reasoningTokens":34}}}"#,
+        "
+"
+    );
+    fs::write(
+        dir.join("session.jsonl.zstd"),
+        zstd::encode_all(payload.as_bytes(), 3).unwrap(),
+    )
+    .unwrap();
+}
+
+/// A DSH transcript pair whose child header carries no `seedLength`, so only
+/// the per-call `message.id` marks the seeded rows as the parent's work.
+fn write_dsh_seeded_pair_without_seed_length(base: &Path) {
+    let row = concat!(
+        r#"{"type":"assistant/message","seq":39,"time":1785730448979,"data":{"turn":1,"message":{"id":"7ac2e3d7-d558-4b24-b71e-40fc2f42216d","source":{"kind":"model","provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":2885,"outputTokens":25,"cacheReadTokens":0,"reasoningTokens":23}}}"#,
+        "\n"
+    );
+
+    for (session_id, header) in [
+        (
+            "96cf59c9-b347-48b9-b234-a5200913ad05",
+            concat!(
+                r#"{"type":"session","version":0,"id":"96cf59c9-b347-48b9-b234-a5200913ad05","createdAt":1783352134832,"cwd":"/tmp/dsh-workspace"}"#,
+                "\n"
+            ),
+        ),
+        (
+            "ada8966c-9fa3-441b-8721-37ff1e795e6a",
+            concat!(
+                r#"{"type":"session","version":0,"id":"ada8966c-9fa3-441b-8721-37ff1e795e6a","createdAt":1783352137161,"cwd":"/tmp/dsh-workspace","parentSession":"96cf59c9-b347-48b9-b234-a5200913ad05"}"#,
+                "\n"
+            ),
+        ),
+    ] {
+        let dir = dsh_sessions_root(base)
+            .join("-tmp-dsh-workspace")
+            .join(session_id);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("session.jsonl.zstd"),
+            zstd::encode_all(format!("{header}{row}").as_bytes(), 3).unwrap(),
+        )
+        .unwrap();
+    }
 }
 
 fn write_jcode_session(base: &Path) {
@@ -2043,6 +2142,140 @@ fn test_clients_json_cherrystudio_scan_root_stays_inside_the_sandboxed_home() {
         serde_json::json!(cherrystudio_projects_root(tmp.path()).to_string_lossy()),
         "Cherry Studio's scan root must follow the sandboxed home, not the machine's app-data folder"
     );
+}
+
+/// DSH resolves its root from `$DSH_HOME` with a `~/.dsh` fallback, so a
+/// sandboxed `HOME` must move the scan root with it. Asserting the emitted
+/// path directly keeps a discovery regression from surfacing as a bare
+/// `Some(0)` vs `Some(1)` totals mismatch in the tests below.
+#[test]
+fn test_clients_json_dsh_scan_root_stays_inside_the_sandboxed_home() {
+    let tmp = create_empty_fixture_dir();
+    write_dsh_zstd_session(tmp.path());
+
+    let output = cmd_with_home(tmp.path())
+        .args(["clients", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let dsh = json["clients"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["client"] == "dsh")
+        .expect("dsh must appear in `clients --json`");
+
+    assert_eq!(
+        dsh["sessionsPath"],
+        serde_json::json!(dsh_sessions_root(tmp.path()).to_string_lossy()),
+        "DSH's scan root must follow the sandboxed home, not the machine's ~/.dsh"
+    );
+}
+
+/// The zstd lane's cache parity guard.
+///
+/// The first pass decodes the transcript and writes the source cache; the
+/// second serves it warm. Both must report the same reasoning-corrected
+/// buckets — `reasoningTokens` is a subset of `outputTokens`, so 25 output
+/// tokens with 23 reasoning tokens leave 2 in the additive output bucket.
+#[test]
+fn test_dsh_zstd_transcript_counts_identically_cold_and_warm_cache() {
+    let tmp = create_empty_fixture_dir();
+    write_dsh_zstd_session(tmp.path());
+
+    for pass in ["cold", "warm"] {
+        let output = cmd_with_home(tmp.path())
+            .args(["models", "--json", "--client", "dsh", "--no-spinner"])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{pass} cache pass failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        let entries = json["entries"].as_array().unwrap();
+        assert_eq!(entries.len(), 1, "{pass} cache pass");
+        let entry = &entries[0];
+        assert_eq!(entry["client"].as_str(), Some("dsh"), "{pass} cache pass");
+        assert_eq!(
+            entry["provider"].as_str(),
+            Some("deepseek"),
+            "{pass} cache pass"
+        );
+        assert_eq!(
+            entry["model"].as_str(),
+            Some("deepseek-reasoner"),
+            "{pass} cache pass"
+        );
+        assert_eq!(entry["input"].as_i64(), Some(2885), "{pass} cache pass");
+        assert_eq!(entry["output"].as_i64(), Some(2), "{pass} cache pass");
+        assert_eq!(entry["reasoning"].as_i64(), Some(23), "{pass} cache pass");
+        assert_eq!(json["totalMessages"].as_i64(), Some(1), "{pass} cache pass");
+    }
+}
+
+/// A forked DSH session copies the parent's completed prefix into the child
+/// transcript verbatim, so the pair must still bill the seeded call once.
+#[test]
+fn test_dsh_forked_session_counts_the_seeded_prefix_once_cold_and_warm_cache() {
+    let tmp = create_empty_fixture_dir();
+    write_dsh_fork_pair(tmp.path());
+
+    for pass in ["cold", "warm"] {
+        let output = cmd_with_home(tmp.path())
+            .args(["models", "--json", "--client", "dsh", "--no-spinner"])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{pass} cache pass failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        // Two distinct calls: the parent's seq-39 message and the child's own
+        // seq-96 message. The child's copy of seq 39 is the parent's work.
+        assert_eq!(json["totalMessages"].as_i64(), Some(2), "{pass} cache pass");
+        assert_eq!(
+            json["totalInput"].as_i64(),
+            Some(2885 + 97),
+            "{pass} cache pass"
+        );
+        assert_eq!(
+            json["totalOutput"].as_i64(),
+            Some(2 + 5),
+            "{pass} cache pass"
+        );
+    }
+}
+
+/// The lane's cross-file dedup pass, isolated from the seq boundary.
+///
+/// Without `seedLength` in the header the parser cannot tell a seeded row from
+/// an owned one, so the duplicate is only collapsed by the per-call
+/// `message.id` dedup key, cold and warm alike.
+#[test]
+fn test_dsh_repeated_message_ids_across_transcripts_count_once_cold_and_warm_cache() {
+    let tmp = create_empty_fixture_dir();
+    write_dsh_seeded_pair_without_seed_length(tmp.path());
+
+    for pass in ["cold", "warm"] {
+        let output = cmd_with_home(tmp.path())
+            .args(["models", "--json", "--client", "dsh", "--no-spinner"])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{pass} cache pass failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(json["totalMessages"].as_i64(), Some(1), "{pass} cache pass");
+        assert_eq!(json["totalInput"].as_i64(), Some(2885), "{pass} cache pass");
+        assert_eq!(json["totalOutput"].as_i64(), Some(2), "{pass} cache pass");
+    }
 }
 
 #[test]

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -932,6 +932,26 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    // DeepSeek Harness (DSH) writes one zstd-compressed JSONL transcript per
+    // session under `<DSH_HOME>/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd`
+    // (`DSH_HOME` defaults to `~/.dsh`). Each `assistant/message` event carries
+    // authoritative per-call usage (`inputTokens`/`outputTokens`/`cacheReadTokens`)
+    // plus the model/provider it was served by; the `session` event supplies the
+    // workspace (`cwd`) and session id. See `sessions::dsh`.
+    Dsh = 46 => {
+        id: "dsh",
+        display: "DeepSeek Harness",
+        logo: None,
+        root: PathRoot::EnvVar {
+            var: "DSH_HOME",
+            fallback_relative: ".dsh",
+        },
+        relative: "sessions",
+        pattern: "session.jsonl.zstd",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -1047,7 +1067,7 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 46);
+        assert_eq!(ClientId::COUNT, 47);
     }
 
     #[test]

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -933,9 +933,11 @@ define_clients!(
         parse_local: true,
         submit_default: true
     },
-    // DeepSeek Harness (DSH) writes one zstd-compressed JSONL transcript per
-    // session under `<DSH_HOME>/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd`
-    // (`DSH_HOME` defaults to `~/.dsh`). Each `assistant/message` event carries
+    // DeepSeek Harness (DSH) writes one JSONL transcript per session under
+    // `<DSH_HOME>/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd`
+    // (`DSH_HOME` defaults to `~/.dsh`); a backend configured with
+    // `compression: none` writes the same rows to `session.jsonl`, so the scan
+    // pattern accepts both spellings. Each `assistant/message` event carries
     // authoritative per-call usage (`inputTokens`/`outputTokens`/`cacheReadTokens`)
     // plus the model/provider it was served by; the `session` event supplies the
     // workspace (`cwd`) and session id. See `sessions::dsh`.
@@ -948,7 +950,7 @@ define_clients!(
             fallback_relative: ".dsh",
         },
         relative: "sessions",
-        pattern: "session.jsonl.zstd",
+        pattern: "dsh-session-log",
         headless: false,
         parse_local: true,
         submit_default: true
@@ -1487,6 +1489,44 @@ mod tests {
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
             native_join(std::path::Path::new("/custom/kimchi-agent"), "sessions")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_dsh_defaults_to_home_sessions_without_env_override() {
+        let mut env = EnvGuard::capture(&["DSH_HOME"]);
+        env.remove("DSH_HOME");
+
+        let client = ClientId::from_str("dsh").expect("dsh client should be registered");
+        assert_eq!(
+            client.data().resolve_path("/tmp/home"),
+            native_join(std::path::Path::new("/tmp/home"), ".dsh/sessions")
+        );
+        assert_eq!(client.data().pattern, "dsh-session-log");
+    }
+
+    #[test]
+    #[serial]
+    fn test_dsh_honors_dsh_home_env_override() {
+        // DSH resolves its single root as configured path, then `$DSH_HOME`,
+        // then `~/.dsh` (`util/home-paths/src/index.ts`, `resolveDshHome`), and
+        // the shipped base pins the session store to `<home>/sessions`.
+        let mut env = EnvGuard::capture(&["DSH_HOME"]);
+        env.set("DSH_HOME", "/custom/dsh-home");
+
+        let client = ClientId::from_str("dsh").expect("dsh client should be registered");
+        assert_eq!(
+            client.data().resolve_path("/tmp/home"),
+            native_join(std::path::Path::new("/custom/dsh-home"), "sessions")
+        );
+
+        // Env roots disabled: fall back to the home-relative default.
+        assert_eq!(
+            client
+                .data()
+                .resolve_path_with_env_strategy("/tmp/home", false),
+            native_join(std::path::Path::new("/tmp/home"), ".dsh/sessions")
         );
     }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2264,6 +2264,19 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         }
     }
 
+    // DeepSeek Harness (DSH) zstd JSONL transcripts. Every `assistant/message`
+    // carries authoritative usage but never a cost, so pricing is the only cost
+    // source — the generic source cache (which reprices unconditionally) is
+    // safe here, same as opencodereview.
+    parse_cached_lane(
+        &scan_result,
+        &mut source_cache,
+        pricing,
+        &mut all_messages,
+        ClientId::Dsh,
+        sessions::dsh::parse_dsh_file,
+    );
+
     // ZCode (Z.ai GLM-5.2 ADE) JSONL sessions. Token usage may be embedded
     // from the API response; otherwise estimated from content.
     let zcode_messages: Vec<UnifiedMessage> = scan_result
@@ -4359,6 +4372,21 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let cherrystudio_count = summed_parsed_message_count(&cherrystudio_msgs);
     counts.set(ClientId::CherryStudio, cherrystudio_count);
     messages.extend(cherrystudio_msgs);
+
+    // DeepSeek Harness zstd JSONL transcripts.
+    let dsh_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Dsh)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::dsh::parse_dsh_file(path)
+                .into_iter()
+                .map(|message| unified_to_parsed(&message))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let dsh_count = summed_parsed_message_count(&dsh_msgs);
+    counts.set(ClientId::Dsh, dsh_count);
+    messages.extend(dsh_msgs);
 
     let opencodereview_msgs: Vec<ParsedMessage> = scan_result
         .get(ClientId::OpenCodeReview)

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1246,6 +1246,43 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         }
     }
 
+    /// Same as [`parse_cached_lane`], for a client whose transcripts can repeat
+    /// one another's rows verbatim.
+    ///
+    /// A DSH fork seeds the child transcript with the parent's completed prefix
+    /// — same `message.id`, time and usage, under a different session id — so
+    /// the per-source cache alone cannot collapse the copy. Dedup keys survive
+    /// a warm cache hit, so the pass behaves identically cold and warm.
+    fn parse_cached_lane_deduped<F>(
+        scan_result: &scanner::ScanResult,
+        source_cache: &mut message_cache::SourceMessageCache,
+        pricing: Option<&pricing::PricingService>,
+        all_messages: &mut Vec<UnifiedMessage>,
+        scan_client: ClientId,
+        parse: F,
+    ) where
+        F: Fn(&Path) -> Vec<UnifiedMessage> + Sync,
+    {
+        let cache_identity = message_cache::CacheIdentity::for_client(scan_client);
+        let outcomes: Vec<CachedParseOutcome> = scan_result
+            .get(scan_client)
+            .par_iter()
+            .map(|path| load_or_parse_source(cache_identity, path, source_cache, pricing, &parse))
+            .collect();
+        let mut seen: HashSet<String> = HashSet::new();
+        for outcome in outcomes {
+            all_messages.extend(
+                outcome
+                    .messages
+                    .into_iter()
+                    .filter(|message| should_keep_deduped_message(&mut seen, message)),
+            );
+            if let Some(entry) = outcome.cache_entry {
+                source_cache.insert(entry);
+            }
+        }
+    }
+
     fn uncached_prime_outcome(
         mut messages: Vec<UnifiedMessage>,
         accounting: sessions::prime_agent::PrimeFileAccounting,
@@ -2267,8 +2304,10 @@ fn parse_all_messages_with_pricing_with_cache_policy(
     // DeepSeek Harness (DSH) zstd JSONL transcripts. Every `assistant/message`
     // carries authoritative usage but never a cost, so pricing is the only cost
     // source — the generic source cache (which reprices unconditionally) is
-    // safe here, same as opencodereview.
-    parse_cached_lane(
+    // safe here, same as opencodereview. Forking copies the parent's completed
+    // prefix into the child transcript verbatim, so the lane also needs one
+    // cross-file dedup pass on the per-call `message.id`.
+    parse_cached_lane_deduped(
         &scan_result,
         &mut source_cache,
         pricing,
@@ -4373,16 +4412,18 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::CherryStudio, cherrystudio_count);
     messages.extend(cherrystudio_msgs);
 
-    // DeepSeek Harness zstd JSONL transcripts.
-    let dsh_msgs: Vec<ParsedMessage> = scan_result
+    // DeepSeek Harness zstd JSONL transcripts. A fork's seeded prefix repeats
+    // the parent's rows verbatim in a second file, so dedup across the lane.
+    let dsh_msgs_raw: Vec<UnifiedMessage> = scan_result
         .get(ClientId::Dsh)
         .par_iter()
-        .flat_map(|path| {
-            sessions::dsh::parse_dsh_file(path)
-                .into_iter()
-                .map(|message| unified_to_parsed(&message))
-                .collect::<Vec<_>>()
-        })
+        .flat_map(|path| sessions::dsh::parse_dsh_file(path))
+        .collect();
+    let mut dsh_seen: HashSet<String> = HashSet::new();
+    let dsh_msgs: Vec<ParsedMessage> = dsh_msgs_raw
+        .into_iter()
+        .filter(|message| should_keep_deduped_message(&mut dsh_seen, message))
+        .map(|message| unified_to_parsed(&message))
         .collect();
     let dsh_count = summed_parsed_message_count(&dsh_msgs);
     counts.set(ClientId::Dsh, dsh_count);

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1253,6 +1253,17 @@ fn parse_all_messages_with_pricing_with_cache_policy(
     /// — same `message.id`, time and usage, under a different session id — so
     /// the per-source cache alone cannot collapse the copy. Dedup keys survive
     /// a warm cache hit, so the pass behaves identically cold and warm.
+    ///
+    /// Ownership, and what this pass does not decide: when the child header
+    /// carries `seedLength` the parser drops the seeded rows at the source, so
+    /// the parent's copy survives whatever order the scan hands the files over
+    /// in. This pass is the fallback for a header that lost the field, which
+    /// DSH's own readers treat as an unseeded log (`header.seedLength ?? 0` in
+    /// `core/agent/src/inbox.ts` and `schedule/src/invariant.ts`) — nothing in
+    /// the transcript then marks the prefix as inherited. It degrades to
+    /// first-wins in scan-path order: totals and per-model rollups stay
+    /// correct, and only the session label on the surviving row depends on
+    /// which transcript sorts first.
     fn parse_cached_lane_deduped<F>(
         scan_result: &scanner::ScanResult,
         source_cache: &mut message_cache::SourceMessageCache,

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -500,6 +500,10 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                             .unwrap_or(false)
                 }
                 "sessions.json" => file_name == "sessions.json",
+                // DeepSeek Harness: one zstd-compressed JSONL transcript per
+                // session, always named `session.jsonl.zstd` at any depth under
+                // `~/.dsh/sessions/`.
+                "session.jsonl.zstd" => file_name == "session.jsonl.zstd",
                 "wire.jsonl" => file_name == "wire.jsonl",
                 "updates.jsonl" => file_name == "updates.jsonl",
                 "unified.jsonl" => file_name == "unified.jsonl",
@@ -2582,6 +2586,33 @@ mod tests {
                 .unwrap_or_default()
                 == "ui_messages.json"
         }));
+    }
+
+    #[test]
+    fn test_scan_directory_dsh_session_jsonl_zstd() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        // DeepSeek Harness layout: sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd
+        let session_dir = path
+            .join("sessions")
+            .join("--E-Code-proj--")
+            .join("session-abc-123");
+        fs::create_dir_all(&session_dir).unwrap();
+        File::create(session_dir.join("session.jsonl.zstd")).unwrap();
+
+        // Non-matching siblings must be excluded: other zstd files, plain
+        // jsonl transcripts, and any file outside a session dir.
+        File::create(path.join("sessions").join("other.jsonl.zstd")).unwrap();
+        File::create(session_dir.join("session.jsonl")).unwrap();
+        File::create(path.join("sessions").join("unrelated.txt")).unwrap();
+
+        let files = scan_directory(path.to_str().unwrap(), "session.jsonl.zstd");
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].file_name().and_then(|n| n.to_str()),
+            Some("session.jsonl.zstd")
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -500,10 +500,15 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                             .unwrap_or(false)
                 }
                 "sessions.json" => file_name == "sessions.json",
-                // DeepSeek Harness: one zstd-compressed JSONL transcript per
-                // session, always named `session.jsonl.zstd` at any depth under
-                // `~/.dsh/sessions/`.
-                "session.jsonl.zstd" => file_name == "session.jsonl.zstd",
+                // DeepSeek Harness: one JSONL transcript per session at any
+                // depth under `~/.dsh/sessions/`. The `.zstd` suffix marks the
+                // physical encoding only — a backend configured with
+                // `compression: none` writes the same rows to a plain
+                // `session.jsonl` in the same directory — so both spellings
+                // are session logs and the parser sniffs the frame magic.
+                "dsh-session-log" => {
+                    file_name == "session.jsonl.zstd" || file_name == "session.jsonl"
+                }
                 "wire.jsonl" => file_name == "wire.jsonl",
                 "updates.jsonl" => file_name == "updates.jsonl",
                 "unified.jsonl" => file_name == "unified.jsonl",
@@ -2589,7 +2594,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scan_directory_dsh_session_jsonl_zstd() {
+    fn test_scan_directory_dsh_session_log() {
         let dir = TempDir::new().unwrap();
         let path = dir.path();
 
@@ -2601,18 +2606,27 @@ mod tests {
         fs::create_dir_all(&session_dir).unwrap();
         File::create(session_dir.join("session.jsonl.zstd")).unwrap();
 
-        // Non-matching siblings must be excluded: other zstd files, plain
-        // jsonl transcripts, and any file outside a session dir.
+        // `compression: none` writes the same rows to `session.jsonl`; a
+        // second session directory covers that spelling.
+        let plain_dir = path
+            .join("sessions")
+            .join("--E-Code-proj--")
+            .join("session-def-456");
+        fs::create_dir_all(&plain_dir).unwrap();
+        File::create(plain_dir.join("session.jsonl")).unwrap();
+
+        // Non-matching siblings must be excluded: other zstd files and any
+        // differently named file in the tree.
         File::create(path.join("sessions").join("other.jsonl.zstd")).unwrap();
-        File::create(session_dir.join("session.jsonl")).unwrap();
         File::create(path.join("sessions").join("unrelated.txt")).unwrap();
 
-        let files = scan_directory(path.to_str().unwrap(), "session.jsonl.zstd");
-        assert_eq!(files.len(), 1);
-        assert_eq!(
-            files[0].file_name().and_then(|n| n.to_str()),
-            Some("session.jsonl.zstd")
-        );
+        let files = scan_directory(path.to_str().unwrap(), "dsh-session-log");
+        let names: Vec<&str> = files
+            .iter()
+            .filter_map(|file| file.file_name().and_then(|name| name.to_str()))
+            .collect();
+        // Byte-lexical path order: `session-abc-123` sorts before `session-def-456`.
+        assert_eq!(names, vec!["session.jsonl.zstd", "session.jsonl"]);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/dsh.rs
+++ b/crates/tokscale-core/src/sessions/dsh.rs
@@ -1,0 +1,318 @@
+//! DeepSeek Harness (DSH) session parser
+//!
+//! DSH persists one zstd-compressed JSONL transcript per session under
+//! `<DSH_HOME>/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd`
+//! (`DSH_HOME` defaults to `~/.dsh`). The transcript is an append-only event
+//! stream; the rows Tokscale needs are:
+//!
+//! - `session`: session id, `createdAt` (ms), `cwd` (workspace root).
+//! - `request/header`: the provider/model the request was routed to (fallback
+//!   for messages whose `source` is absent).
+//! - `assistant/message`: authoritative per-call usage on `data.usage`
+//!   (`inputTokens`, `outputTokens`, `cacheReadTokens`, ...) plus the serving
+//!   provider/model on `data.message.source`.
+//!
+//! DSH never embeds a cost, so every message leaves the parser at `0.0` and
+//! pricing is its only cost source — the generic source cache is safe here.
+
+use super::utils::lossy_lines;
+use super::{workspace_label_from_key, UnifiedMessage};
+use crate::TokenBreakdown;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Parse one DSH `session.jsonl.zstd` transcript into unified messages.
+///
+/// Each `assistant/message` event with a non-zero `data.usage` becomes one
+/// [`UnifiedMessage`]. Messages without usable timestamps are skipped; usage
+/// with a zero total is skipped so noise rows (e.g. echoed tool-call-only
+/// messages) do not produce zero-token contributions.
+pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(_) => return Vec::new(),
+    };
+    let decoded = match zstd::stream::decode_all(file) {
+        Ok(decoded) => decoded,
+        // A truncated/foreign `.zstd` payload must not abort the whole scan.
+        Err(_) => return Vec::new(),
+    };
+
+    // The transcript directory is named after the session id; it is the
+    // fallback when the leading `session` event is missing.
+    let session_id_from_path = path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let mut session_id: Option<String> = None;
+    let mut workspace_key: Option<String> = None;
+    // Most recent request routing, used when a message lacks its own `source`.
+    let mut fallback_provider: Option<String> = None;
+    let mut fallback_model: Option<String> = None;
+
+    let mut messages = Vec::new();
+    let mut seen = HashSet::new();
+    // Turn numbers that already emitted a turn-start message.
+    let mut turn_started: HashSet<i64> = HashSet::new();
+    // Fallback turn-start marker for transcripts without turn numbers: a
+    // `user/message` arms the next assistant message as a turn start.
+    let mut pending_user_turn = false;
+
+    for line in lossy_lines(decoded.as_slice()) {
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        let Some(event_type) = value.get("type").and_then(Value::as_str) else {
+            continue;
+        };
+        match event_type {
+            "session" => {
+                session_id = value.get("id").and_then(Value::as_str).map(str::to_string);
+                workspace_key = value.get("cwd").and_then(Value::as_str).map(str::to_string);
+            }
+            "request/header" => {
+                let config = value.pointer("/data/header/config");
+                fallback_provider = config
+                    .and_then(|c| c.get("provider"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                fallback_model = config
+                    .and_then(|c| c.get("model"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+            }
+            "user/message" => {
+                pending_user_turn = true;
+            }
+            "assistant/message" => {
+                let Some(usage) = value.pointer("/data/usage") else {
+                    continue;
+                };
+                let tokens = tokens_from_usage(usage);
+                if tokens.total() == 0 {
+                    continue;
+                }
+                let Some(timestamp) = value.get("time").and_then(Value::as_i64) else {
+                    continue;
+                };
+                if timestamp <= 0 {
+                    continue;
+                }
+
+                let source = value.pointer("/data/message/source");
+                let model_id = source
+                    .and_then(|s| s.get("model"))
+                    .and_then(Value::as_str)
+                    .or(fallback_model.as_deref())
+                    .unwrap_or("unknown")
+                    .to_string();
+                let provider_id = source
+                    .and_then(|s| s.get("provider"))
+                    .and_then(Value::as_str)
+                    .or(fallback_provider.as_deref())
+                    .unwrap_or("unknown")
+                    .to_string();
+
+                let sid = session_id
+                    .clone()
+                    .unwrap_or_else(|| session_id_from_path.clone());
+
+                let turn = value.pointer("/data/turn").and_then(Value::as_i64);
+                let is_turn_start = match turn {
+                    Some(turn) => turn_started.insert(turn),
+                    None => std::mem::take(&mut pending_user_turn),
+                };
+
+                let dedup_key = format!(
+                    "dsh:{sid}:{timestamp}:{provider_id}:{model_id}:{}:{}:{}:{}:{}",
+                    tokens.input,
+                    tokens.output,
+                    tokens.cache_read,
+                    tokens.cache_write,
+                    tokens.reasoning
+                );
+                if !seen.insert(dedup_key.clone()) {
+                    continue;
+                }
+
+                let mut message = UnifiedMessage::new_with_dedup(
+                    "dsh",
+                    model_id,
+                    provider_id,
+                    &sid,
+                    timestamp,
+                    tokens,
+                    0.0,
+                    Some(dedup_key),
+                );
+                message.is_turn_start = is_turn_start;
+                if let Some(cwd) = &workspace_key {
+                    if let Some(key) = super::normalize_workspace_key(cwd) {
+                        let label = workspace_label_from_key(&key);
+                        message.set_workspace(Some(key), label);
+                    }
+                }
+                messages.push(message);
+            }
+            _ => {}
+        }
+    }
+
+    messages
+}
+
+fn tokens_from_usage(usage: &Value) -> TokenBreakdown {
+    TokenBreakdown {
+        input: int_field(usage, "inputTokens"),
+        output: int_field(usage, "outputTokens"),
+        cache_read: int_field(usage, "cacheReadTokens"),
+        cache_write: int_field(usage, "cacheWriteTokens"),
+        reasoning: int_field(usage, "reasoningTokens"),
+    }
+}
+
+fn int_field(value: &Value, key: &str) -> i64 {
+    value.get(key).and_then(Value::as_i64).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_zstd_session(lines: &[&str]) -> tempfile::NamedTempFile {
+        let payload = lines.join("\n");
+        let compressed = zstd::encode_all(payload.as_bytes(), 3).unwrap();
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut file, &compressed).unwrap();
+        file
+    }
+
+    #[test]
+    fn parses_assistant_messages_with_usage() {
+        let file = write_zstd_session(&[
+            r#"{"type":"session","version":0,"id":"session-abc","createdAt":1786669406484,"cwd":"E:\\repo\\proj","delegationDepth":0,"agentPreset":"cordis"}"#,
+            r#"{"type":"turn/start","seq":4,"time":1786669450000,"data":{"turn":1}}"#,
+            r#"{"type":"user/message","seq":7,"time":1786669450001,"data":{"turn":1}}"#,
+            r#"{"type":"assistant/message","seq":301,"time":1786669454772,"data":{"turn":1,"step":1,"message":{"role":"assistant","content":[],"source":{"kind":"model","provider":"irix","model":"deepseek-v4-flash"}},"usage":{"inputTokens":130,"outputTokens":159,"cacheReadTokens":13824}}}"#,
+            r#"{"type":"assistant/message","seq":414,"time":1786669459063,"data":{"turn":1,"step":2,"message":{"role":"assistant","content":[],"source":{"kind":"model","provider":"irix","model":"deepseek-v4-flash"}},"usage":{"inputTokens":130,"outputTokens":159,"cacheReadTokens":13824}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert_eq!(messages.len(), 2);
+
+        let first = &messages[0];
+        assert_eq!(first.client, "dsh");
+        assert_eq!(first.model_id, "deepseek-v4-flash");
+        assert_eq!(first.provider_id, "irix");
+        assert_eq!(first.session_id, "session-abc");
+        assert_eq!(first.timestamp, 1786669454772);
+        assert_eq!(first.tokens.input, 130);
+        assert_eq!(first.tokens.output, 159);
+        assert_eq!(first.tokens.cache_read, 13824);
+        assert_eq!(first.tokens.cache_write, 0);
+        assert_eq!(first.tokens.reasoning, 0);
+        assert_eq!(first.cost, 0.0);
+        assert!(first.is_turn_start);
+        assert_eq!(first.workspace_key.as_deref(), Some("E:/repo/proj"));
+        assert_eq!(first.workspace_label.as_deref(), Some("proj"));
+        assert!(first.dedup_key.as_deref().unwrap().starts_with("dsh:session-abc:"));
+
+        // Same turn, later step: not a turn start.
+        assert!(!messages[1].is_turn_start);
+    }
+
+    #[test]
+    fn supports_cache_write_and_reasoning_buckets() {
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-xyz","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"assistant/message","time":1786669454772,"data":{"turn":1,"message":{"source":{"provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":10,"outputTokens":20,"cacheReadTokens":30,"cacheWriteTokens":40,"reasoningTokens":50}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert_eq!(messages.len(), 1);
+        let msg = &messages[0];
+        assert_eq!(msg.tokens.input, 10);
+        assert_eq!(msg.tokens.output, 20);
+        assert_eq!(msg.tokens.cache_read, 30);
+        assert_eq!(msg.tokens.cache_write, 40);
+        assert_eq!(msg.tokens.reasoning, 50);
+        assert_eq!(msg.model_id, "deepseek-reasoner");
+        assert_eq!(msg.provider_id, "deepseek");
+    }
+
+    #[test]
+    fn falls_back_to_request_header_routing_and_folder_session_id() {
+        let file = write_zstd_session(&[
+            r#"{"type":"request/header","seq":11,"time":1786669450062,"data":{"header":{"config":{"provider":"irix","model":"deepseek-v4-flash"}}}}"#,
+            // No `session` event and no `source` on the message: session id
+            // comes from the folder, model/provider from the header.
+            r#"{"type":"assistant/message","time":1786669454772,"data":{"turn":1,"message":{"role":"assistant","content":[]},"usage":{"inputTokens":5,"outputTokens":7}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert_eq!(messages.len(), 1);
+        let msg = &messages[0];
+        let folder = file
+            .path()
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|n| n.to_str())
+            .unwrap();
+        assert_eq!(msg.session_id, folder);
+        assert_eq!(msg.model_id, "deepseek-v4-flash");
+        assert_eq!(msg.provider_id, "irix");
+    }
+
+    #[test]
+    fn skips_zero_usage_and_missing_timestamp() {
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-zero","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"assistant/message","time":1786669454772,"data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":0,"outputTokens":0}}}"#,
+            r#"{"type":"assistant/message","data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":1,"outputTokens":1}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn dedups_identical_replayed_rows_within_a_file() {
+        let line = r#"{"type":"assistant/message","time":1786669454772,"data":{"turn":1,"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20}}}"#;
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-dedup","createdAt":1,"cwd":"/work"}"#,
+            line,
+            line,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert_eq!(messages.len(), 1);
+    }
+
+    #[test]
+    fn missing_or_corrupt_files_yield_no_messages() {
+        assert!(parse_dsh_file(Path::new("/nonexistent/dsh/session.jsonl.zstd")).is_empty());
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut file, b"this is not zstd").unwrap();
+        assert!(parse_dsh_file(file.path()).is_empty());
+    }
+
+    #[test]
+    fn marks_turn_start_when_no_turn_numbers_are_present() {
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-noturn","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"user/message","time":1,"data":{}}"#,
+            r#"{"type":"assistant/message","time":1786669454772,"data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20}}}"#,
+            r#"{"type":"assistant/message","time":1786669455000,"data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":11,"outputTokens":21}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert_eq!(messages.len(), 2);
+        assert!(messages[0].is_turn_start);
+        assert!(!messages[1].is_turn_start);
+    }
+}

--- a/crates/tokscale-core/src/sessions/dsh.rs
+++ b/crates/tokscale-core/src/sessions/dsh.rs
@@ -220,7 +220,11 @@ mod tests {
         assert!(first.is_turn_start);
         assert_eq!(first.workspace_key.as_deref(), Some("E:/repo/proj"));
         assert_eq!(first.workspace_label.as_deref(), Some("proj"));
-        assert!(first.dedup_key.as_deref().unwrap().starts_with("dsh:session-abc:"));
+        assert!(first
+            .dedup_key
+            .as_deref()
+            .unwrap()
+            .starts_with("dsh:session-abc:"));
 
         // Same turn, later step: not a turn start.
         assert!(!messages[1].is_turn_start);

--- a/crates/tokscale-core/src/sessions/dsh.rs
+++ b/crates/tokscale-core/src/sessions/dsh.rs
@@ -1,11 +1,16 @@
 //! DeepSeek Harness (DSH) session parser
 //!
-//! DSH persists one zstd-compressed JSONL transcript per session under
+//! DSH persists one JSONL transcript per session under
 //! `<DSH_HOME>/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd`
-//! (`DSH_HOME` defaults to `~/.dsh`). The transcript is an append-only event
-//! stream; the rows Tokscale needs are:
+//! (`DSH_HOME` defaults to `~/.dsh`). The `.zstd` suffix marks the physical
+//! encoding only: a backend configured with `compression: none` writes the
+//! same rows to a plain `session.jsonl` in the same directory, so this parser
+//! dispatches on the zstd frame magic rather than on the file name.
 //!
-//! - `session`: session id, `createdAt` (ms), `cwd` (workspace root).
+//! The transcript is an append-only event stream; the rows Tokscale needs are:
+//!
+//! - `session`: session id, `createdAt` (ms), `cwd` (workspace root), and the
+//!   `seedLength` fork boundary.
 //! - `request/header`: the provider/model the request was routed to (fallback
 //!   for messages whose `source` is absent).
 //! - `assistant/message`: authoritative per-call usage on `data.usage`
@@ -20,7 +25,50 @@ use super::{workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde_json::Value;
 use std::collections::HashSet;
+use std::io::Read;
 use std::path::Path;
+
+/// Zstandard frame magic number (RFC 8478 section 3.1.1).
+const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
+
+/// Decode buffer for the streaming zstd reader.
+const ZSTD_CHUNK_BYTES: usize = 128 * 1024;
+
+/// Read a DSH transcript, decoding zstd frames when the payload carries them.
+///
+/// A live DSH session appends one zstd frame per flush, so a scan racing a
+/// writer routinely sees a torn trailing frame. DSH itself treats that as
+/// expected and recovers the complete frames plus whatever prefix of the torn
+/// one decodes (`session-persistence-jsonl/src/index.ts`, `readZstdPrefix`),
+/// so decoding must be streaming: `decode_all` would surface one error and
+/// throw the entire session away, reporting zero tokens for a session that is
+/// merely being written to.
+fn read_session_bytes(path: &Path) -> Vec<u8> {
+    let raw = match std::fs::read(path) {
+        Ok(raw) => raw,
+        Err(_) => return Vec::new(),
+    };
+    if raw.len() < ZSTD_MAGIC.len() || raw[..ZSTD_MAGIC.len()] != ZSTD_MAGIC {
+        // `compression: none` writes the same rows uncompressed.
+        return raw;
+    }
+
+    let Ok(mut decoder) = zstd::stream::read::Decoder::new(raw.as_slice()) else {
+        return Vec::new();
+    };
+    let mut decoded = Vec::new();
+    let mut chunk = vec![0u8; ZSTD_CHUNK_BYTES];
+    loop {
+        match decoder.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read) => decoded.extend_from_slice(&chunk[..read]),
+            // Torn trailing frame (or foreign payload): keep the prefix that
+            // did decode. `lossy_lines` then drops the partial final record.
+            Err(_) => break,
+        }
+    }
+    decoded
+}
 
 /// Parse one DSH `session.jsonl.zstd` transcript into unified messages.
 ///
@@ -29,15 +77,10 @@ use std::path::Path;
 /// with a zero total is skipped so noise rows (e.g. echoed tool-call-only
 /// messages) do not produce zero-token contributions.
 pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(path) {
-        Ok(file) => file,
-        Err(_) => return Vec::new(),
-    };
-    let decoded = match zstd::stream::decode_all(file) {
-        Ok(decoded) => decoded,
-        // A truncated/foreign `.zstd` payload must not abort the whole scan.
-        Err(_) => return Vec::new(),
-    };
+    let decoded = read_session_bytes(path);
+    if decoded.is_empty() {
+        return Vec::new();
+    }
 
     // The transcript directory is named after the session id; it is the
     // fallback when the leading `session` event is missing.
@@ -51,6 +94,9 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
 
     let mut session_id: Option<String> = None;
     let mut workspace_key: Option<String> = None;
+    // Fork boundary: how many leading events this session inherited verbatim
+    // from its parent. Zero for a session that was never forked.
+    let mut seed_length: i64 = 0;
     // Most recent request routing, used when a message lacks its own `source`.
     let mut fallback_provider: Option<String> = None;
     let mut fallback_model: Option<String> = None;
@@ -74,6 +120,11 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
             "session" => {
                 session_id = value.get("id").and_then(Value::as_str).map(str::to_string);
                 workspace_key = value.get("cwd").and_then(Value::as_str).map(str::to_string);
+                seed_length = value
+                    .get("seedLength")
+                    .and_then(Value::as_i64)
+                    .filter(|length| *length > 0)
+                    .unwrap_or(0);
             }
             "request/header" => {
                 let config = value.pointer("/data/header/config");
@@ -90,6 +141,21 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
                 pending_user_turn = true;
             }
             "assistant/message" => {
+                // Fork/continuation ownership boundary. Forking copies the
+                // parent's completed prefix into the child transcript verbatim
+                // — same `seq`, `time`, `usage` and `message.id` — and records
+                // how many events were inherited as the header's `seedLength`
+                // (`core/session/src/index.ts`, `SessionStore::fork`). Only
+                // events at or after that boundary are this session's own work;
+                // counting the seed again bills the parent's calls twice.
+                if seed_length > 0
+                    && value
+                        .get("seq")
+                        .and_then(Value::as_i64)
+                        .is_some_and(|seq| seq < seed_length)
+                {
+                    continue;
+                }
                 let Some(usage) = value.pointer("/data/usage") else {
                     continue;
                 };
@@ -128,8 +194,24 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
                     None => std::mem::take(&mut pending_user_turn),
                 };
 
+                // `data.message.id` is a per-call `crypto.randomUUID()`
+                // (`llm/llm/src/message.ts`) that a fork copies verbatim, so
+                // scoping the key to it instead of the session id collapses a
+                // seeded copy against the parent's original even when the two
+                // live in different files under different session ids — the
+                // seq boundary above only fires for headers that actually
+                // carry `seedLength`. The rest of the identity stays in the
+                // key: a sanitized or otherwise non-unique id then still
+                // separates calls that differ in time, routing or usage
+                // instead of silently folding them into one.
+                let identity = value
+                    .pointer("/data/message/id")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+                    .map_or_else(|| format!("sid:{sid}"), |id| format!("msg:{id}"));
                 let dedup_key = format!(
-                    "dsh:{sid}:{timestamp}:{provider_id}:{model_id}:{}:{}:{}:{}:{}",
+                    "dsh:{identity}:{timestamp}:{provider_id}:{model_id}:{}:{}:{}:{}:{}",
                     tokens.input,
                     tokens.output,
                     tokens.cache_read,
@@ -166,13 +248,30 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
     messages
 }
 
+/// Split DSH's usage row into Tokscale's five additive buckets.
+///
+/// DSH documents `TokenUsage` as disjoint on the input side — `inputTokens` is
+/// uncached input only, with cache hits reported separately, and the DeepSeek
+/// adapter subtracts them out of `prompt_tokens` before persisting
+/// (`llm/llm/src/types.ts`, `llm-deepseek/src/translate.ts`). `reasoningTokens`
+/// is the exception: it is `completion_tokens_details.reasoning_tokens`, a
+/// SUBSET of the `completion_tokens` that becomes `outputTokens`, which is why
+/// DSH's own token meter sums input + cache + output and omits reasoning
+/// entirely (`llm/token-meter/src/index.ts`, `usageTokens`).
+///
+/// [`TokenBreakdown`] buckets are additive and pricing bills `output` and
+/// `reasoning` at the same output rate, so mapping both fields through would
+/// bill every reasoning token twice. Subtract the overlap, as `senpi.rs`,
+/// `grok.rs` and `zcode.rs` do for the same shape.
 fn tokens_from_usage(usage: &Value) -> TokenBreakdown {
+    let output = int_field(usage, "outputTokens").max(0);
+    let reasoning = int_field(usage, "reasoningTokens").max(0);
     TokenBreakdown {
         input: int_field(usage, "inputTokens"),
-        output: int_field(usage, "outputTokens"),
+        output: output.saturating_sub(reasoning),
         cache_read: int_field(usage, "cacheReadTokens"),
         cache_write: int_field(usage, "cacheWriteTokens"),
-        reasoning: int_field(usage, "reasoningTokens"),
+        reasoning,
     }
 }
 
@@ -224,7 +323,7 @@ mod tests {
             .dedup_key
             .as_deref()
             .unwrap()
-            .starts_with("dsh:session-abc:"));
+            .starts_with("dsh:sid:session-abc:"));
 
         // Same turn, later step: not a turn start.
         assert!(!messages[1].is_turn_start);
@@ -234,19 +333,64 @@ mod tests {
     fn supports_cache_write_and_reasoning_buckets() {
         let file = write_zstd_session(&[
             r#"{"type":"session","id":"session-xyz","createdAt":1,"cwd":"/work"}"#,
-            r#"{"type":"assistant/message","time":1786669454772,"data":{"turn":1,"message":{"source":{"provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":10,"outputTokens":20,"cacheReadTokens":30,"cacheWriteTokens":40,"reasoningTokens":50}}}"#,
+            r#"{"type":"assistant/message","time":1786669454772,"data":{"turn":1,"message":{"source":{"provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":10,"outputTokens":60,"cacheReadTokens":30,"cacheWriteTokens":40,"reasoningTokens":50}}}"#,
         ]);
 
         let messages = parse_dsh_file(file.path());
         assert_eq!(messages.len(), 1);
         let msg = &messages[0];
         assert_eq!(msg.tokens.input, 10);
-        assert_eq!(msg.tokens.output, 20);
+        // `reasoningTokens` is a subset of `outputTokens`, so the additive
+        // output bucket keeps only the non-reasoning remainder.
+        assert_eq!(msg.tokens.output, 10);
         assert_eq!(msg.tokens.cache_read, 30);
         assert_eq!(msg.tokens.cache_write, 40);
         assert_eq!(msg.tokens.reasoning, 50);
         assert_eq!(msg.model_id, "deepseek-reasoner");
         assert_eq!(msg.provider_id, "deepseek");
+    }
+
+    #[test]
+    fn reasoning_tokens_do_not_inflate_the_additive_output_bucket() {
+        // given: DSH's `outputTokens` is the provider's `completion_tokens`
+        // and `reasoningTokens` is `completion_tokens_details.reasoning_tokens`
+        // — a subset of it, which is why DSH's own token meter sums
+        // input + cache + output and never adds reasoning. Tokscale's buckets
+        // are additive and pricing bills output and reasoning at the same
+        // output rate, so mapping both fields through bills reasoning twice.
+        // Numbers taken from a committed DSH transcript
+        // (`examples/acp-agent/tests/snapshots/subagent-fork-in-process`).
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-reasoning","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"assistant/message","seq":39,"time":1785730448979,"data":{"turn":1,"message":{"id":"m-1","source":{"provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":2885,"outputTokens":25,"cacheReadTokens":0,"reasoningTokens":23}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        let tokens = &messages[0].tokens;
+        assert_eq!(tokens.output, 2);
+        assert_eq!(tokens.reasoning, 23);
+        // Mirrors DSH's own `usageTokens`: input + cacheRead + cacheWrite +
+        // output, with reasoning already inside output.
+        assert_eq!(tokens.total(), 2885 + 25);
+    }
+
+    #[test]
+    fn reasoning_equal_to_output_leaves_a_non_zero_message() {
+        // A reasoning-only completion (all output tokens were reasoning)
+        // must survive the zero-usage filter with an empty output bucket.
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-all-reasoning","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"assistant/message","time":1786669454772,"data":{"turn":1,"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":0,"outputTokens":31,"reasoningTokens":31}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.output, 0);
+        assert_eq!(messages[0].tokens.reasoning, 31);
+        assert_eq!(messages[0].tokens.total(), 31);
     }
 
     #[test]
@@ -295,6 +439,175 @@ mod tests {
 
         let messages = parse_dsh_file(file.path());
         assert_eq!(messages.len(), 1);
+    }
+
+    #[test]
+    fn a_repeated_message_id_still_separates_calls_that_differ() {
+        // The sanitized snapshots DSH commits redact `message.id` to a single
+        // placeholder shared by every call in the file, so the id alone is not
+        // a safe dedup key: the rest of the call identity has to stay in it or
+        // distinct calls disappear.
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-placeholder","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"assistant/message","time":1786669454772,"data":{"turn":1,"message":{"id":"{{sessionId}}","source":{"provider":"p","model":"m"}},"usage":{"inputTokens":20,"outputTokens":8}}}"#,
+            r#"{"type":"assistant/message","time":1786669455000,"data":{"turn":1,"message":{"id":"{{sessionId}}","source":{"provider":"p","model":"m"}},"usage":{"inputTokens":28,"outputTokens":2}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_ne!(messages[0].dedup_key, messages[1].dedup_key);
+    }
+
+    #[test]
+    fn skips_the_seeded_prefix_a_fork_inherits_from_its_parent() {
+        // given: DSH forks by copying the parent's completed prefix into the
+        // child transcript verbatim and recording its length as `seedLength`.
+        // Both rows below are the real duplicated pair from
+        // `examples/acp-agent/tests/snapshots/subagent-fork-in-process`:
+        // the parent's seq-39 message reappears in the child under a different
+        // session id with the same time, usage and message id.
+        let parent = write_zstd_session(&[
+            r#"{"type":"session","version":0,"id":"96cf59c9-b347-48b9-b234-a5200913ad05","createdAt":1783352134832,"cwd":"/work","delegationDepth":0}"#,
+            r#"{"type":"assistant/message","seq":39,"time":1785730448979,"data":{"turn":1,"message":{"id":"7ac2e3d7-d558-4b24-b71e-40fc2f42216d","source":{"provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":2885,"outputTokens":25,"cacheReadTokens":0,"reasoningTokens":23}}}"#,
+        ]);
+        let child = write_zstd_session(&[
+            r#"{"type":"session","version":0,"id":"ada8966c-9fa3-441b-8721-37ff1e795e6a","createdAt":1783352137161,"cwd":"/work","parentSession":"96cf59c9-b347-48b9-b234-a5200913ad05","seedLength":42,"origin":"subagent","delegationDepth":1}"#,
+            r#"{"type":"assistant/message","seq":39,"time":1785730448979,"data":{"turn":1,"message":{"id":"7ac2e3d7-d558-4b24-b71e-40fc2f42216d","source":{"provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":2885,"outputTokens":25,"cacheReadTokens":0,"reasoningTokens":23}}}"#,
+            r#"{"type":"assistant/message","seq":96,"time":1786358035361,"data":{"turn":2,"message":{"id":"cdc56e00-c648-4669-92b2-7299e41cb743","source":{"provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":97,"outputTokens":39,"cacheReadTokens":2816,"reasoningTokens":34}}}"#,
+        ]);
+
+        // when
+        let parent_messages = parse_dsh_file(parent.path());
+        let child_messages = parse_dsh_file(child.path());
+
+        // then: the child contributes only its own post-seed work.
+        assert_eq!(parent_messages.len(), 1);
+        assert_eq!(child_messages.len(), 1);
+        assert_eq!(child_messages[0].timestamp, 1786358035361);
+        assert_eq!(child_messages[0].tokens.input, 97);
+    }
+
+    #[test]
+    fn seeded_rows_share_the_parent_dedup_key_across_files() {
+        // The seq boundary only fires when the header carries `seedLength`;
+        // a resumed or re-exported transcript that lost it still repeats the
+        // parent's per-call `message.id`, so the dedup key must be keyed on
+        // that id rather than on the session id, and stay identical across the
+        // two files for the cross-file pass in `lib.rs` to collapse them.
+        let row = r#"{"type":"assistant/message","seq":39,"time":1785730448979,"data":{"turn":1,"message":{"id":"7ac2e3d7-d558-4b24-b71e-40fc2f42216d","source":{"provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":2885,"outputTokens":25,"reasoningTokens":23}}}"#;
+        let parent = write_zstd_session(&[
+            r#"{"type":"session","id":"96cf59c9-b347-48b9-b234-a5200913ad05","createdAt":1,"cwd":"/work"}"#,
+            row,
+        ]);
+        let child = write_zstd_session(&[
+            r#"{"type":"session","id":"ada8966c-9fa3-441b-8721-37ff1e795e6a","createdAt":2,"cwd":"/work","parentSession":"96cf59c9-b347-48b9-b234-a5200913ad05"}"#,
+            row,
+        ]);
+
+        let parent_messages = parse_dsh_file(parent.path());
+        let child_messages = parse_dsh_file(child.path());
+
+        assert_eq!(parent_messages.len(), 1);
+        assert_eq!(child_messages.len(), 1);
+        assert_ne!(parent_messages[0].session_id, child_messages[0].session_id);
+        assert_eq!(
+            parent_messages[0].dedup_key.as_deref(),
+            Some(
+                "dsh:msg:7ac2e3d7-d558-4b24-b71e-40fc2f42216d:1785730448979:deepseek:deepseek-reasoner:2885:2:0:0:23"
+            )
+        );
+        assert_eq!(parent_messages[0].dedup_key, child_messages[0].dedup_key);
+    }
+
+    #[test]
+    fn recovers_the_decodable_prefix_of_a_torn_trailing_frame() {
+        // given: DSH appends one zstd frame per flush, so a scan racing a live
+        // writer sees a complete prefix plus a truncated final frame. DSH's own
+        // reader recovers the complete frames rather than refusing the log, and
+        // `decode_all` would report zero tokens for the whole session.
+        let header = zstd::encode_all(
+            concat!(
+                r#"{"type":"session","id":"session-torn","createdAt":1,"cwd":"/work"}"#,
+                "
+"
+            )
+            .as_bytes(),
+            3,
+        )
+        .unwrap();
+        let committed = zstd::encode_all(
+            concat!(
+                r#"{"type":"assistant/message","time":1786669454772,"data":{"turn":1,"message":{"id":"m-committed","source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20}}}"#,
+                "
+"
+            )
+            .as_bytes(),
+            3,
+        )
+        .unwrap();
+        let torn = zstd::encode_all(
+            concat!(
+                r#"{"type":"assistant/message","time":1786669455000,"data":{"turn":2,"message":{"id":"m-torn","source":{"provider":"p","model":"m"}},"usage":{"inputTokens":11,"outputTokens":21}}}"#,
+                "
+"
+            )
+            .as_bytes(),
+            3,
+        )
+        .unwrap();
+
+        let mut payload = header;
+        payload.extend_from_slice(&committed);
+        // Cut the final frame short, the way an interrupted append leaves it.
+        payload.extend_from_slice(&torn[..torn.len() / 2]);
+
+        // Non-vacuity: the one-shot decoder this parser used to call refuses
+        // the whole payload, which is exactly the 0-token report being fixed.
+        assert!(zstd::stream::decode_all(payload.as_slice()).is_err());
+
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut file, &payload).unwrap();
+
+        // when
+        let messages = parse_dsh_file(file.path());
+
+        // then: the committed frame still counts.
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "session-torn");
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 20);
+    }
+
+    #[test]
+    fn parses_the_uncompressed_session_jsonl_spelling() {
+        // `compression: none` writes the same rows to a plain `session.jsonl`
+        // in the same session directory, so dispatch on the frame magic rather
+        // than the file name.
+        let dir = tempfile::tempdir().unwrap();
+        let session_dir = dir.path().join("session-plain");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        let path = session_dir.join("session.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                r#"{"type":"session","id":"session-plain","createdAt":1,"cwd":"/work"}"#,
+                "
+",
+                r#"{"type":"assistant/message","time":1786669454772,"data":{"turn":1,"message":{"id":"m-plain","source":{"provider":"p","model":"m"}},"usage":{"inputTokens":12,"outputTokens":34,"reasoningTokens":4}}}"#,
+                "
+"
+            ),
+        )
+        .unwrap();
+
+        let messages = parse_dsh_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "session-plain");
+        assert_eq!(messages[0].tokens.input, 12);
+        assert_eq!(messages[0].tokens.output, 30);
+        assert_eq!(messages[0].tokens.reasoning, 4);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -20,6 +20,7 @@ pub mod crush;
 pub mod cursor;
 pub mod devin;
 pub mod droid;
+pub mod dsh;
 pub mod freebuff;
 pub mod gemini;
 pub mod gjc;

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -75,6 +75,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   reasonix: "Reasonix",
   "prime-agent": "Prime Agent",
   cherrystudio: "Cherry Studio",
+  dsh: "DeepSeek Harness",
 };
 
 // Client logos from GitHub CDN (public repo)
@@ -133,6 +134,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
   reasonix: `${GITHUB_CDN_BASE}/client-synthetic.png`,
   "prime-agent": "https://github.com/PrimeIntellect-ai.png",
   cherrystudio: `${GITHUB_CDN_BASE}/client-cherrystudio.png`,
+  dsh: "https://github.com/deepseek-ai.png",
 };
 
 export const SOURCE_COLORS: Record<ClientType, string> = {
@@ -184,6 +186,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   reasonix: "#6366F1",
   "prime-agent": "#6C63FF",
   cherrystudio: "#FA7298",
+  dsh: "#4D6BFE",
 };
 
 // Derived values

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -47,6 +47,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "reasonix",
   "prime-agent",
   "cherrystudio",
+  "dsh",
 ] as const;
 
 export type CcMirrorClientType = `cc-mirror/${string}`;


### PR DESCRIPTION
Supersedes #1123 (contributor @Ankairis, head fce70cf1). Both of that PR's commits are cherry-picked with authorship preserved; the three commits on top fix what a review against the vendor repo `deepseek-ai/deepseek-harness` and its 150 committed session transcripts reproduced.

## Reasoning tokens were billed twice

`dsh.rs` mapped `reasoningTokens` into its own additive bucket. DSH's `outputTokens` is the provider's `completion_tokens` and `reasoningTokens` is `completion_tokens_details.reasoning_tokens` inside it (`packages/llm/llm-deepseek/src/translate.ts`), which is why DSH's own token meter sums input + cacheRead + cacheWrite + output and omits reasoning entirely (`packages/llm/token-meter/src/index.ts`, `usageTokens`). Tokscale's `TokenBreakdown` buckets are additive and pricing bills `output` and `reasoning` at the same output rate, so every DSH session over-reported.

Measured across all 150 committed transcripts (303 `assistant/message` rows): 14148 output tokens, 4786 reasoning tokens - 33.8% of output was double-billed, and `reasoningTokens <= outputTokens` holds on every row. Reasoning is now subtracted from output, following `sessions/senpi.rs`, `grok.rs` and `zcode.rs`.

The PR's `supports_cache_write_and_reasoning_buckets` test pinned the wrong behaviour with a physically impossible row (output 20, reasoning 50); it now uses output 60 / reasoning 50 and asserts the 10-token remainder.

## A fork's seeded prefix was counted twice

Dedup was keyed on the session id, but a fork writes the parent's completed prefix into the child transcript verbatim - same `seq`, `time`, `usage` and `message.id` - under a different session id, and records the inherited length as the header's `seedLength` (`packages/core/session/src/index.ts`, `SessionStore.fork`).

Reproduced in `examples/acp-agent/tests/snapshots/subagent-fork-in-process`: `session.jsonl` and `session.1.jsonl` both carry the assistant message at time 1785730448979 with `message.id` `7ac2e3d7-d558-4b24-b71e-40fc2f42216d`, so 2885 input + 25 output tokens were counted twice. `session.1.jsonl`'s header states `seedLength: 42` and the duplicated event is `seq: 39`.

Two guards, since only the first depends on the header field being present:

- `assistant/message` events below the seed boundary are skipped.
- The dedup key is scoped to the per-call `message.id` (a `crypto.randomUUID()`, `packages/llm/llm/src/message.ts`) instead of the session id, and the lane runs through `should_keep_deduped_message` like codex/kimchi/cline. The rest of the call identity stays in the key, so a sanitized transcript whose ids are redacted to one placeholder (`{{sessionId}}` in the committed goal snapshots) still separates distinct calls.

Verified non-vacuous: with both guards removed the new CLI fork test reports 3 messages instead of 2.

## A torn trailing zstd frame discarded the whole session

`zstd::stream::decode_all` returns `Err` on a truncated final frame and the parser returned no messages, so a scan racing a live append reported 0 tokens for the entire session. DSH treats that state as expected and recovers the complete frames plus the decodable prefix of the torn one (`packages/session/session-persistence-jsonl/src/index.ts`, `readZstdPrefix`). Decoding is now incremental and keeps the prefix, matching the `lossy_lines` behaviour of every other lane. The regression test asserts `decode_all` fails on the same payload.

## Uncompressed `session.jsonl`

The `.zstd` suffix marks the physical encoding only; a backend configured with `compression: none` writes the same rows to `session.jsonl` in the same session directory (`session-persistence-jsonl/src/format.ts`, `logSuffix`). The scan pattern accepts both names and the parser dispatches on the zstd frame magic rather than the file name. All four READMEs updated.

## Test coverage added

- `clients --json` scan root stays inside a sandboxed `HOME` (mirrors the Cherry Studio guard); `cmd_with_home` now clears `DSH_HOME`.
- Cold/warm cache parity for a zstd source.
- Fork pair counted once, cold and warm, through the seq boundary and through the message-id key alone.
- `DSH_HOME` root resolution: `$DSH_HOME` override, `~/.dsh` fallback, and env-roots-disabled fallback (`util/home-paths/src/index.ts`, `resolveDshHome`; the shipped base pins the store to `<home>/sessions`).
- Parser units for the reasoning subset, a reasoning-only completion, the seed boundary, cross-file key equality, torn-frame recovery, the uncompressed spelling, and a non-unique message id.

## Gates

- `cargo fmt --all -- --check`: clean
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo test --locked --workspace --all-features --no-fail-fast`: 2995 passed, 0 failed, 6 ignored
- `bun run --cwd packages/frontend test`: 910 passed, 6 skipped; `typecheck`: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DeepSeek Harness (DSH) client with correct token accounting, resilient zstd transcript parsing, and fork-safe dedup. Previously DSH wasn’t ingested, reasoning tokens double-counted output, and truncated zstd frames zeroed sessions; now DSH sessions are ingested, output excludes reasoning subset, and partial frames are recovered.

- Discovery: new `dsh-session-log` under `<DSH_HOME or ~/.dsh>/sessions`; accepts `session.jsonl.zstd` and uncompressed `session.jsonl` by sniffing zstd magic.
- Parser: streaming zstd decode keeps the decodable prefix of a torn final frame; extracts `assistant/message` usage; falls back to `request/header` for routing and folder name for session id; normalizes workspace and marks turn starts even without turn numbers.
- Accounting: maps DSH usage into additive buckets; subtracts `reasoningTokens` from `outputTokens`; skips zero-usage and untimestamped rows.
- Fork/dedup: skips events before `seedLength`; dedup key scoped to per-call `message.id` (+ time/provider/model/usage) so forked prefixes collapse across files; lane runs through cross-file dedup; docs clarify that when `seedLength` is missing, dedup is first-wins in scan order and only the surviving row’s session label varies (totals/rollups are unchanged).
- CLI/UI/frontend: `--client dsh` filter; `clients --json` reports the DSH sessions path; adds “DeepSeek Harness” name/logo/color and a compact TUI label.
- Tests: sandboxed `HOME`/`DSH_HOME` scan-root resolution; cold/warm parity for zstd logs; fork pair counted once with and without `seedLength`; torn-frame recovery; uncompressed spelling; repeated `message.id` handled.

**Rollout**
- No migrations. Set `DSH_HOME` if your DeepSeek Harness data root is not `~/.dsh`.

<sup>Written for commit 4ca4458f7b4aef52deb1e681035d968eafc3d746. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

