### PR TITLE
fix(antigravity-cli): resolve routing-label rows from display labels

### DIFF
--- a/crates/tokscale-core/src/sessions/antigravity_cli.rs
+++ b/crates/tokscale-core/src/sessions/antigravity_cli.rs
@@ -146,6 +146,15 @@ impl SessionModels {
                 unresolved_labels.extend(label);
                 continue;
             };
+            if is_antigravity_routing_label(model) {
+                // A routing label names the router that served the request, never
+                // the model that answered it, so it is no evidence of a concrete
+                // model for this display label. Treat it like a row with no #19:
+                // it must not occupy the by_display slot, which would trip the
+                // ambiguity check against a real sibling id and drop the mapping.
+                unresolved_labels.extend(label);
+                continue;
+            }
             distinct.insert(model);
             if let Some(label) = label {
                 by_display
@@ -214,6 +223,31 @@ impl SessionModels {
     }
 }
 
+/// Antigravity CLI's generic routing label. It names which router served the
+/// request, never which model did, so a row carrying it carries no model
+/// identity of its own. Kept in sync with `is_generic_routing_label` in lib.rs,
+/// which excludes the label from submission when no concrete model is recovered
+/// here.
+fn is_antigravity_routing_label(model: &str) -> bool {
+    model.trim().eq_ignore_ascii_case("gemini-default")
+}
+
+/// Map an Antigravity `#21` display label to a concrete model id.
+///
+/// Display labels are server-supplied names (the app's `_getModelLabel` switch
+/// emits them from `MODEL_PLACEHOLDER_*` ids) and could be renamed or localized,
+/// so only labels verified against real user databases are mapped here; anything
+/// else returns `None` and the routing label is preserved for the submission-time
+/// exclusion rather than guessed at.
+fn display_label_to_model_id(label: &str) -> Option<&'static str> {
+    match label.trim() {
+        "Gemini 3.5 Flash (Low)" => Some("gemini-3.5-flash"),
+        "Gemini 3.5 Flash (Medium)" => Some("gemini-3.5-flash-medium"),
+        "Gemini 3.5 Flash (High)" => Some("gemini-3.5-flash-high"),
+        _ => None,
+    }
+}
+
 fn parse_gen_metadata(
     blob: &[u8],
     session_id: &str,
@@ -262,8 +296,18 @@ fn parse_gen_metadata(
         }
     }
 
-    let model_raw = non_empty_string_field(chat_model, 19)
+    let response_model = non_empty_string_field(chat_model, 19);
+    let model_raw = response_model
+        .filter(|m| !is_antigravity_routing_label(m))
         .or_else(|| session_models.recover(chat_model))
+        .or_else(|| {
+            // Routing labels carry no model identity of their own, but the
+            // sibling `#21` display label names the tier. Recover the concrete
+            // id from it; if the label is unknown, keep the routing label so
+            // the submission-time exclusion still applies.
+            non_empty_string_field(chat_model, 21).and_then(display_label_to_model_id)
+        })
+        .or(response_model)
         .unwrap_or("unknown");
     let model_id = pricing::aliases::resolve_alias(model_raw)
         .unwrap_or(model_raw)
@@ -1206,5 +1250,139 @@ mod tests {
         );
         // Anything without the scheme prefix is rejected.
         assert_eq!(file_uri_to_path("not-a-file-uri"), None);
