### PR TITLE
fix(wrapped): point the OpenClaw logo at a URL that resolves

### DIFF
--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -2530,7 +2530,7 @@ mod tests {
     fn test_client_logo_url_openclaw() {
         assert_eq!(
             client_logo_url("OpenClaw"),
-            Some("https://tokscale.ai/assets/logos/openclaw.png")
+            Some("https://github.com/openclaw.png")
         );
     }
 

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -483,7 +483,7 @@ define_clients!(
     OpenClaw = 7 => {
         id: "openclaw",
         display: "OpenClaw",
-        logo: Some("https://tokscale.ai/assets/logos/openclaw.png"),root: PathRoot::Home,
+        logo: Some("https://github.com/openclaw.png"),root: PathRoot::Home,
         relative: ".openclaw/agents",
         pattern: "*.jsonl*",
         headless: false,
@@ -2068,5 +2068,40 @@ mod tests {
         assert!(ClientId::Kiro.parse_local());
         assert!(ClientId::Kiro.submit_default());
         assert!(!ClientId::Kiro.supports_headless());
+    }
+
+    /// Every `tokscale.ai/assets/logos/<file>` logo must be backed by a file
+    /// that is actually committed under the frontend's public assets, because
+    /// that directory is what gets deployed to the domain.
+    ///
+    /// This catches the failure this test was added for: the OpenClaw entry
+    /// pointed at `openclaw.png` while the committed asset is `openclaw.jpg`,
+    /// so the URL 404ed and `wrapped` silently rendered no OpenClaw logo. The
+    /// fetch is deliberately fault-tolerant, and the unit test that covered the
+    /// URL asserted the broken string verbatim, so nothing failed.
+    #[test]
+    fn test_hosted_logo_urls_have_a_committed_asset() {
+        const HOSTED_PREFIX: &str = "https://tokscale.ai/assets/logos/";
+
+        let logos_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../packages/frontend/public/assets/logos");
+        // Published crates and pruned checkouts do not carry the frontend.
+        if !logos_dir.is_dir() {
+            return;
+        }
+
+        let missing: Vec<String> = ClientId::iter()
+            .filter_map(|client| Some((client, client.logo_url()?)))
+            .filter_map(|(client, url)| Some((client, url.strip_prefix(HOSTED_PREFIX)?)))
+            .filter(|(_, file)| !logos_dir.join(file).exists())
+            .map(|(client, file)| format!("{} -> {}", client.as_str(), file))
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "logo URLs with no committed asset in {}: {:?}",
+            logos_dir.display(),
+            missing
+        );
     }
 }


### PR DESCRIPTION
## The bug

`client_logo_url("OpenClaw")` returned `https://tokscale.ai/assets/logos/openclaw.png`, which **404s**. The committed asset is `packages/frontend/public/assets/logos/openclaw.jpg` — a `.jpg`, not a `.png` — so that hosted path never existed.

Every wrapped image containing OpenClaw has been rendering without its logo.

## Why nothing caught it

Both halves of the system tolerated the failure:

- The download in `wrapped.rs` is wrapped in `if let Ok(..)`, so a failed fetch silently renders no logo instead of erroring.
- The unit test covering the URL asserted the broken string **verbatim**, so it passed while pinning the bug in place.

## The fix

Points at `https://github.com/openclaw.png`, matching how Prime Agent (`github.com/PrimeIntellect-ai.png`) and JetBrains already source their logos.

That URL serves **JPEG** despite the `.png` suffix. That is fine and already relied upon elsewhere: `image::open` sniffs content rather than trusting the extension, and both the PNG and JPEG decoders are linked after #1132. `github.com/PrimeIntellect-ai.png` has the same property and renders correctly today.

## The regression test

`test_hosted_logo_urls_have_a_committed_asset` asserts that for every client whose logo points at `tokscale.ai/assets/logos/`, a file of that exact name exists under the frontend's public assets — the directory that gets deployed to the domain.

It is a **filesystem** check rather than a network one, so it stays deterministic and offline, and it skips itself when the frontend is not present in the checkout.

Verified non-vacuous by reintroducing the old URL:

```
logo URLs with no committed asset in .../packages/frontend/public/assets/logos: ["openclaw -> openclaw.png"]
test result: FAILED. 0 passed; 1 failed
```

## Scope

Audited all **34** image URLs referenced under `crates/` by fetching each and checking the response. OpenClaw was the only genuinely broken one — the three other non-200s are `example.com` placeholders inside test fixtures.

`cargo test --release -p tokscale-core -p tokscale-cli` 0 failures, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OpenClaw logo URL so wrapped images render its logo. Previously `client_logo_url("OpenClaw")` returned a 404 (`https://tokscale.ai/assets/logos/openclaw.png`), so the logo was omitted; now it uses `https://github.com/openclaw.png`, which resolves. The image loader sniffs content, so the JPEG served behind a `.png` suffix works without changes.

- Aligns with how other clients source logos (GitHub avatar URLs).
- Updates the CLI test to expect the new URL.
- Adds an offline regression test that ensures any `tokscale.ai/assets/logos/` URL has a matching file under `packages/frontend/public/assets/logos`; it skips when the frontend directory is absent.
- Audited all referenced logo URLs; OpenClaw was the only real failure.
- No migrations or config changes required.

<sup>Written for commit 0bb59e017d9050e7cf385a9f83dae919f8bdd727. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

