### PR TITLE
refactor(core): share SQLite, usage-struct and JSONL drivers across the session parsers

### DIFF
--- a/crates/tokscale-core/src/sessions/antigravity_cli.rs
+++ b/crates/tokscale-core/src/sessions/antigravity_cli.rs
@@ -41,7 +41,7 @@
 //! server-supplied name that gets renamed (`Gemini 3 Flash` → `Gemini 3.5 Flash
 //! (High)`) and could be localized.
 
-use super::utils::open_readonly_sqlite_opt;
+use super::utils::{open_readonly_sqlite_opt, sqlite_for_each_row_on};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::{pricing, provider_identity, TokenBreakdown};
 use rusqlite::Connection;
@@ -61,20 +61,23 @@ pub fn parse_antigravity_cli_file(path: &Path) -> Vec<UnifiedMessage> {
 
     let (timestamp, workspace_key, workspace_label) = read_trajectory_meta(&conn, path);
 
-    let mut stmt = match conn.prepare("SELECT data FROM gen_metadata ORDER BY idx") {
-        Ok(stmt) => stmt,
-        // Not an Antigravity CLI database (table missing) — nothing to count.
-        Err(_) => return Vec::new(),
-    };
-    let rows = match stmt.query_map([], |row| row.get::<_, Vec<u8>>(0)) {
-        Ok(rows) => rows,
-        Err(_) => return Vec::new(),
-    };
-
     // Buffered rather than streamed so a row missing its own `#19` can borrow
     // attribution from anywhere in the conversation, not just from rows that
     // happen to precede it.
-    let blobs: Vec<Vec<u8>> = rows.flatten().collect();
+    //
+    // Quiet: a database without `gen_metadata` is not an Antigravity CLI
+    // database at all, so there is nothing to warn about.
+    let mut blobs: Vec<Vec<u8>> = Vec::new();
+    sqlite_for_each_row_on(
+        &conn,
+        path,
+        "SELECT data FROM gen_metadata ORDER BY idx",
+        None,
+        &mut |row| {
+            blobs.push(row.get::<_, Vec<u8>>(0)?);
+            Ok(())
+        },
+    );
     let session_models = SessionModels::from_blobs(&blobs);
 
     let mut messages = Vec::new();

--- a/crates/tokscale-core/src/sessions/augment.rs
+++ b/crates/tokscale-core/src/sessions/augment.rs
@@ -36,9 +36,11 @@
 //! always set. If a future format needs multiple messages per turn, revisit
 //! that flag before counting turns.
 
-use super::utils::{file_modified_timestamp_ms, parse_timestamp_str, read_file_or_none};
+use super::utils::{
+    file_modified_timestamp_ms, parse_timestamp_str, read_file_or_none, AnthropicUsage,
+};
 use super::UnifiedMessage;
-use crate::{provider_identity, TokenBreakdown};
+use crate::provider_identity;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -83,15 +85,7 @@ struct AugmentExchange {
 /// do not fail the turn.
 #[derive(Debug, Deserialize)]
 struct AugmentResponseNode {
-    token_usage: Option<AugmentTokenUsage>,
-}
-
-#[derive(Debug, Deserialize)]
-struct AugmentTokenUsage {
-    input_tokens: Option<i64>,
-    output_tokens: Option<i64>,
-    cache_read_input_tokens: Option<i64>,
-    cache_creation_input_tokens: Option<i64>,
+    token_usage: Option<AnthropicUsage>,
 }
 
 fn model_id(model: Option<&str>) -> String {
@@ -111,23 +105,13 @@ fn provider_for_model(model: &str) -> String {
         .to_string()
 }
 
-fn tokens_from_usage(usage: &AugmentTokenUsage) -> TokenBreakdown {
-    TokenBreakdown {
-        input: usage.input_tokens.unwrap_or(0).max(0),
-        output: usage.output_tokens.unwrap_or(0).max(0),
-        cache_read: usage.cache_read_input_tokens.unwrap_or(0).max(0),
-        cache_write: usage.cache_creation_input_tokens.unwrap_or(0).max(0),
-        reasoning: 0,
-    }
-}
-
-fn usage_is_nonzero(usage: &AugmentTokenUsage) -> bool {
-    tokens_from_usage(usage).total() > 0
+fn usage_is_nonzero(usage: &AnthropicUsage) -> bool {
+    usage.to_breakdown().total() > 0
 }
 
 /// Prefer the last non-empty observation so a later full total wins over an
 /// earlier partial if the format ever streams multiple usage nodes.
-fn last_token_usage(nodes: &[AugmentResponseNode]) -> Option<&AugmentTokenUsage> {
+fn last_token_usage(nodes: &[AugmentResponseNode]) -> Option<&AnthropicUsage> {
     nodes
         .iter()
         .rev()
@@ -216,7 +200,7 @@ pub fn parse_augment_file(path: &Path) -> Vec<UnifiedMessage> {
             continue;
         };
 
-        let tokens = tokens_from_usage(usage);
+        let tokens = usage.to_breakdown();
 
         let model = model_id(
             exchange

--- a/crates/tokscale-core/src/sessions/cherrystudio.rs
+++ b/crates/tokscale-core/src/sessions/cherrystudio.rs
@@ -26,12 +26,11 @@
 //! `input_tokens` (cache miss), `cache_read_input_tokens` (cache hit),
 //! `cache_creation_input_tokens` (cache write) and `output_tokens`.
 
-use super::utils::{file_modified_timestamp_ms, parse_timestamp_str};
+use super::utils::{file_modified_timestamp_ms, for_each_json_line, parse_timestamp_str};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 const CLIENT_ID: &str = "cherrystudio";
@@ -247,14 +246,9 @@ fn workspace_from_path(path: &Path) -> (Option<String>, Option<String>) {
 /// Parse a Cherry Studio Claude Code transcript into unified messages, collapsing
 /// only repeated records with a stable per-request, message, or event identity.
 pub fn parse_cherrystudio_file(path: &Path) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(path) {
-        Ok(f) => f,
-        Err(_) => return Vec::new(),
-    };
     let fallback_timestamp = file_modified_timestamp_ms(path);
     let (workspace_key, workspace_label) = workspace_from_path(path);
 
-    let reader = BufReader::new(file);
     let mut records = Vec::new();
     let session_id = path
         .file_stem()
@@ -262,23 +256,18 @@ pub fn parse_cherrystudio_file(path: &Path) -> Vec<UnifiedMessage> {
         .unwrap_or("unknown")
         .to_string();
 
-    for line in reader.lines() {
-        let Ok(line) = line else { continue };
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
+    for_each_json_line(path, &mut |_index, line| {
         let Ok(record) = serde_json::from_str::<Value>(line) else {
-            continue;
+            return;
         };
         if record.get("type").and_then(Value::as_str) != Some("assistant") {
-            continue;
+            return;
         }
         let Some(message) = record.get("message").and_then(Value::as_object) else {
-            continue;
+            return;
         };
         let Some(usage) = message.get("usage").and_then(Value::as_object) else {
-            continue;
+            return;
         };
 
         let input = usage
@@ -299,7 +288,7 @@ pub fn parse_cherrystudio_file(path: &Path) -> Vec<UnifiedMessage> {
             .trim()
             .to_string();
         if model.is_empty() || model == "<synthetic>" || model.eq_ignore_ascii_case("unknown") {
-            continue;
+            return;
         }
 
         let cache_read = usage
@@ -317,7 +306,7 @@ pub fn parse_cherrystudio_file(path: &Path) -> Vec<UnifiedMessage> {
             .saturating_add(cache_read)
             .saturating_add(cache_creation);
         if total <= 0 {
-            continue;
+            return;
         }
 
         // Hold every valid row until the whole transcript has been read. A
@@ -385,7 +374,7 @@ pub fn parse_cherrystudio_file(path: &Path) -> Vec<UnifiedMessage> {
             request_id,
             aliases,
         });
-    }
+    });
     dedupe_usage_records(records)
 }
 

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -6,7 +6,7 @@
 
 use super::utils::{
     estimate_tokens, extract_i64, extract_string, file_modified_timestamp_ms,
-    parse_timestamp_value, read_file_or_none,
+    parse_timestamp_value, read_file_or_none, AnthropicUsage,
 };
 use super::{
     normalize_agent_name, normalize_workspace_key, workspace_label_from_key, UnifiedMessage,
@@ -21,8 +21,11 @@ use std::path::{Path, PathBuf};
 type ParentSubagentTypeCache = HashMap<PathBuf, HashMap<String, String>>;
 
 /// Claude Code entry structure (from JSONL files)
+///
+/// `pub(crate)` because the shared usage block it embeds is crate-internal;
+/// nothing outside this module ever named these types.
 #[derive(Debug, Deserialize)]
-pub struct ClaudeEntry {
+pub(crate) struct ClaudeEntry {
     #[serde(rename = "type")]
     pub entry_type: String,
     pub timestamp: Option<String>,
@@ -65,22 +68,14 @@ impl CcMirrorVariantMetadata {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct ClaudeMessage {
+pub(crate) struct ClaudeMessage {
     pub model: Option<String>,
-    pub usage: Option<ClaudeUsage>,
+    pub usage: Option<AnthropicUsage>,
     /// Message ID for deduplication (used with requestId)
     pub id: Option<String>,
     /// Optional billing or routing provider emitted by wrappers around Claude Code.
     #[serde(rename = "providerId", alias = "provider_id", alias = "provider")]
     pub provider_id: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ClaudeUsage {
-    pub input_tokens: Option<i64>,
-    pub output_tokens: Option<i64>,
-    pub cache_read_input_tokens: Option<i64>,
-    pub cache_creation_input_tokens: Option<i64>,
 }
 
 /// Resolve the subagent display name for a sidechain transcript file.
@@ -888,7 +883,7 @@ fn duration_between_ms(start_ms: Option<i64>, end_ms: Option<i64>) -> Option<i64
 
 fn merge_claude_duplicate(
     existing: &mut UnifiedMessage,
-    usage: &ClaudeUsage,
+    usage: &AnthropicUsage,
     parsed_timestamp: Option<i64>,
 ) {
     // Per-field max merge: each token field is updated independently.

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -11,6 +11,11 @@ use super::utils::{
 use super::{
     normalize_agent_name, normalize_workspace_key, workspace_label_from_key, UnifiedMessage,
 };
+
+/// The Anthropic `usage` block, kept reachable under its historical name so
+/// `sessions::claudecode::ClaudeUsage` still resolves to the same four fields
+/// after the type moved into `sessions::utils`.
+pub use super::utils::AnthropicUsage as ClaudeUsage;
 use crate::{pricing, provider_identity, TokenBreakdown};
 use serde::Deserialize;
 use serde_json::Value;
@@ -21,11 +26,8 @@ use std::path::{Path, PathBuf};
 type ParentSubagentTypeCache = HashMap<PathBuf, HashMap<String, String>>;
 
 /// Claude Code entry structure (from JSONL files)
-///
-/// `pub(crate)` because the shared usage block it embeds is crate-internal;
-/// nothing outside this module ever named these types.
 #[derive(Debug, Deserialize)]
-pub(crate) struct ClaudeEntry {
+pub struct ClaudeEntry {
     #[serde(rename = "type")]
     pub entry_type: String,
     pub timestamp: Option<String>,
@@ -68,7 +70,7 @@ impl CcMirrorVariantMetadata {
 }
 
 #[derive(Debug, Deserialize)]
-pub(crate) struct ClaudeMessage {
+pub struct ClaudeMessage {
     pub model: Option<String>,
     pub usage: Option<AnthropicUsage>,
     /// Message ID for deduplication (used with requestId)

--- a/crates/tokscale-core/src/sessions/commandcode.rs
+++ b/crates/tokscale-core/src/sessions/commandcode.rs
@@ -37,12 +37,12 @@
 //! (the configured agent model), falling back to "unknown".
 
 use super::utils::{
-    estimate_tokens, file_modified_timestamp_ms, session_id_from_path, workspace_key_from_path,
+    estimate_tokens, file_modified_timestamp_ms, for_each_json_line, session_id_from_path,
+    workspace_key_from_path,
 };
 use super::{workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde::Deserialize;
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 const CLIENT_ID: &str = "commandcode";
@@ -74,11 +74,6 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
     {
         return Vec::new();
     }
-
-    let file = match std::fs::File::open(path) {
-        Ok(file) => file,
-        Err(_) => return Vec::new(),
-    };
 
     let fallback_timestamp = file_modified_timestamp_ms(path);
     let raw_model = model_from_config(path);
@@ -115,20 +110,10 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
     let mut pending_turn_start = false;
     let mut assistant_index = 0usize;
 
-    let reader = BufReader::new(file);
-    for line in reader.lines() {
-        let line = match line {
-            Ok(line) => line,
-            Err(_) => continue,
-        };
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
+    for_each_json_line(path, &mut |_index, trimmed| {
         let entry = match serde_json::from_str::<CommandCodeEntry>(trimmed) {
             Ok(entry) => entry,
-            Err(_) => continue,
+            Err(_) => return,
         };
 
         if session_id.is_none() {
@@ -150,7 +135,7 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
 
                 if input + output == 0 {
                     pending_turn_start = false;
-                    continue;
+                    return;
                 }
 
                 let resolved_session = session_id
@@ -196,7 +181,7 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
                 turn_input_chars += chars;
             }
         }
-    }
+    });
 
     messages
 }

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -4,38 +4,22 @@
 //! Copilot Chat monitoring. Chat spans and inference log records are preferred;
 //! aggregate agent records are only used as a fallback to avoid double counting.
 
-use super::utils::file_modified_timestamp_ms;
+use super::utils::{file_modified_timestamp_ms, for_each_json_line};
 use super::UnifiedMessage;
 use crate::provider_identity::inferred_provider_from_model;
 use crate::TokenBreakdown;
 use serde_json::{Map, Value};
 use std::collections::{HashMap, HashSet};
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 pub fn parse_copilot_file(path: &Path) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(path) {
-        Ok(file) => file,
-        Err(_) => return Vec::new(),
-    };
-
     let fallback_timestamp = file_modified_timestamp_ms(path);
     let mut records = Vec::new();
-    for line in BufReader::new(file).lines() {
-        let line = match line {
-            Ok(line) => line,
-            Err(_) => continue,
-        };
-
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
+    for_each_json_line(path, &mut |_index, trimmed| {
         if let Ok(record) = serde_json::from_str::<Value>(trimmed) {
             records.push(record);
         }
-    }
+    });
 
     let trace_contexts = collect_trace_contexts(&records);
     let candidates: Vec<CopilotUsageCandidate> = records

--- a/crates/tokscale-core/src/sessions/copilot_desktop.rs
+++ b/crates/tokscale-core/src/sessions/copilot_desktop.rs
@@ -3,7 +3,7 @@
 //! The macOS desktop app stores aggregate token totals in `~/.copilot/data.db`
 //! and per-session event metadata in `~/.copilot/session-state/{session_id}`.
 
-use super::utils::{lossy_lines, open_readonly_sqlite};
+use super::utils::{lossy_lines, sqlite_for_each_row};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::provider_identity::inferred_provider_from_model;
 use chrono::{DateTime, NaiveDateTime};
@@ -239,20 +239,7 @@ fn shutdown_deltas(
 }
 
 pub fn parse_copilot_desktop_db(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match open_readonly_sqlite(db_path) {
-        Ok(conn) => conn,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to open Copilot Desktop database"
-            );
-            return Vec::new();
-        }
-    };
-
-    let mut stmt = match conn.prepare(
-        r#"
+    let query = r#"
         SELECT
             id,
             title,
@@ -268,53 +255,29 @@ pub fn parse_copilot_desktop_db(db_path: &Path) -> Vec<UnifiedMessage> {
            OR total_output_tokens > 0
            OR total_cached_tokens > 0
            OR total_reasoning_tokens > 0
-        "#,
-    ) {
-        Ok(stmt) => stmt,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to prepare Copilot Desktop sessions query"
-            );
-            return Vec::new();
-        }
-    };
+        "#;
 
-    let rows = match stmt.query_map([], |row| {
-        Ok(CopilotDesktopSessionRow {
-            id: row.get(0)?,
-            model: row.get(2)?,
-            total_input_tokens: row.get::<_, Option<i64>>(3)?.unwrap_or(0),
-            total_output_tokens: row.get::<_, Option<i64>>(4)?.unwrap_or(0),
-            total_cached_tokens: row.get::<_, Option<i64>>(5)?.unwrap_or(0),
-            total_reasoning_tokens: row.get::<_, Option<i64>>(6)?.unwrap_or(0),
-            created_at: row.get(8)?,
-        })
-    }) {
-        Ok(rows) => rows,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to execute Copilot Desktop sessions query"
-            );
-            return Vec::new();
-        }
-    };
+    let mut messages = Vec::new();
+    sqlite_for_each_row(
+        db_path,
+        query,
+        Some("Copilot Desktop session"),
+        &mut |row| {
+            let session = CopilotDesktopSessionRow {
+                id: row.get(0)?,
+                model: row.get(2)?,
+                total_input_tokens: row.get::<_, Option<i64>>(3)?.unwrap_or(0),
+                total_output_tokens: row.get::<_, Option<i64>>(4)?.unwrap_or(0),
+                total_cached_tokens: row.get::<_, Option<i64>>(5)?.unwrap_or(0),
+                total_reasoning_tokens: row.get::<_, Option<i64>>(6)?.unwrap_or(0),
+                created_at: row.get(8)?,
+            };
+            messages.extend(session_row_to_messages(db_path, session));
+            Ok(())
+        },
+    );
 
-    rows.flat_map(|row| match row {
-        Ok(row) => session_row_to_messages(db_path, row),
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to decode Copilot Desktop session row"
-            );
-            Vec::new()
-        }
-    })
-    .collect()
+    messages
 }
 
 /// Turn one `sessions` row into the messages its usage actually belongs to.

--- a/crates/tokscale-core/src/sessions/crush.rs
+++ b/crates/tokscale-core/src/sessions/crush.rs
@@ -11,7 +11,7 @@
 //! report showing 0 tokens for crush is EXPECTED behavior, NOT a bug — the
 //! signal Crush provides is cost, not tokens.
 
-use super::utils::open_readonly_sqlite_opt;
+use super::utils::{open_readonly_sqlite_opt, sqlite_for_each_row_on};
 use super::UnifiedMessage;
 use crate::bucket_tz::BucketTimezone;
 use crate::TokenBreakdown;
@@ -65,12 +65,12 @@ pub fn parse_crush_sqlite_in(
         return Vec::new();
     };
 
-    let root_sessions = load_root_sessions(&conn);
+    let root_sessions = load_root_sessions(db_path, &conn);
     if root_sessions.is_empty() {
         return Vec::new();
     }
 
-    let assistant_buckets = load_assistant_buckets(&conn, bucket_timezone);
+    let assistant_buckets = load_assistant_buckets(db_path, &conn, bucket_timezone);
     let db_namespace = db_path.to_string_lossy().to_string();
     let mut messages = Vec::new();
 
@@ -139,7 +139,7 @@ pub fn parse_crush_sqlite_in(
     messages
 }
 
-fn load_root_sessions(conn: &Connection) -> Vec<CrushSession> {
+fn load_root_sessions(db_path: &Path, conn: &Connection) -> Vec<CrushSession> {
     let query = r#"
         SELECT id, cost, created_at, updated_at
         FROM sessions
@@ -148,27 +148,23 @@ fn load_root_sessions(conn: &Connection) -> Vec<CrushSession> {
         ORDER BY created_at ASC
     "#;
 
-    let mut stmt = match conn.prepare(query) {
-        Ok(stmt) => stmt,
-        Err(_) => return Vec::new(),
-    };
-
-    let rows = match stmt.query_map([], |row| {
-        Ok(CrushSession {
+    // Quiet: Crush databases from before the `sessions` schema simply have
+    // nothing to contribute here.
+    let mut sessions = Vec::new();
+    sqlite_for_each_row_on(conn, db_path, query, None, &mut |row| {
+        sessions.push(CrushSession {
             id: row.get(0)?,
             cost: row.get::<_, Option<f64>>(1)?.unwrap_or(0.0),
             created_at: row.get::<_, Option<i64>>(2)?.unwrap_or(0),
             updated_at: row.get::<_, Option<i64>>(3)?.unwrap_or(0),
-        })
-    }) {
-        Ok(rows) => rows,
-        Err(_) => return Vec::new(),
-    };
-
-    rows.flatten().collect()
+        });
+        Ok(())
+    });
+    sessions
 }
 
 fn load_assistant_buckets(
+    db_path: &Path,
     conn: &Connection,
     bucket_timezone: &BucketTimezone,
 ) -> HashMap<String, Vec<DayBucket>> {
@@ -191,29 +187,19 @@ fn load_assistant_buckets(
         ORDER BY st.root_session_id ASC, m.created_at ASC
     "#;
 
-    let mut stmt = match conn.prepare(query) {
-        Ok(stmt) => stmt,
-        Err(_) => return HashMap::new(),
-    };
-
-    let rows = match stmt.query_map([], |row| {
-        let session_id: String = row.get(0)?;
-        let created_at: i64 = row.get::<_, Option<i64>>(1)?.unwrap_or(0);
-        Ok((session_id, created_at))
-    }) {
-        Ok(rows) => rows,
-        Err(_) => return HashMap::new(),
-    };
-
     let mut session_days: HashMap<String, BTreeMap<String, DayBucket>> = HashMap::new();
 
-    for row in rows.flatten() {
-        let (session_id, created_at) = row;
+    // Quiet: Crush databases from before the `messages` schema simply have
+    // nothing to contribute here.
+    sqlite_for_each_row_on(conn, db_path, query, None, &mut |row| {
+        let session_id: String = row.get(0)?;
+        let created_at: i64 = row.get::<_, Option<i64>>(1)?.unwrap_or(0);
+
         let Some(timestamp_ms) = normalize_crush_timestamp_ms(created_at) else {
-            continue;
+            return Ok(());
         };
         let Some(local_day) = local_day_key(timestamp_ms, bucket_timezone) else {
-            continue;
+            return Ok(());
         };
 
         let day_map = session_days.entry(session_id).or_default();
@@ -223,7 +209,8 @@ fn load_assistant_buckets(
         });
         bucket.timestamp_ms = bucket.timestamp_ms.min(timestamp_ms);
         bucket.message_count = bucket.message_count.saturating_add(1);
-    }
+        Ok(())
+    });
 
     session_days
         .into_iter()

--- a/crates/tokscale-core/src/sessions/devin.rs
+++ b/crates/tokscale-core/src/sessions/devin.rs
@@ -5,14 +5,13 @@
 //! - Devin Desktop NDJSON event streams (`~/Library/Application Support/Devin/User/acp-events/*.ndjson`)
 
 use super::utils::{
-    back_anchor_timestamp, file_modified_timestamp_ms, open_readonly_sqlite_opt,
-    sqlite_for_each_row_on,
+    back_anchor_timestamp, file_modified_timestamp_ms, for_each_json_line,
+    open_readonly_sqlite_opt, sqlite_for_each_row_on,
 };
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 // ---------------------------------------------------------------------------
@@ -408,25 +407,15 @@ pub fn parse_devin_desktop_ndjson_with_lookup(
     path: &Path,
     lookup: &DevinDesktopSessionLookup,
 ) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(path) {
-        Ok(file) => file,
-        Err(_) => return Vec::new(),
-    };
-
     let fallback_timestamp = file_modified_timestamp_ms(path);
     let file_session_id = session_id_from_ndjson_path(path);
     let mut legacy_messages = Vec::new();
     let mut acp_usage: Option<DevinDesktopAcpUsage> = None;
     let mut title: Option<String> = None;
 
-    for (line_index, line) in BufReader::new(file).lines().enumerate() {
-        let Ok(line) = line else { continue };
-        if line.is_empty() {
-            continue;
-        }
-
-        let Ok(event) = serde_json::from_str::<DevinDesktopEvent>(&line) else {
-            continue;
+    for_each_json_line(path, &mut |line_index, line| {
+        let Ok(event) = serde_json::from_str::<DevinDesktopEvent>(line) else {
+            return;
         };
 
         // The Desktop app streams ACP events. Usage is not reliably present in
@@ -435,7 +424,7 @@ pub fn parse_devin_desktop_ndjson_with_lookup(
         // yield no messages. This keeps the parser future-proof and avoids
         // double-counting the CLI DB data.
         let Some(notification) = event.notification else {
-            continue;
+            return;
         };
 
         if notification
@@ -452,7 +441,7 @@ pub fn parse_devin_desktop_ndjson_with_lookup(
             {
                 title = Some(updated_title);
             }
-            continue;
+            return;
         }
 
         if notification
@@ -497,7 +486,7 @@ pub fn parse_devin_desktop_ndjson_with_lookup(
                 if let Some(timestamp) = notification_timestamp(&notification) {
                     usage.timestamp = Some(timestamp);
                 }
-                continue;
+                return;
             }
         }
 
@@ -511,7 +500,7 @@ pub fn parse_devin_desktop_ndjson_with_lookup(
             .or_else(|| notification.pointer("/metadata"));
 
         let Some(usage) = usage else {
-            continue;
+            return;
         };
 
         let input = usage
@@ -536,7 +525,7 @@ pub fn parse_devin_desktop_ndjson_with_lookup(
             .max(0);
 
         if input == 0 && output == 0 && cache_read == 0 && cache_write == 0 {
-            continue;
+            return;
         }
 
         let model_hint = notification_model(&notification);
@@ -558,7 +547,7 @@ pub fn parse_devin_desktop_ndjson_with_lookup(
             },
             line_index,
         ));
-    }
+    });
 
     if let Some(usage) = acp_usage {
         let tokens = TokenBreakdown {

--- a/crates/tokscale-core/src/sessions/devin.rs
+++ b/crates/tokscale-core/src/sessions/devin.rs
@@ -4,7 +4,10 @@
 //! - Devin CLI SQLite database (`~/.local/share/devin/cli/sessions.db`)
 //! - Devin Desktop NDJSON event streams (`~/Library/Application Support/Devin/User/acp-events/*.ndjson`)
 
-use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms, open_readonly_sqlite_opt};
+use super::utils::{
+    back_anchor_timestamp, file_modified_timestamp_ms, open_readonly_sqlite_opt,
+    sqlite_for_each_row_on,
+};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
@@ -112,40 +115,35 @@ pub fn load_devin_desktop_session_lookup(
         let Some(conn) = open_readonly_sqlite_opt(db_path) else {
             continue;
         };
-        let mut stmt = match conn.prepare(
+        // Quiet: a Devin Desktop database without a `sessions` table is one of
+        // the candidate paths this scan probes, not a fault.
+        sqlite_for_each_row_on(
+            &conn,
+            db_path,
             "SELECT id, title, model, working_directory FROM sessions \
              WHERE title IS NOT NULL AND TRIM(title) != ''",
-        ) {
-            Ok(stmt) => stmt,
-            Err(_) => continue,
-        };
-        let rows = match stmt.query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, Option<String>>(2)?,
-                row.get::<_, Option<String>>(3)?,
-            ))
-        }) {
-            Ok(rows) => rows,
-            Err(_) => continue,
-        };
+            None,
+            &mut |row| {
+                let session_id: String = row.get(0)?;
+                let title: String = row.get(1)?;
+                let model_id: Option<String> = row.get(2)?;
+                let workspace: Option<String> = row.get(3)?;
 
-        for row in rows.flatten() {
-            let (session_id, title, model_id, workspace) = row;
-            let title = title.trim();
-            if title.is_empty() {
-                continue;
-            }
-            lookup.insert(
-                title.to_string(),
-                DevinDesktopSession {
-                    session_id,
-                    model_id: model_id.filter(|model| !model.is_empty()),
-                    workspace,
-                },
-            );
-        }
+                let title = title.trim();
+                if title.is_empty() {
+                    return Ok(());
+                }
+                lookup.insert(
+                    title.to_string(),
+                    DevinDesktopSession {
+                        session_id,
+                        model_id: model_id.filter(|model| !model.is_empty()),
+                        workspace,
+                    },
+                );
+                Ok(())
+            },
+        );
     }
 
     lookup
@@ -177,42 +175,26 @@ pub fn parse_devin_cli_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         ORDER BY m.row_id
     "#;
 
-    let mut stmt = match conn.prepare(query) {
-        Ok(s) => s,
-        Err(_) => return Vec::new(),
-    };
-
-    let rows = match stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, i64>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, String>(2)?,
-            row.get::<_, Option<i64>>(3)?,
-            row.get::<_, Option<String>>(4)?,
-            row.get::<_, Option<String>>(5)?,
-        ))
-    }) {
-        Ok(r) => r,
-        Err(_) => return Vec::new(),
-    };
-
     let mut messages = Vec::new();
 
-    for row_result in rows {
-        let (row_id, session_id, chat_json, created_at_ms, session_model, workspace) =
-            match row_result {
-                Ok(r) => r,
-                Err(_) => continue,
-            };
+    // Quiet: a Devin CLI database that predates `message_nodes` simply has no
+    // rows to offer, which is not a fault worth logging.
+    sqlite_for_each_row_on(&conn, db_path, query, None, &mut |row| {
+        let row_id: i64 = row.get(0)?;
+        let session_id: String = row.get(1)?;
+        let chat_json: String = row.get(2)?;
+        let created_at_ms: Option<i64> = row.get(3)?;
+        let session_model: Option<String> = row.get(4)?;
+        let workspace: Option<String> = row.get(5)?;
 
         // Confirm role == assistant (the SQL filter should already guarantee this,
         // but parsing lets us skip corrupt rows cleanly).
         let chat_msg: DevinChatMessage = match serde_json::from_str(&chat_json) {
             Ok(m) => m,
-            Err(_) => continue,
+            Err(_) => return Ok(()),
         };
         if chat_msg.role != "assistant" {
-            continue;
+            return Ok(());
         }
 
         let metadata = chat_msg.metadata;
@@ -229,7 +211,7 @@ pub fn parse_devin_cli_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             .unwrap_or_default()
             .to_string();
         if model_id.is_empty() {
-            continue;
+            return Ok(());
         }
 
         let provider = provider_identity::inferred_provider_from_model(&model_id)
@@ -265,7 +247,7 @@ pub fn parse_devin_cli_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         // precedence markers for a matching Desktop ACP session. Otherwise a
         // zero-metric CLI row could suppress the only real usage record.
         if tokens.total() == 0 {
-            continue;
+            return Ok(());
         }
 
         let recorded_timestamp = created_at_ms.unwrap_or(fallback_timestamp);
@@ -311,7 +293,8 @@ pub fn parse_devin_cli_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         }
 
         messages.push(unified);
-    }
+        Ok(())
+    });
 
     messages
 }

--- a/crates/tokscale-core/src/sessions/droid.rs
+++ b/crates/tokscale-core/src/sessions/droid.rs
@@ -9,7 +9,7 @@ use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
 use serde_json::Value;
-use std::io::{BufRead, BufReader, Seek};
+use std::io::{BufReader, Seek};
 use std::path::{Path, PathBuf};
 
 /// Droid settings.json structure
@@ -115,9 +115,12 @@ fn extract_model_from_jsonl(jsonl_path: &Path) -> Option<String> {
     let reader = BufReader::new(file);
 
     // Scan more lines for parity with TypeScript which reads entire file
-    // Cap at 500 lines to avoid performance issues with very large files
-    for line in reader.lines().take(500) {
-        let line = line.ok()?;
+    // Cap at 500 lines to avoid performance issues with very large files.
+    //
+    // `lossy_lines` rather than `lines()`: the latter ends the iteration on the
+    // first line that is not valid UTF-8, and `line.ok()?` abandoned model
+    // extraction for the whole file at that point.
+    for line in lossy_lines(reader).take(500) {
         // Look for Model: pattern in system-reminder
         if let Some(pos) = line.find("Model:") {
             let after_model = &line[pos + 6..];

--- a/crates/tokscale-core/src/sessions/gjc.rs
+++ b/crates/tokscale-core/src/sessions/gjc.rs
@@ -20,12 +20,11 @@
 //! session, timestamp, model and token breakdown keeps structurally identical
 //! replays (depth-1 vs depth-2 files) collapsed to one message.
 
-use super::utils::{file_modified_timestamp_ms, CamelUsage};
+use super::utils::{file_modified_timestamp_ms, for_each_json_line, CamelUsage};
 use super::{normalize_workspace_key, workspace_label_from_key, CostSource, UnifiedMessage};
 use crate::provider_identity::inferred_provider_from_model;
 use crate::TokenBreakdown;
 use serde::Deserialize;
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 /// A single JSONL entry. The `session` header reuses `id`/`timestamp`/`cwd`;
@@ -95,14 +94,8 @@ fn derive_dedup_key(
 /// Per-line parse: malformed/partial/legacy lines are skipped, never aborting
 /// the file. The `session` header and `service_tier_change` lines emit nothing.
 pub fn parse_gjc_file(path: &Path) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(path) {
-        Ok(f) => f,
-        Err(_) => return Vec::new(),
-    };
-
     let fallback_timestamp = file_modified_timestamp_ms(path);
 
-    let reader = BufReader::new(file);
     let mut messages: Vec<UnifiedMessage> = Vec::with_capacity(64);
     let mut buffer = Vec::with_capacity(4096);
 
@@ -110,22 +103,12 @@ pub fn parse_gjc_file(path: &Path) -> Vec<UnifiedMessage> {
     let mut workspace_key: Option<String> = None;
     let mut workspace_label: Option<String> = None;
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
-
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
+    for_each_json_line(path, &mut |_index, trimmed| {
         buffer.clear();
         buffer.extend_from_slice(trimmed.as_bytes());
         let entry = match simd_json::from_slice::<GjcEntry>(&mut buffer) {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(_) => return,
         };
 
         match entry.entry_type.as_str() {
@@ -137,30 +120,30 @@ pub fn parse_gjc_file(path: &Path) -> Vec<UnifiedMessage> {
                     workspace_label = workspace_label_from_key(&key);
                     workspace_key = Some(key);
                 }
-                continue;
+                return;
             }
             "message" => {}
             // service_tier_change and any other entry types: skip.
-            _ => continue,
+            _ => return,
         }
 
         let message = match entry.message {
             Some(m) => m,
-            None => continue,
+            None => return,
         };
 
         if message.role.as_deref() != Some("assistant") {
-            continue;
+            return;
         }
 
         let usage = match message.usage {
             Some(u) => u,
-            None => continue,
+            None => return,
         };
 
         let model = match message.model {
             Some(m) => m,
-            None => continue,
+            None => return,
         };
 
         // A missing provider field is recoverable: infer it from the model name
@@ -228,7 +211,7 @@ pub fn parse_gjc_file(path: &Path) -> Vec<UnifiedMessage> {
         }
         unified.set_workspace(workspace_key.clone(), workspace_label.clone());
         messages.push(unified);
-    }
+    });
 
     messages
 }

--- a/crates/tokscale-core/src/sessions/gjc.rs
+++ b/crates/tokscale-core/src/sessions/gjc.rs
@@ -20,7 +20,7 @@
 //! session, timestamp, model and token breakdown keeps structurally identical
 //! replays (depth-1 vs depth-2 files) collapsed to one message.
 
-use super::utils::file_modified_timestamp_ms;
+use super::utils::{file_modified_timestamp_ms, CamelUsage};
 use super::{normalize_workspace_key, workspace_label_from_key, CostSource, UnifiedMessage};
 use crate::provider_identity::inferred_provider_from_model;
 use crate::TokenBreakdown;
@@ -53,30 +53,12 @@ struct GjcMessage {
     source: Option<String>,
     /// Unix-ms timestamp (preferred for ordering/date).
     timestamp: Option<i64>,
-    usage: Option<GjcUsage>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct GjcUsage {
-    input: Option<i64>,
-    output: Option<i64>,
-    cache_read: Option<i64>,
-    cache_write: Option<i64>,
-    #[allow(dead_code)]
-    total_tokens: Option<i64>,
-    cost: Option<GjcCost>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GjcCost {
-    /// Authoritative total cost in USD.
-    total: Option<f64>,
+    usage: Option<CamelUsage>,
 }
 
 /// Reuse the embedded `usage.cost.total` (USD) only when present, finite, and
 /// non-negative. Otherwise return `0.0` so the dispatch pricing guard reprices.
-fn embedded_cost(usage: &GjcUsage) -> (f64, CostSource) {
+fn embedded_cost(usage: &CamelUsage) -> (f64, CostSource) {
     match usage.cost.as_ref().and_then(|c| c.total) {
         Some(total) if total.is_finite() && total >= 0.0 => (total, CostSource::ProviderReported),
         _ => (0.0, CostSource::Unknown),
@@ -201,13 +183,7 @@ pub fn parse_gjc_file(path: &Path) -> Vec<UnifiedMessage> {
                 .unwrap_or(fallback_timestamp)
         });
 
-        let tokens = TokenBreakdown {
-            input: usage.input.unwrap_or(0).max(0),
-            output: usage.output.unwrap_or(0).max(0),
-            cache_read: usage.cache_read.unwrap_or(0).max(0),
-            cache_write: usage.cache_write.unwrap_or(0).max(0),
-            reasoning: 0,
-        };
+        let tokens = usage.to_breakdown();
 
         let (cost, cost_source) = embedded_cost(&usage);
 

--- a/crates/tokscale-core/src/sessions/goose.rs
+++ b/crates/tokscale-core/src/sessions/goose.rs
@@ -6,12 +6,11 @@
 //! - Legacy Block/goose: `~/.local/share/Block/goose/sessions/sessions.db`
 //! - Custom: `$GOOSE_PATH_ROOT/data/sessions/sessions.db`
 
-use super::utils::{open_readonly_sqlite, resolved_provider, timestamp_secs_to_ms};
+use super::utils::{resolved_provider, sqlite_for_each_row, timestamp_secs_to_ms};
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use serde::Deserialize;
 use std::path::Path;
-use tracing::warn;
 
 #[derive(Debug, Deserialize)]
 struct GooseModelConfig {
@@ -47,18 +46,6 @@ fn parse_created_at(s: &str) -> f64 {
 }
 
 pub fn parse_goose_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match open_readonly_sqlite(db_path) {
-        Ok(c) => c,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to open Goose sessions database"
-            );
-            return Vec::new();
-        }
-    };
-
     let query = r#"
         SELECT
             id,
@@ -76,118 +63,75 @@ pub fn parse_goose_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
           AND TRIM(model_config_json) != ''
     "#;
 
-    let mut stmt = match conn.prepare(query) {
-        Ok(s) => s,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to prepare Goose session query"
-            );
-            return Vec::new();
+    let mut messages = Vec::new();
+    sqlite_for_each_row(db_path, query, Some("Goose session"), &mut |row| {
+        let session_id: String = row.get(0)?;
+        let model_config_json: Option<String> = row.get(1)?;
+        let provider_name: Option<String> = row.get(2)?;
+        let created_at: String = row.get(3)?;
+        let total_tokens: Option<i64> = row.get(4)?;
+        let input_tokens: Option<i64> = row.get(5)?;
+        let output_tokens: Option<i64> = row.get(6)?;
+        let accumulated_total_tokens: Option<i64> = row.get(7)?;
+        let accumulated_input_tokens: Option<i64> = row.get(8)?;
+        let accumulated_output_tokens: Option<i64> = row.get(9)?;
+
+        let Some(model_config) = model_config_json.as_ref() else {
+            return Ok(());
+        };
+        let Some(model_id) = parse_model_config(model_config) else {
+            return Ok(());
+        };
+
+        let created_at_ts = parse_created_at(&created_at);
+
+        let input = accumulated_input_tokens
+            .or(input_tokens)
+            .unwrap_or(0)
+            .max(0);
+        let output = accumulated_output_tokens
+            .or(output_tokens)
+            .unwrap_or(0)
+            .max(0);
+        let total = accumulated_total_tokens
+            .or(total_tokens)
+            .unwrap_or(0)
+            .max(0);
+
+        if input == 0 && output == 0 && total == 0 {
+            return Ok(());
         }
-    };
 
-    let rows = match stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, Option<String>>(1)?,
-            row.get::<_, Option<String>>(2)?,
-            row.get::<_, String>(3)?,
-            row.get::<_, Option<i64>>(4)?,
-            row.get::<_, Option<i64>>(5)?,
-            row.get::<_, Option<i64>>(6)?,
-            row.get::<_, Option<i64>>(7)?,
-            row.get::<_, Option<i64>>(8)?,
-            row.get::<_, Option<i64>>(9)?,
-        ))
-    }) {
-        Ok(r) => r,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to execute Goose session query"
-            );
-            return Vec::new();
-        }
-    };
-
-    rows.filter_map(|row| match row {
-        Ok(row) => Some(row),
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to decode Goose session row"
-            );
-            None
-        }
-    })
-    .filter_map(
-        |(
-            session_id,
-            model_config_json,
-            provider_name,
-            created_at,
-            total_tokens,
-            input_tokens,
-            output_tokens,
-            accumulated_total_tokens,
-            accumulated_input_tokens,
-            accumulated_output_tokens,
-        )| {
-            let model_config = model_config_json.as_ref()?;
-            let model_id = parse_model_config(model_config)?;
-
-            let created_at_ts = parse_created_at(&created_at);
-
-            let input = accumulated_input_tokens
-                .or(input_tokens)
-                .unwrap_or(0)
-                .max(0);
-            let output = accumulated_output_tokens
-                .or(output_tokens)
-                .unwrap_or(0)
-                .max(0);
-            let total = accumulated_total_tokens
-                .or(total_tokens)
-                .unwrap_or(0)
-                .max(0);
-
-            if input == 0 && output == 0 && total == 0 {
-                return None;
-            }
-
-            let provider = resolved_provider(provider_name, &model_id, "goose");
-            let mut msg = UnifiedMessage::new(
-                "goose",
-                model_id,
-                provider,
-                session_id.clone(),
-                timestamp_secs_to_ms(created_at_ts),
-                TokenBreakdown {
-                    input,
-                    output,
-                    cache_read: 0,
-                    cache_write: 0,
-                    // INFERRED, not a real field: Goose's schema has no reasoning
-                    // token column. We heuristically attribute any gap between the
-                    // reported total and (input + output) to reasoning. This is a
-                    // best-effort estimate, not a measured count.
-                    reasoning: if total > input + output {
-                        (total - input - output).max(0)
-                    } else {
-                        0
-                    },
+        let provider = resolved_provider(provider_name, &model_id, "goose");
+        let mut msg = UnifiedMessage::new(
+            "goose",
+            model_id,
+            provider,
+            session_id.clone(),
+            timestamp_secs_to_ms(created_at_ts),
+            TokenBreakdown {
+                input,
+                output,
+                cache_read: 0,
+                cache_write: 0,
+                // INFERRED, not a real field: Goose's schema has no reasoning
+                // token column. We heuristically attribute any gap between the
+                // reported total and (input + output) to reasoning. This is a
+                // best-effort estimate, not a measured count.
+                reasoning: if total > input + output {
+                    (total - input - output).max(0)
+                } else {
+                    0
                 },
-                0.0,
-            );
-            msg.dedup_key = Some(session_id);
-            Some(msg)
-        },
-    )
-    .collect()
+            },
+            0.0,
+        );
+        msg.dedup_key = Some(session_id);
+        messages.push(msg);
+        Ok(())
+    });
+
+    messages
 }
 
 #[cfg(test)]

--- a/crates/tokscale-core/src/sessions/hermes.rs
+++ b/crates/tokscale-core/src/sessions/hermes.rs
@@ -4,7 +4,9 @@
 //! - `~/.hermes/state.db`
 //! - `$HERMES_HOME/state.db`
 
-use super::utils::{open_readonly_sqlite, resolved_provider, timestamp_secs_to_ms};
+use super::utils::{
+    open_readonly_sqlite, resolved_provider, sqlite_for_each_row_on, timestamp_secs_to_ms,
+};
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use rusqlite::Connection;
@@ -124,44 +126,12 @@ fn decode_usage_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<HermesUsageRow>
 /// all (prepare or execute failure) so the caller can fall back, and `Some` —
 /// possibly empty — when it ran and simply matched nothing.
 fn query_usage_rows(db_path: &Path, conn: &Connection, query: &str) -> Option<Vec<HermesUsageRow>> {
-    let mut stmt = match conn.prepare(query) {
-        Ok(stmt) => stmt,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to prepare Hermes session query"
-            );
-            return None;
-        }
-    };
-
-    let rows = match stmt.query_map([], decode_usage_row) {
-        Ok(rows) => rows,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to execute Hermes session query"
-            );
-            return None;
-        }
-    };
-
-    Some(
-        rows.filter_map(|row| match row {
-            Ok(row) => Some(row),
-            Err(err) => {
-                warn!(
-                    db_path = %db_path.display(),
-                    error = %err,
-                    "Failed to decode Hermes session row"
-                );
-                None
-            }
-        })
-        .collect(),
-    )
+    let mut rows = Vec::new();
+    let scan = sqlite_for_each_row_on(conn, db_path, query, Some("Hermes session"), &mut |row| {
+        rows.push(decode_usage_row(row)?);
+        Ok(())
+    });
+    scan.ran().then_some(rows)
 }
 
 fn build_message(row: HermesUsageRow, dedup_key: String) -> UnifiedMessage {

--- a/crates/tokscale-core/src/sessions/jcode.rs
+++ b/crates/tokscale-core/src/sessions/jcode.rs
@@ -4,7 +4,9 @@
 //! Jcode stores authoritative assistant token usage on messages under
 //! `token_usage`; user/tool messages without usage are skipped.
 
-use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms, parse_timestamp_str};
+use super::utils::{
+    back_anchor_timestamp, file_modified_timestamp_ms, for_each_json_line, parse_timestamp_str,
+};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
@@ -345,53 +347,43 @@ pub fn parse_jcode_file(path: &Path) -> Vec<UnifiedMessage> {
     }
 
     let journal_path = jcode_journal_path(path);
-    if let Ok(file) = std::fs::File::open(&journal_path) {
-        use std::io::{BufRead, BufReader};
-        let journal_fallback_timestamp = file_modified_timestamp_ms(&journal_path);
-        for (line_index, line) in BufReader::new(file).lines().enumerate() {
-            let Ok(line) = line else {
-                continue;
-            };
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            let Ok(entry) = serde_json::from_str::<JcodeJournalEntry>(trimmed) else {
-                continue;
-            };
-            if let Some(meta) = entry.meta {
-                context.apply_meta(meta);
-            }
-            let journal_messages = parse_jcode_messages(
-                lenient_jcode_messages(entry.append_messages),
-                &mut context,
-                journal_fallback_timestamp,
-                &format!("journal:{line_index}"),
-                Some(&index_by_dedup_key),
-            );
-            for mut message in journal_messages {
-                match message
-                    .dedup_key
-                    .as_ref()
-                    .and_then(|key| index_by_dedup_key.get(key).copied())
-                {
-                    Some(existing_index) => {
-                        // Preserve the snapshot's turn-start flag: turn structure
-                        // is derived from snapshot ordering, while the journal only
-                        // carries the corrected token_usage for this message_id.
-                        message.is_turn_start = parsed[existing_index].is_turn_start;
-                        parsed[existing_index] = message;
+    let journal_fallback_timestamp = file_modified_timestamp_ms(&journal_path);
+    for_each_json_line(&journal_path, &mut |line_index, trimmed| {
+        let Ok(entry) = serde_json::from_str::<JcodeJournalEntry>(trimmed) else {
+            return;
+        };
+        if let Some(meta) = entry.meta {
+            context.apply_meta(meta);
+        }
+        let journal_messages = parse_jcode_messages(
+            lenient_jcode_messages(entry.append_messages),
+            &mut context,
+            journal_fallback_timestamp,
+            &format!("journal:{line_index}"),
+            Some(&index_by_dedup_key),
+        );
+        for mut message in journal_messages {
+            match message
+                .dedup_key
+                .as_ref()
+                .and_then(|key| index_by_dedup_key.get(key).copied())
+            {
+                Some(existing_index) => {
+                    // Preserve the snapshot's turn-start flag: turn structure
+                    // is derived from snapshot ordering, while the journal only
+                    // carries the corrected token_usage for this message_id.
+                    message.is_turn_start = parsed[existing_index].is_turn_start;
+                    parsed[existing_index] = message;
+                }
+                None => {
+                    if let Some(key) = message.dedup_key.clone() {
+                        index_by_dedup_key.insert(key, parsed.len());
                     }
-                    None => {
-                        if let Some(key) = message.dedup_key.clone() {
-                            index_by_dedup_key.insert(key, parsed.len());
-                        }
-                        parsed.push(message);
-                    }
+                    parsed.push(message);
                 }
             }
         }
-    }
+    });
 
     parsed
 }

--- a/crates/tokscale-core/src/sessions/junie.rs
+++ b/crates/tokscale-core/src/sessions/junie.rs
@@ -2,13 +2,12 @@
 //!
 //! Junie stores local sessions under `~/.junie/sessions/<session-id>/events.jsonl`.
 
-use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms};
+use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms, for_each_json_line};
 use super::UnifiedMessage;
 use crate::{pricing, provider_identity, TokenBreakdown};
 use chrono::{Local, LocalResult, NaiveDateTime, TimeZone};
 use serde_json::Value;
 use std::collections::HashSet;
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 const USAGE_EVENT_KIND: &str = "LlmResponseMetadataEvent";
@@ -20,11 +19,6 @@ const SKIP_EVENT_KINDS: &[&str] = &[
 ];
 
 pub fn parse_junie_file(path: &Path) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(path) {
-        Ok(file) => file,
-        Err(_) => return Vec::new(),
-    };
-
     let session_id = session_id_from_path(path);
     let default_timestamp =
         session_timestamp_from_id(&session_id).unwrap_or_else(|| file_modified_timestamp_ms(path));
@@ -32,39 +26,36 @@ pub fn parse_junie_file(path: &Path) -> Vec<UnifiedMessage> {
     let mut messages = Vec::new();
     let mut seen = HashSet::new();
 
-    for line in BufReader::new(file).lines() {
-        let Ok(line) = line else {
-            continue;
-        };
+    for_each_json_line(path, &mut |_index, line| {
         // Cheap pre-filter only: Junie state snapshots can be very large and do
         // not carry the usage rows Tokscale needs, so skip lines that mention
         // neither relevant kind before paying for JSON parsing. The authoritative
         // skip decision is made on the parsed event kind below.
         if !line.contains(USAGE_EVENT_KIND) && !line.contains(USER_PROMPT_KIND) {
-            continue;
+            return;
         }
 
-        let Ok(value) = serde_json::from_str::<Value>(&line) else {
-            continue;
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            return;
         };
         // Skip noise events by matching the parsed event kind, not a raw substring
         // search: a legitimate usage/prompt line may merely *mention* a skipped
         // kind in its text and must not be dropped.
         if let Some(kind) = parsed_event_kind(&value) {
             if SKIP_EVENT_KINDS.contains(&kind) {
-                continue;
+                return;
             }
         }
         if event_kind(&value) == Some(USER_PROMPT_KIND) {
             pending_turn_start = true;
-            continue;
+            return;
         }
 
         let Some(agent_event) = value
             .pointer("/event/agentEvent")
             .filter(|event| string_field(event, "kind") == Some(USAGE_EVENT_KIND))
         else {
-            continue;
+            return;
         };
 
         // `explicit_timestamp` is the recorded `timestampMs` for this event, as
@@ -78,7 +69,7 @@ pub fn parse_junie_file(path: &Path) -> Vec<UnifiedMessage> {
         let timestamp = explicit_timestamp.unwrap_or(default_timestamp);
         let agent = agent_name(agent_event);
         let Some(usages) = agent_event.get("modelUsage").and_then(Value::as_array) else {
-            continue;
+            return;
         };
 
         let mut turn_start_assigned = false;
@@ -164,7 +155,7 @@ pub fn parse_junie_file(path: &Path) -> Vec<UnifiedMessage> {
         // produced no counted usage does not leak `is_turn_start` onto a later,
         // unrelated turn's usage event.
         pending_turn_start = false;
-    }
+    });
 
     messages
 }

--- a/crates/tokscale-core/src/sessions/kimi.rs
+++ b/crates/tokscale-core/src/sessions/kimi.rs
@@ -8,12 +8,11 @@
 //! ~/.kimi-code/sessions/[WORKSPACE]/[SESSION]/agents/[AGENT]/wire.jsonl
 //!   Token data comes from usage.record lines.
 
-use super::utils::file_modified_timestamp_ms;
+use super::utils::{file_modified_timestamp_ms, for_each_json_line};
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 /// Top-level wire.jsonl line: either metadata or a timestamped message
@@ -174,33 +173,17 @@ struct KimiCodeWireLine {
 
 /// Parse a Kimi Code wire.jsonl file.
 pub fn parse_kimi_code_file(path: &Path) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(path) {
-        Ok(f) => f,
-        Err(_) => return Vec::new(),
-    };
-
     let session_id = extract_session_id_from_kimi_code_path(path);
     let fallback_timestamp = file_modified_timestamp_ms(path);
 
-    let reader = BufReader::new(file);
     let mut messages: Vec<UnifiedMessage> = Vec::new();
     let mut latest_request_model: Option<String> = None;
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
-
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
+    for_each_json_line(path, &mut |_index, trimmed| {
         let mut bytes = trimmed.as_bytes().to_vec();
         let wire_line = match simd_json::from_slice::<KimiCodeWireLine>(&mut bytes) {
             Ok(wl) => wl,
-            Err(_) => continue,
+            Err(_) => return,
         };
 
         // usage.record can contain only a symbolic config reference, while the
@@ -213,14 +196,14 @@ pub fn parse_kimi_code_file(path: &Path) -> Vec<UnifiedMessage> {
             {
                 latest_request_model = Some(model);
             }
-            continue;
+            return;
         }
 
         // Only process usage.record lines.
         // step.end also carries usage, but it duplicates the same usage.record
         // that was emitted in the same turn, so we ignore it to avoid double counting.
         if wire_line.line_type != "usage.record" {
-            continue;
+            return;
         }
 
         // Only count turn-scoped usage. kimi-code tags every usage.record with
@@ -229,12 +212,12 @@ pub fn parse_kimi_code_file(path: &Path) -> Vec<UnifiedMessage> {
         // own tooling treats a missing usageScope as session-scoped, so require
         // an explicit "turn" to avoid counting aggregate records.
         if wire_line.usage_scope.as_deref() != Some("turn") {
-            continue;
+            return;
         }
 
         // Skip entries with zero tokens
         let Some(tokens) = wire_line.usage.as_ref().and_then(TokenUsage::to_breakdown) else {
-            continue;
+            return;
         };
 
         let model = wire_line
@@ -264,67 +247,51 @@ pub fn parse_kimi_code_file(path: &Path) -> Vec<UnifiedMessage> {
             tokens,
             0.0,
         ));
-    }
+    });
 
     messages
 }
 
 /// Parse a Kimi CLI wire.jsonl file
 pub fn parse_kimi_file(path: &Path) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(path) {
-        Ok(f) => f,
-        Err(_) => return Vec::new(),
-    };
-
     let model = read_model_from_config(path);
     let session_id = extract_session_id(path);
     let fallback_timestamp = file_modified_timestamp_ms(path);
 
-    let reader = BufReader::new(file);
     let mut messages: Vec<UnifiedMessage> = Vec::new();
     let mut timestamp_sources: Vec<TimestampSource> = Vec::new();
     let mut keyed_indices: HashMap<String, usize> = HashMap::new();
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
-
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
+    for_each_json_line(path, &mut |_index, trimmed| {
         let mut bytes = trimmed.as_bytes().to_vec();
         let wire_line = match simd_json::from_slice::<WireLine>(&mut bytes) {
             Ok(wl) => wl,
-            Err(_) => continue,
+            Err(_) => return,
         };
 
         // Skip metadata lines (first line: {"type": "metadata", ...})
         if wire_line.line_type.as_deref() == Some("metadata") {
-            continue;
+            return;
         }
 
         let message = match wire_line.message {
             Some(m) => m,
-            None => continue,
+            None => return,
         };
 
         // Only process StatusUpdate messages
         if message.msg_type != "StatusUpdate" {
-            continue;
+            return;
         }
 
         let payload = match message.payload {
             Some(p) => p,
-            None => continue,
+            None => return,
         };
 
         let token_usage = match payload.token_usage {
             Some(u) => u,
-            None => continue,
+            None => return,
         };
 
         // Convert Unix seconds (float) to milliseconds, falling back to file
@@ -343,7 +310,7 @@ pub fn parse_kimi_file(path: &Path) -> Vec<UnifiedMessage> {
 
         // Skip entries with zero tokens
         let Some(tokens) = token_usage.to_breakdown() else {
-            continue;
+            return;
         };
 
         let dedup_key = payload.message_id;
@@ -365,7 +332,7 @@ pub fn parse_kimi_file(path: &Path) -> Vec<UnifiedMessage> {
             message,
             timestamp_source,
         );
-    }
+    });
 
     messages
 }

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -14,15 +14,14 @@
 //! response_size / 4 (output).
 
 use super::utils::{
-    back_anchor_timestamp, estimate_tokens, file_modified_timestamp_ms, session_id_from_path,
-    sqlite_for_each_row,
+    back_anchor_timestamp, estimate_tokens, file_modified_timestamp_ms, for_each_json_line,
+    session_id_from_path, sqlite_for_each_row,
 };
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 const CLIENT_ID: &str = "kiro";
@@ -167,57 +166,45 @@ pub fn parse_kiro_file(path: &Path) -> Vec<UnifiedMessage> {
     };
     let mut content_by_message_id: HashMap<String, KiroMessageContent> = HashMap::new();
 
-    if let Ok(jsonl_file) = std::fs::File::open(&jsonl_path) {
-        let reader = BufReader::new(jsonl_file);
-        let mut pending_prompt: Option<(usize, Option<i64>)> = None;
+    let mut pending_prompt: Option<(usize, Option<i64>)> = None;
 
-        for line in reader.lines() {
-            let line = match line {
-                Ok(l) => l,
-                Err(_) => continue,
-            };
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
+    for_each_json_line(&jsonl_path, &mut |_index, trimmed| {
+        let mut bytes = trimmed.as_bytes().to_vec();
+        let entry = match simd_json::from_slice::<KiroJsonlEntry>(&mut bytes) {
+            Ok(entry) => entry,
+            Err(_) => return,
+        };
+
+        let Some(data) = entry.data else {
+            return;
+        };
+        let Some(message_id) = data.message_id else {
+            return;
+        };
+
+        let text_chars = text_char_count(data.content.as_deref());
+
+        match entry.kind.as_str() {
+            "Prompt" => {
+                let timestamp_ms = data
+                    .meta
+                    .and_then(|meta| meta.timestamp)
+                    .map(seconds_to_millis);
+                pending_prompt = Some((text_chars, timestamp_ms));
             }
-
-            let mut bytes = trimmed.as_bytes().to_vec();
-            let entry = match simd_json::from_slice::<KiroJsonlEntry>(&mut bytes) {
-                Ok(entry) => entry,
-                Err(_) => continue,
-            };
-
-            let Some(data) = entry.data else {
-                continue;
-            };
-            let Some(message_id) = data.message_id else {
-                continue;
-            };
-
-            let text_chars = text_char_count(data.content.as_deref());
-
-            match entry.kind.as_str() {
-                "Prompt" => {
-                    let timestamp_ms = data
-                        .meta
-                        .and_then(|meta| meta.timestamp)
-                        .map(seconds_to_millis);
-                    pending_prompt = Some((text_chars, timestamp_ms));
-                }
-                "AssistantMessage" => {
-                    let message = content_by_message_id.entry(message_id).or_default();
-                    if let Some((prompt_chars, prompt_ts)) = pending_prompt.take() {
-                        message.prompt_chars += prompt_chars;
-                        if message.prompt_timestamp_ms.is_none() {
-                            message.prompt_timestamp_ms = prompt_ts;
-                        }
+            "AssistantMessage" => {
+                let message = content_by_message_id.entry(message_id).or_default();
+                if let Some((prompt_chars, prompt_ts)) = pending_prompt.take() {
+                    message.prompt_chars += prompt_chars;
+                    if message.prompt_timestamp_ms.is_none() {
+                        message.prompt_timestamp_ms = prompt_ts;
                     }
-                    message.assistant_chars += text_chars;
                 }
-                _ => {}
+                message.assistant_chars += text_chars;
             }
+            _ => {}
         }
-    }
+    });
 
     turns
         .into_iter()
@@ -445,12 +432,6 @@ fn parse_kiro_ide_session_file(path: &Path) -> Vec<UnifiedMessage> {
         return Vec::new();
     }
 
-    let jsonl_file = match std::fs::File::open(&messages_path) {
-        Ok(f) => f,
-        Err(_) => return Vec::new(),
-    };
-    let reader = BufReader::new(jsonl_file);
-
     const DEFAULT_CONTEXT_WINDOW: i64 = 200_000;
 
     #[derive(Default)]
@@ -472,19 +453,10 @@ fn parse_kiro_ide_session_file(path: &Path) -> Vec<UnifiedMessage> {
     let mut flat_model_id: Option<String> = None;
     let mut flat_assistant_turns: i32 = 0;
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
+    for_each_json_line(&messages_path, &mut |_index, trimmed| {
         let entry: Value = match serde_json::from_str(trimmed) {
             Ok(v) => v,
-            Err(_) => continue,
+            Err(_) => return,
         };
 
         // Structured format: each line has `payload.type`
@@ -565,7 +537,7 @@ fn parse_kiro_ide_session_file(path: &Path) -> Vec<UnifiedMessage> {
                     }
                     _ => {}
                 }
-                continue;
+                return;
             }
         }
 
@@ -578,7 +550,7 @@ fn parse_kiro_ide_session_file(path: &Path) -> Vec<UnifiedMessage> {
         if flat_counts.assistant_chars > assistant_before {
             flat_assistant_turns += 1;
         }
-    }
+    });
 
     // Flush any in-flight structured turn
     if let Some(turn) = current_turn.take() {

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -14,8 +14,8 @@
 //! response_size / 4 (output).
 
 use super::utils::{
-    back_anchor_timestamp, estimate_tokens, file_modified_timestamp_ms, open_readonly_sqlite,
-    session_id_from_path,
+    back_anchor_timestamp, estimate_tokens, file_modified_timestamp_ms, session_id_from_path,
+    sqlite_for_each_row,
 };
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
@@ -24,7 +24,6 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use tracing::warn;
 
 const CLIENT_ID: &str = "kiro";
 const PROVIDER_ID: &str = "amazon-bedrock";
@@ -1260,56 +1259,16 @@ pub(crate) fn suppress_snapshots_covered_by_executions(
 }
 
 pub fn parse_kiro_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match open_readonly_sqlite(db_path) {
-        Ok(c) => c,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to open Kiro CLI database"
-            );
-            return Vec::new();
-        }
-    };
-
     let query = "SELECT key, conversation_id, value FROM conversations_v2";
-    let mut stmt = match conn.prepare(query) {
-        Ok(s) => s,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to prepare Kiro conversations query"
-            );
-            return Vec::new();
-        }
-    };
-
-    let rows = match stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, String>(2)?,
-        ))
-    }) {
-        Ok(r) => r,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to execute Kiro conversations query"
-            );
-            return Vec::new();
-        }
-    };
-
     let mut messages = Vec::new();
 
