### PR TITLE
fix(pricing): resolve OpenAI Daybreak Blue alias

### DIFF
--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -133,13 +133,16 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("grok-composer-2.5-fast", "composer-2.5-fast");
     // OpenAI documents the API spelling below as a moving alias for
     // `gpt-5.6-sol`; Codex records the same alias with its `gpt-` prefix.
-    // Keep both spellings pinned to the currently documented target so the
-    // upstream GPT-5.6 Sol row supplies all token-bucket rates.
+    // Keep the API, Codex, and provider-qualified spellings pinned to the
+    // currently documented target so the upstream GPT-5.6 Sol row supplies
+    // all token-bucket rates. The qualified form must be explicit because
+    // provider-prefix stripping does not run alias resolution a second time.
     // Sources (accessed 2026-08-17):
     // https://developers.openai.com/api/docs/guides/safety-checks/cybersecurity
     // https://developers.openai.com/api/docs/pricing
     m.insert("daybreak-blue-latest", "gpt-5.6-sol");
     m.insert("gpt-daybreak-blue-latest", "gpt-5.6-sol");
+    m.insert("openai/gpt-daybreak-blue-latest", "gpt-5.6-sol");
 
     // Synthetic model variants (only where resolver needs help)
     m.insert("kimi-k2.5-nvfp4", "kimi-k2.5"); // Quantization variant → base model pricing
@@ -229,6 +232,10 @@ mod tests {
             resolve_alias("GPT-DAYBREAK-BLUE-LATEST"),
             Some("gpt-5.6-sol")
         );
+        assert_eq!(
+            resolve_alias("openai/gpt-daybreak-blue-latest"),
+            Some("gpt-5.6-sol")
+        );
     }
 
     #[test]
@@ -252,25 +259,25 @@ mod tests {
             reasoning: 0,
         };
 
-        let result = service
-            .lookup_with_source_and_provider("gpt-daybreak-blue-latest", None, Some("openai"))
-            .expect("the Codex alias must resolve to the GPT-5.6 Sol row");
-        assert_eq!(result.source, "LiteLLM");
-        assert_eq!(result.matched_key, "gpt-5.6-sol");
-        assert!(result.evidence.alias_applied);
-        assert!(service.covers_usage_with_provider(
-            "gpt-daybreak-blue-latest",
-            Some("openai"),
-            &usage,
-        ));
-
-        let cost = service.calculate_cost_with_provider(
-            "gpt-daybreak-blue-latest",
-            Some("openai"),
-            &usage,
-        );
         let expected = 1_000.0 * 5e-6 + 100.0 * 30e-6 + 500.0 * 0.5e-6 + 200.0 * 6.25e-6;
