### PR TITLE
fix(pricing): price Kimi Work models and correct the kimi-for-coding target

### DIFF
--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -12,9 +12,21 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("k2-p6", "kimi-k2.6");
     m.insert("kimi-k2p6", "kimi-k2.6");
     m.insert("kimi-k2.5-thinking", "kimi-k2-thinking");
-    m.insert("kimi-for-coding", "kimi-k2.5");
+    // Kimi CLI reports `kimi-for-coding` for Kimi K2.7 Code (its config sets
+    // `display_name = "K2.7 Coding"`). It was previously aliased to k2.5, which
+    // priced it about a third under the real rate.
+    m.insert("kimi-for-coding", "kimi-k2.7-code");
     m.insert("kimi-for-coding-highspeed", "kimi-k2.7-code-highspeed");
     m.insert("k3", "kimi-k3");
+    // Kimi Work (the Kimi desktop app's agent mode) embeds the same kimi-code
+    // kernel and writes the same wire protocol, but reports its own ids.
+    // Unaliased they fuzzy-match badly: `k2d6-agent` landed on
+    // `xai/grok-4.20-multi-agent-beta-0309`, and the `k3-agent*` ids fell into
+    // the Models.dev `kimi-for-coding/*` subscription namespace, which prices
+    // at $0.00.
+    m.insert("k2d6-agent", "kimi-k2.6");
+    m.insert("k3-agent", "kimi-k3");
+    m.insert("k3-agent-swarm", "kimi-k3");
 
     // MiniMax M3: Ollama Cloud and other routers report the model with the
     // lowercase bare id `minimax-m3` (and mixed-case variants), while the
@@ -152,7 +164,17 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
 });
 
 pub fn resolve_alias(model_id: &str) -> Option<&'static str> {
-    MODEL_ALIASES.get(model_id.to_lowercase().as_str()).copied()
+    let lowered = model_id.to_lowercase();
+    if let Some(target) = MODEL_ALIASES.get(lowered.as_str()) {
+        return Some(target);
+    }
+    // kimi-code reports some rows as `kimi-code/<id>`. The Kimi parser strips
+    // that prefix before pricing, but any other path reaching pricing with the
+    // qualified form would otherwise miss every alias above and fall through to
+    // the Models.dev `kimi-for-coding/*` namespace, which prices at $0.00 — so
+    // the qualified and bare spellings of the same model would disagree.
+    let bare = lowered.strip_prefix("kimi-code/")?;
+    MODEL_ALIASES.get(bare).copied()
 }
 
 #[cfg(test)]
@@ -211,6 +233,45 @@ mod tests {
             Some("kimi-k2.7-code-highspeed")
         );
         assert_eq!(resolve_alias("k3"), Some("kimi-k3"));
+    }
+
+    #[test]
+    fn resolves_kimi_work_agent_ids_to_their_underlying_models() {
+        // Kimi Work reports its own ids. Without these they fuzzy-match badly:
+        // `k2d6-agent` resolved to `xai/grok-4.20-multi-agent-beta-0309`, and
+        // the `k3-agent*` ids landed in the zero-priced `kimi-for-coding/*`
+        // subscription namespace.
+        assert_eq!(resolve_alias("k2d6-agent"), Some("kimi-k2.6"));
+        assert_eq!(resolve_alias("k3-agent"), Some("kimi-k3"));
+        assert_eq!(resolve_alias("k3-agent-swarm"), Some("kimi-k3"));
+        assert_eq!(resolve_alias("K3-AGENT-SWARM"), Some("kimi-k3"));
+    }
+
+    #[test]
+    fn kimi_for_coding_prices_as_k2p7_code_not_k2p5() {
+        // Kimi CLI's own config names this "K2.7 Coding"; the previous k2.5
+        // target priced it about a third under the real rate.
+        assert_eq!(resolve_alias("kimi-for-coding"), Some("kimi-k2.7-code"));
+        assert_eq!(
+            resolve_alias("kimi-for-coding-highspeed"),
+            Some("kimi-k2.7-code-highspeed")
+        );
+    }
+
+    #[test]
+    fn qualified_kimi_code_ids_resolve_like_their_bare_form() {
+        // A `kimi-code/<id>` row must not price differently from `<id>`.
+        for bare in ["k3", "kimi-for-coding", "k2d6-agent", "k3-agent"] {
+            let qualified = format!("kimi-code/{bare}");
+            assert_eq!(
+                resolve_alias(&qualified),
+                resolve_alias(bare),
+                "qualified id {qualified} must resolve like {bare}"
+            );
+            assert!(resolve_alias(&qualified).is_some());
+        }
+        // An unknown id stays unknown whether or not it carries the prefix.
+        assert_eq!(resolve_alias("kimi-code/not-a-real-model"), None);
     }
 
     #[test]


