### PR TITLE
feat: add ccusage import format

### DIFF
--- a/crates/tokscale-cli/src/commands/import.rs
+++ b/crates/tokscale-cli/src/commands/import.rs
@@ -1,10 +1,11 @@
 //! Import historical usage from third-party aggregate exports.
 //!
-//! Currently supports the clawdboard.ai account export ("daily aggregates").
-//! The importer normalizes that export into tokscale's native [`GraphResult`],
-//! which the CLI then writes out as standard tokscale JSON (identical in shape
-//! to `tokscale graph`) for review, archival, or a future server-supported
-//! backfill.
+//! Supports the clawdboard.ai account export ("daily aggregates") and
+//! `ccusage`'s own `daily --json` output (the `cc.json` that viberank and
+//! similar dashboards ingest). The importer normalizes either into tokscale's
+//! native [`GraphResult`], which the CLI then writes out as standard tokscale
+//! JSON (identical in shape to `tokscale graph`) for review, archival, or a
+//! future server-supported backfill.
 //!
 //! Motivation: `tokscale submit` computes totals from *raw* local session
 //! files. Once those files are gone (Claude Code deletes transcripts after
@@ -28,7 +29,7 @@ use tokscale_core::{
 };
 
 /// Import source formats understood by [`parse_export`].