-        assert!((cost - expected).abs() < 1e-12, "unexpected cost: {cost}");
+        for model_id in [
+            "gpt-daybreak-blue-latest",
+            "openai/gpt-daybreak-blue-latest",
+        ] {
+            let result = service
+                .lookup_with_source_and_provider(model_id, None, Some("openai"))
+                .expect("the Codex alias must resolve to the GPT-5.6 Sol row");
+            assert_eq!(result.source, "LiteLLM");
+            assert_eq!(result.matched_key, "gpt-5.6-sol");
+            assert!(result.evidence.alias_applied);
+            assert!(service.covers_usage_with_provider(model_id, Some("openai"), &usage));
+
+            let cost = service.calculate_cost_with_provider(model_id, Some("openai"), &usage);
+            assert!(
+                (cost - expected).abs() < 1e-12,
+                "unexpected cost for {model_id}: {cost}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -143,6 +143,7 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("daybreak-blue-latest", "gpt-5.6-sol");
     m.insert("gpt-daybreak-blue-latest", "gpt-5.6-sol");
     m.insert("openai/gpt-daybreak-blue-latest", "gpt-5.6-sol");
+    m.insert("openai/daybreak-blue-latest", "gpt-5.6-sol");
 
     // Synthetic model variants (only where resolver needs help)
     m.insert("kimi-k2.5-nvfp4", "kimi-k2.5"); // Quantization variant → base model pricing
@@ -232,6 +233,13 @@ mod tests {
             resolve_alias("GPT-DAYBREAK-BLUE-LATEST"),
             Some("gpt-5.6-sol")
         );
+        // Both qualified spellings, for the same reason the comment on the
+        // table gives: prefix stripping does not re-run alias resolution, so
+        // neither can fall back to its bare form.
+        assert_eq!(
+            resolve_alias("openai/daybreak-blue-latest"),
+            Some("gpt-5.6-sol")
+        );
         assert_eq!(
             resolve_alias("openai/gpt-daybreak-blue-latest"),
             Some("gpt-5.6-sol")
@@ -261,7 +269,9 @@ mod tests {
 
         let expected = 1_000.0 * 5e-6 + 100.0 * 30e-6 + 500.0 * 0.5e-6 + 200.0 * 6.25e-6;
         for model_id in [
+            "daybreak-blue-latest",
             "gpt-daybreak-blue-latest",
+            "openai/daybreak-blue-latest",
             "openai/gpt-daybreak-blue-latest",
         ] {
             let result = service

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -131,6 +131,15 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("gemini-3-flash-a", "gemini-3.5-flash-high");
     m.insert("grok-composer-2.5", "composer-2.5");
     m.insert("grok-composer-2.5-fast", "composer-2.5-fast");
+    // OpenAI documents the API spelling below as a moving alias for
+    // `gpt-5.6-sol`; Codex records the same alias with its `gpt-` prefix.
+    // Keep both spellings pinned to the currently documented target so the
+    // upstream GPT-5.6 Sol row supplies all token-bucket rates.
+    // Sources (accessed 2026-08-17):
+    // https://developers.openai.com/api/docs/guides/safety-checks/cybersecurity
+    // https://developers.openai.com/api/docs/pricing
+    m.insert("daybreak-blue-latest", "gpt-5.6-sol");
+    m.insert("gpt-daybreak-blue-latest", "gpt-5.6-sol");
 
     // Synthetic model variants (only where resolver needs help)
     m.insert("kimi-k2.5-nvfp4", "kimi-k2.5"); // Quantization variant → base model pricing
@@ -207,6 +216,61 @@ mod tests {
             resolve_alias("GROK-COMPOSER-2.5-FAST"),
             Some("composer-2.5-fast")
         );
+    }
+
+    #[test]
+    fn resolves_openai_daybreak_blue_aliases_to_gpt_5_6_sol() {
+        assert_eq!(resolve_alias("daybreak-blue-latest"), Some("gpt-5.6-sol"));
+        assert_eq!(
+            resolve_alias("gpt-daybreak-blue-latest"),
+            Some("gpt-5.6-sol")
+        );
+        assert_eq!(
+            resolve_alias("GPT-DAYBREAK-BLUE-LATEST"),
+            Some("gpt-5.6-sol")
+        );
+    }
+
+    #[test]
+    fn codex_daybreak_blue_usage_uses_the_underlying_openai_price() {
+        let pricing = super::super::litellm::ModelPricing {
+            input_cost_per_token: Some(5e-6),
+            output_cost_per_token: Some(30e-6),
+            cache_read_input_token_cost: Some(0.5e-6),
+            cache_creation_input_token_cost: Some(6.25e-6),
+            ..Default::default()
+        };
+        let service = super::super::PricingService::new(
+            HashMap::from([("gpt-5.6-sol".to_string(), pricing)]),
+            HashMap::new(),
+        );
+        let usage = crate::TokenBreakdown {
+            input: 1_000,
+            output: 100,
+            cache_read: 500,
+            cache_write: 200,
+            reasoning: 0,
+        };
+
+        let result = service
+            .lookup_with_source_and_provider("gpt-daybreak-blue-latest", None, Some("openai"))
+            .expect("the Codex alias must resolve to the GPT-5.6 Sol row");
+        assert_eq!(result.source, "LiteLLM");
+        assert_eq!(result.matched_key, "gpt-5.6-sol");
+        assert!(result.evidence.alias_applied);
+        assert!(service.covers_usage_with_provider(
+            "gpt-daybreak-blue-latest",
+            Some("openai"),
+            &usage,
+        ));
+
+        let cost = service.calculate_cost_with_provider(
+            "gpt-daybreak-blue-latest",
+            Some("openai"),
+            &usage,
+        );
+        let expected = 1_000.0 * 5e-6 + 100.0 * 30e-6 + 500.0 * 0.5e-6 + 200.0 * 6.25e-6;
+        assert!((cost - expected).abs() < 1e-12, "unexpected cost: {cost}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- map OpenAI’s Daybreak Blue aliases to the documented `gpt-5.6-sol` target
- support API, Codex, and provider-qualified model IDs
- add regression coverage for pricing lookup, token-bucket coverage, and cost calculation

## Testing
- `cargo test -p tokscale-core pricing::aliases::tests`
- `cargo test -p tokscale-core`
- `cargo fmt --all --check`

Closes #1114.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves all OpenAI Daybreak Blue model IDs to `gpt-5.6-sol` so pricing lookup, token-bucket rates, and cost calculation consistently use the GPT-5.6 Sol row. Previously, provider-qualified `openai/daybreak-blue-latest` (and some aliases) could resolve to none and be unpriced; now all covered.

**Review notes**
- Adds aliases for `daybreak-blue-latest`, `gpt-daybreak-blue-latest`, `openai/daybreak-blue-latest`, and `openai/gpt-daybreak-blue-latest`; resolution is case-insensitive.
- Pins all aliases to `gpt-5.6-sol`; provider-qualified forms are explicit because prefix stripping does not re-run alias resolution.
- Extends `tokscale-core` tests to verify pricing lookup, token-bucket coverage, and cost for all four spellings via `lookup_with_source_and_provider` and `calculate_cost_with_provider`.

<sup>Written for commit f3296218f060f3deebabea48ad74f021f5a624b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

