### PR TITLE
fix(frontend): make quickstart label scroll to commands

### DIFF
--- a/packages/frontend/src/components/landing/sections/QuickstartSection.tsx
+++ b/packages/frontend/src/components/landing/sections/QuickstartSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import Image from "next/image";
 import styled, { css, keyframes } from "styled-components";
 import { useCopy, useSquircleClip } from "../hooks";
@@ -8,12 +9,21 @@ import { SquircleBorder } from "../components";
 export function QuickstartSection() {
   const tui = useCopy("bunx tokscale@latest");
   const submit = useCopy("bunx tokscale@latest submit");
+  const cardsWrapperRef = useRef<HTMLDivElement>(null);
   const {
     setElementRef: setCardsRowRef,
     clipPath: cardsRowClipPath,
     svgDef: cardsRowSvgDef,
     borderDef: cardsRowBorderDef,
   } = useSquircleClip<HTMLDivElement>(32, 0.6, true, 1);
+
+  const scrollToCommands = () => {
+    const wrapper = cardsWrapperRef.current;
+    if (!wrapper) return;
+
+    // Scroll to the wrapper, not the row — the row's clip-path would clip the target.
+    wrapper.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
 
   return (
     <>
@@ -41,16 +51,12 @@ export function QuickstartSection() {
       <SeparatorBar />
 
       {/* Quickstart Label */}
-      <QuickstartLabel
-        href="https://github.com/junhoyeo/tokscale#installation"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
+      <QuickstartLabel type="button" onClick={scrollToCommands}>
         <QuickstartText>Quickstart</QuickstartText>
       </QuickstartLabel>
 
       {/* Quickstart Cards */}
-      <QuickstartCardsWrapper>
+      <QuickstartCardsWrapper ref={cardsWrapperRef}>
         <QuickstartCardsRow
           ref={setCardsRowRef}
           style={{
@@ -139,16 +145,28 @@ const SeparatorBar = styled.div`
 `;
 
 /* ── Quickstart Label ── */
-const QuickstartLabel = styled.a`
+const QuickstartLabel = styled.button`
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 20px 32px;
   background: #0073ff;
+  border: none;
   border-left: 1px solid #10233e;
   border-right: 1px solid #10233e;
-  text-decoration: none;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.9;
+  }
+  &:active {
+    transform: scale(0.99);
+  }
+  &:focus-visible {
+    outline: 2px solid #75b6ff;
+    outline-offset: 3px;
+  }
 `;
 
 const QuickstartText = styled.span`
@@ -165,6 +183,8 @@ const QuickstartText = styled.span`
 const QuickstartCardsWrapper = styled.div`
   width: 100%;
   padding-bottom: 64px;
+  /* 72px clears the fixed nav (40px at top: 17px) plus breathing room */
+  scroll-margin-top: 72px;
 `;
 
 const QuickstartCardsRow = styled.div`

--- a/packages/frontend/src/components/landing/sections/QuickstartSection.tsx
+++ b/packages/frontend/src/components/landing/sections/QuickstartSection.tsx
@@ -41,7 +41,11 @@ export function QuickstartSection() {
       <SeparatorBar />
 
       {/* Quickstart Label */}
-      <QuickstartLabel>
+      <QuickstartLabel
+        href="https://github.com/junhoyeo/tokscale#installation"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         <QuickstartText>Quickstart</QuickstartText>
       </QuickstartLabel>
 
@@ -135,7 +139,7 @@ const SeparatorBar = styled.div`
 `;
 
 /* ── Quickstart Label ── */
-const QuickstartLabel = styled.div`
+const QuickstartLabel = styled.a`
   width: 100%;
   display: flex;
   align-items: center;
@@ -144,6 +148,7 @@ const QuickstartLabel = styled.div`
   background: #0073ff;
   border-left: 1px solid #10233e;
   border-right: 1px solid #10233e;
+  text-decoration: none;
 `;
 
 const QuickstartText = styled.span`


### PR DESCRIPTION
## Summary

- Make the QUICKSTART label on the landing page clickable.
- Link it to the Quick Start section.

Closes #1107

## Testing

- `make test/frontend`
- `make typecheck`
- Manual verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the landing page Quickstart label a button that smoothly scrolls to the command cards to improve discoverability and keyboard navigation. Previously it was a non-interactive label; now it performs in-page scroll with proper focus and hover states.

- Converts `QuickstartLabel` from `div` to `button` and adds an onClick that calls `scrollIntoView({ behavior: "smooth", block: "start" })` on the cards wrapper.
- Adds `scroll-margin-top: 72px` to `QuickstartCardsWrapper` to prevent overlap with the fixed nav.
- Preserves styling and adds cursor, hover/active feedback, and a focus-visible outline; removes the external link behavior.

<sup>Written for commit deaa7b316be848674b429937ebfbfcfdea44bf98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

