### PR TITLE
test(claude): pin that the provenance rebuild clears a stale char estimate

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -7947,6 +7947,123 @@ mod tests {
     /// stale too. Every existing user upgrades with a populated cache, so the
     /// first warm scan after the upgrade has to rebuild that provenance.
     ///
+    /// #1011: a pre-#1037 cache entry carries a `ceil(chars/4)` estimate that
+    /// the API-reported `input_tokens` of the next turn already counted. The
+    /// parser stopped minting those in #1037, but that alone does not clean an
+    /// entry already on disk — the reporter measured an upgrade changing
+    /// nothing, and asked for a migration.
+    ///
+    /// No migration is needed, and this pins why. Every such entry predates
+    /// retention provenance (#1037 merged 2026-08-06, #1085 on 2026-08-11), so
+    /// it is markerless, and `needs_retention_provenance_migration` already
+    /// routes markerless Claude entries through a full re-parse. The estimate
+    /// is re-derived away as a side effect of a mechanism built for something
+    /// else.
+    ///
+    /// The fixture is arranged so a fix that merely *kept* the cached rows
+    /// would fail: the seeded estimate is a row the current parser cannot
+    /// produce, so if the warm scan still reports it, the entry was served
+    /// rather than rebuilt.
+    #[test]
+    #[serial_test::serial]
+    fn test_claude_legacy_char_estimate_is_dropped_by_the_provenance_rebuild() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _env = redirect_cache_home(cache_home.path());
+
+        let claude_dir = client_scan_root(source_home.path(), ClientId::Claude).join("myproject");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let transcript = claude_dir.join("estimate-session.jsonl");
+
+        // One assistant turn, and a tool_result with content but no token
+        // metadata — the shape Claude Code always writes, which is what made
+        // the old fallback fire on every one of them.
+        let assistant = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}"#;
+        let tool_result = r#"{"type":"user","timestamp":"2024-12-01T10:00:05.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_001","content":"0123456789012345678901234567890123456789"}]}}"#;
+        std::fs::write(&transcript, format!("{assistant}\n{tool_result}\n")).unwrap();
+
+        let scan = || {
+            parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+                false,
+                &scanner::ScannerSettings::default(),
+            )
+        };
+        let total_input =
+            |messages: &[UnifiedMessage]| messages.iter().map(|m| m.tokens.input).sum::<i64>();
+
+        let clean = scan();
+        assert_eq!(
+            total_input(&clean),
+            100,
+            "current parser must report only the API number"
+        );
+
+        // Rewrite the entry the way a pre-#1037 release left it: the estimate
+        // as its own path-scoped row, and no provenance marker.
+        // Exactly what `estimate_tokens_from_chars` would have produced for the
+        // 40-character tool_result above.
+        let estimate = 40_usize.div_ceil(4) as i64;
+        {
+            let mut cache = message_cache::SourceMessageCache::load();
+            let mut entries: Vec<message_cache::CachedSourceEntry> = cache
+                .all_entries()
+                .into_iter()
+                .filter(message_cache::CachedSourceEntry::is_claude_namespace)
+                .collect();
+            assert_eq!(entries.len(), 1, "the transcript must be cached");
+            let entry = &mut entries[0];
+            entry.messages.push(UnifiedMessage::new_with_dedup(
+                "claude",
+                "claude-3-5-sonnet",
+                "anthropic",
+                "estimate-session",
+                1_733_047_205_000,
+                TokenBreakdown {
+                    input: estimate,
+                    output: 0,
+                    cache_read: 0,
+                    cache_write: 0,
+                    reasoning: 0,
+                },
+                0.0,
+                Some("claude:tool_result:estimate-session:tool_result:toolu_001".to_string()),
+            ));
+            entry.fallback_timestamp_indices.clear();
+            cache.insert(entries.pop().unwrap());
+            cache.save_if_dirty();
+        }
+
+        let poisoned = message_cache::SourceMessageCache::load()
+            .all_entries()
+            .into_iter()
+            .filter(message_cache::CachedSourceEntry::is_claude_namespace)
+            .flat_map(|entry| entry.messages)
+            .map(|message| message.tokens.input)
+            .sum::<i64>();
+        assert_eq!(
+            poisoned,
+            100 + estimate,
+            "the seeded cache must actually be inflated, or this test proves nothing"
+        );
+
+        let warm = scan();
+        assert_eq!(
+            total_input(&warm),
+            100,
+            "a markerless entry must be rebuilt, dropping the stale char estimate"
+        );
+        assert!(
+            !warm.iter().any(|m| m
+                .dedup_key
+                .as_deref()
+                .is_some_and(|k| k.contains(":tool_result:"))),
+            "the phantom tool_result row must not survive the rebuild"
+        );
+    }
+
     /// The strongest statement of "not stale" is that the warm scan agrees
     /// with a cold scan of the same bytes, cost included.
     #[test]