-pub const SUPPORTED_FORMATS: &[&str] = &["clawdboard"];
+pub const SUPPORTED_FORMATS: &[&str] = &["clawdboard", "ccusage"];
 
 /// Result of a successful import.
 pub struct ImportOutcome {
@@ -73,6 +74,7 @@ pub struct ImportOutcome {
 pub fn parse_export(format: &str, json: &str) -> Result<ImportOutcome> {
     match format {
         "clawdboard" => parse_clawdboard_export(json),
+        "ccusage" => parse_ccusage_export(json),
         other => bail!(
             "unsupported import format '{}' (supported: {})",
             other,
@@ -314,6 +316,325 @@ pub fn parse_clawdboard_export(json: &str) -> Result<ImportOutcome> {
         multi_model_fallback_rows,
         breakdown_reconciliation_warnings,
     })
+}
+
+// ---------------------------------------------------------------------------
+// ccusage export schema (`ccusage daily --json`, a.k.a. cc.json)
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize)]
+struct CcusageExport {
+    #[serde(default)]
+    daily: Vec<CcusageDaily>,
+}
+
+/// One calendar day of the unified report.
+///
+/// Unlike clawdboard, a row is *not* scoped to one client: the unified report
+/// merges every detected agent for that date into a single row and records the
+/// participants in `metadata.agents`. The per-client split has to be recovered
+/// from `modelBreakdowns` — see [`resolve_client`].
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CcusageDaily {
+    /// The unified report emits `period`; the per-agent reports (and older
+    /// ccusage releases) emit `date`. Accept either rather than forcing users
+    /// to know which subcommand produced their file.
+    #[serde(default)]
+    date: Option<String>,
+    #[serde(default)]
+    period: Option<String>,
+    #[serde(default)]
+    input_tokens: i64,
+    #[serde(default)]
+    output_tokens: i64,
+    #[serde(default)]
+    cache_creation_tokens: i64,
+    #[serde(default)]
+    cache_read_tokens: i64,
+    #[serde(default)]
+    reasoning_output_tokens: i64,
+    /// Numeric in ccusage, but dashboards that re-serialize cc.json sometimes
+    /// stringify it. [`CostValue`] accepts both.
+    #[serde(default)]
+    total_cost: Option<CostValue>,
+    #[serde(default)]
+    models_used: Vec<String>,
+    #[serde(default)]
+    model_breakdowns: Vec<CcusageModelBreakdown>,
+    #[serde(default)]
+    metadata: Option<CcusageMetadata>,
+}
+
+#[derive(serde::Deserialize)]
+struct CcusageMetadata {
+    #[serde(default)]
+    agents: Vec<String>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CcusageModelBreakdown {
+    model_name: String,
+    #[serde(default)]
+    cost: f64,
+    #[serde(default)]
+    input_tokens: i64,
+    #[serde(default)]
+    output_tokens: i64,
+    #[serde(default)]
+    cache_read_tokens: i64,
+    #[serde(default)]
+    cache_creation_tokens: i64,
+    #[serde(default)]
+    reasoning_output_tokens: i64,
+}
+
+/// A cost field that may arrive as a JSON number or as a stringified number.
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum CostValue {
+    Number(f64),
+    Text(String),
+}
+
+impl CostValue {
+    fn resolve(&self, unparseable_count: &mut usize) -> f64 {
+        match self {
+            CostValue::Number(v) => *v,
+            CostValue::Text(s) => parse_cost_string(Some(s), unparseable_count),
+        }
+    }
+}
+
+/// Pick the client a model's usage belongs to.
+///
+/// `agents` is the ground truth for *which* clients ran that day, so the
+/// resolver never invents one that is not listed. When the day had a single
+/// agent every model is trivially its own; when several ran, the model family
+/// decides. A model that matches no listed agent is left unattributed rather
+/// than silently folded into the first one — misattributed usage is worse than
+/// usage the caller is told about.
+fn resolve_client(model: &str, agents: &[String]) -> Option<String> {
+    if agents.len() == 1 {
+        return Some(normalize_client_id(&agents[0]));
+    }
+
+    let family = model_family(model)?;
+    let normalized: Vec<String> = agents.iter().map(|a| normalize_client_id(a)).collect();
+
+    if normalized.is_empty() {
+        return Some(family.to_string());
+    }
+    normalized.into_iter().find(|a| a == family)
+}
+
+/// Map a model id to the client that conventionally produces it in a ccusage
+/// report. Mirrors the vendor families `inferred_provider_from_model` knows,
+/// narrowed to the CLIs ccusage attributes usage to.
+fn model_family(model: &str) -> Option<&'static str> {
+    let lower = model.to_lowercase();
+    let has_word = |w: &str| {
+        lower
+            .split(|c: char| !c.is_ascii_alphanumeric())
+            .any(|seg| seg == w)
+    };
+
+    if lower.contains("claude")
+        || has_word("opus")
+        || has_word("sonnet")
+        || has_word("haiku")
+        || has_word("fable")
+    {
+        return Some("claude");
+    }
+    if lower.contains("gpt") || lower.contains("codex") || has_word("o1") || has_word("o3") {
+        return Some("codex");
+    }
+    if lower.contains("gemini") {
+        return Some("gemini");
+    }
+    None
+}
+
+/// Parse a `ccusage daily --json` export into normalized tokscale data.
+///
+/// Grouping matches [`parse_clawdboard_export`]: one [`DailyContribution`] per
+/// date, one [`ClientContribution`] per (client, model) within it.
+pub fn parse_ccusage_export(json: &str) -> Result<ImportOutcome> {
+    let export: CcusageExport =
+        serde_json::from_str(json).context("failed to parse ccusage export JSON")?;
+
+    if export.daily.is_empty() {
+        bail!("ccusage export contains no daily rows to import");
+    }
+
+    let mut days: BTreeMap<String, DayBuilder> = BTreeMap::new();
+    let mut unknown: BTreeSet<String> = BTreeSet::new();
+    let mut negative_values_clamped = 0usize;
+    let mut suspect_cost_rows = 0usize;
+    let mut future_dated_rows = 0usize;
+    let mut unparseable_cost_rows = 0usize;
+    let mut non_finite_cost_rows = 0usize;
+    let mut multi_model_fallback_rows = 0usize;
+    let mut breakdown_reconciliation_warnings: Vec<String> = Vec::new();
+    let today = chrono::Utc::now().date_naive();
+
+    for row in &export.daily {
+        let date = row
+            .period
+            .as_deref()
+            .or(row.date.as_deref())
+            .ok_or_else(|| {
+                anyhow::anyhow!("ccusage daily row is missing both `period` and `date`")
+            })?
+            .to_string();
+        let parsed_date = parse_calendar_date(&date)?;
+        if parsed_date > today {
+            future_dated_rows += 1;
+        }
+
+        let agents: Vec<String> = row
+            .metadata
+            .as_ref()
+            .map(|m| m.agents.clone())
+            .unwrap_or_default();
+        let day = days.entry(date.clone()).or_default();
+
+        if row.model_breakdowns.is_empty() {
+            // No per-model split: attribute the aggregate to the first listed
+            // model, mirroring the clawdboard fallback.
+            let model = row
+                .models_used
+                .first()
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string());
+            if row.models_used.len() > 1 {
+                multi_model_fallback_rows += 1;
+            }
+            let client = attribute(&model, &agents, &mut unknown);
+            let raw_cost = row
+                .total_cost
+                .as_ref()
+                .map(|c| c.resolve(&mut unparseable_cost_rows))
+                .unwrap_or(0.0);
+            let raw_cost = sanitize_cost(raw_cost, &mut non_finite_cost_rows);
+            let cost = clamp_f64(raw_cost, &mut negative_values_clamped);
+            let tokens = TokenBreakdown {
+                input: clamp_i64(row.input_tokens, &mut negative_values_clamped),
+                output: clamp_i64(row.output_tokens, &mut negative_values_clamped),
+                cache_read: clamp_i64(row.cache_read_tokens, &mut negative_values_clamped),
+                cache_write: clamp_i64(row.cache_creation_tokens, &mut negative_values_clamped),
+                reasoning: clamp_i64(row.reasoning_output_tokens, &mut negative_values_clamped),
+            };
+            if cost > 0.0 && tokens.total() == 0 && !is_cursor_legacy_tokenless(&client, &model) {
+                suspect_cost_rows += 1;
+            }
+            add_row(day, &client, &model, tokens, cost);
+            continue;
+        }
+
+        let mut mb_input = 0i64;
+        let mut mb_output = 0i64;
+        let mut mb_cache_read = 0i64;
+        let mut mb_cache_write = 0i64;
+        let mut mb_cost = 0.0f64;
+
+        for mb in &row.model_breakdowns {
+            let client = attribute(&mb.model_name, &agents, &mut unknown);
+            let tokens = TokenBreakdown {
+                input: clamp_i64(mb.input_tokens, &mut negative_values_clamped),
+                output: clamp_i64(mb.output_tokens, &mut negative_values_clamped),
+                cache_read: clamp_i64(mb.cache_read_tokens, &mut negative_values_clamped),
+                cache_write: clamp_i64(mb.cache_creation_tokens, &mut negative_values_clamped),
+                reasoning: clamp_i64(mb.reasoning_output_tokens, &mut negative_values_clamped),
+            };
+            let raw_cost = sanitize_cost(mb.cost, &mut non_finite_cost_rows);
+            let cost = clamp_f64(raw_cost, &mut negative_values_clamped);
+            if cost > 0.0
+                && tokens.total() == 0
+                && !is_cursor_legacy_tokenless(&client, &mb.model_name)
+            {
+                suspect_cost_rows += 1;
+            }
+
+            mb_input = mb_input.saturating_add(tokens.input);
+            mb_output = mb_output.saturating_add(tokens.output);
+            mb_cache_read = mb_cache_read.saturating_add(tokens.cache_read);
+            mb_cache_write = mb_cache_write.saturating_add(tokens.cache_write);
+            mb_cost += cost;
+
+            add_row(day, &client, &mb.model_name, tokens, cost);
+        }
+
+        // ccusage always populates the aggregate scalars alongside the
+        // breakdowns, so a divergence here means the file was edited or
+        // truncated — worth surfacing before the numbers reach a leaderboard.
+        let agg_total = row
+            .input_tokens
+            .max(0)
+            .saturating_add(row.output_tokens.max(0))
+            .saturating_add(row.cache_read_tokens.max(0))
+            .saturating_add(row.cache_creation_tokens.max(0));
+        let mb_total = mb_input
+            .saturating_add(mb_output)
+            .saturating_add(mb_cache_read)
+            .saturating_add(mb_cache_write);
+        if agg_total != 0 && tokens_diverge(mb_total, agg_total) {
+            breakdown_reconciliation_warnings.push(format!(
+                "{date}: modelBreakdowns sum to {mb_total} token(s) but aggregate totals report {agg_total}"
+            ));
+        }
+        if let Some(raw) = row.total_cost.as_ref() {
+            let agg_cost = sanitize_cost(
+                raw.resolve(&mut unparseable_cost_rows),
+                &mut non_finite_cost_rows,
+            );
+            if costs_diverge(mb_cost, agg_cost) {
+                breakdown_reconciliation_warnings.push(format!(
+                    "{date}: modelBreakdowns sum to cost {mb_cost:.4} but aggregate totalCost reports {agg_cost:.4}"
+                ));
+            }
+        }
+    }
+
+    let mut contributions: Vec<DailyContribution> = days
+        .into_iter()
+        .map(|(date, builder)| finalize_day(date, builder))
+        .collect();
+    contributions.sort_by(|a, b| a.date.cmp(&b.date));
+    calculate_intensities(&mut contributions);
+
+    let graph = generate_graph_result(contributions, 0);
+
+    Ok(ImportOutcome {
+        graph,
+        unknown_clients: unknown.into_iter().collect(),
+        negative_values_clamped,
+        suspect_cost_rows,
+        future_dated_rows,
+        unparseable_cost_rows,
+        non_finite_cost_rows,
+        multi_model_fallback_rows,
+        breakdown_reconciliation_warnings,
+    })
+}
+
+/// Resolve a model to its client, recording anything unattributable so the
+/// caller can warn. The leaderboard rejects unknown clients, so `"unknown"`
+/// is a visible placeholder rather than a silent default.
+fn attribute(model: &str, agents: &[String], unknown: &mut BTreeSet<String>) -> String {
+    match resolve_client(model, agents) {
+        Some(client) if ClientId::from_str(&client).is_some() => client,
+        Some(client) => {
+            unknown.insert(client.clone());
+            client
+        }
+        None => {
+            unknown.insert("unknown".to_string());
+            "unknown".to_string()
+        }
+    }
 }
 
 /// Validate that `s` is both shaped like `YYYY-MM-DD` (matching the