+    }
+
+    // A `gemini-default` routing-label row in a conversation whose other rows
+    // carry the concrete `#19` for the same display label is resolved from that
+    // sibling evidence, exactly like a row with no `#19` at all.
+    #[test]
+    fn routing_label_row_is_resolved_from_sibling_display_label() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("routing-sibling.db");
+        write_conversation(
+            &path,
+            &[
+                build_row(
+                    Some("gemini-3.5-flash-high"),
+                    Some("Gemini 3.5 Flash (High)"),
+                    "resp-0",
+                ),
+                build_row(
+                    Some("gemini-default"),
+                    Some("Gemini 3.5 Flash (High)"),
+                    "resp-1",
+                ),
+            ],
+        );
+
+        let messages = parse_antigravity_cli_file(&path);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[1].model_id, "gemini-3.5-flash-high");
+        assert_eq!(messages[1].provider_id, "google");
+    }
+
+    // A routing-label row must not occupy the by_display slot for its label:
+    // otherwise a sibling concrete id would read as ambiguous and the whole
+    // mapping would be dropped.
+    #[test]
+    fn routing_label_does_not_poison_by_display_ambiguity() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("routing-no-poison.db");
+        write_conversation(
+            &path,
+            &[
+                build_row(
+                    Some("gemini-3.6-flash"),
+                    Some("Gemini 3.6 Flash (High)"),
+                    "resp-0",
+                ),
+                build_row(
+                    Some("gemini-default"),
+                    Some("Gemini 3.6 Flash (High)"),
+                    "resp-1",
+                ),
+                build_row(None, Some("Gemini 3.6 Flash (High)"), "resp-2"),
+            ],
+        );
+
+        let messages = parse_antigravity_cli_file(&path);
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[1].model_id, "gemini-3.6-flash");
+        assert_eq!(messages[2].model_id, "gemini-3.6-flash");
+    }
+
+    // When a routing-label row has no sibling evidence, the `#21` display label
+    // itself names the tier. This is the case observed in real data: entire
+    // Antigravity CLI conversations carry `gemini-default` with "Gemini 3.5
+    // Flash (Low)" / "(Medium)" labels and no other `#19` at all (#1116).
+    #[test]
+    fn routing_label_resolved_from_display_label_parsing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("routing-display.db");
+        write_conversation(
+            &path,
+            &[
+                build_row(
+                    Some("gemini-default"),
+                    Some("Gemini 3.5 Flash (Low)"),
+                    "resp-0",
+                ),
+                build_row(
+                    Some("gemini-default"),
+                    Some("Gemini 3.5 Flash (Medium)"),
+                    "resp-1",
+                ),
+            ],
+        );
+
+        let messages = parse_antigravity_cli_file(&path);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].model_id, "gemini-3.5-flash");
+        assert_eq!(messages[0].provider_id, "google");
+        assert_eq!(messages[1].model_id, "gemini-3.5-flash-medium");
+        assert_eq!(messages[1].provider_id, "google");
+    }
+
+    // A routing-label row whose display label is not in the verified map, and
+    // whose file offers no sibling evidence, keeps the routing label verbatim so
+    // the submission-time exclusion still applies rather than guessing.
+    #[test]
+    fn routing_label_without_any_evidence_is_kept() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("routing-unresolved.db");
+        write_conversation(
+            &path,
+            &[build_row(
+                Some("gemini-default"),
+                Some("Gemini 9.9 Flash (Mystery)"),
+                "resp-0",
+            )],
+        );
+
+        let messages = parse_antigravity_cli_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-default");
+        assert_eq!(messages[0].provider_id, "google");
+    }
+
+    // A recovered value from the display label is a concrete model id, so it
+    // still flows through the alias table like any directly-read `#19`.
+    #[test]
+    fn routing_label_recover_still_resolves_through_the_alias_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("routing-alias.db");
+        write_conversation(
+            &path,
+            &[build_row(
+                Some("gemini-default"),
+                Some("Gemini 3.5 Flash (High)"),
+                "resp-0",
+            )],
+        );
+
+        let messages = parse_antigravity_cli_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-3.5-flash-high");
+        assert_eq!(messages[0].provider_id, "google");
     }
 }