### PR DESCRIPTION
Resolves the local half of #1011 — by showing it is already fixed, and that the remedy is a release rather than a migration.

## What I was about to build, and why I didn't

#1011 asked for a cache migration. #1037 stopped the parser minting a `ceil(chars/4)` estimate on `tool_result` blocks, but entries already on disk kept it; the reporter measured an upgrade changing nothing (23,132,812 before and after, against a true 2,827,429) and I said I'd prioritise a migration.

An adversarial review pointed out the migration would be redundant, and it's right. Every affected entry predates retention provenance:

| | merged |
|---|---|
| #1037 char-estimate fix | 2026-08-06 19:30 UTC |
| #1085 retention provenance | 2026-08-11 05:43 UTC |

So every entry carrying an estimate is markerless, and `needs_retention_provenance_migration` (`message_cache.rs:1307`) already routes markerless Claude entries through a full re-parse (`lib.rs:983`). The estimate is re-derived away as a side effect of a mechanism built for a different problem.

## But it has never shipped

`git tag --contains` the provenance commit returns nothing. Latest tag is **v4.13.0, cut 2026-08-10 — one day before #1085 merged**, and `main` is 32 commits ahead.

That is exactly why the reporter's measurement holds and will keep holding: v4.11.0 had the parser fix but not the cleaner, so upgrading into it changed nothing. **The remedy is a release.**

## This PR

A regression test pinning the behavior, so a later change to the rebuild cannot silently reintroduce the inflation.

It is arranged to be non-vacuous. The fixture seeds a row the current parser cannot produce — a path-scoped `:tool_result:` message carrying exactly the estimate a 40-character tool_result would have generated — and asserts the seeded cache really is inflated *before* scanning, so it cannot pass by the cache having been clean all along.

Mutation, disabling the rebuild:

```
assertion `left == right` failed: a markerless entry must be rebuilt, dropping the stale char estimate
  left: 110
 right: 100
```

Ten estimated tokens surviving — the rebuild is doing the work.

## Gates

`cargo fmt --check` clean, `cargo clippy --all-features --all-targets -D warnings` clean, `cargo test -p tokscale-core --lib` 1780 passed / 0 failed.

## Out of scope

The server half. Stored submissions stay inflated no matter what the CLI reports, because the merge guard refuses reductions (`helpers.ts:233`). That needs its own design and the one sketched in #1011 does not survive review — bumping `SUBMISSION_PARSER_VERSION` would break Droid, since it is not Claude-specific (`main.rs:4612`). Tracking separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a regression test in `tokscale-core` that proves the retention-provenance rebuild drops legacy Claude `tool_result` char-based token estimates, so #1011 does not require a cache migration. Released builds still show inflation until we ship a release that includes the rebuild.

**Review notes**
- Seeds a cache row the current parser cannot produce (`:tool_result:` with `ceil(chars/4)`), verifies inflation, then asserts the warm scan re-parses and removes both the extra input tokens and the phantom `:tool_result:` row.
- Disabling the rebuild fails the test (110 vs 100 input tokens), confirming the rebuild is doing the work.
- Test-only change in `crates/tokscale-core/src/lib.rs`; no production logic modified.

**Rollout**
- No cache migration required; the per-entry retention-provenance rebuild cleans stale estimates.
- Ship a release that includes #1085; latest tag predates it, which is why the reporter saw no change.
- Server-side submissions remain inflated due to the merge guard; out of scope here and tracked separately.

<sup>Written for commit fd043cd074b305297c0386d91c40012b27a87fdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

