### PR TITLE
fix(core): recover BOM-prefixed Pi transcripts and align Prime's accounting walk

### DIFF
--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -416,7 +416,10 @@ impl PiParseOptions {
 }
 
 enum PiLines {
-    Standard(std::io::Lines<BufReader<std::fs::File>>),
+    Standard {
+        lines: std::io::Lines<BufReader<std::fs::File>>,
+        at_start: bool,
+    },
     Lossy(super::utils::LossyLinesWithBytes<BufReader<std::fs::File>>),
 }
 
@@ -447,12 +450,31 @@ impl Iterator for PiLines {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             match self {
-                Self::Standard(lines) => match lines.next() {
-                    Some(Ok(line)) => return Some(PiLine::Standard(line)),
+                Self::Standard { lines, at_start } => match lines.next() {
+                    Some(Ok(mut line)) => {
+                        // A UTF-8 BOM decodes cleanly, so it survives as U+FEFF
+                        // glued to the front of the first record, where
+                        // `str::trim` leaves it (U+FEFF is not White_Space) and
+                        // the header then fails to parse. A header that fails to
+                        // parse discards the whole transcript rather than one
+                        // record, so strip the marker here exactly as the lossy
+                        // reader already does for Prime Agent.
+                        if std::mem::take(at_start) {
+                            if let Some(stripped) = line.strip_prefix('\u{feff}') {
+                                line = stripped.to_string();
+                            }
+                        }
+                        return Some(PiLine::Standard(line));
+                    }
                     // `reader.lines()` historically skipped all unreadable
                     // records and continued. In particular, an invalid-UTF-8
                     // line must not truncate valid records that follow it.
-                    Some(Err(_)) => continue,
+                    Some(Err(_)) => {
+                        // The marker can only precede the first record, and that
+                        // record was just consumed.
+                        *at_start = false;
+                        continue;
+                    }
                     None => return None,
                 },
                 Self::Lossy(lines) => return lines.next().map(PiLine::Lossy),
@@ -564,7 +586,10 @@ fn parse_pi_format_file_inner(
     let lines = if options.lossy_line_reader {
         PiLines::Lossy(lossy_lines_with_bytes(reader))
     } else {
-        PiLines::Standard(reader.lines())
+        PiLines::Standard {
+            lines: reader.lines(),
+            at_start: true,
+        }
     };
     let mut messages: Vec<UnifiedMessage> = Vec::with_capacity(64);
     let mut buffer = Vec::with_capacity(4096);
@@ -854,6 +879,54 @@ mod tests {
 
         let messages = parse_pi_file(file.path());
         assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.total(), 28);
+    }
+
+    #[test]
+    fn utf8_bom_before_the_header_keeps_the_transcript() {
+        // A BOM decodes cleanly, so `str::trim` leaves U+FEFF glued to the
+        // front of the header (it is not White_Space) and the header fails to
+        // parse. That failure drops the entire transcript, not one record, so
+        // every Pi-format client has to strip it the way the lossy reader
+        // already does for Prime Agent.
+        let file = create_test_file(concat!(
+            "\u{feff}",
+            r#"{"type":"session","id":"session-with-bom","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project"}"#,
+            "\n",
+            r#"{"type":"message","id":"assistant-1","timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","usage":{"input":20,"output":8}}}"#,
+            "\n",
+        ));
+
+        for messages in [
+            parse_pi_file(file.path()),
+            crate::sessions::senpi::parse_senpi_file(file.path()),
+            crate::sessions::kimchi::parse_kimchi_file(file.path()),
+            parse_prime_test_file(file.path()),
+        ] {
+            assert_eq!(messages.len(), 1);
+            assert_eq!(messages[0].session_id, "session-with-bom");
+            assert_eq!(messages[0].tokens.total(), 28);
+        }
+    }
+
+    #[test]
+    fn a_marker_after_the_first_record_still_costs_only_its_own_record() {
+        // The strip is scoped to the file's first line, where a byte-order mark
+        // can actually appear. A U+FEFF anywhere else stays an ordinary
+        // malformed record, which the reader already loses alone.
+        let file = create_test_file(concat!(
+            r#"{"type":"session","id":"session-clean","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project"}"#,
+            "\n\u{feff}",
+            r#"{"type":"message","id":"assistant-1","timestamp":"2026-08-08T00:00:01.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","usage":{"input":1,"output":1}}}"#,
+            "\n",
+            r#"{"type":"message","id":"assistant-2","timestamp":"2026-08-08T00:00:02.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","usage":{"input":20,"output":8}}}"#,
+            "\n",
+        ));
+
+        let messages = parse_pi_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "session-clean");
         assert_eq!(messages[0].tokens.total(), 28);
     }
 

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -480,6 +480,71 @@ fn damaged_session_placeholder(path: &Path) -> String {
     format!("unknown:path:{:x}", hasher.finalize())
 }
 
+/// One record, one decision: does this entry become a [`UnifiedMessage`]?
+///
+/// Two walks read the same transcript. [`parse_pi_format_file_inner`] streams it
+/// and builds messages; Prime Agent's accounting walk replays already-parsed
+/// messages positionally against the same records
+/// (`sessions::prime_agent::analyze_prime_agent_accounting`). A record that only
+/// one of them counts shifts every later index in the other, which silently
+/// re-targets Prime's usage reconciliation. Both therefore ask this function
+/// rather than restating the rules, so neither can drift from the other.
+struct PiEmittedRecord<'a> {
+    message: &'a PiMessage,
+    usage: &'a PiUsage,
+    recorded_model: &'a str,
+}
+
+fn pi_emitted_record<'a>(
+    entry: &'a PiSessionEntry,
+    options: PiParseOptions,
+    is_rlm_subagent: bool,
+) -> Option<PiEmittedRecord<'a>> {
+    if entry.entry_type != "message" {
+        return None;
+    }
+
+    let message = entry.message.as_ref()?;
+    if message.role.as_deref() != Some("assistant") {
+        return None;
+    }
+
+    // An RLM child's completion timestamp participates in matching its
+    // usage back to the parent attribution. Recovering a replacement-
+    // damaged value as "missing" would make that match impossible while
+    // still emitting the child, so the parent's aggregate and child would
+    // both be counted. Other Pi messages do not use this timestamp as a
+    // reconciliation join and remain recoverable.
+    if options.lossy_line_reader
+        && is_rlm_subagent
+        && (entry.has_damaged_timestamp()
+            || entry
+                .timestamp
+                .as_deref()
+                .is_some_and(|timestamp| chrono::DateTime::parse_from_rfc3339(timestamp).is_err()))
+    {
+        return None;
+    }
+
+    let usage = message.usage.as_ref()?;
+    if options.lossy_line_reader && usage.has_damaged_key() {
+        return None;
+    }
+
+    let recorded_model = message.model.as_deref()?;
+    Some(PiEmittedRecord {
+        message,
+        usage,
+        recorded_model,
+    })
+}
+
+/// [`pi_emitted_record`] under the preset RLM transcripts are parsed with, as a
+/// yes/no answer for a walk that already holds the emitted messages.
+pub(crate) fn rlm_entry_emits_message(entry: &PiSessionEntry, is_rlm_subagent: bool) -> bool {
+    pi_emitted_record(entry, PiParseOptions::prime_agent(), is_rlm_subagent).is_some()
+}
+
 fn parse_pi_format_file_inner(
     path: &Path,
     client: &str,
@@ -596,50 +661,16 @@ fn parse_pi_format_file_inner(
             continue;
         }
 
-        if entry.entry_type != "message" {
-            observer.observe_entry(&entry, None);
-            continue;
-        }
-
-        let Some(message) = entry.message.as_ref() else {
-            observer.observe_entry(&entry, None);
-            continue;
-        };
-
-        if message.role.as_deref() != Some("assistant") {
-            observer.observe_entry(&entry, None);
-            continue;
-        }
-
-        // An RLM child's completion timestamp participates in matching its
-        // usage back to the parent attribution. Recovering a replacement-
-        // damaged value as "missing" would make that match impossible while
-        // still emitting the child, so the parent's aggregate and child would
-        // both be counted. Other Pi messages do not use this timestamp as a
-        // reconciliation join and remain recoverable.
-        if options.lossy_line_reader
-            && is_rlm_subagent
-            && (entry.has_damaged_timestamp()
-                || entry.timestamp.as_deref().is_some_and(|timestamp| {
-                    chrono::DateTime::parse_from_rfc3339(timestamp).is_err()
-                }))
-        {
-            observer.observe_entry(&entry, None);
-            continue;
-        }
-
-        let Some(usage) = message.usage.as_ref() else {
+        let Some(PiEmittedRecord {
+            message,
+            usage,
+            recorded_model,
+        }) = pi_emitted_record(&entry, options, is_rlm_subagent)
+        else {
             observer.observe_entry(&entry, None);
             continue;
         };
-        if options.lossy_line_reader && usage.has_damaged_key() {
-            continue;
-        }
 
-        let Some(recorded_model) = message.model.as_deref() else {
-            observer.observe_entry(&entry, None);
-            continue;
-        };
         let model = if !accepts_replacement_field(recorded_model, options.lossy_line_reader) {
             "unknown"
         } else {

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -10,8 +10,8 @@
 
 use super::pi::{
     has_replacement_character, parse_pi_format_rlm_file_with_observer,
-    pre_header_line_is_skippable, raw_json_has_damaged_lineage_header_key, PiFormatObserver,
-    PiSessionEntry, PiSessionHeader, PiUsage, PRE_SESSION_METADATA_TYPES,
+    pre_header_line_is_skippable, raw_json_has_damaged_lineage_header_key, rlm_entry_emits_message,
+    PiFormatObserver, PiSessionEntry, PiSessionHeader, PiUsage, PRE_SESSION_METADATA_TYPES,
 };
 use super::utils::{lossy_lines_with_bytes, parse_timestamp_str};
 use super::UnifiedMessage;
@@ -499,23 +499,16 @@ pub(crate) fn analyze_prime_agent_accounting(
         let Some(entry) = parse_pi_json_line::<PiSessionEntry>(trimmed, &mut buffer) else {
             continue;
         };
-        let emitted = entry
-            .message
-            .as_ref()
-            .filter(|message| {
-                entry.entry_type == "message"
-                    && message.role.as_deref() == Some("assistant")
-                    && message
-                        .usage
-                        .as_ref()
-                        .is_some_and(|usage| !usage.has_damaged_key())
-                    && message.model.is_some()
-            })
-            .and_then(|_| {
+        // Which records became messages is the parser's decision, not a rule
+        // restated here: a record counted on only one side shifts every later
+        // index of `messages` and re-targets the reconciliation below.
+        let emitted = rlm_entry_emits_message(&entry, accounting.is_rlm_child)
+            .then(|| {
                 let parsed = messages.get(message_index);
                 message_index += 1;
                 parsed
-            });
+            })
+            .flatten();
         accounting.observe_entry(&entry, emitted);
     }
 
@@ -1535,6 +1528,62 @@ mod tests {
         assert_eq!(messages[0].tokens.output, 70);
         assert_eq!(messages[0].tokens.cache_read, 20);
         assert_eq!(messages[0].tokens.cache_write, 10);
+    }
+
+    #[test]
+    fn unparseable_child_timestamp_does_not_shift_accounting_alignment() {
+        // The streaming parser drops an RLM child's message when its timestamp
+        // cannot be matched back to a parent attribution. The accounting-only
+        // walk replays cached messages positionally, so it has to drop the same
+        // record or every later index refers to the wrong message.
+        let file = session_file(
+            r#"{"type":"session","version":3,"id":"child","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/tmp/project","parentSession":"/tmp/parent.jsonl","rlmDepth":1}
+{"type":"message","id":"assistant-unparseable","parentId":null,"timestamp":"2026-08-08 00:00:01","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"response-unparseable","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2}}}
+{"type":"message","id":"assistant-valid","parentId":null,"timestamp":"2026-08-08T00:00:02.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-5","responseId":"response-valid","usage":{"input":20,"output":8,"cacheRead":0,"cacheWrite":0,"totalTokens":28}}}
+{"type":"child_usage_attributed","id":"usage-valid","parentId":"assistant-valid","timestamp":"2026-08-08T00:00:03.000Z","targetId":"assistant-valid","childUsage":{"input":3,"output":2,"cacheRead":0,"cacheWrite":0,"totalTokens":5},"aggregateUsage":{"input":20,"output":8,"cacheRead":0,"cacheWrite":0,"totalTokens":28},"origin":"spawn_task"}"#,
+        );
+
+        let (messages, streamed) = parse_prime_agent_file_with_accounting(file.path());
+        let replayed = analyze_prime_agent_accounting(file.path(), &messages);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("prime-agent:response:response-valid")
+        );
+
+        let adjustment_keys = |accounting: &PrimeFileAccounting| {
+            accounting
+                .adjustments
+                .iter()
+                .map(|adjustment| adjustment.dedup_key.clone())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            adjustment_keys(&replayed),
+            vec!["prime-agent:response:response-valid".to_string()]
+        );
+        assert_eq!(adjustment_keys(&replayed), adjustment_keys(&streamed));
+
+        let child_joins = |accounting: &PrimeFileAccounting| {
+            accounting
+                .child_message_usages
+                .iter()
+                .map(|usage| (usage.timestamp, usage.usage.clone()))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(child_joins(&replayed), child_joins(&streamed));
+        assert_eq!(
+            child_joins(&replayed),
+            vec![(
+                parse_timestamp_str("2026-08-08T00:00:02.000Z"),
+                TokenBreakdown {
+                    input: 20,
+                    output: 8,
+                    ..TokenBreakdown::default()
+                }
+            )]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two independent defects in the shared Pi-format session reader (`crates/tokscale-core/src/sessions/pi.rs`), one commit each. Both were reproduced with a failing test before the fix; every existing test passes unmodified.

## 1. Prime's accounting walk consumed a message the parser never emitted

`parse_pi_format_file_inner` drops an RLM child's assistant message when the entry timestamp is damaged or is not RFC 3339, because that timestamp is the join key that matches the child's usage back to the parent's `child_usage_attributed` record. `analyze_prime_agent_accounting` walks the same transcript a second time and pairs each eligible record with `messages[message_index]`, but its hand-written eligibility predicate had no timestamp clause. On such a record the two walks disagree: the replay consumes a slot the parser never filled, and every later index is off by one.

Reproduced before the fix with a child transcript whose first assistant record carries `"timestamp":"2026-08-08 00:00:01"` — valid ISO 8601, rejected by `parse_from_rfc3339`:

- **The adjustment is lost.** The streaming walk yields `["prime-agent:response:response-valid"]`; the replay yields `[]`. `reconcile_prime_agent_messages` then never subtracts the attributed child usage from the parent aggregate, so the child's tokens are counted twice.
- **The join key is corrupted.** `child_message_usages` pairs the skipped record's timestamp (`1786147201000`) with the surviving record's usage (`input 20 / output 8`), where the parser produces `1786147202000`. That vector is the left side of the ±1000 ms attribution match, so the shift can authorise or block a subtraction against an unrelated parent.

The fix is one predicate instead of two. `pi_emitted_record` now owns the "which records become messages" decision, and both walks call it — the accounting walk through `rlm_entry_emits_message`, which pins the RLM option preset so the caller cannot ask the question under the wrong parse options. Copying the missing timestamp clause into `prime_agent.rs` would have closed this instance and left the next divergence free to happen; the duplicated predicate already carried three other clauses that were kept in sync by hand. One consequence worth naming: the damaged-usage skip now notifies the observer like every other skip does. The only observer ignores entries that produced no message, so the accounting it builds is unchanged.

**Reachability today.** `analyze_prime_agent_accounting` has exactly one production call site — the v4-to-v5 accounting backfill in `lib.rs`, taken when a cache entry sits at the current parser version but predates `prime_accounting`. Only the legacy shard migration produces such an entry, and `read_shard` rejects a shard whose `parser_version` differs from the current identity *before* it can migrate. Every format-4 shard for `prime-agent` was written when `ClientId::PrimeAgent` had no `parser_version` arm at all — the arm was added in 43d4abd, by which time `CACHE_FORMAT_VERSION` was already 5 — so those shards carry parser version 1 against today's 4 and read as stale. The defect is latent rather than live, exactly as the comment in `message_cache.rs` claims. It is repaired rather than deleted because the walk is the migration path the next format bump reuses, it is already covered end to end by `test_prime_agent_legacy_cache_backfills_accounting_once`, and the defect is the duplicated predicate rather than the walk itself.

## 2. A byte-order mark deleted an entire Pi, Senpi or Kimchi transcript

A UTF-8 BOM decodes cleanly, so it survives as U+FEFF glued to the front of the first record. `str::trim` does not remove it — U+FEFF is not `White_Space` — so the session header fails to parse, and a header that fails to parse discards the whole transcript rather than one record. One three-byte marker therefore erased every message in the file. Prime Agent was already immune because its lossy reader strips the marker; Pi, Senpi and Kimchi are on the strict reader and were not. Measured before the fix on a BOM-prefixed transcript: `pi=0, senpi=0, kimchi=0, prime=1`.

The strict reader now strips a leading U+FEFF at the same point the lossy reader does — the first physical line of the file, and only there.

**Why the narrow fix rather than moving the three clients onto the lossy reader.** `lossy_line_reader` is not a reader selector; it is the parser's strictness switch. It also gates replacement-character sanitisation of `model`, `provider`, `cwd` and `session_info.name`, the placeholder substitution for a damaged session id, the damaged-usage-key drop, the RLM timestamp gate, and the whole-file rejection of a header with invalid lineage. Flipping it for Pi, Senpi and Kimchi would change session ids, agent names and workspace keys, and could drop transcripts that are counted today — far more than BOM handling — and it would change the parse of byte-identical input that *is* cached, forcing `parser_version` bumps (Pi 2→3, Senpi 1→2, Kimchi 2→3) and a full re-scan for every user of those clients.

The narrow fix needs no bump and evicts nothing: a transcript that parses to zero messages is never written to the source cache (`messages.is_empty()` suppresses the entry, and both warm-hit paths require a non-empty entry), so a BOM-prefixed file has no cached state to invalidate. It is simply parsed on the next scan.

**Not fixed, deliberately.** An invalid-UTF-8 byte inside the header line still discards the transcript for the three strict clients. `BufRead::lines()` yields `Err` without the bytes, so the header is gone before the parser sees it and there is nothing to recover it from; the next line then fails the header type check. Prime survives that case only because lossy decoding preserves the line with U+FFFD. Recovering it for the other clients means reading bytes and decoding leniently — the broad change above, with the version bumps it implies — so it is left for that decision rather than smuggled in here.

## Gates

```
cargo test --release -p tokscale-core -p tokscale-cli
  tokscale-core lib      1782 passed; 0 failed; 2 ignored
  tokscale-core it       42 passed across the per-client integration targets
  tokscale-cli  bin      1111 passed; 0 failed; 1 ignored
  tokscale-cli  cli_tests 167 passed; 0 failed
cargo clippy --all-targets -- -D warnings   clean
cargo fmt --check                            clean
```

`trae::sync::tests::test_losing_contender_leaves_no_orphan_after_release` failed twice on a loaded machine during earlier runs of the combined command and passes in isolation and on the committed tip; it contends on an fs2 file lock and is unrelated to this change, which touches only the Pi-format session parsers.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Prime’s accounting replay aligned with parsed messages and recovers Pi/Senpi/Kimchi transcripts that start with a UTF‑8 BOM. Previously, the replay consumed a message the parser never emitted for some RLM child records and a BOM caused strict readers to drop the entire transcript; now both walks share one “emitted record” rule and the strict reader strips a leading BOM on the first line.

- Prime accounting uses a single predicate in `pi.rs` (`pi_emitted_record`, exposed as `rlm_entry_emits_message`) to decide which records become messages.
- Old vs new: RLM child assistant with a non‑RFC3339 timestamp was skipped by the parser but counted by the replay, shifting indexes and corrupting adjustments; both now skip it, preserving alignment and correct child usage joins.
- Side effect: the damaged‑usage skip notifies the observer; accounting output is unchanged because observers ignore non‑emitting entries.
- Reachability: the bug was latent (only in legacy v4→v5 backfill paths); this keeps the migration path correct.

- The strict reader for Pi/Senpi/Kimchi strips a leading U+FEFF only on the file’s first line (`PiLines::Standard`), matching Prime’s lossy reader.
- Old vs new: a BOM made the header unparsable and dropped the entire transcript; now the transcript parses normally.
- Scope and rollout: no parser‑version bump, no cache invalidation, no migration steps required.

<sup>Written for commit a3cd734eac83e3de35ccf23eacce02e06bc79920. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