--- a/crates/tokscale-core/src/sessions/antigravity_cli.rs
+++ b/crates/tokscale-core/src/sessions/antigravity_cli.rs
@@ -241,7 +241,7 @@ fn is_antigravity_routing_label(model: &str) -> bool {
 /// exclusion rather than guessed at.
 fn display_label_to_model_id(label: &str) -> Option<&'static str> {
     match label.trim() {
-        "Gemini 3.5 Flash (Low)" => Some("gemini-3.5-flash"),
+        "Gemini 3.5 Flash (Low)" => Some("gemini-3.5-flash-extra-low"),
         "Gemini 3.5 Flash (Medium)" => Some("gemini-3.5-flash-medium"),
         "Gemini 3.5 Flash (High)" => Some("gemini-3.5-flash-high"),
         _ => None,
@@ -1337,7 +1337,7 @@ mod tests {
 
         let messages = parse_antigravity_cli_file(&path);
         assert_eq!(messages.len(), 2);
-        assert_eq!(messages[0].model_id, "gemini-3.5-flash");
+        assert_eq!(messages[0].model_id, "gemini-3.5-flash-extra-low");
         assert_eq!(messages[0].provider_id, "google");
         assert_eq!(messages[1].model_id, "gemini-3.5-flash-medium");
         assert_eq!(messages[1].provider_id, "google");


### PR DESCRIPTION
## Problem

Antigravity CLI writes the generic routing label `gemini-default` as `chatModel.responseModel` (`#19`) whenever the router picked the model, leaving the concrete tier only in the sibling `#21` display label (e.g. `"Gemini 3.5 Flash (Low)"`). The parser preserved the label verbatim, so those rows were excluded from `tokscale submit` as unpriced — despite carrying a tier-identifying display label in the same row.

On real data this silently dropped **~218M tokens / ~$74** of Gemini usage across 9 Antigravity CLI conversations (reported in #1116).

## Root cause

1. The Antigravity CLI parser (`crates/tokscale-core/src/sessions/antigravity_cli.rs`) keeps `#19` verbatim when present. `gemini-default` is not a concrete model id, so it later trips the submission-time routing-label exclusion (`is_generic_routing_label` in `lib.rs`).
2. `SessionModels::from_blobs` treated `gemini-default` as a real model id, so a file mixing routing labels and real ids would report a false ambiguity and drop the display-label mapping entirely.

## Change

Resolve routing-label rows in three steps, in `parse_gen_metadata`:

1. A concrete `#19` is used as before.
2. Otherwise recover the machine id from a sibling row sharing the display label (the existing `SessionModels::recover` mechanism).
3. Otherwise map the display label itself through a small verified lookup table (`display_label_to_model_id`).

A routing label is never treated as evidence of a concrete model, so it no longer occupies the `by_display` slot and can't poison the ambiguity check against a real sibling id. Rows that still resolve to nothing keep `gemini-default` verbatim, so the submission-time exclusion continues to apply rather than guessing a model.

Display labels are server-supplied names (the app's `_getModelLabel` switch emits them from `MODEL_PLACEHOLDER_*` ids) and could be renamed or localized, so only labels verified against real user databases are mapped — `Gemini 3.5 Flash (Low)` → `gemini-3.5-flash`, `(Medium)` → `gemini-3.5-flash-medium`, `(High)` → `gemini-3.5-flash-high`. Anything unknown returns `None` and preserves the routing label.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --locked --workspace --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features` — all pass (25 antigravity_cli tests including 5 new ones)
- Built the CLI and ran `tokscale models` against real local data: the `gemini-default` row disappears and the usage resolves to `gemini-3.5-flash` ($57.09) and `gemini-3.5-flash-medium` ($16.92), increasing the reported total by ~$74 — matching the previously excluded amount.

Fixes #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves `antigravity-cli` routing-label rows by recovering concrete Gemini model IDs from display labels or sibling evidence, so previously excluded usage is priced. Also maps "Gemini 3.5 Flash (Low)" to `gemini-3.5-flash-extra-low` to align with the alias table and avoid splitting Low-tier usage across model rows.

- Parser changes in `tokscale-core`: updates `parse_gen_metadata`; adds `is_antigravity_routing_label` and `display_label_to_model_id`.
- Behavior: previously preserved `gemini-default` in `#19` and `tokscale submit` skipped those rows; now resolve via concrete `#19` > sibling sharing `#21` display label > verified display-label map; else keep `gemini-default`.
- Routing labels never occupy the `by_display` slot; recovered IDs still resolve through pricing aliases.

**Rollout**
- No config changes. Re-run `tokscale models` and `tokscale submit` to include previously excluded Gemini usage.

<sup>Written for commit 0ea0ea8134bca9c7c5d8e49d27a1db7ea1d8199a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