-    for row in rows.flatten() {
-        let (cwd, conversation_id, json_str) = row;
+    sqlite_for_each_row(db_path, query, Some("Kiro conversation"), &mut |row| {
+        let cwd: String = row.get(0)?;
+        let conversation_id: String = row.get(1)?;
+        let json_str: String = row.get(2)?;
         let parsed = match serde_json::from_str::<KiroDbConversation>(&json_str) {
             Ok(p) => p,
-            Err(_) => continue,
+            Err(_) => return Ok(()),
         };
 
         let context_window = parsed
@@ -1383,7 +1342,8 @@ pub fn parse_kiro_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             message.set_workspace(workspace_key.clone(), workspace_label.clone());
             messages.push(message);
         }
-    }
+        Ok(())
+    });
 
     messages
 }

--- a/crates/tokscale-core/src/sessions/openclaw.rs
+++ b/crates/tokscale-core/src/sessions/openclaw.rs
@@ -3,9 +3,8 @@
 //! Parses OpenClaw transcript JSONL files from agent directories.
 //! Supports legacy sessions.json index parsing for compatibility.
 
-use super::utils::read_file_or_none;
+use super::utils::{read_file_or_none, CamelUsage};
 use super::UnifiedMessage;
-use crate::TokenBreakdown;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
@@ -41,7 +40,7 @@ struct OpenClawEntry {
 #[derive(Debug, Deserialize)]
 struct OpenClawMessage {
     role: Option<String>,
-    usage: Option<OpenClawUsage>,
+    usage: Option<CamelUsage>,
     timestamp: Option<i64>,
     provider: Option<String>,
     model: Option<String>,
@@ -52,25 +51,6 @@ struct OpenClawModelData {
     provider: Option<String>,
     #[serde(rename = "modelId")]
     model_id: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct OpenClawUsage {
-    input: Option<i64>,
-    output: Option<i64>,
-    #[serde(rename = "cacheRead")]
-    cache_read: Option<i64>,
-    #[serde(rename = "cacheWrite")]
-    cache_write: Option<i64>,
-    #[serde(rename = "totalTokens")]
-    #[allow(dead_code)]
-    total_tokens: Option<i64>,
-    cost: Option<OpenClawCost>,
-}
-
-#[derive(Debug, Deserialize)]
-struct OpenClawCost {
-    total: Option<f64>,
 }
 
 pub fn parse_openclaw_index(index_path: &Path) -> Vec<UnifiedMessage> {
@@ -226,7 +206,7 @@ fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedM
                     current_model = Some(model.clone());
                     current_provider = Some(provider.clone());
                     let timestamp = msg.timestamp.unwrap_or(file_mtime_ms);
-                    let cost = usage.cost.and_then(|c| c.total).unwrap_or(0.0);
+                    let cost = usage.cost.as_ref().and_then(|c| c.total).unwrap_or(0.0);
 
                     messages.push(UnifiedMessage::new(
                         "openclaw",
@@ -234,13 +214,7 @@ fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedM
                         provider,
                         session_id.to_string(),
                         timestamp,
-                        TokenBreakdown {
-                            input: usage.input.unwrap_or(0).max(0),
-                            output: usage.output.unwrap_or(0).max(0),
-                            cache_read: usage.cache_read.unwrap_or(0).max(0),
-                            cache_write: usage.cache_write.unwrap_or(0).max(0),
-                            reasoning: 0,
-                        },
+                        usage.to_breakdown(),
                         cost.max(0.0),
                     ));
                 }

--- a/crates/tokscale-core/src/sessions/openclaw.rs
+++ b/crates/tokscale-core/src/sessions/openclaw.rs
@@ -3,11 +3,10 @@
 //! Parses OpenClaw transcript JSONL files from agent directories.
 //! Supports legacy sessions.json index parsing for compatibility.
 
-use super::utils::{read_file_or_none, CamelUsage};
+use super::utils::{for_each_json_line, read_file_or_none, CamelUsage};
 use super::UnifiedMessage;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Deserialize)]
@@ -115,11 +114,6 @@ fn resolve_session_path(index_dir: &Path, entry: &SessionEntry) -> PathBuf {
 }
 
 fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(session_path) {
-        Ok(f) => f,
-        Err(_) => return Vec::new(),
-    };
-
     // Get file modification time as fallback for missing timestamps
     let file_mtime_ms = std::fs::metadata(session_path)
         .and_then(|m| m.modified())
@@ -128,28 +122,17 @@ fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedM
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0);
 
