### PR TITLE
feat(sessions): add Oh My Pi (omp) as a local session source

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -69,7 +69,8 @@
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`、`manicode-staging`; `CODEBUFF_DATA_DIR` でオーバーライド可能) |
 | <img width="48px" src=".github/assets/client-freebuff.png" alt="Freebuff" /> | [Freebuff](https://github.com/CodebuffAI/freebuff) | Codebuff と同じ `~/.config/manicode/` を共有（同一ランタイム）；トークン使用量はトランスクリプトから推定（ローカル使用量なし；`FREEBUFF_DATA_DIR` でオーバーライド可能） |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` |
-| <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` and `~/.omp/agent/sessions/` ([Oh My Pi](https://github.com/can1357/oh-my-pi)) |
+| <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` |
+| <img width="48px" src="https://github.com/can1357.png" alt="Oh My Pi" /> | [Oh My Pi](https://github.com/can1357/oh-my-pi) | `~/.omp/agent/sessions/**/*.jsonl` |
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/` (`SENPI_CODING_AGENT_DIR` でオーバーライド可能) |
 | <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/`（`KIMCHI_CODING_AGENT_DIR` でオーバーライド可能） |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Reasonix" /> | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | `~/.reasonix/stats/*.jsonl`（`REASONIX_STATE_HOME` または `REASONIX_HOME` でオーバーライド可能） |
@@ -179,7 +180,7 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
   - 設定可能なカラーテーマのGitHubスタイル貢献グラフ
   - リアルタイムフィルタリングとソート
   - ゼロフリッカーレンダリング
-- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Prime Agent、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic、Cherry Studio、fxの使用量を追跡
+- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Prime Agent、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic、Cherry Studio、fx、Oh My Piの使用量を追跡
 - **リアルタイム価格** - 1時間ディスクキャッシュ付きでLiteLLMから現在の価格を取得；OpenRouter自動フォールバックと新規モデル向けCursor価格サポート
 - **詳細な内訳** - 入力、出力、キャッシュ読み書き、推論トークン追跡
 - **ネイティブRustコア** - 10倍高速な処理のため、すべての解析と集計をRustで実行
@@ -1451,7 +1452,8 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 | Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | OpenCodeと同様に`xdg-basedir`を使用 |
 | Cursor | API同期 | API同期 | Cursor API から取得したデータを `usage*.csv` としてキャッシュ；デスクトップ自動ログインは `state.vscdb` の認証のみ；ローカルの `~/.cursor` セッションデータは解析しない |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | すべてのプラットフォームで同じパス |
-| Pi | `~/.pi/` and `~/.omp/` | `%USERPROFILE%\.pi\` and `%USERPROFILE%\.omp\` | すべてのプラットフォームで同じパス（Pi と [Oh My Pi](https://github.com/can1357/oh-my-pi) の両方をサポート） |
+| Pi | `~/.pi/` | `%USERPROFILE%\.pi\` | すべてのプラットフォームで同じパス |
+| Oh My Pi | `~/.omp/` | `%USERPROFILE%\.omp\` | すべてのプラットフォームで同じパス（[Oh My Pi](https://github.com/can1357/oh-my-pi)） |
 | Kimchi Coding | `~/.config/kimchi/harness/sessions/` | `%USERPROFILE%\.config\kimchi\harness\sessions\` | `KIMCHI_CODING_AGENT_DIR` 環境変数でオーバーライド可能；Pi互換のJSONLセッション |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | すべてのプラットフォームで同じパス |
 | Kimi Code | `~/.kimi-code/` | `%USERPROFILE%\.kimi-code\` | すべてのプラットフォームで同じパス |
@@ -1733,7 +1735,7 @@ HermesはSQLiteの`sessions`テーブルにセッションレベルの使用量�
 
 ### Pi
 
-場所: `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl` および `~/.omp/agent/sessions/<encoded-cwd>/*.jsonl`（[Oh My Pi](https://github.com/can1357/oh-my-pi)）
+場所: `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl`。[Oh My Pi](https://github.com/can1357/oh-my-pi) は同じセッション形式を `~/.omp/agent/sessions/` に書き込み、独立した `omp` クライアントとして追跡されます。
 
 セッションヘッダーとメッセージエントリを含むJSONL形式：
 ```json

--- a/README.ko.md
+++ b/README.ko.md
@@ -69,7 +69,8 @@
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`, `manicode-staging`; `CODEBUFF_DATA_DIR`로 오버라이드 가능) |
 | <img width="48px" src=".github/assets/client-freebuff.png" alt="Freebuff" /> | [Freebuff](https://github.com/CodebuffAI/freebuff) | Codebuff와 동일한 `~/.config/manicode/` 공유 (동일 런타임); 토큰 사용량은 트랜스크립트에서 추정 (로컬 사용량 없음; `FREEBUFF_DATA_DIR`로 오버라이드 가능) |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` |
-| <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` and `~/.omp/agent/sessions/` ([Oh My Pi](https://github.com/can1357/oh-my-pi)) |
+| <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` |
+| <img width="48px" src="https://github.com/can1357.png" alt="Oh My Pi" /> | [Oh My Pi](https://github.com/can1357/oh-my-pi) | `~/.omp/agent/sessions/**/*.jsonl` |
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/` (`SENPI_CODING_AGENT_DIR`로 오버라이드 가능) |
 | <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/` (`KIMCHI_CODING_AGENT_DIR`로 오버라이드 가능) |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Reasonix" /> | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | `~/.reasonix/stats/*.jsonl` (`REASONIX_STATE_HOME` 또는 `REASONIX_HOME`으로 오버라이드 가능) |
@@ -177,7 +178,7 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
   - 설정 가능한 색상 테마의 GitHub 스타일 기여 그래프
   - 실시간 필터링 및 정렬
   - 깜빡임 없는 렌더링
-- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Prime Agent, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic, Cherry Studio, fx 사용량 통합 추적
+- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Prime Agent, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic, Cherry Studio, fx, Oh My Pi 사용량 통합 추적
 - **실시간 가격 반영** - LiteLLM에서 최신 가격을 가져와(디스크 캐시 1시간) 비용 계산; OpenRouter 자동 폴백 및 신규 모델용 Cursor 가격 지원
 - **상세 분석** - 입력, 출력, 캐시 읽기/쓰기, 추론 토큰까지 추적
 - **네이티브 Rust 코어** - 모든 파싱과 집계를 Rust로 처리해 최대 10배 빠른 성능
@@ -1452,7 +1453,8 @@ AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장�
 | Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | OpenCode와 동일하게 `xdg-basedir` 사용 |
 | Cursor | API 동기화 | API 동기화 | API로 가져와 `usage*.csv`로 캐시; 데스크톱 자동 로그인은 `state.vscdb` 인증만 읽음; 로컬 `~/.cursor` 세션 데이터는 파싱하지 않음 |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | 모든 플랫폼에서 동일한 경로 |
-| Pi | `~/.pi/` and `~/.omp/` | `%USERPROFILE%\.pi\` and `%USERPROFILE%\.omp\` | 모든 플랫폼에서 동일한 경로 (Pi 및 [Oh My Pi](https://github.com/can1357/oh-my-pi) 모두 지원) |
+| Pi | `~/.pi/` | `%USERPROFILE%\.pi\` | 모든 플랫폼에서 동일한 경로 |
+| Oh My Pi | `~/.omp/` | `%USERPROFILE%\.omp\` | 모든 플랫폼에서 동일한 경로 ([Oh My Pi](https://github.com/can1357/oh-my-pi)) |
 | Kimchi Coding | `~/.config/kimchi/harness/sessions/` | `%USERPROFILE%\.config\kimchi\harness\sessions\` | `KIMCHI_CODING_AGENT_DIR` 환경변수로 오버라이드 가능; Pi 호환 JSONL 세션 |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | 모든 플랫폼에서 동일한 경로 |
 | Kimi Code | `~/.kimi-code/` | `%USERPROFILE%\.kimi-code\` | 모든 플랫폼에서 동일한 경로 |
@@ -1772,7 +1774,7 @@ Hermes는 세션 수준 사용량을 SQLite `sessions` 테이블에 저장합니
 
 ### Pi
 
-위치: `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl` 및 `~/.omp/agent/sessions/<encoded-cwd>/*.jsonl` ([Oh My Pi](https://github.com/can1357/oh-my-pi))
+위치: `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl`. [Oh My Pi](https://github.com/can1357/oh-my-pi)는 동일한 세션 형식을 `~/.omp/agent/sessions/` 아래에 기록하며 별도의 `omp` 클라이언트로 추적됩니다.
 
 세션 헤더와 메시지 항목을 포함하는 JSONL 형식:
 ```json

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`, `manicode-staging`; override via `CODEBUFF_DATA_DIR`) |
 | <img width="48px" src=".github/assets/client-freebuff.png" alt="Freebuff" /> | [Freebuff](https://github.com/CodebuffAI/freebuff) | shares `~/.config/manicode/` with Codebuff (same runtime); token usage is estimated from the transcript (no local usage; override via `FREEBUFF_DATA_DIR`) |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` |
-| <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` and `~/.omp/agent/sessions/` ([Oh My Pi](https://github.com/can1357/oh-my-pi)) |
+| <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` |
+| <img width="48px" src="https://github.com/can1357.png" alt="Oh My Pi" /> | [Oh My Pi](https://github.com/can1357/oh-my-pi) | `~/.omp/agent/sessions/**/*.jsonl` |
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/` (override via `SENPI_CODING_AGENT_DIR`) |
 | <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/` (override via `KIMCHI_CODING_AGENT_DIR`) |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Reasonix" /> | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | `~/.reasonix/stats/*.jsonl` (override via `REASONIX_STATE_HOME` or `REASONIX_HOME`) |
@@ -177,7 +178,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with configurable color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Prime Agent, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic, Cherry Studio, and fx
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Prime Agent, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic, Cherry Studio, fx, and Oh My Pi
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -1489,7 +1490,8 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | Uses `xdg-basedir` like OpenCode |
 | Cursor | API sync | API sync | Data fetched from Cursor API and cached as `usage*.csv`; desktop auto-login reads auth only from `state.vscdb`; local `~/.cursor` session data is not parsed |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | Same path on all platforms |
-| Pi | `~/.pi/` and `~/.omp/` | `%USERPROFILE%\.pi\` and `%USERPROFILE%\.omp\` | Same path on all platforms (supports both Pi and [Oh My Pi](https://github.com/can1357/oh-my-pi)) |
+| Pi | `~/.pi/` | `%USERPROFILE%\.pi\` | Same path on all platforms |
+| Oh My Pi | `~/.omp/` | `%USERPROFILE%\.omp\` | Same path on all platforms ([Oh My Pi](https://github.com/can1357/oh-my-pi)) |
 | Kimchi Coding | `~/.config/kimchi/harness/sessions/` | `%USERPROFILE%\.config\kimchi\harness\sessions\` | Configurable via `KIMCHI_CODING_AGENT_DIR` env var; Pi-compatible JSONL sessions |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | Same path on all platforms |
 | Kimi Code | `~/.kimi-code/` | `%USERPROFILE%\.kimi-code\` | Same path on all platforms |
@@ -1809,7 +1811,7 @@ Hermes stores session-level usage in a SQLite `sessions` table. Tokscale imports
 
 ### Pi
 
-Location: `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl` and `~/.omp/agent/sessions/<encoded-cwd>/*.jsonl` ([Oh My Pi](https://github.com/can1357/oh-my-pi))
+Location: `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl`. [Oh My Pi](https://github.com/can1357/oh-my-pi) writes the same session format under `~/.omp/agent/sessions/` and is tracked as its own `omp` client.
 
 JSONL format with session header and message entries:
 ```json

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -70,7 +70,8 @@
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/`（+ `manicode-dev`、`manicode-staging`；可通过 `CODEBUFF_DATA_DIR` 覆盖） |
 | <img width="48px" src=".github/assets/client-freebuff.png" alt="Freebuff" /> | [Freebuff](https://github.com/CodebuffAI/freebuff) | 与 Codebuff 共用 `~/.config/manicode/`（同一运行时）；令牌消耗从转录估算（无本地用量；可通过 `FREEBUFF_DATA_DIR` 覆盖） |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` |
-| <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` 和 `~/.omp/agent/sessions/`（[Oh My Pi](https://github.com/can1357/oh-my-pi)） |
+| <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` |
+| <img width="48px" src="https://github.com/can1357.png" alt="Oh My Pi" /> | [Oh My Pi](https://github.com/can1357/oh-my-pi) | `~/.omp/agent/sessions/**/*.jsonl` |
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/`（通过 `SENPI_CODING_AGENT_DIR` 覆盖） |
 | <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/`（可通过 `KIMCHI_CODING_AGENT_DIR` 覆盖） |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Reasonix" /> | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | `~/.reasonix/stats/*.jsonl`（可通过 `REASONIX_STATE_HOME` 或 `REASONIX_HOME` 覆盖） |
@@ -177,7 +178,7 @@
   - 支持可配置颜色主题的 GitHub 风格贡献图
   - 实时筛选和排序
   - 零闪烁渲染
-- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Prime Agent、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic、Cherry Studio 和 fx 的使用情况
+- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Prime Agent、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic、Cherry Studio、fx 和 Oh My Pi 的使用情况
 - **实时定价** - 从 LiteLLM 获取当前价格，带 1 小时磁盘缓存；OpenRouter 自动回退和新模型的 Cursor 定价支持
 - **详细分解** - 输入、输出、缓存读写和推理 Token 跟踪
 - **原生 Rust 核心** - 所有解析和聚合在 Rust 中完成，处理速度提升 10 倍
@@ -1451,7 +1452,8 @@ AI 编程工具将会话数据存储在跨平台位置。大多数工具在所�
 | Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | 与 OpenCode 一样使用 `xdg-basedir` |
 | Cursor | API 同步 | API 同步 | 通过 API 获取并缓存为 `usage*.csv`；桌面端自动登录仅读取 `state.vscdb` 认证；不解析本地 `~/.cursor` 会话数据 |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | 所有平台使用相同路径 |
-| Pi | `~/.pi/` and `~/.omp/` | `%USERPROFILE%\.pi\` and `%USERPROFILE%\.omp\` | 所有平台使用相同路径（支持 Pi 和 [Oh My Pi](https://github.com/can1357/oh-my-pi)） |
+| Pi | `~/.pi/` | `%USERPROFILE%\.pi\` | 所有平台使用相同路径 |
+| Oh My Pi | `~/.omp/` | `%USERPROFILE%\.omp\` | 所有平台使用相同路径（[Oh My Pi](https://github.com/can1357/oh-my-pi)） |
 | Kimchi Coding | `~/.config/kimchi/harness/sessions/` | `%USERPROFILE%\.config\kimchi\harness\sessions\` | 可通过 `KIMCHI_CODING_AGENT_DIR` 环境变量覆盖；Pi 兼容的 JSONL 会话 |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | 所有平台使用相同路径 |
 | Kimi Code | `~/.kimi-code/` | `%USERPROFILE%\.kimi-code\` | 所有平台使用相同路径 |
@@ -1771,7 +1773,7 @@ Hermes 将会话级使用量存储在 SQLite `sessions` 表中。Tokscale 导入
 
 ### Pi
 
-位置：`~/.pi/agent/sessions/<encoded-cwd>/*.jsonl` 和 `~/.omp/agent/sessions/<encoded-cwd>/*.jsonl`（[Oh My Pi](https://github.com/can1357/oh-my-pi)）
+位置：`~/.pi/agent/sessions/<encoded-cwd>/*.jsonl`。[Oh My Pi](https://github.com/can1357/oh-my-pi) 将相同的会话格式写入 `~/.omp/agent/sessions/`，并作为独立的 `omp` 客户端进行跟踪。
 
 包含会话头和消息条目的 JSONL 格式：
 ```json

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1094,6 +1094,7 @@ pub enum ClientFilter {
     Dsh,
     Mcode,
     Fx,
+    Omp,
     Synthetic,
 }
 
@@ -1153,6 +1154,7 @@ impl ClientFilter {
             Self::Dsh => "dsh",
             Self::Mcode => "mcode",
             Self::Fx => "fx",
+            Self::Omp => "omp",
             Self::Synthetic => "synthetic",
         }
     }
@@ -1215,6 +1217,7 @@ impl ClientFilter {
             Self::Dsh => Some(ClientId::Dsh),
             Self::Mcode => Some(ClientId::Mcode),
             Self::Fx => Some(ClientId::Fx),
+            Self::Omp => Some(ClientId::Omp),
             Self::Synthetic => None,
         }
     }
@@ -1273,6 +1276,7 @@ impl ClientFilter {
             ClientId::Dsh => Self::Dsh,
             ClientId::Mcode => Self::Mcode,
             ClientId::Fx => Self::Fx,
+            ClientId::Omp => Self::Omp,
         }
     }
 

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -56,6 +56,10 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
     // Fx: `s` is the global "sources" picker binding; `X` mirrors the fX
     // mnemonic (lowercase `x` belongs to Mux).
     ClientUi { hotkey: 'X' },
+    // Oh My Pi: every case of `o`, `m` and `p` is already taken (OpenCode /
+    // OpenClaw, MiMo Code / Mcode, Pi / Prime Agent), and `s` is the global
+    // "sources" picker binding, so `Y` stands in for the Y in "oh mY pi".
+    ClientUi { hotkey: 'Y' },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1649,6 +1649,7 @@ mod tests {
         assert_eq!(clients[46], ClientId::Dsh);
         assert_eq!(clients[47], ClientId::Mcode);
         assert_eq!(clients[48], ClientId::Fx);
+        assert_eq!(clients[49], ClientId::Omp);
     }
 
     #[test]
@@ -1703,6 +1704,7 @@ mod tests {
             "DeepSeek Harness",
             "MiniMax Code",
             "Fx",
+            "Oh My Pi",
         ];
 
         assert_eq!(expected.len(), ClientId::COUNT);
@@ -1749,6 +1751,7 @@ mod tests {
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::PrimeAgent), 'P');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Mcode), 'M');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Fx), 'X');
+        assert_eq!(crate::tui::client_ui::hotkey(ClientId::Omp), 'Y');
     }
 
     #[test]

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -986,6 +986,23 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    // Oh My Pi is a pi-mono descendant and writes the same session JSONL, one
+    // level deeper than Pi: `<encoded-cwd>/<timestamp>_<uuid>.jsonl` for the
+    // session and `<timestamp>_<uuid>/<AgentName>.jsonl` for its subagents.
+    // The root is fixed rather than an env-var root on purpose: omp reads
+    // `PI_CODING_AGENT_DIR`, the same variable Pi uses, so honoring it would let
+    // one override point both clients at a single tree and double-count it.
+    Omp = 49 => {
+        id: "omp",
+        display: "Oh My Pi",
+        logo: None,
+        root: PathRoot::Home,
+        relative: ".omp/agent/sessions",
+        pattern: "*.jsonl",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -1101,7 +1118,34 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 49);
+        assert_eq!(ClientId::COUNT, 50);
+    }
+
+    #[test]
+    fn test_omp_client_registered_as_local_session_source() {
+        let client = ClientId::from_str("omp").expect("omp client should be registered");
+        assert_eq!(client.data().relative_path, ".omp/agent/sessions");
+        assert_eq!(client.data().pattern, "*.jsonl");
+        assert!(client.data().parse_local);
+        assert!(client.data().submit_default);
+        assert!(!client.data().headless);
+    }
+
+    #[test]
+    #[serial]
+    fn test_omp_root_ignores_pi_coding_agent_dir() {
+        // given: omp reads PI_CODING_AGENT_DIR for its own session directory,
+        // but Pi uses that same variable. Honoring it here would let a single
+        // override point both clients at one tree and double-count every
+        // message in it, so omp's root must stay fixed under the home dir.
+        let mut env = EnvGuard::capture(&["PI_CODING_AGENT_DIR"]);
+        env.set("PI_CODING_AGENT_DIR", "/tmp/somewhere-else");
+
+        let client = ClientId::from_str("omp").expect("omp client should be registered");
+        assert_eq!(
+            client.data().resolve_path("/tmp/home"),
+            native_join(std::path::Path::new("/tmp/home"), ".omp/agent/sessions")
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2179,6 +2179,15 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         sessions::senpi::parse_senpi_file,
     );
 
+    parse_cached_lane(
+        &scan_result,
+        &mut source_cache,
+        pricing,
+        &mut all_messages,
+        ClientId::Omp,
+        sessions::omp::parse_omp_file,
+    );
+
     let augment_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Augment)
         .par_iter()
@@ -4665,6 +4674,20 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let senpi_count = senpi_msgs.len() as i32;
     counts.set(ClientId::Senpi, senpi_count);
     messages.extend(senpi_msgs);
+
+    let omp_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Omp)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::omp::parse_omp_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let omp_count = omp_msgs.len() as i32;
+    counts.set(ClientId::Omp, omp_count);
+    messages.extend(omp_msgs);
 
     let augment_msgs_raw: Vec<UnifiedMessage> = scan_result
         .get(ClientId::Augment)

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1118,6 +1118,11 @@ fn parser_version(client: ClientId) -> u32 {
         // are versioned from the start so later parser changes have an
         // obvious local counter to bump, like every other client here.
         ClientId::Fx => 1,
+        // omp delegates to the shared pi-format parser, so any pi.rs parse
+        // change that bumps ClientId::Pi must be evaluated for Omp (and Senpi)
+        // too — the shared code path changes what byte-identical omp files
+        // parse to even though omp's own module did not change.
+        ClientId::Omp => 1,
         _ => 1,
     }
 }

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -1770,12 +1770,6 @@ fn scan_all_clients_with_env_strategy_inner(
         );
     }
 
-    // Oh My Pi fork (https://github.com/can1357/oh-my-pi) — same JSONL format, different root
-    if enabled.contains(&ClientId::Pi) {
-        let omp_path = join_native(home_dir, ".omp/agent/sessions");
-        push_unique_scan_task(&mut tasks, &mut seen_scan_roots, ClientId::Pi, omp_path);
-    }
-
     if enabled.contains(&ClientId::PrimeAgent) {
         // Prime Agent lets the session directory move independently from its
         // agent directory. Its RLM child session tree is always a sibling of
@@ -4511,20 +4505,21 @@ mod tests {
     }
 
     #[test]
-    fn test_scan_all_clients_omp_scanned_as_pi() {
+    fn test_scan_all_clients_omp_scanned_as_omp() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
         setup_mock_omp_dir(home);
 
         let result =
-            scan_all_clients_with_env_strategy(home.to_str().unwrap(), &["pi".to_string()], false);
-        assert_eq!(result.get(ClientId::Pi).len(), 1);
-        assert!(result.get(ClientId::Pi)[0].ends_with("2026-04-06T03-04-28Z_omp_ses_001.jsonl"));
+            scan_all_clients_with_env_strategy(home.to_str().unwrap(), &["omp".to_string()], false);
+        assert_eq!(result.get(ClientId::Omp).len(), 1);
+        assert!(result.get(ClientId::Omp)[0].ends_with("2026-04-06T03-04-28Z_omp_ses_001.jsonl"));
+        assert!(result.get(ClientId::Pi).is_empty());
         assert!(result.get(ClientId::OpenCode).is_empty());
     }
 
     #[test]
-    fn test_scan_all_clients_pi_from_both_paths() {
+    fn test_scan_all_clients_omp_not_scanned_as_pi() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
         setup_mock_pi_dir(home);
@@ -4532,7 +4527,27 @@ mod tests {
 
         let result =
             scan_all_clients_with_env_strategy(home.to_str().unwrap(), &["pi".to_string()], false);
-        assert_eq!(result.get(ClientId::Pi).len(), 2);
+        assert_eq!(result.get(ClientId::Pi).len(), 1);
+        assert!(result.get(ClientId::Pi)[0].ends_with("1733011200000_pi_ses_001.jsonl"));
+        assert!(result.get(ClientId::Omp).is_empty());
+    }
+
+    #[test]
+    fn test_scan_all_clients_pi_and_omp_each_scan_only_their_own_root() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_pi_dir(home);
+        setup_mock_omp_dir(home);
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["pi".to_string(), "omp".to_string()],
+            false,
+        );
+        assert_eq!(result.get(ClientId::Pi).len(), 1);
+        assert!(result.get(ClientId::Pi)[0].ends_with("1733011200000_pi_ses_001.jsonl"));
+        assert_eq!(result.get(ClientId::Omp).len(), 1);
+        assert!(result.get(ClientId::Omp)[0].ends_with("2026-04-06T03-04-28Z_omp_ses_001.jsonl"));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -38,6 +38,7 @@ pub mod kiro;
 pub mod mcode;
 pub mod micode;
 pub mod mux;
+pub mod omp;
 pub mod openclaw;
 pub mod opencode;
 pub mod opencode_schema;

--- a/crates/tokscale-core/src/sessions/omp.rs
+++ b/crates/tokscale-core/src/sessions/omp.rs
@@ -1,0 +1,174 @@
+//! Oh My Pi (omp) session parser
+//!
+//! Oh My Pi is a pi-mono descendant and writes the same session JSONL record
+//! format, so parsing delegates to [`super::pi::parse_pi_format_file`]; only the
+//! scan root and client id differ.
+//!
+//! Layout is one level deeper than Pi's. A top-level session is
+//! `~/.omp/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl`, and when that
+//! session spawns subagents they are written as sibling files inside a directory
+//! of the same name: `<timestamp>_<uuid>/<AgentName>.jsonl`, plus advisor runs
+//! under `<timestamp>_<uuid>/__advisor.<name>.jsonl`. Every one of those is a
+//! complete session file with its own header, so the recursive `*.jsonl` scan
+//! picks them up and each is parsed independently — the same way Pi's own
+//! subagent files are handled.
+//!
+//! The scan root is deliberately a plain `~/.omp/agent/sessions` rather than an
+//! env-var root. Oh My Pi reads `PI_CODING_AGENT_DIR` for its session directory,
+//! but that is the *same* variable Pi itself uses, so honoring it here would make
+//! a single override point both clients at one tree and double-count it. Pi is
+//! registered with a fixed home-relative root for the same reason.
+
+use super::pi::parse_pi_format_file;
+use super::UnifiedMessage;
+use std::path::Path;
+
+/// Parse an Oh My Pi JSONL session file.
+pub fn parse_omp_file(path: &Path) -> Vec<UnifiedMessage> {
+    parse_pi_format_file(path, "omp", "omp")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn create_test_file(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    #[test]
+    fn test_parse_omp_session_with_full_usage_record() {
+        // given: the record layout omp writes today — a versioned session header
+        // followed by an assistant message carrying the nested usage object.
+        let content = r#"{"type":"session","version":3,"id":"01a01fc8-e982-7000-b3c1-4cca8048e34a","timestamp":"2026-08-20T15:27:35.811Z","cwd":"/tmp/workspace"}
+{"type":"message","id":"b2","parentId":null,"timestamp":"2026-08-20T15:27:40.000Z","message":{"role":"assistant","model":"z-ai/glm-5.2:free","provider":"openrouter-glm-free-zdr","usage":{"input":17,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":27}}}"#;
+        let file = create_test_file(content);
+
+        // when
+        let messages = parse_omp_file(file.path());
+
+        // then
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "omp");
+        assert_eq!(
+            messages[0].session_id,
+            "01a01fc8-e982-7000-b3c1-4cca8048e34a"
+        );
+        assert_eq!(messages[0].model_id, "z-ai/glm-5.2:free");
+        assert_eq!(messages[0].tokens.input, 17);
+        assert_eq!(messages[0].tokens.output, 10);
+        assert_eq!(
+            messages[0].workspace_key,
+            Some("/tmp/workspace".to_string())
+        );
+        assert_eq!(messages[0].workspace_label, Some("workspace".to_string()));
+    }
+
+    #[test]
+    fn test_parse_omp_subagent_file_is_a_standalone_session() {
+        // given: a subagent transcript from `<session>/<AgentName>.jsonl`. It
+        // carries its own session header, so it must parse on its own rather
+        // than depending on the parent file being read first.
+        let content = r#"{"type":"session","version":3,"id":"01a00742-c3eb-7000-92ab-e3294db5e528-TelegramBrokerMap","timestamp":"2026-08-15T21:10:11.179Z","cwd":"/tmp/proj"}
+{"type":"message","id":"s1","parentId":null,"timestamp":"2026-08-15T21:10:20.000Z","message":{"role":"assistant","model":"claude-opus-5","provider":"anthropic","usage":{"input":12,"output":34,"cacheRead":0,"cacheWrite":0,"totalTokens":46}}}"#;
+        let file = create_test_file(content);
+
+        // when
+        let messages = parse_omp_file(file.path());
+
+        // then
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "omp");
+        assert_eq!(messages[0].tokens.output, 34);
+    }
+
+    #[test]
+    fn test_parse_omp_falls_back_to_omp_when_provider_unrecoverable() {
+        // given: an unrecognizable model with no provider falls back to the omp
+        // client id rather than pi's, and the message is still counted.
+        let content = r#"{"type":"session","version":3,"id":"omp_ses_fallback","timestamp":"2026-08-20T15:27:35.811Z","cwd":"/tmp"}
+{"type":"message","id":"b2","parentId":null,"timestamp":"2026-08-20T15:27:40.000Z","message":{"role":"assistant","model":"totally-unrecognized-model-xyz","usage":{"input":100,"output":50,"cacheRead":0,"cacheWrite":0,"totalTokens":150}}}"#;
+        let file = create_test_file(content);
+
+        // when
+        let messages = parse_omp_file(file.path());
+
+        // then
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].provider_id, "omp");
+    }
+
+    #[test]
+    fn test_parse_omp_infers_provider_from_model_before_client_fallback() {
+        // given: a provider-less message whose model id names a recognizable
+        // family. Inference must win over the `omp` fallback, because pricing
+        // keys off the vendor rather than the harness that recorded the turn.
+        let content = r#"{"type":"session","version":3,"id":"omp_ses_precedence","timestamp":"2026-08-20T15:27:35.811Z","cwd":"/tmp"}
+{"type":"message","id":"b1","parentId":null,"timestamp":"2026-08-20T15:27:40.000Z","message":{"role":"assistant","model":"gpt-5","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2}}}"#;
+        let file = create_test_file(content);
+
+        // when
+        let messages = parse_omp_file(file.path());
+
+        // then
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].provider_id, "openai");
+    }
+
+    #[test]
+    fn test_parse_omp_keeps_complete_records_before_truncated_trailing_line() {
+        // given: omp appends while a turn is streaming, so the last line of a
+        // live session file can be a half-written JSON object. Usage already
+        // complete above it must still be counted.
+        let content = concat!(
+            r#"{"type":"session","version":3,"id":"omp_ses_live","timestamp":"2026-08-20T15:27:35.811Z","cwd":"/tmp"}"#,
+            "\n",
+            r#"{"type":"message","id":"b2","parentId":null,"timestamp":"2026-08-20T15:27:40.000Z","message":{"role":"assistant","model":"claude-opus-5","provider":"anthropic","usage":{"input":2,"output":3,"cacheRead":0,"cacheWrite":0,"totalTokens":5}}}"#,
+            "\n",
+            r#"{"type":"message","id":"b3","message":{"role":"assistant""#,
+        );
+        let file = create_test_file(content);
+
+        // when
+        let messages = parse_omp_file(file.path());
+
+        // then
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 2);
+        assert_eq!(messages[0].tokens.output, 3);
+    }
+
+    #[test]
+    fn test_parse_omp_ignores_non_assistant_and_control_entries() {
+        // given: user turns carry no usage, and omp interleaves control records
+        // between assistant turns. Neither may produce a message.
+        let content = r#"{"type":"session","version":3,"id":"omp_ses_control","timestamp":"2026-08-20T15:27:35.811Z","cwd":"/tmp"}
+{"type":"message","id":"c2","parentId":null,"timestamp":"2026-08-20T15:27:40.000Z","message":{"role":"user","content":"hi"}}
+{"type":"thinking_level_change","id":"c3","parentId":"c2","timestamp":"2026-08-20T15:27:41.000Z","thinkingLevel":"high"}"#;
+        let file = create_test_file(content);
+
+        // when
+        let messages = parse_omp_file(file.path());
+
+        // then
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_omp_empty_and_headerless_files_are_empty() {
+        // given
+        let empty = create_test_file("");
+        let headerless = create_test_file(
+            r#"{"type":"message","id":"b2","parentId":null,"timestamp":"2026-08-20T15:27:40.000Z","message":{"role":"assistant","model":"claude-opus-5","provider":"anthropic","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2}}}"#,
+        );
+
+        // when / then
+        assert!(parse_omp_file(empty.path()).is_empty());
+        assert!(parse_omp_file(headerless.path()).is_empty());
+    }
+}

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -1,12 +1,12 @@
 //! Pi (badlogic/pi-mono) session parser
 //!
-//! Parses JSONL files from `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl` (and,
-//! via the `pi` client's OMP scan root, `~/.omp/agent/sessions/...`). Current
+//! Parses JSONL files from `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl`. Current
 //! OMP builds write a `title` metadata record before the `session` header in
 //! newly-created session files; see [`PRE_SESSION_METADATA_TYPES`].
 //!
 //! Pi descendants reuse this record layout verbatim, so [`parse_pi_format_file`]
-//! is shared: see `sessions::senpi` for Senpi (OmO Native).
+//! is shared: see `sessions::senpi` for Senpi (OmO Native) and `sessions::omp`
+//! for Oh My Pi, which owns the `~/.omp/agent/sessions` root.
 
 use super::utils::{file_modified_timestamp_ms, for_each_json_line_with_bytes, parse_json_line};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,7 @@
     "gemini",
     "codex",
     "fx",
+    "omp",
     "cli"
   ]
 }

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -78,6 +78,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   cherrystudio: "Cherry Studio",
   dsh: "DeepSeek Harness",
   fx: "Fx",
+  omp: "Oh My Pi",
 };
 
 // Client logos from GitHub CDN (public repo)
@@ -139,6 +140,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
   cherrystudio: `${GITHUB_CDN_BASE}/client-cherrystudio.png`,
   dsh: "https://github.com/deepseek-ai.png",
   fx: `${GITHUB_CDN_BASE}/client-fx.png`,
+  omp: "https://github.com/can1357.png",
 };
 
 export const SOURCE_COLORS: Record<ClientType, string> = {
@@ -193,6 +195,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   cherrystudio: "#FA7298",
   dsh: "#4D6BFE",
   fx: "#0070F3",
+  omp: "#E11D48",
 };
 
 // Derived values

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -50,6 +50,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "cherrystudio",
   "dsh",
   "fx",
+  "omp",
 ] as const;
 
 export type CcMirrorClientType = `cc-mirror/${string}`;

--- a/packages/tokscale/package.json
+++ b/packages/tokscale/package.json
@@ -25,6 +25,7 @@
     "gemini",
     "cursor",
     "fx",
+    "omp",
     "cli"
   ],
   "dependencies": {


### PR DESCRIPTION
## What

Adds Oh My Pi (`omp`) as a local session source, so its usage is counted alongside Pi rather than silently missing.

## How

omp is a pi-mono descendant and writes the same session JSONL record format, so parsing delegates to `pi::parse_pi_format_file` — the same one-line pattern `senpi.rs`, `gjc.rs` and `prime_agent.rs` already use. Only the scan root and client id differ.

The layout sits one level deeper than Pi's:

```
~/.omp/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl                    # session
~/.omp/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>/<AgentName>.jsonl        # subagents
~/.omp/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>/__advisor.<name>.jsonl   # advisor runs
```

Each subagent file carries its own session header, so the recursive `*.jsonl` scan picks them up and parses each independently.

## One deliberate decision worth reviewing

**The root is a fixed `PathRoot::Home`, not a `PathRoot::EnvVar`.** omp honours `PI_CODING_AGENT_DIR` for its session directory — but that is the *same* variable Pi uses. Wiring it as an env-var root would mean a single override points both clients at one tree and double-counts every message in it. Pi is registered with a fixed home-relative root for exactly this reason, so omp follows it. `test_omp_root_ignores_pi_coding_agent_dir` pins the behaviour so it does not get "fixed" into a regression later.

Happy to switch to an env-var root if you would rather have the override and handle the collision another way.

## Verification

- `cargo test -p tokscale-core` — 1815 pass. The only failure is the pre-existing `test_discover_micode_dbs_in_dirs_collapses_same_file_via_symlink`, which calls `std::os::windows::fs::symlink_dir(..).unwrap()` and needs Developer Mode/admin on Windows; unrelated to this change.
- `cargo fmt --all -- --check` clean; `cargo clippy` adds no new warnings.
- Against a real install, `tokscale clients` reports the two as separate sources with no double-counting:

```
Pi
sessions: ~\.pi\agent\sessions
messages: 25.1K

Oh My Pi
sessions: ~\.omp\agent\sessions
messages: 5.6K
```

Pi's 25.1K is unchanged from before the adapter existed.

## Notes

- New client discriminant `Omp = 49`; the `ClientId::COUNT` test is updated 49 -> 50.
- TUI hotkey is `Y` — every case of `o`, `m` and `p` was already taken (OpenCode/OpenClaw, MiMo Code/Mcode, Pi/Prime Agent) and `s` is the global sources binding, so `Y` stands in for the Y in "oh mY pi". Happy to change it.
- No logo URL set, matching other recently-added clients.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Oh My Pi (`omp`) as its own local session source and gives it sole ownership of `~/.omp/agent/sessions`. Previously `omp` files were ignored or counted under Pi, causing double counting when both were enabled; now `omp` is parsed and attributed to `omp` only.

- Scanner: drop the `.omp` special-case under Pi; register `ClientId::Omp` with `PathRoot::Home`, `relative` `.omp/agent/sessions`, and `pattern` `*.jsonl`. New tests pin that Pi scans only `~/.pi/...`, `omp` scans only `~/.omp/...`.
- Root policy: ignore `PI_CODING_AGENT_DIR` for `omp` to avoid collisions with Pi; test `test_omp_root_ignores_pi_coding_agent_dir` pins this.
- Parser: add `sessions::omp` delegating to `pi::parse_pi_format_file`; recursive scan picks up subagent/advisor `*.jsonl`. Cache version arm for `omp` notes shared Pi-format parser; Pi parser bumps may invalidate `omp` caches.
- Core wiring: include `omp` in cached and local parsing lanes; update counts; `ClientId::COUNT` is now 50.
- CLI/TUI: add `Omp` filter (`omp`) and hotkey `Y`; update registry tests.
- Frontend/Docs: register display name, logo, and color; update data-location and platform-path tables across all READMEs; add `omp` to `packages/cli` and `packages/tokscale` keywords and to `packages/frontend` client registries.

<sup>Written for commit bccd63ab3dc2a0c6289aea7d484185d3e4b0e2f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

