### PR TITLE
fix(pricing): correct MiniMax-M3 first-party rates in alias regression fixture

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -184,7 +184,7 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
 - **ネイティブRustコア** - 10倍高速な処理のため、すべての解析と集計をRustで実行
 - **Web可視化** - 2Dと3Dビューのインタラクティブ貢献グラフ
 - **柔軟なフィルタリング** - プラットフォーム、日付範囲、年別フィルタリング
-- **タスク別レポート** - マルチバックエンド対応（Apple FM、Claude、Codex、Gemini、Kiro）の LLM によるセッション要約とタスクグルーピング
+- **タスク別レポート** - マルチバックエンド対応（Apple FM、Claude、Codex、Gemini、Kiro、MiniMax）の LLM によるセッション要約とタスクグルーピング
 - **JSONエクスポート** - 外部可視化ツール用のデータ生成
 - **ソーシャルプラットフォーム** - 使用量の共有、リーダーボード競争、公開プロフィール閲覧
 
@@ -765,6 +765,7 @@ LLM 要約は**デフォルトで有効**になっています（`--no-summarize
 | `codex` | `codex --quiet` | Codex CLI がインストールされ認証済みである必要があります。 |
 | `gemini` | `gemini -p` | Gemini CLI がインストールされ認証済みである必要があります。 |
 | `kiro` | `kiro --non-interactive` | Kiro CLI がインストールされ認証済みである必要があります。 |
+| `minimax` | （HTTP API） | OpenAI 互換の chat-completions API を使用するため、CLI は不要です。`MINIMAX_API_KEY` または `MINIMAX_API_TOKEN` を設定してください。既定ではグローバルエンドポイント（`https://api.minimax.io/v1`）で `MiniMax-M3` を使用します。`MINIMAX_API_REGION=cn` を設定すると `https://api.minimaxi.com/v1` を使用し、`MINIMAX_MODEL` で別のモデル（例: `MiniMax-M2.7`）を選択できます。 |
 
 **仕組み:**
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -182,7 +182,7 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
 - **네이티브 Rust 코어** - 모든 파싱과 집계를 Rust로 처리해 최대 10배 빠른 성능
 - **웹 시각화** - 2D 및 3D 뷰의 인터랙티브 기여 그래프
 - **유연한 필터링** - 플랫폼, 날짜 범위 또는 연도별 필터링
-- **작업 기반 리포트** - LLM 기반 세션 요약 및 작업 그룹화, 여러 백엔드 지원 (Apple FM, Claude, Codex, Gemini, Kiro)
+- **작업 기반 리포트** - LLM 기반 세션 요약 및 작업 그룹화, 여러 백엔드 지원 (Apple FM, Claude, Codex, Gemini, Kiro, MiniMax)
 - **JSON 내보내기** - 외부 시각화 도구/자동화용 데이터 생성
 - **소셜 플랫폼** - 사용량 공유, 리더보드 경쟁, 공개 프로필 조회
 
@@ -760,6 +760,7 @@ tokscale report --workspace my-project --client opencode
 | `codex` | `codex --quiet` | Codex CLI가 설치되어 인증되어 있어야 함. |
 | `gemini` | `gemini -p` | Gemini CLI가 설치되어 인증되어 있어야 함. |
 | `kiro` | `kiro --non-interactive` | Kiro CLI가 설치되어 인증되어 있어야 함. |
+| `minimax` | (HTTP API) | OpenAI 호환 chat-completions API를 사용하므로 CLI가 필요하지 않음. `MINIMAX_API_KEY` 또는 `MINIMAX_API_TOKEN` 설정. 기본값은 글로벌 엔드포인트(`https://api.minimax.io/v1`)의 `MiniMax-M3`이며, `MINIMAX_API_REGION=cn`을 설정하면 `https://api.minimaxi.com/v1`을 사용하고 `MINIMAX_MODEL`로 다른 모델(예: `MiniMax-M2.7`)을 선택할 수 있음. |
 
 **동작 방식:**
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
 - **Web visualization** - Interactive contribution graph with 2D and 3D views
 - **Flexible filtering** - Filter by platform, date range, or year
-- **Task-attributed reports** - LLM-powered session summarization and task grouping with multi-backend support (Apple FM, Claude, Codex, Gemini, Kiro)
+- **Task-attributed reports** - LLM-powered session summarization and task grouping with multi-backend support (Apple FM, Claude, Codex, Gemini, Kiro, MiniMax)
 - **Export to JSON** - Generate data for external visualization tools
 - **Social Platform** - Share your usage, compete on leaderboards, and view public profiles
 