@@ -862,5 +1183,214 @@ mod tests {
             "outputTokens":0,"cacheReadTokens":0,"cacheCreationTokens":0}]}]}"#;
         let out = parse_clawdboard_export(json).unwrap();
         assert_eq!(out.suspect_cost_rows, 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // ccusage
+    // -----------------------------------------------------------------------
+
+    /// A `ccusage daily --json` row as the unified report emits it: `period`
+    /// rather than `date`, and one row carrying both agents' models.
+    const CCUSAGE_MIXED: &str = r#"{
+      "daily": [
+        {
+          "agent": "all",
+          "period": "2026-08-14",
+          "inputTokens": 1100,
+          "outputTokens": 2200,
+          "cacheCreationTokens": 300,
+          "cacheReadTokens": 4400,
+          "totalCost": 30.0,
+          "totalTokens": 8000,
+          "metadata": { "agents": ["claude", "codex"] },
+          "modelsUsed": ["claude-opus-5", "gpt-5.6-sol"],
+          "modelBreakdowns": [
+            { "modelName": "claude-opus-5", "cost": 20.0, "inputTokens": 100,
+              "outputTokens": 200, "cacheReadTokens": 400, "cacheCreationTokens": 300 },
+            { "modelName": "gpt-5.6-sol", "cost": 10.0, "inputTokens": 1000,
+              "outputTokens": 2000, "cacheReadTokens": 4000, "cacheCreationTokens": 0,
+              "reasoningOutputTokens": 700 }
+          ]
+        }
+      ]
+    }"#;
+
+    fn client_rows(out: &ImportOutcome, day: usize) -> Vec<(String, String)> {
+        out.graph.contributions[day]
+            .clients
+            .iter()
+            .map(|c| (c.client.clone(), c.model_id.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn ccusage_splits_a_shared_day_by_model_family() {
+        // The point of the format: one row, two agents. Attributing the whole
+        // row to a single client would move $10 of Codex spend onto Claude.
+        let out = parse_ccusage_export(CCUSAGE_MIXED).unwrap();
+        assert_eq!(
+            client_rows(&out, 0),
+            vec![
+                ("claude".to_string(), "claude-opus-5".to_string()),
+                ("codex".to_string(), "gpt-5.6-sol".to_string()),
+            ]
+        );
+
+        let claude = &out.graph.contributions[0].clients[0];
+        let codex = &out.graph.contributions[0].clients[1];
+        assert!((claude.cost - 20.0).abs() < 1e-9);
+        assert!((codex.cost - 10.0).abs() < 1e-9);
+        assert!(out.unknown_clients.is_empty());
+    }
+
+    #[test]
+    fn ccusage_preserves_reasoning_tokens() {
+        // Codex reports reasoning output separately; dropping it understates
+        // the day and breaks the server's token-sum check.
+        let out = parse_ccusage_export(CCUSAGE_MIXED).unwrap();
+        assert_eq!(out.graph.contributions[0].token_breakdown.reasoning, 700);
+        assert_eq!(out.graph.contributions[0].clients[1].tokens.reasoning, 700);
+    }
+
+    #[test]
+    fn ccusage_day_totals_match_client_rows() {
+        let out = parse_ccusage_export(CCUSAGE_MIXED).unwrap();
+        let day = &out.graph.contributions[0];
+        let summed: i64 = day.clients.iter().map(|c| c.tokens.total()).sum();
+        let cost: f64 = day.clients.iter().map(|c| c.cost).sum();
+        assert_eq!(day.totals.tokens, summed);
+        assert_eq!(day.token_breakdown.total(), summed);
+        assert!((day.totals.cost - cost).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ccusage_accepts_date_as_well_as_period() {
+        // Per-agent reports and older releases emit `date`.
+        let json = r#"{"daily":[{"date":"2026-08-14","totalCost":1.0,
+            "metadata":{"agents":["claude"]},
+            "modelBreakdowns":[{"modelName":"claude-opus-5","cost":1.0,"inputTokens":10,
+            "outputTokens":20,"cacheReadTokens":0,"cacheCreationTokens":0}]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        assert_eq!(out.graph.contributions[0].date, "2026-08-14");
+    }
+
+    #[test]
+    fn ccusage_row_without_any_date_is_rejected() {
+        let json = r#"{"daily":[{"totalCost":1.0,"modelsUsed":["claude-opus-5"]}]}"#;
+        let err = match parse_ccusage_export(json) {
+            Ok(_) => panic!("a row with neither `period` nor `date` must be rejected"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains("period"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn ccusage_single_agent_day_needs_no_model_inference() {
+        // A day with one agent is unambiguous even for a model the family
+        // matcher has never seen — the export already told us who ran.
+        let json = r#"{"daily":[{"period":"2026-08-14","totalCost":1.0,
+            "metadata":{"agents":["opencode"]},
+            "modelBreakdowns":[{"modelName":"some-private-model","cost":1.0,"inputTokens":10,
+            "outputTokens":20,"cacheReadTokens":0,"cacheCreationTokens":0}]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        assert_eq!(out.graph.contributions[0].clients[0].client, "opencode");
+        assert!(out.unknown_clients.is_empty());
+    }
+
+    #[test]
+    fn ccusage_unattributable_model_on_a_shared_day_is_flagged() {
+        // Two agents ran and the model matches neither. Folding it into the
+        // first agent would silently misattribute it, so it is surfaced.
+        let json = r#"{"daily":[{"period":"2026-08-14","totalCost":1.0,
+            "metadata":{"agents":["claude","codex"]},
+            "modelBreakdowns":[{"modelName":"mystery-1","cost":1.0,"inputTokens":10,
+            "outputTokens":20,"cacheReadTokens":0,"cacheCreationTokens":0}]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        assert_eq!(out.unknown_clients, vec!["unknown".to_string()]);
+        assert_eq!(out.graph.contributions[0].clients[0].client, "unknown");
+    }
+
+    #[test]
+    fn ccusage_infers_family_when_metadata_is_absent() {
+        // Older exports carry no `metadata.agents` at all.
+        let json = r#"{"daily":[{"period":"2026-08-14","totalCost":1.0,
+            "modelBreakdowns":[{"modelName":"gpt-5.5","cost":1.0,"inputTokens":10,
+            "outputTokens":20,"cacheReadTokens":0,"cacheCreationTokens":0}]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        assert_eq!(out.graph.contributions[0].clients[0].client, "codex");
+    }
+
+    #[test]
+    fn ccusage_accepts_stringified_cost() {
+        // Dashboards that round-trip cc.json sometimes serialize the
+        // aggregate cost as a string.
+        let json = r#"{"daily":[{"period":"2026-08-14","totalCost":"1.25",
+            "inputTokens":10,"outputTokens":20,
+            "metadata":{"agents":["claude"]},"modelsUsed":["claude-opus-5"]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        assert!((out.graph.contributions[0].totals.cost - 1.25).abs() < 1e-9);
+        assert_eq!(out.unparseable_cost_rows, 0);
+    }
+
+    #[test]
+    fn ccusage_reconciliation_warns_when_breakdowns_diverge() {
+        let json = r#"{"daily":[{"period":"2026-08-14","inputTokens":10000,
+            "outputTokens":0,"cacheReadTokens":0,"cacheCreationTokens":0,"totalCost":1.0,
+            "metadata":{"agents":["claude"]},
+            "modelBreakdowns":[{"modelName":"claude-opus-5","cost":1.0,"inputTokens":10,
+            "outputTokens":0,"cacheReadTokens":0,"cacheCreationTokens":0}]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        assert_eq!(out.breakdown_reconciliation_warnings.len(), 1);
+        assert!(out.breakdown_reconciliation_warnings[0].contains("2026-08-14"));
+    }
+
+    #[test]
+    fn ccusage_empty_export_is_an_error() {
+        assert!(parse_ccusage_export(r#"{"daily":[]}"#).is_err());
+    }
+
+    #[test]
+    fn ccusage_negative_values_are_clamped() {
+        let json = r#"{"daily":[{"period":"2026-08-14","totalCost":1.0,
+            "metadata":{"agents":["claude"]},
+            "modelBreakdowns":[{"modelName":"claude-opus-5","cost":-1.0,"inputTokens":-10,
+            "outputTokens":20,"cacheReadTokens":0,"cacheCreationTokens":0}]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        assert_eq!(out.negative_values_clamped, 2);
+        assert_eq!(out.graph.contributions[0].token_breakdown.input, 0);
+        assert!(out.graph.contributions[0].totals.cost.abs() < 1e-9);
+    }
+
+    #[test]
+    fn ccusage_days_are_sorted_and_intensities_assigned() {
+        let json = r#"{"daily":[
+            {"period":"2026-08-15","totalCost":1.0,"metadata":{"agents":["claude"]},
+             "modelBreakdowns":[{"modelName":"claude-opus-5","cost":1.0,"inputTokens":10,
+             "outputTokens":0,"cacheReadTokens":0,"cacheCreationTokens":0}]},
+            {"period":"2026-08-13","totalCost":9.0,"metadata":{"agents":["claude"]},
+             "modelBreakdowns":[{"modelName":"claude-opus-5","cost":9.0,"inputTokens":90,
+             "outputTokens":0,"cacheReadTokens":0,"cacheCreationTokens":0}]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        let dates: Vec<&str> = out
+            .graph
+            .contributions
+            .iter()
+            .map(|c| c.date.as_str())
+            .collect();
+        assert_eq!(dates, vec!["2026-08-13", "2026-08-15"]);
+        let top = out
+            .graph
+            .contributions
+            .iter()
+            .max_by(|a, b| a.intensity.cmp(&b.intensity))
+            .unwrap();
+        assert_eq!(top.date, "2026-08-13");
+    }
+
+    #[test]
+    fn ccusage_parse_export_dispatches_by_format() {
+        assert!(parse_export("ccusage", CCUSAGE_MIXED).is_ok());
+        assert!(parse_export("clawdboard", SAMPLE).is_ok());
+        assert!(parse_export("viberank", CCUSAGE_MIXED).is_err());
     }
 }

--- a/crates/tokscale-cli/src/commands/import.rs
+++ b/crates/tokscale-cli/src/commands/import.rs
@@ -13,6 +13,21 @@
 //! even though a competing dashboard may still hold the aggregates. This
 //! importer recovers that history into tokscale's format.
 //!
+//! ccusage shapes, and what the importer assumes about each:
+//!
+//! - plain `ccusage daily --json` — `date`, no `metadata`, no reasoning. Every
+//!   model is attributed by family, since nothing names the agents.
+//! - the unified/agent-aware report — `period`, `agent: "all"`, and
+//!   `metadata.agents` naming the participants. Reasoning, when present, is
+//!   nested under `metadata`, not beside the other token fields.
+//! - `ccusage-codex` — spells cost `costUSD` and puts `reasoningOutputTokens`
+//!   beside the token fields (see ccusage#831).
+//!
+//! Across all three, `totalTokens` is `input + output + cacheCreation +
+//! cacheRead`; reasoning is never a term of its own in it. See
+//! [`ccusage_token_breakdown`] for why that matters when mapping into
+//! tokscale's additive buckets.
+//!
 //! IMPORTANT — upload boundary: importing only *normalizes* data to a file. It
 //! does not submit anything to the leaderboard. Backfilled aggregates are not
 //! independently verifiable the way locally-scanned sessions are, so uploading
@@ -142,7 +157,12 @@ struct ClawdboardModelBreakdown {
 fn normalize_client_id(source: &str) -> String {
     match source.trim().to_lowercase().as_str() {
         "claude-code" | "claude_code" | "claudecode" => "claude".to_string(),
-        "codex-cli" => "codex".to_string(),
+        "codex-cli" | "codex_cli" | "ccusage-codex" => "codex".to_string(),
+        // `model_family` answers in canonical client ids, and `resolve_client`
+        // matches an agent to a model by comparing the two as strings. A CLI
+        // suffix that survives normalization therefore never matches its own
+        // models and drops the whole agent's usage into `unknown`.
+        "gemini-cli" | "gemini_cli" => "gemini".to_string(),
         other => other.to_string(),
     }
 }
@@ -354,10 +374,20 @@ struct CcusageDaily {
     cache_read_tokens: i64,
     #[serde(default)]
     reasoning_output_tokens: i64,
+    /// `input + output + cacheCreation + cacheRead`, as ccusage computes it.
+    /// Reasoning is never a term in this sum — see [`ccusage_token_breakdown`].
+    /// Used only as a cross-check; the buckets remain the source of truth.
+    #[serde(default)]
+    total_tokens: Option<i64>,
     /// Numeric in ccusage, but dashboards that re-serialize cc.json sometimes
     /// stringify it. [`CostValue`] accepts both.
     #[serde(default)]
     total_cost: Option<CostValue>,
+    /// `ccusage-codex` spells the same field `costUSD` (see ccusage#831).
+    /// Spelled out explicitly: `rename_all = "camelCase"` would derive
+    /// `costUsd`, which matches nothing.
+    #[serde(default, rename = "costUSD", alias = "costUsd")]
+    cost_usd: Option<CostValue>,
     #[serde(default)]
     models_used: Vec<String>,
     #[serde(default)]
@@ -366,10 +396,51 @@ struct CcusageDaily {
     metadata: Option<CcusageMetadata>,
 }
 
+impl CcusageDaily {
+    /// `totalCost`, or `ccusage-codex`'s `costUSD` spelling of it.
+    fn declared_cost(&self) -> Option<&CostValue> {
+        self.total_cost.as_ref().or(self.cost_usd.as_ref())
+    }
+
+    /// Reasoning tokens for the row as a whole.
+    ///
+    /// The unified report nests this under `metadata`; `ccusage-codex` puts it
+    /// beside the other token fields. Accept both — reading only the flat
+    /// spelling silently scores every real unified export as zero-reasoning.
+    fn row_reasoning_tokens(&self) -> i64 {
+        let nested = self
+            .metadata
+            .as_ref()
+            .map(|m| m.reasoning_output_tokens)
+            .unwrap_or(0);
+        self.reasoning_output_tokens.max(nested)
+    }
+
+    /// Whether the row carries no usage at all. ccusage emits a row for every
+    /// day in the range, including days with nothing on them.
+    fn is_empty_day(&self) -> bool {
+        self.model_breakdowns.is_empty()
+            && self.models_used.is_empty()
+            && self.input_tokens <= 0
+            && self.output_tokens <= 0
+            && self.cache_creation_tokens <= 0
+            && self.cache_read_tokens <= 0
+            && self.row_reasoning_tokens() <= 0
+            && self
+                .declared_cost()
+                .map(|c| !c.is_positive())
+                .unwrap_or(true)
+    }
+}
+
 #[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct CcusageMetadata {
     #[serde(default)]
     agents: Vec<String>,
+    /// Where the unified report actually records reasoning output.
+    #[serde(default)]
+    reasoning_output_tokens: i64,
 }
 
 #[derive(serde::Deserialize)]
@@ -405,6 +476,44 @@ impl CostValue {
             CostValue::Text(s) => parse_cost_string(Some(s), unparseable_count),
         }
     }
+
+    /// Whether this cost is a real charge, for emptiness checks only. Parse
+    /// failures are deliberately not counted here — a row rejected as empty is
+    /// never reported on, so counting it would inflate the warning.
+    fn is_positive(&self) -> bool {
+        let mut ignored = 0usize;
+        self.resolve(&mut ignored) > 0.0
+    }
+}
+
+/// Build a tokscale [`TokenBreakdown`] from one ccusage row or model breakdown.
+///
+/// ccusage's own `totalTokens` is `input + output + cacheCreation + cacheRead`;
+/// reasoning is never a term in it (verified against real exports and against
+/// ccusage's documented examples). tokscale's buckets are additive and
+/// `TokenBreakdown::total()` sums `reasoning` as a fifth term, so mapping
+/// `reasoningOutputTokens` straight through reports a day *larger* than the
+/// file it came from. Reasoning is an OpenAI output-detail subset, so the
+/// additive `output` bucket keeps only the non-reasoning remainder — the same
+/// correction `dsh.rs`, `grok.rs`, `senpi.rs`, `zcode.rs` and `reasonix.rs`
+/// apply to this shape.
+fn ccusage_token_breakdown(
+    input: i64,
+    output: i64,
+    cache_read: i64,
+    cache_write: i64,
+    reasoning: i64,
+    clamped: &mut usize,
+) -> TokenBreakdown {
+    let output = clamp_i64(output, clamped);
+    let reasoning = clamp_i64(reasoning, clamped);
+    TokenBreakdown {
+        input: clamp_i64(input, clamped),
+        output: output.saturating_sub(reasoning),
+        cache_read: clamp_i64(cache_read, clamped),
+        cache_write: clamp_i64(cache_write, clamped),
+        reasoning,
+    }
 }
 
 /// Pick the client a model's usage belongs to.
@@ -415,6 +524,14 @@ impl CostValue {
 /// decides. A model that matches no listed agent is left unattributed rather
 /// than silently folded into the first one — misattributed usage is worse than
 /// usage the caller is told about.
+///
+/// Known limit: this splits by *family*, not by which client actually made the
+/// call, and a family can belong to more than one listed agent. On a day with
+/// `["claude", "opencode"]`, Claude models all land on `claude` even though
+/// OpenCode routinely drives them — the unified row does not record enough to
+/// tell them apart. Splitting exactly needs ccusage's `--by-agent` output,
+/// where each agent carries its own `modelBreakdowns`; supporting that shape
+/// would remove the guess entirely and is the right follow-up here.
 fn resolve_client(model: &str, agents: &[String]) -> Option<String> {
     if agents.len() == 1 {
         return Some(normalize_client_id(&agents[0]));
@@ -490,6 +607,16 @@ pub fn parse_ccusage_export(json: &str) -> Result<ImportOutcome> {
             })?
             .to_string();
         let parsed_date = parse_calendar_date(&date)?;
+
+        // ccusage emits a row for every day in the range, so a real export
+        // routinely carries days with no usage at all. Attributing one would
+        // mint a phantom `unknown` client from the empty model list and warn
+        // that the import would be rejected — for a day that contributes
+        // nothing. Drop it before it can reach attribution.
+        if row.is_empty_day() {
+            continue;
+        }
+
         if parsed_date > today {
             future_dated_rows += 1;
         }
@@ -514,19 +641,19 @@ pub fn parse_ccusage_export(json: &str) -> Result<ImportOutcome> {
             }
             let client = attribute(&model, &agents, &mut unknown);
             let raw_cost = row
-                .total_cost
-                .as_ref()
+                .declared_cost()
                 .map(|c| c.resolve(&mut unparseable_cost_rows))
                 .unwrap_or(0.0);
             let raw_cost = sanitize_cost(raw_cost, &mut non_finite_cost_rows);
             let cost = clamp_f64(raw_cost, &mut negative_values_clamped);
-            let tokens = TokenBreakdown {
-                input: clamp_i64(row.input_tokens, &mut negative_values_clamped),
-                output: clamp_i64(row.output_tokens, &mut negative_values_clamped),
-                cache_read: clamp_i64(row.cache_read_tokens, &mut negative_values_clamped),
-                cache_write: clamp_i64(row.cache_creation_tokens, &mut negative_values_clamped),
-                reasoning: clamp_i64(row.reasoning_output_tokens, &mut negative_values_clamped),
-            };
+            let tokens = ccusage_token_breakdown(
+                row.input_tokens,
+                row.output_tokens,
+                row.cache_read_tokens,
+                row.cache_creation_tokens,
+                row.row_reasoning_tokens(),
+                &mut negative_values_clamped,
+            );
             if cost > 0.0 && tokens.total() == 0 && !is_cursor_legacy_tokenless(&client, &model) {
                 suspect_cost_rows += 1;
             }
@@ -534,21 +661,19 @@ pub fn parse_ccusage_export(json: &str) -> Result<ImportOutcome> {
             continue;
         }
 
-        let mut mb_input = 0i64;
-        let mut mb_output = 0i64;
-        let mut mb_cache_read = 0i64;
-        let mut mb_cache_write = 0i64;
+        let mut mb_total = 0i64;
         let mut mb_cost = 0.0f64;
 
         for mb in &row.model_breakdowns {
             let client = attribute(&mb.model_name, &agents, &mut unknown);
-            let tokens = TokenBreakdown {
-                input: clamp_i64(mb.input_tokens, &mut negative_values_clamped),
-                output: clamp_i64(mb.output_tokens, &mut negative_values_clamped),
-                cache_read: clamp_i64(mb.cache_read_tokens, &mut negative_values_clamped),
-                cache_write: clamp_i64(mb.cache_creation_tokens, &mut negative_values_clamped),
-                reasoning: clamp_i64(mb.reasoning_output_tokens, &mut negative_values_clamped),
-            };
+            let tokens = ccusage_token_breakdown(
+                mb.input_tokens,
+                mb.output_tokens,
+                mb.cache_read_tokens,
+                mb.cache_creation_tokens,
+                mb.reasoning_output_tokens,
+                &mut negative_values_clamped,
+            );
             let raw_cost = sanitize_cost(mb.cost, &mut non_finite_cost_rows);
             let cost = clamp_f64(raw_cost, &mut negative_values_clamped);
             if cost > 0.0
@@ -558,10 +683,10 @@ pub fn parse_ccusage_export(json: &str) -> Result<ImportOutcome> {
                 suspect_cost_rows += 1;
             }
 
-            mb_input = mb_input.saturating_add(tokens.input);
-            mb_output = mb_output.saturating_add(tokens.output);
-            mb_cache_read = mb_cache_read.saturating_add(tokens.cache_read);
-            mb_cache_write = mb_cache_write.saturating_add(tokens.cache_write);
+            // `total()` re-adds the reasoning that `ccusage_token_breakdown`
+            // moved out of `output`, so this sum is back in ccusage's own
+            // vocabulary and is directly comparable to the row's scalars.
+            mb_total = mb_total.saturating_add(tokens.total());
             mb_cost += cost;
 
             add_row(day, &client, &mb.model_name, tokens, cost);
@@ -576,16 +701,22 @@ pub fn parse_ccusage_export(json: &str) -> Result<ImportOutcome> {
             .saturating_add(row.output_tokens.max(0))
             .saturating_add(row.cache_read_tokens.max(0))
             .saturating_add(row.cache_creation_tokens.max(0));
-        let mb_total = mb_input
-            .saturating_add(mb_output)
-            .saturating_add(mb_cache_read)
-            .saturating_add(mb_cache_write);
         if agg_total != 0 && tokens_diverge(mb_total, agg_total) {
             breakdown_reconciliation_warnings.push(format!(
                 "{date}: modelBreakdowns sum to {mb_total} token(s) but aggregate totals report {agg_total}"
             ));
         }
-        if let Some(raw) = row.total_cost.as_ref() {
+        // The row's own `totalTokens` is the one number the file states about
+        // itself, and it is the cross-check that catches a token bucket being
+        // mapped through twice. Compare it against what tokscale will report.
+        if let Some(declared) = row.total_tokens.filter(|t| *t > 0) {
+            if tokens_diverge(mb_total, declared) {
+                breakdown_reconciliation_warnings.push(format!(
+                    "{date}: imported {mb_total} token(s) but the export's own totalTokens reports {declared}"
+                ));
+            }
+        }
+        if let Some(raw) = row.declared_cost() {
             let agg_cost = sanitize_cost(
                 raw.resolve(&mut unparseable_cost_rows),
                 &mut non_finite_cost_rows,
@@ -1250,6 +1381,103 @@ mod tests {
         let out = parse_ccusage_export(CCUSAGE_MIXED).unwrap();
         assert_eq!(out.graph.contributions[0].token_breakdown.reasoning, 700);
         assert_eq!(out.graph.contributions[0].clients[1].tokens.reasoning, 700);
+    }
+
+    #[test]
+    fn ccusage_day_total_matches_the_export_declared_total() {
+        // The anti-double-count guard. ccusage's `totalTokens` is
+        // input+output+cacheCreation+cacheRead and never counts reasoning as a
+        // term of its own, while tokscale's buckets are additive. Mapping
+        // `reasoningOutputTokens` through without taking it out of `output`
+        // reported 8700 for this row -- 700 more than the file says it is.
+        let out = parse_ccusage_export(CCUSAGE_MIXED).unwrap();
+        let day = &out.graph.contributions[0];
+        assert_eq!(day.totals.tokens, 8000, "must match the row's totalTokens");
+        // The reasoning is still tracked, just not counted twice.
+        assert_eq!(day.token_breakdown.reasoning, 700);
+        assert_eq!(day.token_breakdown.output, 2200 - 700);
+        assert!(
+            out.breakdown_reconciliation_warnings.is_empty(),
+            "a self-consistent export must not warn: {:?}",
+            out.breakdown_reconciliation_warnings
+        );
+    }
+
+    #[test]
+    fn ccusage_reads_reasoning_nested_under_metadata() {
+        // The unified report records reasoning under `metadata`, not beside
+        // the other token fields. Reading only the flat spelling scores every
+        // real unified export as zero-reasoning.
+        let json = r#"{"daily":[{"period":"2026-08-14","totalCost":1.0,
+            "inputTokens":10,"outputTokens":100,"totalTokens":110,
+            "metadata":{"agents":["codex"],"reasoningOutputTokens":40},
+            "modelsUsed":["gpt-5.6-sol"]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        let day = &out.graph.contributions[0];
+        assert_eq!(day.token_breakdown.reasoning, 40);
+        assert_eq!(
+            day.token_breakdown.output, 60,
+            "100 output less 40 reasoning"
+        );
+        assert_eq!(day.totals.tokens, 110, "still the declared total");
+    }
+
+    #[test]
+    fn ccusage_empty_day_row_is_skipped() {
+        // ccusage emits a row per day in the range, so real exports carry
+        // days with nothing on them. Attributing one mints a phantom
+        // `unknown` client and warns that the import would be rejected.
+        let json = r#"{"daily":[
+            {"date":"2025-11-21","inputTokens":0,"outputTokens":0,
+             "cacheCreationTokens":0,"cacheReadTokens":0,"totalTokens":0,
+             "totalCost":0,"modelsUsed":[],"modelBreakdowns":[]},
+            {"date":"2025-11-22","totalCost":1.0,"modelsUsed":["claude-opus-5"],
+             "modelBreakdowns":[{"modelName":"claude-opus-5","cost":1.0,
+             "inputTokens":10,"outputTokens":20}]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        assert!(
+            out.unknown_clients.is_empty(),
+            "an empty day must not mint a client: {:?}",
+            out.unknown_clients
+        );
+        let dates: Vec<&str> = out
+            .graph
+            .contributions
+            .iter()
+            .map(|c| c.date.as_str())
+            .collect();
+        assert_eq!(dates, vec!["2025-11-22"]);
+    }
+
+    #[test]
+    fn ccusage_gemini_cli_agent_resolves_to_its_own_models() {
+        // `model_family` answers "gemini"; an agent spelled `gemini-cli` has
+        // to normalize to the same id or its usage lands in `unknown`.
+        let json = r#"{"daily":[{"period":"2026-08-14","totalCost":2.0,
+            "metadata":{"agents":["claude-code","gemini-cli"]},
+            "modelBreakdowns":[
+              {"modelName":"gemini-3-pro","cost":1.0,"inputTokens":10,"outputTokens":20},
+              {"modelName":"claude-opus-5","cost":1.0,"inputTokens":10,"outputTokens":20}]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        assert_eq!(
+            client_rows(&out, 0),
+            vec![
+                ("claude".to_string(), "claude-opus-5".to_string()),
+                ("gemini".to_string(), "gemini-3-pro".to_string()),
+            ]
+        );
+        assert!(out.unknown_clients.is_empty());
+    }
+
+    #[test]
+    fn ccusage_accepts_the_codex_cost_usd_spelling() {
+        // `ccusage-codex` emits `costUSD` where `ccusage` emits `totalCost`
+        // (ccusage#831). Reading only one spelling imports the day at $0.
+        let json = r#"{"daily":[{"period":"2026-08-14","costUSD":3.5,
+            "inputTokens":10,"outputTokens":20,
+            "metadata":{"agents":["codex"]},"modelsUsed":["gpt-5.6-sol"]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        assert!((out.graph.contributions[0].totals.cost - 3.5).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -241,7 +241,7 @@ enum Commands {
         no_spinner: bool,
     },
     #[command(
-        about = "Import historical usage from a third-party aggregate export (e.g. clawdboard) into tokscale JSON"
+        about = "Import historical usage from an aggregate export (clawdboard, ccusage) into tokscale JSON"
     )]
     Import {
         #[arg(help = "Path to the export file to import")]
@@ -249,7 +249,7 @@ enum Commands {
         #[arg(
             long,
             default_value = "clawdboard",
-            help = "Export format (currently only 'clawdboard')"
+            help = "Export format: 'clawdboard' or 'ccusage' (ccusage daily --json output)"
         )]
         format: String,
         #[arg(
@@ -5270,8 +5270,9 @@ fn run_graph_command(
     Ok(())
 }
 
-/// Import a third-party aggregate export (currently clawdboard) and emit it as
-/// standard tokscale JSON — the same shape `tokscale graph` produces.
+/// Import an aggregate export (clawdboard, or ccusage's own `daily --json`)
+/// and emit it as standard tokscale JSON — the same shape `tokscale graph`
+/// produces.
 ///
 /// This deliberately does NOT upload: backfilled aggregates cannot be verified
 /// the way locally-scanned sessions are, so submitting them requires


### PR DESCRIPTION
Adds `--format ccusage` to `tokscale import`, alongside the existing clawdboard importer. Addresses part of #888.

## Why ccusage and not another dashboard

The importer exists because raw sessions expire and aggregates outlive them. clawdboard is one place those aggregates survive, but `ccusage daily --json` is the format almost everyone already has a copy of: it is what people generate to submit to viberank and similar boards, and the file usually stays on disk long after `~/.claude/projects` has been rotated away. Supporting the ccusage shape directly covers the common recovery path without asking anyone to sign up for a third-party dashboard first.

## The part that needed care

A clawdboard row is scoped to one client — the row carries `source`, so attribution is a lookup. A ccusage unified row is not: one date is one row, every agent that ran that day is merged into it, and the participants are only named in `metadata.agents`. Attributing such a row to a single client silently moves spend between clients. On my own export a single day carries both `claude-opus-5` and `gpt-5.6-sol`; collapsing it would have shifted $10 of Codex spend onto Claude for that day alone.

So the resolver works per model, not per row, and it treats `metadata.agents` as ground truth rather than a hint:

- one agent that day → every model is trivially that client, no inference at all, which also means a private or unrecognized model name still lands correctly
- several agents → the model family picks among the agents that are actually listed
- a model matching none of them → left as `unknown` and reported in `unknown_clients`

That last case is deliberate. Folding an unmatched model into the first listed agent would produce a clean-looking import that is quietly wrong; the leaderboard rejects `unknown`, so surfacing it is what lets the caller fix the export instead of uploading bad attribution.

## Shape variations handled

- `period` (unified report) and `date` (per-agent reports, older releases) — a row with neither is rejected rather than silently dropped
- `reasoningOutputTokens`, which Codex reports separately. Dropping it understates the day and breaks the server's token-sum check
- `totalCost` as a number, or as a string when a dashboard has round-tripped the file

Reconciliation, clamping, cost sanitization, future-date and suspect-cost warnings reuse the existing helpers, so both importers report through the same `ImportOutcome` and the CLI summary needed no changes.

## Verification

Round-tripped a real 104-day export (2026-04-24 → 2026-08-15) recovered from a decommissioned machine:

```
Date range: 2026-04-24 to 2026-08-15
Active days: 104
Total tokens: 70,763,790,393
Total cost:   $91283.97
Clients:      claude, codex, unknown
```

Totals match the source file exactly. The split lands at `claude $51,680.46` / `codex $39,346.88`, and the only `unknown` is a $256.63 `Other` bucket that the upstream dashboard had already collapsed — which is precisely the case the resolver is meant to flag rather than guess at.

13 new unit tests cover the mixed-agent split, reasoning tokens, both date fields, the string-cost variant, single-agent trust, unattributable models, absent metadata, reconciliation, clamping, ordering, and dispatch. `cargo test --workspace --all-features`, `cargo clippy --locked --workspace --all-features -- -D warnings`, and `cargo fmt --all -- --check` all pass.

## Out of scope

This does not change the upload boundary. Import still only normalizes to a file, and the module docs still point at #888 for the server-side tagging that backfilled data would need before it could be submitted. I would rather this land as a way to *recover* history than as a way to route around that distinction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--format ccusage` to `tokscale import` to ingest `ccusage daily --json` exports and recover from `cc.json` when raw sessions are gone. Old: only `clawdboard`; new: `ccusage` supported. No change to output shape or the upload boundary (import still writes a normalized file only).

- Resolves unified rows per model using `metadata.agents`: single-agent days attribute directly; multi-agent days pick by model family; no match becomes `unknown` and is surfaced.
- Handles schema variants: accepts `period` or `date` (rejects rows with neither); accepts `totalCost` as number or string and `ccusage-codex` `costUSD`; reads reasoning from `metadata.reasoningOutputTokens` or the flat field; subtracts reasoning from `output` so totals align with `totalTokens`.
- Skips empty-day rows to avoid minting phantom `unknown` clients.
- Normalizes agent ids to match families (`claude-code`→`claude`, `gemini-cli`→`gemini`, `ccusage-codex`→`codex`) so models resolve to their own clients.
- Reconciles per-model sums against aggregates and declared `totalTokens`; warns on divergence; reuses existing clamping, cost sanitization, and warning paths (`ImportOutcome` unchanged).
- CLI help lists `ccusage`; default format remains `clawdboard`.

<sup>Written for commit fd3dc2d2b9c4e6bc7ec4ac80205c822684d19548. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

