### PR TITLE
fix(opencode): support session_v2 metadata

### DIFF
--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -270,6 +270,27 @@ mod tests {
         conn
     }
 
+    /// Build a database shaped like current OpenCode v2: `session_v2` carries
+    /// metadata while `session_message` holds the assistant usage payloads.
+    fn create_opencode_session_v2_sqlite_db(db_path: &Path) -> Connection {
+        let conn = Connection::open(db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE session_v2 (
+                id TEXT PRIMARY KEY,
+                directory TEXT NOT NULL,
+                title TEXT
+            );
+            CREATE TABLE session_message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                type TEXT NOT NULL,
+                data TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
     /// A representative v2 assistant payload: no `role` field, model + provider
     /// nested under `$.model`, integer timestamps.
     const V2_ASSISTANT_DATA: &str = r#"{
@@ -362,6 +383,79 @@ mod tests {
         assert_eq!(
             msg.cost_source,
             crate::sessions::CostSource::ProviderReported
+        );
+    }
+    #[test]
+    fn test_parse_v2_session_v2_message_reads_tokens_and_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = create_opencode_session_v2_sqlite_db(&db_path);
+        conn.execute(
+            "INSERT INTO session_v2 (id, directory, title) VALUES (?1, ?2, ?3)",
+            rusqlite::params![
+                "ses_current_v2",
+                "/Users/alice/current-opencode-repo",
+                "Current OpenCode session"
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_message (id, session_id, type, data) VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![
+                "msg_current_v2",
+                "ses_current_v2",
+                "assistant",
+                V2_ASSISTANT_DATA
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_opencode_sqlite(&db_path);
+        assert_eq!(messages.len(), 1, "current session_v2 rows should parse");
+        let msg = &messages[0];
+        assert_eq!(
+            msg.workspace_key.as_deref(),
+            Some("/Users/alice/current-opencode-repo")
+        );
+        assert_eq!(msg.workspace_label.as_deref(), Some("current-opencode-repo"));
+        assert_eq!(msg.session_title.as_deref(), Some("Current OpenCode session"));
+        assert_eq!(msg.dedup_key.as_deref(), Some("msg_current_v2"));
+    }
+
+    #[test]
+    fn test_parse_v2_session_message_without_metadata_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE session_message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                type TEXT NOT NULL,
+                data TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_message (id, session_id, type, data) VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![
+                "msg_without_metadata",
+                "ses_without_metadata",
+                "assistant",
+                V2_ASSISTANT_DATA
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_opencode_sqlite(&db_path);
+        assert_eq!(messages.len(), 1, "usage should parse without session metadata");
+        assert_eq!(messages[0].workspace_key, None);
+        assert_eq!(messages[0].session_title, None);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("msg_without_metadata")
         );
     }
 

--- a/crates/tokscale-core/src/sessions/opencode_schema.rs
+++ b/crates/tokscale-core/src/sessions/opencode_schema.rs
@@ -320,11 +320,29 @@ impl OpenCodeSchemaConfig {
 // Query variants
 // =============================================================================
 
-/// OpenCode v2 (`opencode-next.db`): per-message rows in `session_message`,
-/// role in the `type` column, model + provider nested under `$.model`.
-/// Databases whose `session` table predates the `title` column fall back to the
-/// title-less variant — the title is optional, not a gating column.
+/// OpenCode v2: per-message rows in `session_message`, role in the `type`
+/// column, model + provider nested under `$.model`. Current databases store
+/// session metadata in `session_v2`; older v2 databases use `session`.
+/// Databases whose metadata table predates the `title` column fall back to a
+/// title-less variant, and the final query preserves usage parsing when the
+/// metadata table is absent.
 const OPENCODE_V2_QUERIES: &[&str] = &[
+    r#"
+        SELECT sm.id, sm.session_id, sm.data, NULLIF(s.directory, '') AS workspace_root, s.title AS session_title
+        FROM session_message sm
+        LEFT JOIN session_v2 s ON s.id = sm.session_id
+        WHERE sm.type = 'assistant'
+          AND json_extract(sm.data, '$.tokens') IS NOT NULL
+        ORDER BY sm.id, sm.session_id
+    "#,
+    r#"
+        SELECT sm.id, sm.session_id, sm.data, NULLIF(s.directory, '') AS workspace_root, NULL AS session_title
+        FROM session_message sm
+        LEFT JOIN session_v2 s ON s.id = sm.session_id
+        WHERE sm.type = 'assistant'
+          AND json_extract(sm.data, '$.tokens') IS NOT NULL
+        ORDER BY sm.id, sm.session_id
+    "#,
     r#"
         SELECT sm.id, sm.session_id, sm.data, NULLIF(s.directory, '') AS workspace_root, s.title AS session_title
         FROM session_message sm
@@ -337,6 +355,13 @@ const OPENCODE_V2_QUERIES: &[&str] = &[
         SELECT sm.id, sm.session_id, sm.data, NULLIF(s.directory, '') AS workspace_root, NULL AS session_title
         FROM session_message sm
         LEFT JOIN session s ON s.id = sm.session_id
+        WHERE sm.type = 'assistant'
+          AND json_extract(sm.data, '$.tokens') IS NOT NULL
+        ORDER BY sm.id, sm.session_id
+    "#,
+    r#"
+        SELECT sm.id, sm.session_id, sm.data, NULL AS workspace_root, NULL AS session_title
+        FROM session_message sm
         WHERE sm.type = 'assistant'
           AND json_extract(sm.data, '$.tokens') IS NOT NULL
         ORDER BY sm.id, sm.session_id


### PR DESCRIPTION
Fixes #1155

## Summary
- Parse OpenCode v2 databases that store session metadata in `session_v2`.
- Retain compatibility with older `session` metadata tables.
- Preserve usage parsing when a `session_message` database has no metadata table.
- Add regression coverage for the current schema and metadata-free fallback.

## Validation
- `git diff --check`
- Not run: Rust formatter and tests, because the local machine has no Rust toolchain installed.

Co-Authored-By: Warp <agent@warp.dev>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support OpenCode v2 databases that store session metadata in `session_v2`, while keeping compatibility with older `session` tables and metadata-free databases. Previously we only read metadata from `session`; now we also join `session_v2`, restoring workspace and title fields for current databases without changing parsing for older ones.

- OPENCODE v2 query order now tries `session_v2` (with/without `title`), then `session` (with/without `title`), and finally a no-metadata fallback; still filters for `assistant` rows with `$.tokens`.
- Adds tests to ensure `session_v2` metadata is read and that usage parsing works when no metadata table exists. No migration or config changes for `tokscale-core`.

<sup>Written for commit 7f8ceed3d32241592c0e175bfad0e7b18481831c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