-    let reader = BufReader::new(file);
     let mut messages = Vec::with_capacity(64);
     let mut current_model: Option<String> = None;
     let mut current_provider: Option<String> = None;
     let mut buffer = Vec::with_capacity(4096);
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
-
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
+    for_each_json_line(session_path, &mut |_index, trimmed| {
         buffer.clear();
         buffer.extend_from_slice(trimmed.as_bytes());
         let entry: OpenClawEntry = match simd_json::from_slice(&mut buffer) {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(_) => return,
         };
 
         match entry.entry_type.as_str() {
@@ -163,7 +146,7 @@ fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedM
             }
             "custom" => {
                 if entry.custom_type.as_deref() != Some("model-snapshot") {
-                    continue;
+                    return;
                 }
 
                 if let Some(data) = entry.data {
@@ -178,12 +161,12 @@ fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedM
             "message" => {
                 if let Some(msg) = entry.message {
                     if msg.role.as_deref() != Some("assistant") {
-                        continue;
+                        return;
                     }
 
                     let usage = match msg.usage {
                         Some(u) => u,
-                        None => continue,
+                        None => return,
                     };
 
                     let model = msg
@@ -200,7 +183,7 @@ fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedM
 
                     let model = match model {
                         Some(model) => model,
-                        None => continue,
+                        None => return,
                     };
 
                     current_model = Some(model.clone());
@@ -221,7 +204,7 @@ fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedM
             }
             _ => {}
         }
-    }
+    });
 
     messages
 }