@@ -766,6 +766,7 @@ tokscale report --workspace my-project --client opencode
 | `codex` | `codex --quiet` | Requires Codex CLI installed and authenticated. |
 | `gemini` | `gemini -p` | Requires Gemini CLI installed and authenticated. |
 | `kiro` | `kiro --non-interactive` | Requires Kiro CLI installed and authenticated. |
+| `minimax` | (HTTP API) | OpenAI-compatible chat-completions API, so no CLI is needed. Set `MINIMAX_API_KEY` or `MINIMAX_API_TOKEN`. Defaults to `MiniMax-M3` on the global endpoint (`https://api.minimax.io/v1`); set `MINIMAX_API_REGION=cn` to use `https://api.minimaxi.com/v1`, and `MINIMAX_MODEL` to select another model (for example `MiniMax-M2.7`). |
 
 **How it works:**
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -182,7 +182,7 @@
 - **原生 Rust 核心** - 所有解析和聚合在 Rust 中完成，处理速度提升 10 倍
 - **Web 可视化** - 带 2D 和 3D 视图的交互式贡献图
 - **灵活筛选** - 按平台、日期范围或年份筛选
-- **任务归因报告** - 由 LLM 驱动的会话摘要与任务分组，支持多种后端（Apple FM、Claude、Codex、Gemini、Kiro）
+- **任务归因报告** - 由 LLM 驱动的会话摘要与任务分组，支持多种后端（Apple FM、Claude、Codex、Gemini、Kiro、MiniMax）
 - **导出为 JSON** - 为外部可视化工具生成数据
 - **社交平台** - 分享使用情况、排行榜竞争、查看公开个人资料
 
@@ -764,6 +764,7 @@ tokscale report --workspace my-project --client opencode
 | `codex` | `codex --quiet` | 需要已安装并已认证的 Codex CLI。 |
 | `gemini` | `gemini -p` | 需要已安装并已认证的 Gemini CLI。 |
 | `kiro` | `kiro --non-interactive` | 需要已安装并已认证的 Kiro CLI。 |
