### PR TITLE
refactor(core): put the Pi-format parsers on the shared session drivers

### DIFF
--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -235,8 +235,8 @@ pub struct PiUsage {
     pub cache_write: Option<i64>,
     #[allow(dead_code)]
     pub total_tokens: Option<i64>,
-    /// Parsed so the omission below is a real decision rather than an accident
-    /// of the schema, but never summed: see the note at the emit site.
+    /// Parsed so the omission in [`PiUsage::to_breakdown`] is a real decision
+    /// rather than an accident of the schema, but never summed.
     #[allow(dead_code)]
     pub reasoning: Option<i64>,
     #[serde(flatten)]
@@ -244,6 +244,24 @@ pub struct PiUsage {
 }
 
 impl PiUsage {
+    /// Token breakdown with every field clamped at zero, in the spelling
+    /// `utils::CamelUsage` uses for the same wire shape.
+    ///
+    /// `reasoning` is read but deliberately not mapped onto
+    /// `TokenBreakdown::reasoning`. In the Pi format reasoning tokens are a
+    /// subset of `output` (Pi's own `totalTokens` excludes them), whereas
+    /// tokscale totals `reasoning` as its own additive bucket. Mapping it
+    /// through would double count.
+    pub(crate) fn to_breakdown(&self) -> TokenBreakdown {
+        TokenBreakdown {
+            input: self.input.unwrap_or(0).max(0),
+            output: self.output.unwrap_or(0).max(0),
+            cache_read: self.cache_read.unwrap_or(0).max(0),
+            cache_write: self.cache_write.unwrap_or(0).max(0),
+            reasoning: 0,
+        }
+    }
+
     pub(crate) fn has_damaged_key(&self) -> bool {
         const TOKEN_COUNTER_KEYS: &[&str] = &[
             "input",
@@ -726,24 +744,13 @@ fn parse_pi_format_file_inner(
             .map(|timestamp| timestamp.timestamp_millis());
         let timestamp = recorded_timestamp.unwrap_or(fallback_timestamp);
 
-        // `usage.reasoning` is read but deliberately not mapped onto
-        // `TokenBreakdown::reasoning`. In the Pi format reasoning tokens are a
-        // subset of `output` (Pi's own `totalTokens` excludes them), whereas
-        // tokscale totals `reasoning` as its own additive bucket. Mapping it
-        // through would double count.
         let mut unified = UnifiedMessage::new_with_agent(
             client,
             model,
             provider.as_str(),
             session_id.clone().unwrap_or_else(|| "unknown".to_string()),
             timestamp,
-            TokenBreakdown {
-                input: usage.input.unwrap_or(0).max(0),
-                output: usage.output.unwrap_or(0).max(0),
-                cache_read: usage.cache_read.unwrap_or(0).max(0),
-                cache_write: usage.cache_write.unwrap_or(0).max(0),
-                reasoning: 0,
-            },
+            usage.to_breakdown(),
             0.0,
             agent.clone(),
         );

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -8,7 +8,9 @@
 //! Pi descendants reuse this record layout verbatim, so [`parse_pi_format_file`]
 //! is shared: see `sessions::senpi` for Senpi (OmO Native).
 
-use super::utils::{file_modified_timestamp_ms, lossy_lines_with_bytes, LossyLine};
+use super::utils::{
+    file_modified_timestamp_ms, lossy_lines_with_bytes, parse_json_line, LossyLine,
+};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::provider_identity::inferred_provider_from_model;
 use crate::TokenBreakdown;
@@ -624,16 +626,14 @@ fn parse_pi_format_file_inner(
         }
 
         if session_id.is_none() {
-            buffer.clear();
-            buffer.extend_from_slice(trimmed.as_bytes());
-            let entry_type = match simd_json::from_slice::<PiEntryTypeProbe>(&mut buffer) {
-                Ok(probe) => probe.entry_type,
-                Err(_)
-                    if options.lossy_line_reader && pre_header_line_is_skippable(trimmed, None) =>
+            let entry_type = match parse_json_line::<PiEntryTypeProbe>(trimmed, &mut buffer) {
+                Some(probe) => probe.entry_type,
+                None if options.lossy_line_reader
+                    && pre_header_line_is_skippable(trimmed, None) =>
                 {
                     continue;
                 }
-                Err(_) => return Vec::new(),
+                None => return Vec::new(),
             };
 
             if entry_type != "session" {
@@ -643,11 +643,8 @@ fn parse_pi_format_file_inner(
                 return Vec::new();
             }
 
-            buffer.clear();
-            buffer.extend_from_slice(trimmed.as_bytes());
-            let header = match simd_json::from_slice::<PiSessionHeader>(&mut buffer) {
-                Ok(h) => h,
-                Err(_) => return Vec::new(),
+            let Some(header) = parse_json_line::<PiSessionHeader>(trimmed, &mut buffer) else {
+                return Vec::new();
             };
             let has_raw_damaged_lineage_key = line
                 .raw_bytes()
@@ -676,11 +673,8 @@ fn parse_pi_format_file_inner(
             continue;
         }
 
-        buffer.clear();
-        buffer.extend_from_slice(trimmed.as_bytes());
-        let entry = match simd_json::from_slice::<PiSessionEntry>(&mut buffer) {
-            Ok(e) => e,
-            Err(_) => continue,
+        let Some(entry) = parse_json_line::<PiSessionEntry>(trimmed, &mut buffer) else {
+            continue;
         };
 
         if entry.entry_type == "session_info" {

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -8,16 +8,14 @@
 //! Pi descendants reuse this record layout verbatim, so [`parse_pi_format_file`]
 //! is shared: see `sessions::senpi` for Senpi (OmO Native).
 
-use super::utils::{
-    file_modified_timestamp_ms, lossy_lines_with_bytes, parse_json_line, LossyLine,
-};
+use super::utils::{file_modified_timestamp_ms, for_each_json_line_with_bytes, parse_json_line};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::provider_identity::inferred_provider_from_model;
 use crate::TokenBreakdown;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
-use std::io::{BufRead, BufReader};
+use std::ops::ControlFlow;
 use std::path::Path;
 
 /// Pi session header (first line of JSONL)
@@ -435,74 +433,6 @@ impl PiParseOptions {
     }
 }
 
-enum PiLines {
-    Standard {
-        lines: std::io::Lines<BufReader<std::fs::File>>,
-        at_start: bool,
-    },
-    Lossy(super::utils::LossyLinesWithBytes<BufReader<std::fs::File>>),
-}
-
-enum PiLine {
-    Standard(String),
-    Lossy(LossyLine),
-}
-
-impl PiLine {
-    fn text(&self) -> &str {
-        match self {
-            Self::Standard(text) => text,
-            Self::Lossy(line) => &line.text,
-        }
-    }
-
-    fn raw_bytes(&self) -> Option<&[u8]> {
-        match self {
-            Self::Standard(_) => None,
-            Self::Lossy(line) => Some(&line.bytes),
-        }
-    }
-}
-
-impl Iterator for PiLines {
-    type Item = PiLine;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            match self {
-                Self::Standard { lines, at_start } => match lines.next() {
-                    Some(Ok(mut line)) => {
-                        // A UTF-8 BOM decodes cleanly, so it survives as U+FEFF
-                        // glued to the front of the first record, where
-                        // `str::trim` leaves it (U+FEFF is not White_Space) and
-                        // the header then fails to parse. A header that fails to
-                        // parse discards the whole transcript rather than one
-                        // record, so strip the marker here exactly as the lossy
-                        // reader already does for Prime Agent.
-                        if std::mem::take(at_start) {
-                            if let Some(stripped) = line.strip_prefix('\u{feff}') {
-                                line = stripped.to_string();
-                            }
-                        }
-                        return Some(PiLine::Standard(line));
-                    }
-                    // `reader.lines()` historically skipped all unreadable
-                    // records and continued. In particular, an invalid-UTF-8
-                    // line must not truncate valid records that follow it.
-                    Some(Err(_)) => {
-                        // The marker can only precede the first record, and that
-                        // record was just consumed.
-                        *at_start = false;
-                        continue;
-                    }
-                    None => return None,
-                },
-                Self::Lossy(lines) => return lines.next().map(PiLine::Lossy),
-            }
-        }
-    }
-}
-
 fn accepts_replacement_field(value: &str, lossy_line_reader: bool) -> bool {
     !lossy_line_reader || !has_replacement_character(value)
 }
@@ -595,22 +525,8 @@ fn parse_pi_format_file_inner(
     options: PiParseOptions,
     observer: &mut impl PiFormatObserver,
 ) -> Vec<UnifiedMessage> {
-    let file = match std::fs::File::open(path) {
-        Ok(f) => f,
-        Err(_) => return Vec::new(),
-    };
-
     let fallback_timestamp = file_modified_timestamp_ms(path);
 
-    let reader = BufReader::new(file);
-    let lines = if options.lossy_line_reader {
-        PiLines::Lossy(lossy_lines_with_bytes(reader))
-    } else {
-        PiLines::Standard {
-            lines: reader.lines(),
-            at_start: true,
-        }
-    };
     let mut messages: Vec<UnifiedMessage> = Vec::with_capacity(64);
     let mut buffer = Vec::with_capacity(4096);
 
@@ -619,11 +535,20 @@ fn parse_pi_format_file_inner(
     let mut workspace_label: Option<String> = None;
     let mut agent: Option<String> = None;
     let mut is_rlm_subagent = false;
-    for line in lines {
-        let trimmed = line.text().trim();
-        if trimmed.is_empty() {
-            continue;
+    // A header this parser rejects discards the whole transcript, not one
+    // record, so the sink stops the scan and nothing is returned.
+    let mut malformed_transcript = false;
+
+    for_each_json_line_with_bytes(path, &mut |line| {
+        // Pi, Senpi and Kimchi keep the byte-strict record skipping of
+        // `BufRead::lines()`: a record whose bytes are not valid UTF-8 is
+        // dropped rather than read through its replacement characters.
+        // Reading it lossily would make them emit messages they do not emit
+        // today, which is the opt-in `PiParseOptions::standard` defers.
+        if !options.lossy_line_reader && !line.valid_utf8 {
+            return ControlFlow::Continue(());
         }
+        let trimmed = line.trimmed;
 
         if session_id.is_none() {
             let entry_type = match parse_json_line::<PiEntryTypeProbe>(trimmed, &mut buffer) {
@@ -631,28 +556,32 @@ fn parse_pi_format_file_inner(
                 None if options.lossy_line_reader
                     && pre_header_line_is_skippable(trimmed, None) =>
                 {
-                    continue;
+                    return ControlFlow::Continue(());
                 }
-                None => return Vec::new(),
+                None => {
+                    malformed_transcript = true;
+                    return ControlFlow::Break(());
+                }
             };
 
             if entry_type != "session" {
                 if PRE_SESSION_METADATA_TYPES.contains(&entry_type.as_str()) {
-                    continue;
+                    return ControlFlow::Continue(());
                 }
-                return Vec::new();
+                malformed_transcript = true;
+                return ControlFlow::Break(());
             }
 
             let Some(header) = parse_json_line::<PiSessionHeader>(trimmed, &mut buffer) else {
-                return Vec::new();
+                malformed_transcript = true;
+                return ControlFlow::Break(());
             };
-            let has_raw_damaged_lineage_key = line
-                .raw_bytes()
-                .is_some_and(raw_json_has_damaged_lineage_header_key);
             if options.lossy_line_reader
-                && (header.has_invalid_lineage() || has_raw_damaged_lineage_key)
+                && (header.has_invalid_lineage()
+                    || raw_json_has_damaged_lineage_header_key(line.bytes))
             {
-                return Vec::new();
+                malformed_transcript = true;
+                return ControlFlow::Break(());
             }
 
             observer.observe_header(&header);
@@ -670,11 +599,11 @@ fn parse_pi_format_file_inner(
             workspace_key = clean_cwd.and_then(normalize_workspace_key);
             workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
             is_rlm_subagent = header.rlm_depth.unwrap_or(0) > 0;
-            continue;
+            return ControlFlow::Continue(());
         }
 
         let Some(entry) = parse_json_line::<PiSessionEntry>(trimmed, &mut buffer) else {
-            continue;
+            return ControlFlow::Continue(());
         };
 
         if entry.entry_type == "session_info" {
@@ -695,7 +624,7 @@ fn parse_pi_format_file_inner(
                     .and_then(pi_subagent_name)
             };
             observer.observe_entry(&entry, None);
-            continue;
+            return ControlFlow::Continue(());
         }
 
         let Some(PiEmittedRecord {
@@ -705,7 +634,7 @@ fn parse_pi_format_file_inner(
         }) = pi_emitted_record(&entry, options, is_rlm_subagent)
         else {
             observer.observe_entry(&entry, None);
-            continue;
+            return ControlFlow::Continue(());
         };
 
         let model = if !accepts_replacement_field(recorded_model, options.lossy_line_reader) {
@@ -783,9 +712,8 @@ fn parse_pi_format_file_inner(
                         !accepts_replacement_field(id, options.lossy_line_reader)
                     });
                     if has_damaged_id {
-                        let raw_line = line.raw_bytes().unwrap_or_else(|| line.text().as_bytes());
                         unified.dedup_key =
-                            Some(damaged_cross_session_dedup_key(namespace, raw_line));
+                            Some(damaged_cross_session_dedup_key(namespace, line.bytes));
                     }
                 }
             } else if let Some(message_id) = entry.id.as_deref().filter(|id| !id.trim().is_empty())
@@ -797,6 +725,11 @@ fn parse_pi_format_file_inner(
         unified.set_workspace(workspace_key.clone(), workspace_label.clone());
         observer.observe_entry(&entry, Some(&unified));
         messages.push(unified);
+        ControlFlow::Continue(())
+    });
+
+    if malformed_transcript {
+        return Vec::new();
     }
 
     messages

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -226,6 +226,10 @@ pub struct PiMessage {
     pub response_id: Option<String>,
 }
 
+/// The camelCase usage block of a Pi record: `utils::CamelUsage`'s
+/// `{input, output, cacheRead, cacheWrite, totalTokens}` plus `reasoning` and
+/// a flattened map of every remaining key. See the note on `CamelUsage` for
+/// why the two shapes are not merged.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PiUsage {

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -13,10 +13,10 @@ use super::pi::{
     pre_header_line_is_skippable, raw_json_has_damaged_lineage_header_key, rlm_entry_emits_message,
     PiFormatObserver, PiSessionEntry, PiSessionHeader, PRE_SESSION_METADATA_TYPES,
 };
-use super::utils::{lossy_lines_with_bytes, parse_timestamp_str};
+use super::utils::{lossy_lines_with_bytes, parse_json_line, parse_timestamp_str};
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
@@ -426,12 +426,6 @@ fn referenced_lineage_path(source_file: &Path, referenced: &Path) -> PathBuf {
     }
 }
 
-fn parse_pi_json_line<T: DeserializeOwned>(line: &str, buffer: &mut Vec<u8>) -> Option<T> {
-    buffer.clear();
-    buffer.extend_from_slice(line.as_bytes());
-    simd_json::from_slice(buffer).ok()
-}
-
 /// Read Prime-only accounting records that are intentionally absent from the
 /// shared Pi message representation. `messages` may come from the source cache;
 /// their stable order is used to associate target entry ids with emitted rows.
@@ -456,7 +450,7 @@ pub(crate) fn analyze_prime_agent_accounting(
             continue;
         }
         if !found_header {
-            if let Some(header) = parse_pi_json_line::<PiSessionHeader>(trimmed, &mut buffer) {
+            if let Some(header) = parse_json_line::<PiSessionHeader>(trimmed, &mut buffer) {
                 if header.entry_type == "session" {
                     let has_raw_damaged_lineage_key =
                         raw_json_has_damaged_lineage_header_key(&line.bytes);
@@ -468,8 +462,8 @@ pub(crate) fn analyze_prime_agent_accounting(
                     continue;
                 }
             }
-            let parsed_type = parse_pi_json_line::<serde_json::Value>(trimmed, &mut buffer)
-                .and_then(|value| {
+            let parsed_type =
+                parse_json_line::<serde_json::Value>(trimmed, &mut buffer).and_then(|value| {
                     value
                         .get("type")
                         .and_then(|kind| kind.as_str())
@@ -486,7 +480,7 @@ pub(crate) fn analyze_prime_agent_accounting(
             return PrimeFileAccounting::default();
         }
 
-        let Some(entry) = parse_pi_json_line::<PiSessionEntry>(trimmed, &mut buffer) else {
+        let Some(entry) = parse_json_line::<PiSessionEntry>(trimmed, &mut buffer) else {
             continue;
         };
         // Which records became messages is the parser's decision, not a rule

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -11,7 +11,7 @@
 use super::pi::{
     has_replacement_character, parse_pi_format_rlm_file_with_observer,
     pre_header_line_is_skippable, raw_json_has_damaged_lineage_header_key, rlm_entry_emits_message,
-    PiFormatObserver, PiSessionEntry, PiSessionHeader, PiUsage, PRE_SESSION_METADATA_TYPES,
+    PiFormatObserver, PiSessionEntry, PiSessionHeader, PRE_SESSION_METADATA_TYPES,
 };
 use super::utils::{lossy_lines_with_bytes, parse_timestamp_str};
 use super::UnifiedMessage;
@@ -249,8 +249,8 @@ impl PiFormatObserver for PrimeAccountingBuilder<'_> {
                     .push(PrimeAttribution {
                         id: id.clone(),
                         timestamp: entry_timestamp,
-                        child_usage: usage_breakdown(child_usage),
-                        aggregate_usage: usage_breakdown(aggregate_usage),
+                        child_usage: child_usage.to_breakdown(),
+                        aggregate_usage: aggregate_usage.to_breakdown(),
                     });
             }
             return;
@@ -303,16 +303,6 @@ pub(crate) fn transcript_decode_call_counts() -> (usize, usize) {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     (counter.messages, counter.accounting)
-}
-
-fn usage_breakdown(usage: &PiUsage) -> TokenBreakdown {
-    TokenBreakdown {
-        input: usage.input.unwrap_or(0).max(0),
-        output: usage.output.unwrap_or(0).max(0),
-        cache_read: usage.cache_read.unwrap_or(0).max(0),
-        cache_write: usage.cache_write.unwrap_or(0).max(0),
-        reasoning: 0,
-    }
 }
 
 fn add_usage(total: &mut TokenBreakdown, usage: &TokenBreakdown) {

--- a/crates/tokscale-core/src/sessions/prime_agent.rs
+++ b/crates/tokscale-core/src/sessions/prime_agent.rs
@@ -13,12 +13,12 @@ use super::pi::{
     pre_header_line_is_skippable, raw_json_has_damaged_lineage_header_key, rlm_entry_emits_message,
     PiFormatObserver, PiSessionEntry, PiSessionHeader, PRE_SESSION_METADATA_TYPES,
 };
-use super::utils::{lossy_lines_with_bytes, parse_json_line, parse_timestamp_str};
+use super::utils::{for_each_json_line_with_bytes, parse_json_line, parse_timestamp_str};
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::io::BufReader;
+use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 
 #[cfg(test)]
@@ -436,30 +436,28 @@ pub(crate) fn analyze_prime_agent_accounting(
     #[cfg(test)]
     record_transcript_decode(path, true);
 
-    let Ok(file) = std::fs::File::open(path) else {
-        return PrimeFileAccounting::default();
-    };
-
     let mut accounting = PrimeAccountingBuilder::new(path);
     let mut found_header = false;
     let mut message_index = 0usize;
     let mut buffer = Vec::with_capacity(4096);
-    for line in lossy_lines_with_bytes(BufReader::new(file)) {
-        let trimmed = line.text.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
+    // A header the shared parser rejects discards the whole transcript here
+    // too, so the sink stops the scan and no accounting is reported.
+    let mut malformed_transcript = false;
+
+    for_each_json_line_with_bytes(path, &mut |line| {
+        let trimmed = line.trimmed;
         if !found_header {
             if let Some(header) = parse_json_line::<PiSessionHeader>(trimmed, &mut buffer) {
                 if header.entry_type == "session" {
-                    let has_raw_damaged_lineage_key =
-                        raw_json_has_damaged_lineage_header_key(&line.bytes);
-                    if header.has_invalid_lineage() || has_raw_damaged_lineage_key {
-                        return PrimeFileAccounting::default();
+                    if header.has_invalid_lineage()
+                        || raw_json_has_damaged_lineage_header_key(line.bytes)
+                    {
+                        malformed_transcript = true;
+                        return ControlFlow::Break(());
                     }
                     found_header = true;
                     accounting.observe_header(&header);
-                    continue;
+                    return ControlFlow::Continue(());
                 }
             }
             let parsed_type =
@@ -475,13 +473,14 @@ pub(crate) fn analyze_prime_agent_accounting(
             if is_pre_session_metadata
                 || pre_header_line_is_skippable(trimmed, parsed_type.as_deref())
             {
-                continue;
+                return ControlFlow::Continue(());
             }
-            return PrimeFileAccounting::default();
+            malformed_transcript = true;
+            return ControlFlow::Break(());
         }
 
         let Some(entry) = parse_json_line::<PiSessionEntry>(trimmed, &mut buffer) else {
-            continue;
+            return ControlFlow::Continue(());
         };
         // Which records became messages is the parser's decision, not a rule
         // restated here: a record counted on only one side shifts every later
@@ -494,6 +493,11 @@ pub(crate) fn analyze_prime_agent_accounting(
             })
             .flatten();
         accounting.observe_entry(&entry, emitted);
+        ControlFlow::Continue(())
+    });
+
+    if malformed_transcript {
+        return PrimeFileAccounting::default();
     }
 
     accounting.finish()

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -585,8 +585,15 @@ impl AnthropicUsage {
 /// with `rename_all` and the other with per-field `rename`, so the JSON both
 /// accept is identical.
 ///
-/// `pi.rs` models the same wire shape with its own `PiUsage` (a flattened
-/// extras map it needs and this type does not) and is left alone.
+/// `pi::PiUsage` models the same wire shape and still stays separate, because
+/// the keys the two read are not the same set. `PiUsage` reads `reasoning` and
+/// routes every other key into the flattened extras map its damaged-key
+/// detection needs; this type reads `cost` and ignores the rest. A struct
+/// holding the union of those fields rejects documents that each accepts
+/// today: a Pi record whose `cost` is not an object stops deserializing, and
+/// so does a `gjc`/`openclaw` record whose `reasoning` is not a number. Losing
+/// the usage block drops the whole message, and `cost` is present on every Pi
+/// usage block, so that is not a theoretical edge.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct CamelUsage {

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -5,7 +5,9 @@ use rusqlite::{Connection, OpenFlags};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::Value;
+use std::borrow::Cow;
 use std::io::BufRead;
+use std::ops::ControlFlow;
 use std::path::Path;
 use std::time::SystemTime;
 use tracing::warn;
@@ -28,25 +30,6 @@ pub(crate) fn lossy_lines<R: BufRead>(reader: R) -> LossyLines<R> {
         buf: Vec::new(),
         at_start: true,
     }
-}
-
-/// Iterate lossy-decoded lines while retaining their exact source bytes.
-///
-/// Most parsers need only [`lossy_lines`]. Prime Agent additionally derives a
-/// stable fallback deduplication key from corrupted records, where hashing the
-/// decoded string would collapse distinct invalid UTF-8 sequences to the same
-/// replacement character.
-pub(crate) fn lossy_lines_with_bytes<R: BufRead>(reader: R) -> LossyLinesWithBytes<R> {
-    LossyLinesWithBytes {
-        reader,
-        buf: Vec::new(),
-        at_start: true,
-    }
-}
-
-pub(crate) struct LossyLine {
-    pub text: String,
-    pub bytes: Vec<u8>,
 }
 
 pub(crate) struct LossyLines<R> {
@@ -137,55 +120,71 @@ pub(crate) fn for_each_json_line(path: &Path, sink: &mut dyn FnMut(usize, &str))
     }
 }
 
+/// One line of a JSONL transcript, borrowed out of the driver's reusable
+/// buffer.
+pub(crate) struct JsonLineBytes<'a> {
+    /// The line's exact source bytes, with the line terminator and a leading
+    /// BOM removed and nothing else trimmed.
+    pub(crate) bytes: &'a [u8],
+    /// `bytes` decoded lossily, then trimmed.
+    pub(crate) trimmed: &'a str,
+    /// False when `bytes` was not valid UTF-8, so `trimmed` carries a
+    /// replacement character the source does not contain.
+    pub(crate) valid_utf8: bool,
+}
+
+/// Read `path` as line-delimited JSON like [`for_each_json_line`], additionally
+/// handing the sink each line's source bytes and whether they decoded
+/// losslessly.
+///
+/// The Pi-format family needs both halves. Prime Agent hashes the exact bytes
+/// of a damaged record into its fallback deduplication key, where the decoded
+/// text would collapse distinct invalid sequences onto the same U+FFFD, and it
+/// inspects those bytes for a lineage key mangled by invalid UTF-8, which is
+/// undetectable once the line is decoded. Pi, Senpi and Kimchi in turn still
+/// drop a record whose bytes are not valid UTF-8 rather than reading it
+/// through its replacement characters, which is what `valid_utf8` preserves.
+///
+/// The sink returns [`ControlFlow::Break`] to end the scan, for the header
+/// checks that discard a whole transcript rather than one record.
+///
+/// `sink` is `&mut dyn FnMut` for the same reason as [`for_each_json_line`]: a
+/// type parameter would monomorphize the driver once per calling parser.
+pub(crate) fn for_each_json_line_with_bytes(
+    path: &Path,
+    sink: &mut dyn FnMut(JsonLineBytes<'_>) -> ControlFlow<()>,
+) {
+    let Ok(file) = std::fs::File::open(path) else {
+        return;
+    };
+
+    let mut reader = std::io::BufReader::new(file);
+    let mut buf = Vec::new();
+    let mut at_start = true;
+
+    while let Some(start) = read_line_payload(&mut reader, &mut buf, &mut at_start) {
+        let bytes = &buf[start..];
+        let text = String::from_utf8_lossy(bytes);
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let line = JsonLineBytes {
+            bytes,
+            trimmed,
+            valid_utf8: matches!(text, Cow::Borrowed(_)),
+        };
+        if sink(line).is_break() {
+            break;
+        }
+    }
+}
+
 impl<R: BufRead> Iterator for LossyLines<R> {
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {
         read_lossy_line(&mut self.reader, &mut self.buf, &mut self.at_start)
-    }
-}
-
-pub(crate) struct LossyLinesWithBytes<R> {
-    reader: R,
-    buf: Vec<u8>,
-    at_start: bool,
-}
-
-impl<R: BufRead> Iterator for LossyLinesWithBytes<R> {
-    type Item = LossyLine;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.buf.clear();
-        match self.reader.read_until(b'\n', &mut self.buf) {
-            Ok(0) => None,
-            Ok(_) => {
-                if self.buf.last() == Some(&b'\n') {
-                    self.buf.pop();
-                    if self.buf.last() == Some(&b'\r') {
-                        self.buf.pop();
-                    }
-                }
-
-                let mut bytes = self.buf.as_slice();
-                if std::mem::take(&mut self.at_start) {
-                    // A UTF-8 BOM decodes cleanly but leaves U+FEFF glued to the
-                    // front of the first record, where it makes an otherwise
-                    // valid JSON line fail to parse and be skipped in silence.
-                    bytes = bytes.strip_prefix("\u{feff}".as_bytes()).unwrap_or(bytes);
-                }
-
-                Some(LossyLine {
-                    text: String::from_utf8_lossy(bytes).into_owned(),
-                    bytes: bytes.to_vec(),
-                })
-            }
-            // Decode failures cannot reach this arm — lossy decoding never
-            // fails — so an error here is a hard I/O failure (vanished network
-            // mount, EIO). `read_until` does not consume input when it fails
-            // that way, so skipping and retrying would spin on the same failing
-            // read forever. Stop instead, and keep the lines read so far.
-            Err(_) => None,
-        }
     }
 }
 
@@ -643,12 +642,57 @@ mod tests {
     }
 
     #[test]
-    fn lossy_lines_with_bytes_preserves_distinct_invalid_sequences() {
-        let raw: &[u8] = b"a\xff\na\xfe\n";
-        let lines: Vec<LossyLine> = lossy_lines_with_bytes(raw).collect();
-        assert_eq!(lines[0].text, lines[1].text);
-        assert_eq!(lines[0].bytes, b"a\xff");
-        assert_eq!(lines[1].bytes, b"a\xfe");
+    fn for_each_json_line_with_bytes_preserves_distinct_invalid_sequences() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("transcript.jsonl");
+        std::fs::write(
+            &path,
+            b"\xef\xbb\xbf {\"clean\":1} \r\n\n  \na\xff\na\xfe\n",
+        )
+        .unwrap();
+
+        let mut lines = Vec::new();
+        for_each_json_line_with_bytes(&path, &mut |line| {
+            lines.push((
+                line.bytes.to_vec(),
+                line.trimmed.to_string(),
+                line.valid_utf8,
+            ));
+            ControlFlow::Continue(())
+        });
+
+        // The BOM is stripped, the terminator is not part of the line, blank
+        // lines are skipped, and `bytes` keeps the untrimmed payload.
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0].0, b" {\"clean\":1} ");
+        assert_eq!(lines[0].1, r#"{"clean":1}"#);
+        assert!(lines[0].2);
+        // Distinct invalid sequences decode to the same replacement character
+        // but keep distinct source bytes, which is what the Prime Agent
+        // fallback deduplication key hashes.
+        assert_eq!(lines[1].1, lines[2].1);
+        assert_eq!(lines[1].0, b"a\xff");
+        assert_eq!(lines[2].0, b"a\xfe");
+        assert!(!lines[1].2);
+        assert!(!lines[2].2);
+    }
+
+    #[test]
+    fn for_each_json_line_with_bytes_stops_on_break() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("transcript.jsonl");
+        std::fs::write(&path, b"first\nsecond\nthird\n").unwrap();
+
+        let mut seen = Vec::new();
+        for_each_json_line_with_bytes(&path, &mut |line| {
+            seen.push(line.trimmed.to_string());
+            if line.trimmed == "second" {
+                return ControlFlow::Break(());
+            }
+            ControlFlow::Continue(())
+        });
+
+        assert_eq!(seen, vec!["first", "second"]);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -2,6 +2,7 @@
 
 use crate::TokenBreakdown;
 use rusqlite::{Connection, OpenFlags};
+use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::Value;
 use std::io::BufRead;
@@ -442,6 +443,18 @@ pub(crate) fn sqlite_for_each_row(
         }
     };
     sqlite_for_each_row_on(&conn, db_path, sql, what, sink)
+}
+
+/// Decode one JSONL line into `T`, using `buffer` as simd-json's scratch space.
+///
+/// simd-json parses in place and so has to own the bytes it reads; a caller
+/// that keeps one buffer for the whole scan pays that copy without allocating
+/// a fresh one per line. A line that does not decode yields `None`, which is
+/// what every JSONL parser does with a record it cannot read.
+pub(crate) fn parse_json_line<T: DeserializeOwned>(line: &str, buffer: &mut Vec<u8>) -> Option<T> {
+    buffer.clear();
+    buffer.extend_from_slice(line.as_bytes());
+    simd_json::from_slice(buffer).ok()
 }
 
 /// Read a file into bytes, returning `None` on any I/O error instead of propagating.


### PR DESCRIPTION
`sessions/pi.rs` and `sessions/prime_agent.rs` were the two parsers left out of #1137, so they were still carrying their own line plumbing. This puts what actually fits onto the shared drivers in `sessions/utils.rs` and documents, with evidence, the two things that do not fit.

## What moved

- **One line driver for the Pi family.** Pi had a two-variant `PiLines`/`PiLine` iterator wrapping either `BufRead::lines()` (Pi, Senpi, Kimchi) or `utils::lossy_lines_with_bytes` (Prime Agent), each with its own BOM handling, and Prime Agent's accounting walk opened and iterated the same file a third way. All three now go through `utils::for_each_json_line_with_bytes`, which shares `read_line_payload` with `for_each_json_line`, so terminator and BOM handling exist once. `lossy_lines_with_bytes`, `LossyLinesWithBytes` and `LossyLine` had no other callers and are deleted.
- **One JSON line decode helper.** `prime_agent::parse_pi_json_line` becomes `utils::parse_json_line`, replacing the three open-coded copies of "clear the buffer, copy the line in, hand it to simd-json" in `pi.rs`.
- **One token breakdown.** `PiUsage::to_breakdown` replaces the inline breakdown at the Pi emit site and `prime_agent::usage_breakdown`, matching `AnthropicUsage::to_breakdown` and `CamelUsage::to_breakdown`.

The driver hands the sink borrowed slices out of its own buffer, so a scan no longer allocates a `String` per line for Pi, or a `String` plus a `Vec<u8>` per line for Prime Agent.

## What did not move, and why

**`for_each_json_line` cannot serve either Pi reader mode.** It hands out only a lossily decoded `&str`, and both halves of the family need more than that, which is why the new driver is a sibling rather than a migration onto it.

- Prime Agent hashes the exact source bytes of a damaged record into `prime-agent:damaged:<sha256>`, and detects a lineage key mangled by invalid UTF-8 by testing those bytes with `str::from_utf8`. Both are gone after a lossy decode: distinct invalid sequences have already collapsed onto one U+FFFD. `rejects_only_headers_with_damaged_lineage_keys` pins exactly this, requiring a raw `0xFF` appended to a complete `parentSession` key to be rejected while the valid-UTF-8 spelling `"parentSession\u{FFFD}"` is accepted.
- Pi, Senpi and Kimchi drop a record whose bytes are not valid UTF-8 rather than reading it through replacement characters. Decoding lossily makes them emit messages they do not emit today. Measured on a record whose model carries one `0xFF` byte, on `main` and on this branch alike:

  ```
  strict=[]  lossy=[("unknown", 28)]
  ```

  Pi skips it; Prime Agent emits it as model `unknown`. Opting the first three clients into the second behaviour needs a parser-version bump for each, which `PiParseOptions::standard` already says it is deferring, so the driver reports `valid_utf8` and they keep skipping.

**`PiUsage` does not fold into `CamelUsage`.** The accepted key sets are not identical: `PiUsage` reads `reasoning` and routes every other key into the flattened extras map `has_damaged_key` needs, while `CamelUsage` reads `cost`. A struct holding the union of both rejects documents that each accepts today (simd-json, the real decode path):

  | document | `PiUsage` | `CamelUsage` | union |
  | --- | --- | --- | --- |
  | real Pi usage block | ok | ok | ok |
  | `"cost": 5` | **ok** | fail | **fail** |
  | `"cost": "free"` | **ok** | fail | **fail** |
  | `"cost": {"total": "x"}` | **ok** | fail | **fail** |
  | `"reasoning": "a lot"` | fail | **ok** | **fail** |
  | `"reasoning": 5` | ok | ok | ok |

  A failed usage block is not a lost cost field, it is a lost message: `pi_emitted_record` requires `message.usage`. And `cost` is on every Pi usage block in the local corpus (18,641 of 18,641 sampled), so the narrowing would sit on the common path. The two stay separate and the note on `CamelUsage` now says so with the reason.

## Verification

Behaviour was replayed over a frozen 1.5 GB copy of the real local corpus, 1,049 transcripts from `~/.prime/agent/sessions`, `~/.prime/agent/session-artifacts` and `~/.senpi`, each parsed as Pi, Senpi, Kimchi and Prime Agent: 371,860 emitted messages compared field by field (session id, model, provider, timestamp, all five token buckets, dedup key, agent, workspace) plus every file's accounting record.

Output is byte-identical to `main` on 372,879 of 372,909 lines. The 30 that differ are accounting records whose attribution order comes from `HashMap` iteration; running the unmodified `main` binary twice permutes the same 30 lines, and their contents are identical as multisets. That nondeterminism predates this branch.

No `parser_version` changed.

## Gates

```
cargo test --release -p tokscale-core -p tokscale-cli
     Running unittests src/bin/fake_codex.rs (target/release/deps/fake_codex-d06643f8e460009c)
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
     Running unittests src/main.rs (target/release/deps/tokscale-e9b2f4323747cf84)
test result: ok. 1111 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 9.00s
     Running tests/cli_tests.rs (target/release/deps/cli_tests-fb621575f1c08b58)
test result: ok. 167 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 11.34s
     Running unittests src/lib.rs (target/release/deps/tokscale_core-b2cf759b19043090)
test result: ok. 1784 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 8.41s
     Running tests/anthropic_catalog.rs (target/release/deps/anthropic_catalog-7bd6e4a8705be7bd)
test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s
     Running tests/codebuff.rs (target/release/deps/codebuff-7fc36a2c56b4939e)
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
     Running tests/freebuff.rs (target/release/deps/freebuff-acbb540750cb289b)
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
     Running tests/gjc.rs (target/release/deps/gjc-b0279e7f0f2696a4)
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
     Running tests/hermes.rs (target/release/deps/hermes-a7a19f91710f2c18)
test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
     Running tests/jcode.rs (target/release/deps/jcode-48e393f87d4e2dcc)
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
     Running tests/junie.rs (target/release/deps/junie-efa40852b91f3542)
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
   Doc-tests tokscale_core
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

3,104 passed, 0 failed, 5 ignored across 12 suites. Every existing test is unmodified. The known `trae::sync` contender flake did not appear.

cargo clippy --all-targets -- -D warnings
Checking tokscale-core v4.13.0 (/Users/junhoyeo/tokscale-worktrees/pi-drivers/crates/tokscale-core)
    Checking tokscale-cli v4.13.0 (/Users/junhoyeo/tokscale-worktrees/pi-drivers/crates/tokscale-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.08s
(exit 0, no warnings)

cargo fmt --check
(exit 0, no output)
```

## Binary size

Stripped release binary, `cargo build --release -p tokscale-cli`, measured per commit:

| commit | bytes | delta |
| --- | --- | --- |
| `main` (1be9f19f) | 16,167,488 | baseline |
| share one token breakdown | 16,167,488 | 0 |
| decode JSON lines through one helper | 16,167,488 | 0 |
| read transcripts through a shared line driver | 16,167,504 | **+16** |
| document why the usage blocks stay separate | 16,167,504 | 0 |

Net +16 bytes. LTO had already merged the duplicated breakdowns and decode sites, so the source dedup buys nothing there, and the driver costs 16 bytes rather than saving any. This is a maintainability and allocation change, not a size win; the earlier round's equivalent item was worth -16 bytes and this one is worth +16.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Pi-format transcript parsing on shared drivers to remove duplication and per-line allocations without changing behavior. Pi and Prime Agent now use one line driver and one JSON decode helper; outputs match `main`.

- Review notes:
  - New `sessions/utils.rs::for_each_json_line_with_bytes` drives both Pi and Prime Agent. It exposes raw bytes, trimmed text, and `valid_utf8`, and allows early stop via `ControlFlow`. BOM and terminator handling live here.
  - New `sessions/utils.rs::parse_json_line` replaces open-coded simd-json calls.
  - `PiUsage::to_breakdown` centralizes token breakdown. Prime accounting now uses it.
  - Kept behavior: Pi/Senpi/Kimchi still drop invalid-UTF-8 records; Prime Agent still inspects and hashes raw bytes. `for_each_json_line` cannot serve these needs and remains separate.
  - Deleted `lossy_lines_with_bytes`, `LossyLinesWithBytes`, and `LossyLine` (no remaining callers).
  - Verified on a 1.5 GB corpus: messages identical; only nondeterministic `HashMap` attribution order differs in 30 accounting lines. No `parser_version` change. No migrations required.

<sup>Written for commit ae638d547777dfd52a0c31e0f0188e1853380303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