--- a/crates/tokscale-core/src/sessions/opencode_schema.rs
+++ b/crates/tokscale-core/src/sessions/opencode_schema.rs
@@ -16,7 +16,7 @@
 //! generics would monomorphize per client and *grow* the binary, which is the
 //! opposite of the point.
 
-use super::utils::open_readonly_sqlite_opt;
+use super::utils::{open_readonly_sqlite_opt, sqlite_for_each_row_on};
 use super::{
     normalize_opencode_agent_name, normalize_workspace_key, workspace_label_from_key,
     UnifiedMessage,
@@ -797,31 +797,23 @@ impl SchemaAccumulator {
 /// generic callback would monomorphize this function once per client and grow
 /// the binary, which is what consolidating these parsers exists to avoid.
 fn collect_rows(
+    db_path: &Path,
     conn: &rusqlite::Connection,
     query: &str,
     on_row: &mut dyn FnMut(OpenCodeSchemaRow),
 ) -> bool {
-    let mut stmt = match conn.prepare(query) {
-        Ok(stmt) => stmt,
-        Err(_) => return false,
-    };
-
-    let rows = match stmt.query_map([], |row| {
+    // Quiet: these queries are schema probes — the caller tries each spelling
+    // in turn, so a query the database does not understand is expected.
+    let scan = sqlite_for_each_row_on(conn, db_path, query, None, &mut |row| {
         let id: String = row.get(0)?;
         let session_id: String = row.get(1)?;
         let data_json: String = row.get(2)?;
         let workspace_root: Option<String> = row.get(3)?;
         let session_title: Option<String> = row.get(4)?;
-        Ok((id, session_id, data_json, workspace_root, session_title))
-    }) {
-        Ok(rows) => rows,
-        Err(_) => return true,
-    };
-
-    for row in rows.flatten() {
-        on_row(row);
-    }
-    true
+        on_row((id, session_id, data_json, workspace_root, session_title));
+        Ok(())
+    });
+    scan.prepared()
 }
 
 /// Parse assistant turns out of a SQLite database that uses the OpenCode
@@ -846,7 +838,7 @@ pub(crate) fn parse_opencode_schema_sqlite(
     let mut acc = SchemaAccumulator::default();
     for group in cfg.query_groups {
         for query in *group {
-            if collect_rows(&conn, query, &mut |row| {
+            if collect_rows(db_path, &conn, query, &mut |row| {
                 acc.ingest(row, &cfg, &db_namespace)
             }) {
                 break;

--- a/crates/tokscale-core/src/sessions/opencodereview.rs
+++ b/crates/tokscale-core/src/sessions/opencodereview.rs
@@ -3,20 +3,16 @@
 //! OpenCodeReview stores sessions as JSONL files under
 //! `~/.opencodereview/sessions/<encoded-repo-path>/<session-id>.jsonl`.
 
-use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms, parse_timestamp_value};
+use super::utils::{
+    back_anchor_timestamp, file_modified_timestamp_ms, for_each_json_line, parse_timestamp_value,
+};
 use super::UnifiedMessage;
 use crate::{pricing, provider_identity, TokenBreakdown};
 use serde_json::Value;
 use std::collections::HashSet;
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 pub fn parse_opencodereview_file(path: &Path) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(path) {
-        Ok(f) => f,
-        Err(_) => return Vec::new(),
-    };
-
     let session_id = session_id_from_path(path);
     let fallback_timestamp = file_modified_timestamp_ms(path);
 
@@ -24,15 +20,13 @@ pub fn parse_opencodereview_file(path: &Path) -> Vec<UnifiedMessage> {
     let mut messages = Vec::new();
     let mut seen = HashSet::new();
 
-    for (line_index, line) in BufReader::new(file).lines().enumerate() {
-        let Ok(line) = line else { continue };
-
+    for_each_json_line(path, &mut |line_index, line| {
         if !line.contains("llm_response") && !line.contains("session_start") {
-            continue;
+            return;
         }
 
-        let Ok(value) = serde_json::from_str::<Value>(&line) else {
-            continue;
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            return;
         };
 
         let record_type = value.get("type").and_then(Value::as_str).unwrap_or("");
@@ -41,21 +35,21 @@ pub fn parse_opencodereview_file(path: &Path) -> Vec<UnifiedMessage> {
             if workspace.is_none() {
                 workspace = value.get("cwd").and_then(Value::as_str).map(str::to_string);
             }
-            continue;
+            return;
         }
 
         if record_type != "llm_response" {
-            continue;
+            return;
         }
 
         let usage = match value.get("usage") {
             Some(u) => u,
-            None => continue,
+            None => return,
         };
 
         let tokens = tokens_from_usage(usage);
         if tokens.total() == 0 {
-            continue;
+            return;
         }
 
         // `explicit_timestamp` is this record's own recorded `timestamp`
@@ -120,7 +114,7 @@ pub fn parse_opencodereview_file(path: &Path) -> Vec<UnifiedMessage> {
             tokens.input, tokens.output, tokens.cache_read, tokens.cache_write,
         );
         if !seen.insert(dedup_key.clone()) {
-            continue;
+            return;
         }
 
         let mut msg = UnifiedMessage::new(
@@ -143,7 +137,7 @@ pub fn parse_opencodereview_file(path: &Path) -> Vec<UnifiedMessage> {
         }
 
         messages.push(msg);
-    }
+    });
 
     messages
 }

--- a/crates/tokscale-core/src/sessions/qwen.rs
+++ b/crates/tokscale-core/src/sessions/qwen.rs
@@ -3,11 +3,10 @@
 //! Parses JSONL files from ~/.qwen/projects/{projectPath}/chats/*.jsonl
 //! Token data comes from assistant messages with usageMetadata field.
 
-use super::utils::{file_modified_timestamp_ms, parse_timestamp_str};
+use super::utils::{file_modified_timestamp_ms, for_each_json_line, parse_timestamp_str};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde::Deserialize;
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 /// Qwen CLI JSONL line structure
@@ -74,45 +73,29 @@ pub fn extract_session_id_with_fallback(path: &Path, json_session_id: Option<&st
 
 /// Parse a Qwen CLI JSONL file
 pub fn parse_qwen_file(path: &Path) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(path) {
-        Ok(f) => f,
-        Err(_) => return Vec::new(),
-    };
-
     let file_mtime = file_modified_timestamp_ms(path);
     let (workspace_key, workspace_label) = qwen_workspace_from_path(path);
 
-    let reader = BufReader::new(file);
     let mut messages: Vec<UnifiedMessage> = Vec::new();
     // Qwen JSONL lines carry no per-message id, so anchor the dedup key to the
     // stable position of the emitted message within its session.
     let mut message_index: usize = 0;
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
-
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
+    for_each_json_line(path, &mut |_index, trimmed| {
         let mut bytes = trimmed.as_bytes().to_vec();
         let qwen_line = match simd_json::from_slice::<QwenLine>(&mut bytes) {
             Ok(q) => q,
-            Err(_) => continue,
+            Err(_) => return,
         };
 
         // Only process assistant type messages with usageMetadata
         if qwen_line.msg_type.as_deref() != Some("assistant") {
-            continue;
+            return;
         }
 
         let usage = match qwen_line.usage_metadata {
             Some(u) => u,
-            None => continue,
+            None => return,
         };
 
         // Parse timestamp, fallback to file mtime
@@ -130,7 +113,7 @@ pub fn parse_qwen_file(path: &Path) -> Vec<UnifiedMessage> {
 
         // Skip entries with zero tokens
         if input + output + cache_read + reasoning == 0 {
-            continue;
+            return;
         }
 
         // Use model from line or fallback to "unknown"
@@ -161,7 +144,7 @@ pub fn parse_qwen_file(path: &Path) -> Vec<UnifiedMessage> {
         );
         unified.set_workspace(workspace_key.clone(), workspace_label.clone());
         messages.push(unified);
-    }
+    });
 
     messages
 }

--- a/crates/tokscale-core/src/sessions/synthetic.rs
+++ b/crates/tokscale-core/src/sessions/synthetic.rs
@@ -3,7 +3,7 @@
 //! Detects synthetic.new API usage across existing agent sessions by model/provider patterns,
 //! and parses Octofriend's SQLite database when token data is available.
 
-use super::utils::open_readonly_sqlite_opt;
+use super::utils::{open_readonly_sqlite_opt, sqlite_for_each_row_on};
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use std::path::Path;
@@ -134,11 +134,16 @@ pub fn parse_octofriend_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
     // SELECT id, session_id, data FROM messages WHERE role = 'assistant' AND tokens IS NOT NULL
     let mut messages = Vec::new();
 
+    // Quiet scans: Octofriend may have any one of these tables, so a missing
+    // one is the expected case rather than a fault worth logging.
+
     // Try 'messages' table first (most likely schema)
-    if let Ok(mut stmt) = conn.prepare(
+    sqlite_for_each_row_on(
+        &conn,
+        db_path,
         "SELECT id, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, cost, timestamp, session_id, provider FROM messages WHERE input_tokens IS NOT NULL OR output_tokens IS NOT NULL",
-    ) {
-        if let Ok(rows) = stmt.query_map([], |row| {
+        None,
+        &mut |row| {
             let id: String = row.get(0)?;
             let model_id: String = row.get::<_, String>(1).unwrap_or_default();
             let input: i64 = row.get::<_, i64>(2).unwrap_or(0);
@@ -151,15 +156,52 @@ pub fn parse_octofriend_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             let session_id: String = row.get::<_, String>(9).unwrap_or_else(|_| "unknown".to_string());
             let provider: String = row.get::<_, String>(10).unwrap_or_else(|_| "synthetic".to_string());
 
-            Ok((id, model_id, input, output, cache_read, cache_write, reasoning, cost, timestamp, session_id, provider))
-        }) {
-            for row_result in rows.flatten() {
-                let (id, model_id, input, output, cache_read, cache_write, reasoning, cost, timestamp, session_id, provider) = row_result;
+            let total = input + output + cache_read + cache_write + reasoning;
+            if total == 0 {
+                return Ok(());
+            }
 
-                let total = input + output + cache_read + cache_write + reasoning;
-                if total == 0 {
-                    continue;
-                }
+            let ts_ms = if timestamp > 1e12 {
+                timestamp as i64
+            } else {
+                (timestamp * 1000.0) as i64
+            };
+
+            let mut msg = UnifiedMessage::new(
+                "synthetic",
+                normalize_synthetic_model(&model_id),
+                provider,
+                session_id,
+                ts_ms,
+                TokenBreakdown {
+                    input: input.max(0),
+                    output: output.max(0),
+                    cache_read: cache_read.max(0),
+                    cache_write: cache_write.max(0),
+                    reasoning: reasoning.max(0),
+                },
+                cost.max(0.0),
+            );
+            msg.dedup_key = Some(id);
+            messages.push(msg);
+            Ok(())
+        },
+    );
+
+    // Try 'token_usage' table as alternative schema
+    if messages.is_empty() {
+        sqlite_for_each_row_on(
+            &conn,
+            db_path,
+            "SELECT id, model, input_tokens, output_tokens, timestamp, session_id FROM token_usage WHERE input_tokens > 0 OR output_tokens > 0",
+            None,
+            &mut |row| {
+                let id: String = row.get(0)?;
+                let model_id: String = row.get::<_, String>(1).unwrap_or_default();
+                let input: i64 = row.get::<_, i64>(2).unwrap_or(0);
+                let output: i64 = row.get::<_, i64>(3).unwrap_or(0);
+                let timestamp: f64 = row.get::<_, f64>(4).unwrap_or(0.0);
+                let session_id: String = row.get::<_, String>(5).unwrap_or_else(|_| "unknown".to_string());
 
                 let ts_ms = if timestamp > 1e12 {
                     timestamp as i64
@@ -170,68 +212,23 @@ pub fn parse_octofriend_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
                 let mut msg = UnifiedMessage::new(
                     "synthetic",
                     normalize_synthetic_model(&model_id),
-                    provider,
+                    "synthetic",
                     session_id,
                     ts_ms,
                     TokenBreakdown {
                         input: input.max(0),
                         output: output.max(0),
-                        cache_read: cache_read.max(0),
-                        cache_write: cache_write.max(0),
-                        reasoning: reasoning.max(0),
+                        cache_read: 0,
+                        cache_write: 0,
+                        reasoning: 0,
                     },
-                    cost.max(0.0),
+                    0.0,
                 );
                 msg.dedup_key = Some(id);
                 messages.push(msg);
-            }
-        }
-    }
-
-    // Try 'token_usage' table as alternative schema
-    if messages.is_empty() {
-        if let Ok(mut stmt) = conn.prepare(
-            "SELECT id, model, input_tokens, output_tokens, timestamp, session_id FROM token_usage WHERE input_tokens > 0 OR output_tokens > 0",
-        ) {
-            if let Ok(rows) = stmt.query_map([], |row| {
-                let id: String = row.get(0)?;
-                let model_id: String = row.get::<_, String>(1).unwrap_or_default();
-                let input: i64 = row.get::<_, i64>(2).unwrap_or(0);
-                let output: i64 = row.get::<_, i64>(3).unwrap_or(0);
-                let timestamp: f64 = row.get::<_, f64>(4).unwrap_or(0.0);
-                let session_id: String = row.get::<_, String>(5).unwrap_or_else(|_| "unknown".to_string());
-
-                Ok((id, model_id, input, output, timestamp, session_id))
-            }) {
-                for row_result in rows.flatten() {
-                    let (id, model_id, input, output, timestamp, session_id) = row_result;
-
-                    let ts_ms = if timestamp > 1e12 {
-                        timestamp as i64
-                    } else {
-                        (timestamp * 1000.0) as i64
-                    };
-
-                    let mut msg = UnifiedMessage::new(
-                        "synthetic",
-                        normalize_synthetic_model(&model_id),
-                        "synthetic",
-                        session_id,
-                        ts_ms,
-                        TokenBreakdown {
-                            input: input.max(0),
-                            output: output.max(0),
-                            cache_read: 0,
-                            cache_write: 0,
-                            reasoning: 0,
-                        },
-                        0.0,
-                    );
-                    msg.dedup_key = Some(id);
-                    messages.push(msg);
-                }
-            }
-        }
+                Ok(())
+            },
+        );
     }
 
     messages

--- a/crates/tokscale-core/src/sessions/tencent_buddy.rs
+++ b/crates/tokscale-core/src/sessions/tencent_buddy.rs
@@ -1,11 +1,11 @@
 //! Shared parsers for Tencent CodeBuddy / WorkBuddy session formats.
 
+use super::utils::for_each_json_line;
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::{provider_identity, TokenBreakdown};
 use chrono::TimeZone;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 const DEFAULT_PROVIDER: &str = "tencent";
@@ -187,11 +187,6 @@ pub(crate) fn parse_jsonl_file(
     default_model: &'static str,
     path: &Path,
 ) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(path) {
-        Ok(file) => file,
-        Err(_) => return Vec::new(),
-    };
-
     let fallback_session_id = path
         .file_stem()
         .and_then(|name| name.to_str())
@@ -201,26 +196,18 @@ pub(crate) fn parse_jsonl_file(
     let mut keyed_indices: HashMap<String, usize> = HashMap::new();
     let mut messages: Vec<UnifiedMessage> = Vec::new();
 
-    for line in BufReader::new(file).lines() {
-        let Ok(line) = line else {
-            continue;
-        };
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
+    for_each_json_line(path, &mut |_index, trimmed| {
         let mut bytes = trimmed.as_bytes().to_vec();
         let item = match simd_json::from_slice::<BuddyLine>(&mut bytes) {
             Ok(item) => item,
-            Err(_) => continue,
+            Err(_) => return,
         };
 
         let is_assistant_message = item.line_type.as_deref() == Some("message")
             && item.role.as_deref() == Some("assistant");
         let is_function_call = item.line_type.as_deref() == Some("function_call");
         if !is_assistant_message && !is_function_call {
-            continue;
+            return;
         }
 
         if item
@@ -228,7 +215,7 @@ pub(crate) fn parse_jsonl_file(
             .as_deref()
             .is_some_and(|status| status != "completed")
         {
-            continue;
+            return;
         }
 
         let usage = item
@@ -246,7 +233,7 @@ pub(crate) fn parse_jsonl_file(
                     .and_then(|provider| provider.raw_usage.as_ref())
             });
         let Some(tokens) = usage.and_then(BuddyUsage::to_breakdown) else {
-            continue;
+            return;
         };
 
         let provider_data = item.provider_data.as_ref();
@@ -296,13 +283,13 @@ pub(crate) fn parse_jsonl_file(
                 if message.tokens.total() >= messages[existing_index].tokens.total() {
                     messages[existing_index] = message;
                 }
-                continue;
+                return;
             }
             keyed_indices.insert(key, messages.len());
         }
 
         messages.push(message);
-    }
+    });
 
     messages
 }
@@ -312,11 +299,6 @@ pub(crate) fn parse_extension_log_file(
     default_model: &'static str,
     path: &Path,
 ) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(path) {
-        Ok(file) => file,
-        Err(_) => return Vec::new(),
-    };
-
     let fallback_timestamp = super::utils::file_modified_timestamp_ms(path);
     let fallback_session_id = path
         .file_stem()
@@ -326,44 +308,40 @@ pub(crate) fn parse_extension_log_file(
     let mut models_by_agent: HashMap<String, String> = HashMap::new();
     let mut messages = Vec::new();
 
-    for line in BufReader::new(file).lines() {
-        let Ok(line) = line else {
-            continue;
-        };
-
+    for_each_json_line(path, &mut |_index, line| {
         if line.contains("[CraftInvokableAgent]") && line.contains("Model prepared:") {
-            if let Some((agent_id, model_id)) = parse_model_prepared_line(&line) {
+            if let Some((agent_id, model_id)) = parse_model_prepared_line(line) {
                 models_by_agent.insert(agent_id, model_id);
             }
-            continue;
+            return;
         }
 
         if !line.contains("[AgentReporter]")
             || !line.contains("Agent execution successful with usage:")
         {
-            continue;
+            return;
         }
 
-        let Some(agent_id) = bracket_value_after(&line, "[AgentReporter]") else {
-            continue;
+        let Some(agent_id) = bracket_value_after(line, "[AgentReporter]") else {
+            return;
         };
         let Some(usage_json) = line.split("Agent execution successful with usage:").nth(1) else {
-            continue;
+            return;
         };
         let usage_json = usage_json.trim();
         let Some(json_end) = usage_json.rfind('}') else {
-            continue;
+            return;
         };
         let mut bytes = usage_json.as_bytes()[..=json_end].to_vec();
         let usage = match simd_json::from_slice::<BuddyUsage>(&mut bytes) {
             Ok(usage) => usage,
-            Err(_) => continue,
+            Err(_) => return,
         };
         let Some(tokens) = usage.to_breakdown() else {
-            continue;
+            return;
         };
 
-        let timestamp = parse_log_timestamp_ms(&line).unwrap_or(fallback_timestamp);
+        let timestamp = parse_log_timestamp_ms(line).unwrap_or(fallback_timestamp);
         let model_id = models_by_agent
             .get(&agent_id)
             .cloned()
@@ -406,7 +384,7 @@ pub(crate) fn parse_extension_log_file(
         }
 
         messages.push(message);
-    }
+    });
 
     messages
 }

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -543,18 +543,20 @@ pub(crate) fn resolved_provider(
 /// their own struct on purpose. Widening this one with aliases would make the
 /// clients above start counting fields they deliberately ignore today, and
 /// change reported totals.
+/// Public because `claudecode` re-exports it as its historical `ClaudeUsage`;
+/// `sessions::utils` itself is crate-private.
 #[derive(Debug, Deserialize)]
-pub(crate) struct AnthropicUsage {
-    pub(crate) input_tokens: Option<i64>,
-    pub(crate) output_tokens: Option<i64>,
-    pub(crate) cache_read_input_tokens: Option<i64>,
-    pub(crate) cache_creation_input_tokens: Option<i64>,
+pub struct AnthropicUsage {
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub cache_read_input_tokens: Option<i64>,
+    pub cache_creation_input_tokens: Option<i64>,
 }
 
 impl AnthropicUsage {
     /// Token breakdown with every field clamped at zero. This block carries no
     /// reasoning bucket, so `reasoning` is always 0.
-    pub(crate) fn to_breakdown(&self) -> TokenBreakdown {
+    pub fn to_breakdown(&self) -> TokenBreakdown {
         TokenBreakdown {
             input: self.input_tokens.unwrap_or(0).max(0),
             output: self.output_tokens.unwrap_or(0).max(0),

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -1,6 +1,8 @@
 //! Shared parsing helpers for session logs.
 
+use crate::TokenBreakdown;
 use rusqlite::{Connection, OpenFlags};
+use serde::Deserialize;
 use serde_json::Value;
 use std::io::BufRead;
 use std::path::Path;
@@ -473,6 +475,81 @@ pub(crate) fn resolved_provider(
             crate::provider_identity::inferred_provider_from_model(model_id).map(str::to_string)
         })
         .unwrap_or_else(|| fallback.to_string())
+}
+
+/// The Anthropic Messages API `usage` block in its snake_case wire spelling.
+///
+/// Shared by the clients that persist Anthropic responses verbatim
+/// (`claudecode`, `augment`), which declared byte-identical copies of it.
+///
+/// Clients whose payload adds fields on top of this shape — a
+/// `reasoning_output_tokens`, a `cached_input_tokens`, a `total_tokens` — keep
+/// their own struct on purpose. Widening this one with aliases would make the
+/// clients above start counting fields they deliberately ignore today, and
+/// change reported totals.
+#[derive(Debug, Deserialize)]
+pub(crate) struct AnthropicUsage {
+    pub(crate) input_tokens: Option<i64>,
+    pub(crate) output_tokens: Option<i64>,
+    pub(crate) cache_read_input_tokens: Option<i64>,
+    pub(crate) cache_creation_input_tokens: Option<i64>,
+}
+
+impl AnthropicUsage {
+    /// Token breakdown with every field clamped at zero. This block carries no
+    /// reasoning bucket, so `reasoning` is always 0.
+    pub(crate) fn to_breakdown(&self) -> TokenBreakdown {
+        TokenBreakdown {
+            input: self.input_tokens.unwrap_or(0).max(0),
+            output: self.output_tokens.unwrap_or(0).max(0),
+            cache_read: self.cache_read_input_tokens.unwrap_or(0).max(0),
+            cache_write: self.cache_creation_input_tokens.unwrap_or(0).max(0),
+            reasoning: 0,
+        }
+    }
+}
+
+/// The camelCase `{input, output, cacheRead, cacheWrite, totalTokens}` usage
+/// block with an authoritative `cost.total` in USD, as written by `gjc` and
+/// `openclaw`. They declared the same struct twice, one spelling the rename
+/// with `rename_all` and the other with per-field `rename`, so the JSON both
+/// accept is identical.
+///
+/// `pi.rs` models the same wire shape with its own `PiUsage` (a flattened
+/// extras map it needs and this type does not) and is left alone.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CamelUsage {
+    pub(crate) input: Option<i64>,
+    pub(crate) output: Option<i64>,
+    pub(crate) cache_read: Option<i64>,
+    pub(crate) cache_write: Option<i64>,
+    /// Reported but unused: the breakdown is summed from the fields above, so
+    /// a disagreeing total must not silently override them.
+    #[allow(dead_code)]
+    pub(crate) total_tokens: Option<i64>,
+    pub(crate) cost: Option<CamelCost>,
+}
+
+impl CamelUsage {
+    /// Token breakdown with every field clamped at zero. This block carries no
+    /// reasoning bucket, so `reasoning` is always 0.
+    pub(crate) fn to_breakdown(&self) -> TokenBreakdown {
+        TokenBreakdown {
+            input: self.input.unwrap_or(0).max(0),
+            output: self.output.unwrap_or(0).max(0),
+            cache_read: self.cache_read.unwrap_or(0).max(0),
+            cache_write: self.cache_write.unwrap_or(0).max(0),
+            reasoning: 0,
+        }
+    }
+}
+
+/// The `cost` sibling of [`CamelUsage`].
+#[derive(Debug, Deserialize)]
+pub(crate) struct CamelCost {
+    /// Authoritative total cost in USD.
+    pub(crate) total: Option<f64>,
 }
 
 #[cfg(test)]

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use std::io::BufRead;
 use std::path::Path;
 use std::time::SystemTime;
+use tracing::warn;
 
 /// Iterate a reader line by line without letting one undecodable byte discard
 /// the rest of the stream.
@@ -236,6 +237,153 @@ pub(crate) fn open_readonly_sqlite(path: &Path) -> rusqlite::Result<Connection> 
 /// Returns `None` if the file cannot be opened — the caller treats that as "no sessions".
 pub(crate) fn open_readonly_sqlite_opt(path: &Path) -> Option<Connection> {
     open_readonly_sqlite(path).ok()
+}
+
+/// Which stage of a [`sqlite_for_each_row`] scan the driver reached.
+///
+/// A bare `bool` is not enough: parsers that keep an older query around as a
+/// fallback need "this database does not have that schema" (`prepare` failed,
+/// so try the next query) to be distinguishable from "the query ran", while
+/// parsers that degrade to a coarser data source need "rows were actually
+/// iterated".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SqliteScan {
+    /// The statement prepared and its rows were iterated — possibly zero rows.
+    Ran,
+    /// The database could not be opened.
+    NotOpened,
+    /// `prepare` rejected the statement, normally a missing table or column.
+    NotPrepared,
+    /// The statement prepared but the query could not execute.
+    NotExecuted,
+}
+
+impl SqliteScan {
+    /// True only when rows were iterated.
+    pub(crate) fn ran(self) -> bool {
+        matches!(self, SqliteScan::Ran)
+    }
+
+    /// True unless `prepare` rejected the statement. Callers that fall back to
+    /// an older schema use this to stop at the first query the database
+    /// understands, even when executing it then failed — an execute failure
+    /// means the schema matched and something else went wrong, so retrying an
+    /// older query would silently read the wrong columns.
+    pub(crate) fn prepared(self) -> bool {
+        !matches!(self, SqliteScan::NotPrepared | SqliteScan::NotOpened)
+    }
+}
+
+/// Run `sql` on an already-open connection and hand every row to `sink`.
+///
+/// `what` labels the data being read (`"Goose session"`) in the warnings for
+/// prepare, execute and row-decode failures. `None` scans silently, which is
+/// what parsers probing an optional table want: a missing table there is the
+/// expected case, not a fault worth logging on every run.
+///
+/// A row that `sink` rejects is skipped and the scan continues, matching
+/// `query_map`'s behaviour where a per-row decode error does not end
+/// iteration. An error stepping the statement does end it, because SQLite
+/// closes the cursor at that point.
+///
+/// `sink` is `&mut dyn FnMut` and not a generic `impl FnMut` on purpose: a type
+/// parameter would monomorphize this driver once per calling parser and grow
+/// the binary, which is what sharing it exists to avoid.
+pub(crate) fn sqlite_for_each_row_on(
+    conn: &Connection,
+    db_path: &Path,
+    sql: &str,
+    what: Option<&str>,
+    sink: &mut dyn FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<()>,
+) -> SqliteScan {
+    let mut stmt = match conn.prepare(sql) {
+        Ok(stmt) => stmt,
+        Err(err) => {
+            if let Some(what) = what {
+                warn!(
+                    db_path = %db_path.display(),
+                    what,
+                    error = %err,
+                    "Failed to prepare session query"
+                );
+            }
+            return SqliteScan::NotPrepared;
+        }
+    };
+
+    let mut rows = match stmt.query([]) {
+        Ok(rows) => rows,
+        Err(err) => {
+            if let Some(what) = what {
+                warn!(
+                    db_path = %db_path.display(),
+                    what,
+                    error = %err,
+                    "Failed to execute session query"
+                );
+            }
+            return SqliteScan::NotExecuted;
+        }
+    };
+
+    loop {
+        match rows.next() {
+            Ok(Some(row)) => {
+                if let Err(err) = sink(row) {
+                    if let Some(what) = what {
+                        warn!(
+                            db_path = %db_path.display(),
+                            what,
+                            error = %err,
+                            "Failed to decode session row"
+                        );
+                    }
+                }
+            }
+            Ok(None) => break,
+            Err(err) => {
+                if let Some(what) = what {
+                    warn!(
+                        db_path = %db_path.display(),
+                        what,
+                        error = %err,
+                        "Failed to decode session row"
+                    );
+                }
+                break;
+            }
+        }
+    }
+
+    SqliteScan::Ran
+}
+
+/// Open `db_path` read-only, run `sql`, and hand every row to `sink`.
+///
+/// The connection-owning half of [`sqlite_for_each_row_on`], for the common
+/// case of one query per database. Parsers that run several queries against
+/// one database should open once and call [`sqlite_for_each_row_on`].
+pub(crate) fn sqlite_for_each_row(
+    db_path: &Path,
+    sql: &str,
+    what: Option<&str>,
+    sink: &mut dyn FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<()>,
+) -> SqliteScan {
+    let conn = match open_readonly_sqlite(db_path) {
+        Ok(conn) => conn,
+        Err(err) => {
+            if let Some(what) = what {
+                warn!(
+                    db_path = %db_path.display(),
+                    what,
+                    error = %err,
+                    "Failed to open session database"
+                );
+            }
+            return SqliteScan::NotOpened;
+        }
+    };
+    sqlite_for_each_row_on(&conn, db_path, sql, what, sink)
 }
 
 /// Read a file into bytes, returning `None` on any I/O error instead of propagating.

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -54,11 +54,15 @@ pub(crate) struct LossyLines<R> {
     at_start: bool,
 }
 
-fn read_lossy_line<R: BufRead>(
+/// Read one line into `buf`, stripping the line terminator and a leading BOM.
+///
+/// Returns the offset in `buf` at which the line's payload starts, so callers
+/// can borrow it without allocating, or `None` at end of input.
+fn read_line_payload<R: BufRead>(
     reader: &mut R,
     buf: &mut Vec<u8>,
     at_start: &mut bool,
-) -> Option<String> {
+) -> Option<usize> {
     buf.clear();
     match reader.read_until(b'\n', buf) {
         Ok(0) => None,
@@ -70,13 +74,65 @@ fn read_lossy_line<R: BufRead>(
                 }
             }
 
-            let mut bytes = buf.as_slice();
-            if std::mem::take(at_start) {
-                bytes = bytes.strip_prefix("\u{feff}".as_bytes()).unwrap_or(bytes);
+            let bom = "\u{feff}".as_bytes();
+            if std::mem::take(at_start) && buf.starts_with(bom) {
+                Some(bom.len())
+            } else {
+                Some(0)
             }
-            Some(String::from_utf8_lossy(bytes).into_owned())
         }
+        // A hard I/O error (vanished mount, EIO) does not consume input, so
+        // retrying would spin on the same failing read forever. Stop instead.
         Err(_) => None,
+    }
+}
+
+fn read_lossy_line<R: BufRead>(
+    reader: &mut R,
+    buf: &mut Vec<u8>,
+    at_start: &mut bool,
+) -> Option<String> {
+    let start = read_line_payload(reader, buf, at_start)?;
+    Some(String::from_utf8_lossy(&buf[start..]).into_owned())
+}
+
+/// Read `path` as line-delimited JSON, handing every non-blank, trimmed line to
+/// `sink` together with its zero-based physical line index.
+///
+/// A missing or unreadable file yields nothing, which is what every JSONL
+/// parser already did by hand.
+///
+/// This also fixes a silent-truncation bug wherever it replaces
+/// `BufReader::lines()`. That iterator ends on the first line that is not valid
+/// UTF-8, so a single stray byte discarded the entire rest of a transcript —
+/// #1031 measured ~2% of an 83 MB Grok `updates.jsonl` surviving. Decoding
+/// lossily per line keeps the damage to the line carrying the bad byte, and
+/// the index stays aligned with the physical file so callers that report line
+/// positions still agree with it.
+///
+/// The line is borrowed out of a reused buffer rather than allocated per line,
+/// so callers that need an owned value must clone it themselves.
+///
+/// `sink` is `&mut dyn FnMut` and not a generic `impl FnMut` on purpose: a type
+/// parameter would monomorphize this driver once per calling parser and grow
+/// the binary, which is what sharing it exists to avoid.
+pub(crate) fn for_each_json_line(path: &Path, sink: &mut dyn FnMut(usize, &str)) {
+    let Ok(file) = std::fs::File::open(path) else {
+        return;
+    };
+
+    let mut reader = std::io::BufReader::new(file);
+    let mut buf = Vec::new();
+    let mut at_start = true;
+    let mut index = 0usize;
+
+    while let Some(start) = read_line_payload(&mut reader, &mut buf, &mut at_start) {
+        let text = String::from_utf8_lossy(&buf[start..]);
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            sink(index, trimmed);
+        }
+        index += 1;
     }
 }
 

--- a/crates/tokscale-core/src/sessions/workbuddy.rs
+++ b/crates/tokscale-core/src/sessions/workbuddy.rs
@@ -4,11 +4,10 @@
 //! Older installs also expose an aggregate `~/.workbuddy/workbuddy.db`; that
 //! database is kept as a fallback when detailed token sources are unavailable.
 
-use super::utils::open_readonly_sqlite;
+use super::utils::sqlite_for_each_row;
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::{provider_identity, TokenBreakdown};
 use std::path::Path;
-use tracing::warn;
 
 const DEFAULT_MODEL: &str = "workbuddy";
 
@@ -42,20 +41,7 @@ struct WorkBuddyUsageRow {
 }
 
 pub fn parse_workbuddy_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match open_readonly_sqlite(db_path) {
-        Ok(conn) => conn,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to open WorkBuddy database"
-            );
-            return Vec::new();
-        }
-    };
-
-    let mut stmt = match conn.prepare(
-        r#"
+    let query = r#"
         SELECT
             su.session_id,
             su.used,
@@ -68,51 +54,21 @@ pub fn parse_workbuddy_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
           AND su.used > 0
           AND su.updated_at IS NOT NULL
           AND su.updated_at > 0
-        "#,
-    ) {
-        Ok(stmt) => stmt,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to prepare WorkBuddy usage query"
-            );
-            return Vec::new();
-        }
-    };
+        "#;
 
-    let rows = match stmt.query_map([], |row| {
-        Ok(WorkBuddyUsageRow {
+    let mut messages = Vec::new();
+    sqlite_for_each_row(db_path, query, Some("WorkBuddy usage"), &mut |row| {
+        messages.push(usage_row_to_message(WorkBuddyUsageRow {
             session_id: row.get(0)?,
             used: row.get::<_, Option<i64>>(1)?.unwrap_or(0),
             updated_at: row.get::<_, Option<i64>>(2)?.unwrap_or(0),
             model: row.get(3)?,
             cwd: row.get(4)?,
-        })
-    }) {
-        Ok(rows) => rows,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to execute WorkBuddy usage query"
-            );
-            return Vec::new();
-        }
-    };
+        }));
+        Ok(())
+    });
 
-    rows.filter_map(|row| match row {
-        Ok(row) => Some(usage_row_to_message(row)),
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to decode WorkBuddy usage row"
-            );
-            None
-        }
-    })
-    .collect()
+    messages
 }
 
 fn usage_row_to_message(row: WorkBuddyUsageRow) -> UnifiedMessage {

--- a/crates/tokscale-core/src/sessions/zcode.rs
+++ b/crates/tokscale-core/src/sessions/zcode.rs
@@ -14,14 +14,14 @@
 //! consistent with tokscale's other estimated sources (see CommandCode, Kiro).
 
 use super::utils::{
-    back_anchor_timestamp, estimate_tokens, file_modified_timestamp_ms, open_readonly_sqlite_opt,
-    session_id_from_path, sqlite_for_each_row_on, workspace_key_from_path,
+    back_anchor_timestamp, estimate_tokens, file_modified_timestamp_ms, for_each_json_line,
+    open_readonly_sqlite_opt, session_id_from_path, sqlite_for_each_row_on,
+    workspace_key_from_path,
 };
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 const CLIENT_ID: &str = "zcode";
@@ -104,11 +104,6 @@ impl ZcodeUsage {
 }
 
 pub fn parse_zcode_file(path: &Path) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(path) {
-        Ok(file) => file,
-        Err(_) => return Vec::new(),
-    };
-
     let fallback_timestamp = file_modified_timestamp_ms(path);
     let session_id_from_path = session_id_from_path(path);
     let workspace_key = workspace_key_from_path(path);
@@ -122,20 +117,10 @@ pub fn parse_zcode_file(path: &Path) -> Vec<UnifiedMessage> {
     let mut pending_turn_start = false;
     let mut assistant_index = 0usize;
 
-    let reader = BufReader::new(file);
-    for line in reader.lines() {
-        let line = match line {
-            Ok(line) => line,
-            Err(_) => continue,
-        };
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
+    for_each_json_line(path, &mut |_index, trimmed| {
         let entry = match serde_json::from_str::<ZcodeEntry>(trimmed) {
             Ok(entry) => entry,
-            Err(_) => continue,
+            Err(_) => return,
         };
 
         if session_id.is_none() {
@@ -177,7 +162,7 @@ pub fn parse_zcode_file(path: &Path) -> Vec<UnifiedMessage> {
                         // emitted, so the next real assistant message in this
                         // turn must keep its is_turn_start marker.
                         context_chars += chars;
-                        continue;
+                        return;
                     }
                     TokenBreakdown {
                         input,
@@ -224,7 +209,7 @@ pub fn parse_zcode_file(path: &Path) -> Vec<UnifiedMessage> {
                 context_chars += chars;
             }
         }
-    }
+    });
 
     messages
 }

--- a/crates/tokscale-core/src/sessions/zcode.rs
+++ b/crates/tokscale-core/src/sessions/zcode.rs
@@ -15,7 +15,7 @@
 
 use super::utils::{
     back_anchor_timestamp, estimate_tokens, file_modified_timestamp_ms, open_readonly_sqlite_opt,
-    session_id_from_path, workspace_key_from_path,
+    session_id_from_path, sqlite_for_each_row_on, workspace_key_from_path,
 };
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
@@ -364,38 +364,38 @@ pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         .prepare("SELECT computed_total_tokens FROM model_usage LIMIT 1")
         .is_err();
 
-    let mut stmt = match conn.prepare(modern_query) {
-        Ok(stmt) => stmt,
-        Err(_) => match conn.prepare(legacy_query) {
-            Ok(stmt) => stmt,
-            Err(_) => return Vec::new(),
-        },
-    };
-
-    let rows = match stmt.query_map([], |row| {
-        Ok(ZcodeUsageRow {
-            id: row.get(0)?,
-            session_id: row.get(1)?,
-            turn_id: row.get(2)?,
-            model_id: row.get(3)?,
-            started_at: row.get(4)?,
-            completed_at: row.get(5)?,
-            duration_ms: row.get(6)?,
-            input_tokens: row.get(7)?,
-            output_tokens: row.get(8)?,
-            reasoning_tokens: row.get(9)?,
-            cache_read_input_tokens: row.get(10)?,
-            cache_creation_input_tokens: row.get(11)?,
-            computed_total_tokens: row.get(12)?,
-            agent: row.get(13)?,
-            mode: row.get(14)?,
-            session_directory: row.get(15)?,
-            session_path: row.get(16)?,
-        })
-    }) {
-        Ok(rows) => rows,
-        Err(_) => return Vec::new(),
-    };
+    // Quiet: a database that understands neither query is not a ZCode usage
+    // store, which is an expected outcome of probing candidate paths.
+    let mut rows: Vec<ZcodeUsageRow> = Vec::new();
+    for query in [modern_query, legacy_query] {
+        let scan = sqlite_for_each_row_on(&conn, db_path, query, None, &mut |row| {
+            rows.push(ZcodeUsageRow {
+                id: row.get(0)?,
+                session_id: row.get(1)?,
+                turn_id: row.get(2)?,
+                model_id: row.get(3)?,
+                started_at: row.get(4)?,
+                completed_at: row.get(5)?,
+                duration_ms: row.get(6)?,
+                input_tokens: row.get(7)?,
+                output_tokens: row.get(8)?,
+                reasoning_tokens: row.get(9)?,
+                cache_read_input_tokens: row.get(10)?,
+                cache_creation_input_tokens: row.get(11)?,
+                computed_total_tokens: row.get(12)?,
+                agent: row.get(13)?,
+                mode: row.get(14)?,
+                session_directory: row.get(15)?,
+                session_path: row.get(16)?,
+            });
+            Ok(())
+        });
+        // A query that prepared is the one this schema supports; only a
+        // prepare failure means "try the older spelling".
+        if scan.prepared() {
+            break;
+        }
+    }
 
     let mut messages = Vec::new();
     // Parallel to `messages`: each row's turn_id (if any), so is_turn_start
@@ -403,12 +403,7 @@ pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
     // timestamp is known (see below).
     let mut turn_ids: Vec<Option<String>> = Vec::new();
 
-    for row_result in rows {
-        let row = match row_result {
-            Ok(row) => row,
-            Err(_) => continue,
-        };
-
+    for row in rows {
         let session_id = row.session_id.unwrap_or_else(|| "unknown".to_string());
         let model_id = row
             .model_id

--- a/crates/tokscale-core/src/sessions/zed.rs
+++ b/crates/tokscale-core/src/sessions/zed.rs
@@ -9,7 +9,7 @@
 //! ACP agents are billed and logged by their own providers/CLIs, and counting
 //! their Zed UI rows would duplicate those sources.
 
-use super::utils::{open_readonly_sqlite, parse_timestamp_str};
+use super::utils::{open_readonly_sqlite, parse_timestamp_str, sqlite_for_each_row_on};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use rusqlite::Connection;
@@ -46,21 +46,10 @@ pub fn parse_zed_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         }
     };
 
-    let query = build_threads_query(&conn);
-    let mut stmt = match conn.prepare(&query) {
-        Ok(stmt) => stmt,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to prepare Zed thread query"
-            );
-            return Vec::new();
-        }
-    };
-
-    let rows = match stmt.query_map([], |row| {
-        Ok(ZedThreadRow {
+    let query = build_threads_query(db_path, &conn);
+    let mut messages = Vec::new();
+    sqlite_for_each_row_on(&conn, db_path, &query, Some("Zed thread"), &mut |row| {
+        let thread = ZedThreadRow {
             id: row.get(0)?,
             updated_at: row.get(1)?,
             created_at: row.get(2)?,
@@ -68,35 +57,18 @@ pub fn parse_zed_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             folder_paths_order: row.get(4)?,
             data_type: row.get(5)?,
             data: row.get(6)?,
-        })
-    }) {
-        Ok(rows) => rows,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to execute Zed thread query"
-            );
-            return Vec::new();
+        };
+        if let Some(message) = parse_thread_row(db_path, thread) {
+            messages.push(message);
         }
-    };
+        Ok(())
+    });
 
-    rows.filter_map(|row| match row {
-        Ok(row) => parse_thread_row(db_path, row),
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to decode Zed thread row"
-            );
-            None
-        }
-    })
-    .collect()
+    messages
 }
 