### PR DESCRIPTION
Addresses parts 1–3 of #1145. Every claim in the issue was reproduced against the real cached pricing datasets before changing anything, rather than taken on trust.

## What was actually happening

Probing `lookup_with_source_and_provider` against the local LiteLLM / Models.dev / OpenRouter caches:

| id | resolved to | source |
|---|---|---|
| `k2d6-agent` | **`xai/grok-4.20-multi-agent-beta-0309`** | LiteLLM |
| `k3-agent` | `kimi-for-coding/k3` | Models.dev |
| `k3-agent-swarm` | `kimi-for-coding/k3` | Models.dev |
| `kimi-for-coding` | `moonshotai/kimi-k2.5` | OpenRouter (alias) |
| `kimi-code/k3` | `kimi-for-coding/k3` | Models.dev |

A Kimi model priced as xAI Grok, and three ids in the `kimi-for-coding/*` subscription namespace that prices at $0.00.

## Cost impact, measured

1M input + 100k output per model, against the real datasets:

| id | before | after |
|---|---:|---:|
| `k2d6-agent` | $2.50 | **$1.35** |
| `kimi-for-coding` | $0.90 | **$1.35** |
| `k3-agent` | $0.00 | **$4.50** |
| `k3-agent-swarm` | $0.00 | **$4.50** |
| `kimi-code/k3` | $0.00 | **$4.50** (now equal to bare `k3`) |

## The `kimi-code/` prefix

`resolve_alias` now falls back to the bare form when an id carries that prefix. The Kimi parser already strips it (`kimi.rs:145`) before pricing, so this is defence in depth for any other path reaching pricing with the qualified spelling — which is what made qualified and bare rows of the same model disagree.

## No parser version bump, and why

The Codex fix in #1146 needed one because it changed cached token buckets. This one does not, because pricing is applied on the read path rather than persisted. Verified rather than assumed — built a warm cache with the previous binary, then read it with the new one:

| | total |
|---|---:|
| previous binary (builds cache) | $3.4000 |
| new binary, **same warm cache** | **$7.2000** |
| new binary, cold cache (control) | $7.2000 |

Warm equals cold, so the corrected prices reach users through their existing cache with no re-scan.

## Not addressed

**Part 4, `k3-256k`.** It still prices at $0.00 via `kimi-for-coding/k3-256k`, which is certainly wrong, but the issue asks whether that is intentional rather than asserting a target. I did not guess: mapping it to `kimi-k3` would be inference, and if Moonshot charges a premium for the 256k context that would silently undercharge instead. Happy to add it if you can confirm the intended target.

**The Kimi Work scan root** from the appendix is also not added here — that is a scanner change rather than a pricing one, and works today through `TOKSCALE_EXTRA_DIRS`.

`cargo test --release -p tokscale-core -p tokscale-cli` 0 failures, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kimi Work and Kimi Code pricing by adding explicit aliases and correcting the `kimi-for-coding` target. Previously `k2d6-agent` priced as xAI Grok and `k3-agent`/`k3-agent-swarm` priced at $0.00; `kimi-for-coding` priced as K2.5. All now resolve to the intended Kimi models, and `kimi-for-coding` maps to K2.7 Code.

**Review notes**
- Adds aliases: `k2d6-agent` → `kimi-k2.6`, `k3-agent`/`k3-agent-swarm` → `kimi-k3`, `kimi-for-coding` → `kimi-k2.7-code` (matching `kimi-for-coding-highspeed`).
- `resolve_alias` now falls back to the bare id for `kimi-code/<id>` so qualified and bare spellings price the same.
- No migration required: pricing is applied on read; existing caches pick up corrected rates (no parser version bump).
- Tests cover new aliases and `kimi-code/` fallback.
- Addresses parts 1–3 of #1145; `k3-256k` remains unchanged pending confirmation.

<sup>Written for commit e64b8a7b1d66b78af9b1a39242f0e138fefafad3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

