### PR TITLE
fix(cli): force HTTP/1.1 for Windows Antigravity RPC to prevent multi…

### DIFF
--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -1921,6 +1921,13 @@ fn antigravity_https_runtime() -> &'static tokio::runtime::Runtime {
 fn antigravity_https_client() -> &'static reqwest::Client {
     HTTPS_RPC_CLIENT.get_or_init(|| {
         reqwest::Client::builder()
+            // The DesktopAgent advertises h2 over ALPN but freezes when reqwest
+            // actually multiplexes over it, so `antigravity sync` hangs until the
+            // timeout below fires. Observed on Windows; pinned for every target
+            // because this client only ever issues the single unary Connect POST
+            // in `rpc_request`, which HTTP/1.1 serves identically — there
+            // is no stream to multiplex and no h2 win to give up on a loopback
+            // socket. Keep it pinned unless that call site grows streaming.
             .http1_only()
             .danger_accept_invalid_certs(true)
             .no_proxy()

--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -1921,6 +1921,7 @@ fn antigravity_https_runtime() -> &'static tokio::runtime::Runtime {
 fn antigravity_https_client() -> &'static reqwest::Client {
     HTTPS_RPC_CLIENT.get_or_init(|| {
         reqwest::Client::builder()
+            .http1_only()
             .danger_accept_invalid_certs(true)
             .no_proxy()
             .timeout(Duration::from_secs(10))


### PR DESCRIPTION
This PR fixes an issue where `tokscale antigravity sync` times out indefinitely on Windows machines.

The Problem:
On Windows, the Antigravity DesktopAgent binds to an ephemeral HTTPS port. When the `reqwest` client connects, it attempts to upgrade to HTTP/2. The local gRPC-web server advertises HTTP/2 support but freezes when multiplexing is attempted, causing `reqwest` to hang until the 10-second timeout hits.

The Fix:
Adding `.http1_only()` to the `antigravity_https_client` builder forces a standard HTTP/1.1 handshake, bypassing the h2 multiplexing freeze and allowing the RPC payload to be successfully queried on Windows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force HTTP/1.1 for the Antigravity HTTPS client to bypass a Windows DesktopAgent h2 multiplexing freeze, unblocking `tokscale antigravity sync`. Previously the client negotiated HTTP/2 with the local gRPC‑web server and hung until the 10s timeout; `.http1_only()` now pins HTTP/1.1 on all OSes with no expected change for the single unary RPC.

**Review notes**
- Verify `tokscale antigravity sync` completes on Windows with DesktopAgent running.
- Sanity-check the command on macOS/Linux for regressions.
- The pin is unconditional (not `#[cfg(windows)]`) because this client issues one unary Connect POST over loopback; keep it unless `rpc_request` adds streaming.

<sup>Written for commit b21fc04d8db8a99fcab9af46ab457da0a63c979d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