+| `minimax` | （HTTP API） | 使用 OpenAI 兼容的 chat-completions API，无需 CLI。设置 `MINIMAX_API_KEY` 或 `MINIMAX_API_TOKEN`。默认在全局端点（`https://api.minimax.io/v1`）使用 `MiniMax-M3`；设置 `MINIMAX_API_REGION=cn` 可改用 `https://api.minimaxi.com/v1`，并可通过 `MINIMAX_MODEL` 选择其他模型（例如 `MiniMax-M2.7`）。 |
 
 **工作原理：**
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -12082,12 +12082,16 @@ mod tests {
         // zeros still counts as "priced" downstream. The alias must pin the
         // canonical first-party `minimax/MiniMax-M3` key instead.
         let mut litellm = HashMap::new();
-        // Real first-party rates.
+        // Real first-party rates: $0.60 input / $2.40 output / $0.12 cache read
+        // per million tokens. The cache-read rate is part of the published
+        // first-party row, so the fixture carries it too — otherwise the guard
+        // below would pass while cached input silently priced at $0.
         litellm.insert(
             "minimax/MiniMax-M3".into(),
             pricing::ModelPricing {
-                input_cost_per_token: Some(3e-7),
-                output_cost_per_token: Some(1.2e-6),
+                input_cost_per_token: Some(6e-7),
+                output_cost_per_token: Some(2.4e-6),
+                cache_read_input_token_cost: Some(1.2e-7),
                 ..Default::default()
             },
         );
@@ -12149,7 +12153,7 @@ mod tests {
             TokenBreakdown {
                 input: 1_000_000,
                 output: 100_000,
-                cache_read: 0,
+                cache_read: 500_000,
                 cache_write: 0,
                 reasoning: 0,
             },
@@ -12158,9 +12162,10 @@ mod tests {
 
         apply_pricing_if_available(&mut msg, Some(&pricing));
 
-        // First-party: 1_000_000 * 3e-7 + 100_000 * 1.2e-6 = 0.42.
-        // The zero-cost row would give 0.0; the fireworks row would give 42.0.
-        let expected = 1_000_000.0 * 3e-7 + 100_000.0 * 1.2e-6;
+        // First-party: 1_000_000 * 6e-7 + 100_000 * 2.4e-6 + 500_000 * 1.2e-7
+        // = 0.9. The zero-cost row would give 0.0; the fireworks row, which
+        // publishes no cache-read rate, would give 42.0.
+        let expected = 1_000_000.0 * 6e-7 + 100_000.0 * 2.4e-6 + 500_000.0 * 1.2e-7;
         assert!(
             (msg.cost - expected).abs() < 1e-12,
             "expected first-party minimax/MiniMax-M3 cost {expected}, got {}",


### PR DESCRIPTION
Reason: The `minimax-m3` alias regression fixture stated stale first-party rates and no cache-read rate, and the `minimax` summarizer backend was missing from the backend tables in all four READMEs.

## Pricing fixture

`test_apply_pricing_if_available_prices_minimax_m3_bare_id_via_alias` builds a fixture dataset where the first-party row competes with a hosted reseller row and a zero-cost third-party row, then asserts the bare `minimax-m3` id resolves to the first-party key. The row standing in for "real first-party rates" was priced at $0.30 input / $1.20 output per million tokens and carried no cache-read rate.

The elected key was still correct, so the test passed — but the numbers a reader takes away from a row commented "Real first-party rates" were wrong, and the missing cache-read rate meant cached input in this fixture priced at $0 with nothing pointing that out.

This updates the row to the current published first-party rates — $0.60 input, $2.40 output, $0.12 cache read per million tokens — and gives the fixture message 500k cached-input tokens so the cache-read rate is covered by the cost assertion rather than sitting in the row unexercised. The asserted cost moves from 0.42 to 0.9.

The two competing rows are untouched: the zero-cost row still yields 0.0 and the reseller row still yields 42.0, so both remain far enough from the first-party result that electing either could not be mistaken for it.

## Summarizer backend tables

`--summarizer minimax` has been dispatchable in `report.rs` since the backend was added, and it appears in the command examples in each README, but the **Summarizer backends** table — the place a reader actually goes to choose a backend — listed only `apple-fm`, `claude`, `codex`, `gemini`, and `kiro` in all four translations. None of the environment variables that configure it were documented there.

This adds a `minimax` row to the table in `README.md`, `README.ja.md`, `README.ko.md`, and `README.zh-cn.md`, documenting the values the code actually reads: `MINIMAX_API_KEY` / `MINIMAX_API_TOKEN` for the key, `MINIMAX_API_REGION=cn` to select `https://api.minimaxi.com/v1` instead of the default `https://api.minimax.io/v1`, and `MINIMAX_MODEL` to override the default `MiniMax-M3`. The backend is also added to the task-attributed-reports feature bullet in each README, which listed the other five backends.

## Checks

- `cargo fmt --all -- --check` — clean
- `cargo test -p tokscale-core --lib` — 1785 passed, 1 pre-existing failure unrelated to this change: `test_empty_parse_results_are_not_cached_for_optional_file_sources` sets a fixture file to mode `0o000` and expects the parse to yield nothing, but the test ran as root, which bypasses the permission check and reads the file anyway. It fails the same way on an unmodified checkout in this environment.
- `cargo test -p tokscale-core --lib minimax` — 5 passed, covering the updated fixture and the alias resolution tests.
- Removing `cache_read_input_token_cost` from the updated row was verified to fail the assertion (0.84 against an expected 0.9), confirming the new rate is actually exercised.

`cargo clippy` was not run — the component was not available in this environment.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale `MiniMax-M3` first‑party rates in the alias regression fixture and adds the `minimax` summarizer backend to all README backend tables. The test now asserts current first‑party pricing, including cache reads, and the docs show how to configure the backend.

- Pricing fixture: Old row used $0.30 input / $1.20 output per million with no cache‑read; new row uses $0.60 input / $2.40 output / $0.12 cache‑read. The message now includes 500k cached‑input tokens, moving the expected cost from 0.42 to 0.9. Competing zero‑cost and reseller rows are unchanged; alias still resolves to the first‑party key.
- Docs: Add `minimax` to backend tables and feature bullets in `README.md`, `README.ja.md`, `README.ko.md`, and `README.zh-cn.md`. Document `MINIMAX_API_KEY`/`MINIMAX_API_TOKEN`, default model `MiniMax-M3`, default endpoint `https://api.minimax.io/v1`, `MINIMAX_API_REGION=cn` to use `https://api.minimaxi.com/v1`, and `MINIMAX_MODEL` to override.

<sup>Written for commit 9a8deda0fab681ced6715b7eb2785e3f2164ab52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