-fn build_threads_query(conn: &Connection) -> String {
-    let columns = thread_columns(conn);
+fn build_threads_query(db_path: &Path, conn: &Connection) -> String {
+    let columns = thread_columns(db_path, conn);
     let created_at = optional_column(&columns, "created_at");
     let folder_paths = optional_column(&columns, "folder_paths");
     let folder_paths_order = optional_column(&columns, "folder_paths_order");
@@ -114,18 +86,21 @@ fn optional_column(columns: &HashSet<String>, column: &'static str) -> &'static 
     }
 }
 
-fn thread_columns(conn: &Connection) -> HashSet<String> {
-    let mut stmt = match conn.prepare("PRAGMA table_info(threads)") {
-        Ok(stmt) => stmt,
-        Err(_) => return HashSet::new(),
-    };
-
-    let rows = match stmt.query_map([], |row| row.get::<_, String>(1)) {
-        Ok(rows) => rows,
-        Err(_) => return HashSet::new(),
-    };
-
-    rows.filter_map(Result::ok).collect()
+fn thread_columns(db_path: &Path, conn: &Connection) -> HashSet<String> {
+    let mut columns = HashSet::new();
+    // Quiet: a database without a `threads` table is simply not a Zed thread
+    // store, which the caller already handles by querying NULL columns.
+    sqlite_for_each_row_on(
+        conn,
+        db_path,
+        "PRAGMA table_info(threads)",
+        None,
+        &mut |row| {
+            columns.insert(row.get::<_, String>(1)?);
+            Ok(())
+        },
+    );
+    columns
 }
 
 fn parse_thread_row(db_path: &Path, row: ZedThreadRow) -> Option<UnifiedMessage> {


### PR DESCRIPTION
Stacked on #1133 — this targets `refactor/opencode-schema-parsers`, so GitHub will retarget it to `main` once that merges. Review the four commits here on their own; the base branch's two commits belong to #1133.

This is a maintainability refactor. The size win is small and that was accepted going in: the whole 50-parser layer is 824 KiB of a 12.7 MiB `.text`, so there is no large lever here. The point is a smaller surface for the next parser to copy-paste from.

## Per-commit byte deltas

Measured with `cargo build --release -p tokscale-cli` in an isolated `CARGO_TARGET_DIR`, one build per commit. The base (#1133 tip) reproduces at 17,028,240 bytes.

| commit | binary | delta |
|---|---|---|
| base (#1133 tip, `765a46c4`) | 17,028,240 | — |
| `refactor(core): share one SQLite row driver...` | 16,995,088 | **-33,152** |
| `refactor(core): share the duplicated usage structs...` | 16,995,072 | **-16** |
| `fix(droid)` + `refactor(core): share one JSONL line driver...` | 16,962,096 | **-32,976** |
| **total** | **16,962,096** | **-66,144** (-0.39%) |

Source: 1,129 lines removed, 842 added across 24 parser files, net **-287 lines** with the two new shared drivers included.

## One SQLite row driver

`utils::sqlite_for_each_row` / `sqlite_for_each_row_on` own open, prepare, execute and per-row-decode failure for every SQLite-backed parser. Each parser keeps only its SQL string and its row-decode closure.

The callback is `&mut dyn FnMut(&Row) -> rusqlite::Result<()>`, not a generic `impl FnMut`: a type parameter would monomorphize the driver once per calling parser and grow the binary, which is the thing this exists to avoid.

The return type is `SqliteScan`, not `bool`, because two callers depend on the distinction. Hermes falls back to coarser session totals only when the per-model query did not run at all, and the OpenCode-schema and ZCode parsers retry an older query only when `prepare` rejected the newer one, never when it prepared and then failed to execute. Parsers that probe optional tables pass `None` for the log label and stay silent, so a missing table is still not reported as a fault.

This collapses the 27 `tracing` callsites in `sessions/` to 11, of which 5 are the driver itself. The remaining 6 are semantic, not boilerplate: Zed payload decode, the Hermes `session_model_usage` probe, Copilot Desktop timestamp parsing.

## Shared usage structs

Six `Deserialize` structs modelled three shapes: `ClaudeUsage` ≡ `AugmentTokenUsage`, `GjcUsage` ≡ `OpenClawUsage`, `GjcCost` ≡ `OpenClawCost`. They become `utils::AnthropicUsage`, `utils::CamelUsage` and `utils::CamelCost`.

Only exact duplicates are merged. The wider relatives of the Anthropic shape (`codex`, `jcode`, `amp`, `droid`, `devin`, `cline`) keep their own structs, and so does `pi::PiUsage`. Folding them in would require `#[serde(alias = ...)]`, and an alias makes a parser start counting a field it deliberately ignores today, which changes reported totals.

Verified zero-widening mechanically: after resolving `rename_all`, per-field `rename` and `alias`, the set of accepted JSON keys of each shared struct is identical to both structs it replaces, so no document can parse differently. An exhaustive pass over all 109 production `Deserialize` structs in `sessions/` found these three pairs and no others, so this is the whole safe surface for the idea.

This one is worth **-16 bytes**. LTO had already inlined those derives into their callers. Reporting it rather than padding it.

## One JSONL line driver, with `claudecode.rs` deliberately excluded

`utils::for_each_json_line` replaces the open/`BufReader`/unwrap/trim/skip-blank prologue in 15 files (16 call sites), handing the sink a trimmed line plus its physical line index. The line is borrowed out of one reused buffer instead of allocated per line, so the driver does strictly less work than `BufReader::lines()`.

**`claudecode.rs` is not migrated, on measurement.** It is the hottest parse path in the product. On a frozen 1.3 GB corpus of real Claude Code transcripts, with the message cache dropped before every run and run order alternated:

| variant | paired median vs base | pairs slower | Wilcoxon p |
|---|---|---|---|
| driver applied to `claudecode.rs` | **+4.5%** (+60 ms) | 29 / 30 | < 0.0001 |
| `claudecode.rs` on `utils::lossy_lines`, no closure | **+6.8%** (+90 ms) | 20 / 20 | 0.0001 |
| `claudecode.rs` left alone (**what this PR ships**) | -0.9% (-12 ms) | 6 / 16 | 0.56 |

The cost is the per-line lossy decode plus the closure boundary; neither alone explains it, and reverting the closure while keeping `lossy_lines` was worse, not better. For a migrated parser with real data, OpenClaw over 138 MB of transcripts measures +1.6% median with p = 0.42 — indistinguishable from noise.

### Correction to the premise behind this item

The audit that motivated this expected a correctness win: 17 JSONL parsers still on raw `BufReader::lines()`, each carrying the #1031 bug where one undecodable byte silently truncated ~98% of an 83 MB Grok log. That is not what those parsers do. #1031 came from `map_while(Result::ok)`, which turns a decode error into end-of-iteration. Every parser here spelled it `Err(_) => continue`, which drops only the offending line and keeps reading — `read_line` consumes the bytes before it validates them, so the iterator resumes on the next line.

Verified directly, on a transcript whose middle record carries a raw `0xFF` byte: before this change tokscale reports the two clean records (500 input tokens, 2 messages); after it reports all three (700 input tokens, 3 messages). So the driver recovers that one line and strips a leading BOM. It does not rescue the rest of a file, because the rest of the file was never lost.

The one genuine instance of the #1031 spelling was `droid.rs`, which wrote `line.ok()?` and therefore abandoned model extraction for the whole file at the first bad byte, leaving the session on a `<provider>-unknown` model id. That is fixed in its own commit.

## Gates

- `cargo test --release -p tokscale-core -p tokscale-cli` — **3,099 passed, 0 failed**, tests unmodified.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

Behaviour was additionally checked end to end by replaying the report over a frozen copy of real local session data before and after: **590 sessions and 29 client/provider/model groups identical** on input, output, cacheRead, cacheWrite, reasoning, messageCount and cost. The `prime-agent` client is excluded from that comparison because it is live on this machine and grows between runs; a reversed-order replay showed zero differences at all.

## Not done

`sessions/pi.rs` and `sessions/prime_agent.rs` are untouched — #1134 is in flight against both. `pi.rs` therefore keeps its own `PiUsage` rather than joining `CamelUsage`, and neither file was moved onto either driver.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shares SQLite, JSONL, and usage-struct drivers across session parsers to reduce boilerplate and binary size while preserving reported metrics and the historical `claudecode::*` public API. Per-parser loops are replaced with shared helpers; behavior is unchanged except `droid` no longer aborts on a bad byte and JSONL readers strip a BOM.

- SQLite: replace per-parser prepare/execute loops with `sessions::utils::sqlite_for_each_row` and `sqlite_for_each_row_on`. Callbacks use `&mut dyn FnMut` to avoid monomorphization. Return `SqliteScan` so Hermes and OpenCode/ZCode can distinguish prepare vs execute failures. Optional table probes pass `None` to stay quiet.
- JSONL: adopt `sessions::utils::for_each_json_line` to reuse a buffer, strip BOM, and keep reading past undecodable bytes. Do not migrate `claudecode.rs` (measured regression on hot path). Fix `droid.rs` to iterate lossy lines so one bad byte no longer aborts model extraction.
- Usage structs: deduplicate identical shapes into `sessions::utils::AnthropicUsage`, `CamelUsage`, and `CamelCost` with no key widening. Re-export `sessions::utils::AnthropicUsage` as `claudecode::ClaudeUsage`; keep `ClaudeEntry`/`ClaudeMessage` public to preserve the crate’s API.
- Gates: tests unchanged and passing; end-to-end session counts, token totals, and costs match. Release binary: -66,144 bytes (-0.39%).

<sup>Written for commit a750bd25942f6eba21230c3e6f4058537c901aaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

