### PR TITLE
fix(dsh): count the compaction summarize call, and close two hygiene gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,10 @@ notepad.md
 ai-todolist.md
 *.tgz
 .sisyphus
-crates/tokscale-cli/tokscale-export-*.json
+# The TUI's export key writes to the process cwd, so these land wherever
+# tokscale (or `cargo test`, from the workspace root) was run from — not only
+# under the CLI crate.
+tokscale-export-*.json
 self-host/tokscale-key.pem
 self-host/
 .next/

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -1843,6 +1843,13 @@ mod tests {
     }
 
     #[test]
+    // `render_systemd_spec` resolves the unit directory from `XDG_CONFIG_HOME`
+    // and the log path from the config dir (`TOKSCALE_CONFIG_DIR`), then
+    // creates that directory. Both are process-global and every sibling test
+    // that sets them is serial, so running this one in parallel with them
+    // reads a half-torn override — the failure surfaces as an `unwrap` on the
+    // `Err` from `create_dir_all`.
+    #[serial_test::serial]
     fn systemd_spec_uses_autosubmit_run() {
         let settings = AutosubmitSettings {
             interval_minutes: 120,

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1114,6 +1114,12 @@ fn parser_version(client: ClientId) -> u32 {
         // them. v6 entries carry a count on every record, which `sessionize`
         // reads as one session per record.
         ClientId::Droid => 7,
+        // v1->v2: `compaction/summary` events carry the provider-reported cost
+        // of DSH's summarize call and used to fall through unread, so v1
+        // entries undercount every session that compacted (#1152). DSH has not
+        // shipped in a release, so this only rebuilds caches written by builds
+        // from main.
+        ClientId::Dsh => 2,
         // First version of the fx (vercel-labs) usage-v2.json parser. Entries
         // are versioned from the start so later parser changes have an
         // obvious local counter to bump, like every other client here.

--- a/crates/tokscale-core/src/sessions/dsh.rs
+++ b/crates/tokscale-core/src/sessions/dsh.rs
@@ -16,6 +16,9 @@
 //! - `assistant/message`: authoritative per-call usage on `data.usage`
 //!   (`inputTokens`, `outputTokens`, `cacheReadTokens`, ...) plus the serving
 //!   provider/model on `data.message.source`.
+//! - `compaction/summary`: the same usage and routing shape for the summarize
+//!   call DSH makes when it compacts a range. Real spend on the same account,
+//!   and disjoint from the loop steps around it.
 //!
 //! DSH never embeds a cost, so every message leaves the parser at `0.0` and
 //! pricing is its only cost source — the generic source cache is safe here.
@@ -140,7 +143,15 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
             "user/message" => {
                 pending_user_turn = true;
             }
-            "assistant/message" => {
+            // A compaction summary is a real provider call, not bookkeeping:
+            // DSH sends the shadowed range to the model and persists what that
+            // call spent on `data.usage`, with the routing fields in the same
+            // place as on an assistant message. It is not a loop step and
+            // shares no `(turn, step)` with one, so it is counted in addition
+            // to the messages around it rather than replacing any of them.
+            // Falling through to `_` billed those calls at zero (#1152).
+            "assistant/message" | "compaction/summary" => {
+                let is_summary = event_type == "compaction/summary";
                 // Fork/continuation ownership boundary. Forking copies the
                 // parent's completed prefix into the child transcript verbatim
                 // — same `seq`, `time`, `usage` and `message.id` — and records
@@ -188,10 +199,19 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
                     .clone()
                     .unwrap_or_else(|| session_id_from_path.clone());
 
-                let turn = value.pointer("/data/turn").and_then(Value::as_i64);
-                let is_turn_start = match turn {
-                    Some(turn) => turn_started.insert(turn),
-                    None => std::mem::take(&mut pending_user_turn),
+                // A summary is not a loop step, so it neither claims a turn
+                // start nor consumes the marker a `user/message` armed for the
+                // next assistant reply — taking it here would hand the turn to
+                // the summary and leave the real reply looking like a
+                // continuation.
+                let is_turn_start = if is_summary {
+                    false
+                } else {
+                    let turn = value.pointer("/data/turn").and_then(Value::as_i64);
+                    match turn {
+                        Some(turn) => turn_started.insert(turn),
+                        None => std::mem::take(&mut pending_user_turn),
+                    }
                 };
 
                 // `data.message.id` is a per-call `crypto.randomUUID()`
@@ -210,8 +230,14 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
                     .map(str::trim)
                     .filter(|id| !id.is_empty())
                     .map_or_else(|| format!("sid:{sid}"), |id| format!("msg:{id}"));
+                // Namespace the summary so it can never collapse against a loop
+                // step: a summary carries no `message.id` of its own, so both
+                // fall back to `sid:` and a summary that happened to match a
+                // reply's timestamp, routing and buckets would otherwise be
+                // dropped as a duplicate of it.
+                let kind = if is_summary { "summary:" } else { "" };
                 let dedup_key = format!(
-                    "dsh:{identity}:{timestamp}:{provider_id}:{model_id}:{}:{}:{}:{}:{}",
+                    "dsh:{kind}{identity}:{timestamp}:{provider_id}:{model_id}:{}:{}:{}:{}:{}",
                     tokens.input,
                     tokens.output,
                     tokens.cache_read,
@@ -327,6 +353,89 @@ mod tests {
 
         // Same turn, later step: not a turn start.
         assert!(!messages[1].is_turn_start);
+    }
+
+    #[test]
+    fn counts_compaction_summary_usage() {
+        // The summarize call DSH makes when it compacts a range. Real spend on
+        // the same account, disjoint from the loop steps around it (#1152).
+        let file = write_zstd_session(&[
+            r#"{"type":"session","version":0,"id":"session-abc","createdAt":1786669406484,"cwd":"/work"}"#,
+            r#"{"type":"user/message","seq":7,"time":1786669450001,"data":{"turn":1}}"#,
+            r#"{"type":"assistant/message","seq":301,"time":1786669454772,"data":{"turn":1,"step":1,"message":{"source":{"provider":"minimax-cn","model":"MiniMax-M3"}},"usage":{"inputTokens":130,"outputTokens":159,"cacheReadTokens":13824}}}"#,
+            r#"{"type":"compaction/summary","seq":402,"time":1786669470000,"data":{"message":{"source":{"provider":"minimax-cn","model":"MiniMax-M3"}},"usage":{"inputTokens":536,"outputTokens":2436,"cacheReadTokens":41472}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert_eq!(messages.len(), 2);
+
+        let summary = &messages[1];
+        assert_eq!(summary.model_id, "MiniMax-M3");
+        assert_eq!(summary.provider_id, "minimax-cn");
+        assert_eq!(summary.session_id, "session-abc");
+        assert_eq!(summary.timestamp, 1786669470000);
+        assert_eq!(summary.tokens.input, 536);
+        assert_eq!(summary.tokens.output, 2436);
+        assert_eq!(summary.tokens.cache_read, 41472);
+        // The 44,444-token summarize call from #1152, counted in addition to
+        // the reply rather than replacing it.
+        assert_eq!(summary.tokens.total(), 44_444);
+        assert_eq!(summary.workspace_key.as_deref(), Some("/work"));
+
+        // A summary is not a loop step, so it never claims the turn.
+        assert!(messages[0].is_turn_start);
+        assert!(!summary.is_turn_start);
+    }
+
+    #[test]
+    fn compaction_summary_does_not_steal_the_turn_start() {
+        // A summary landing between the user's prompt and the reply it
+        // precedes must leave the turn marker for the reply — under both the
+        // numbered-turn and the `user/message`-armed fallback paths.
+        let file = write_zstd_session(&[
+            r#"{"type":"session","version":0,"id":"session-abc","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"user/message","seq":7,"time":1786669450001,"data":{"turn":2}}"#,
+            r#"{"type":"compaction/summary","seq":8,"time":1786669450002,"data":{"turn":2,"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20}}}"#,
+            r#"{"type":"assistant/message","seq":9,"time":1786669450003,"data":{"turn":2,"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":30,"outputTokens":40}}}"#,
+            r#"{"type":"user/message","seq":10,"time":1786669450004,"data":{}}"#,
+            r#"{"type":"compaction/summary","seq":11,"time":1786669450005,"data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":50,"outputTokens":60}}}"#,
+            r#"{"type":"assistant/message","seq":12,"time":1786669450006,"data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":70,"outputTokens":80}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert_eq!(messages.len(), 4);
+
+        let turn_starts: Vec<bool> = messages.iter().map(|m| m.is_turn_start).collect();
+        // summary, reply, summary, reply — only the replies begin a turn.
+        assert_eq!(turn_starts, vec![false, true, false, true]);
+    }
+
+    #[test]
+    fn compaction_summary_without_usage_is_skipped() {
+        // `usage` is optional on the event; an absent value has to stay absent
+        // rather than becoming a zero-token contribution.
+        let file = write_zstd_session(&[
+            r#"{"type":"session","version":0,"id":"session-abc","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"compaction/summary","seq":8,"time":1786669450002,"data":{"shadowedTokenCount":19962}}"#,
+            r#"{"type":"compaction/summary","seq":9,"time":1786669450003,"data":{"usage":{"inputTokens":0,"outputTokens":0}}}"#,
+        ]);
+
+        assert!(parse_dsh_file(file.path()).is_empty());
+    }
+
+    #[test]
+    fn compaction_summary_inside_the_forked_seed_is_not_recounted() {
+        // The seed prefix is the parent's work, verbatim. A summary inside it
+        // is billed to the parent exactly like an assistant message is.
+        let file = write_zstd_session(&[
+            r#"{"type":"session","version":0,"id":"child","createdAt":1,"cwd":"/work","seedLength":10}"#,
+            r#"{"type":"compaction/summary","seq":4,"time":1786669450002,"data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20}}}"#,
+            r#"{"type":"compaction/summary","seq":11,"time":1786669450003,"data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":30,"outputTokens":40}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 30);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -418,8 +418,14 @@ mod tests {
             msg.workspace_key.as_deref(),
             Some("/Users/alice/current-opencode-repo")
         );
-        assert_eq!(msg.workspace_label.as_deref(), Some("current-opencode-repo"));
-        assert_eq!(msg.session_title.as_deref(), Some("Current OpenCode session"));
+        assert_eq!(
+            msg.workspace_label.as_deref(),
+            Some("current-opencode-repo")
+        );
+        assert_eq!(
+            msg.session_title.as_deref(),
+            Some("Current OpenCode session")
+        );
         assert_eq!(msg.dedup_key.as_deref(), Some("msg_current_v2"));
     }
 
@@ -450,7 +456,11 @@ mod tests {
         drop(conn);
 
         let messages = parse_opencode_sqlite(&db_path);
-        assert_eq!(messages.len(), 1, "usage should parse without session metadata");
+        assert_eq!(
+            messages.len(),
+            1,
+            "usage should parse without session metadata"
+        );
         assert_eq!(messages[0].workspace_key, None);
         assert_eq!(messages[0].session_title, None);
         assert_eq!(


### PR DESCRIPTION
Three independent fixes that came out of reviewing the 48 commits on `main` since `v4.13.0` for release readiness. The first is the one with a release-timing argument; the other two are hygiene.

## 1. `fix(dsh)`: count the compaction summarize call — closes #1152

`parse_dsh_file` matched four event types and let everything else fall through `_ => {}`. `compaction/summary` is one of those, and it carries the provider-reported usage of the summarize call DSH makes when it compacts a range. That is a real request on the same account, and it was never counted — **48,895 tokens over three compactions** on the corpus in #1152, 15.1% of that reporter's DSH total.

The event's usage and routing fields sit in the same place as on an assistant message, so the arm joins the existing one and the model/provider fallbacks already work. Two things deliberately differ:

- **A summary never claims a turn start.** It is not a loop step and shares no `(turn, step)` with one. It must also not consume the marker a `user/message` armed for the next reply — taking it would hand the turn to the summary and leave the real reply looking like a continuation.
- **Its dedup key is namespaced.** A summary carries no `message.id` of its own, so it and a loop step both fall back to `sid:`; a summary matching a reply's timestamp, routing and buckets would otherwise be dropped as a duplicate of it. The assistant-message key format is byte-for-byte unchanged, so existing cross-file dedup is untouched.

`usage` is optional on the event, so an absent value stays absent rather than becoming a zero-token contribution, and the seed-prefix boundary a fork inherits applies to summaries exactly as it does to replies.

**Parser version bumped 1 → 2.** Without it an existing cache keeps replaying rows parsed before the arm existed, and those sessions stay undercounted while appearing fixed.

### Why this is worth landing before the next release

DSH has not shipped — #1126 landed after `v4.13.0`. Fixing it now means the number is correct the first time anyone runs it, and the cache bump only rebuilds caches written by builds from `main`. After a release it becomes another shipped-tool-undercounts cycle with a real migration behind it.

## 2. `test(autosubmit)`: serialize the systemd spec test on its env reads

`systemd_spec_uses_autosubmit_run` was the only test in the module reaching the process-global config env without holding the serial lock. `render_systemd_spec` resolves the unit directory from `XDG_CONFIG_HOME` and the log path from `TOKSCALE_CONFIG_DIR`, then creates that directory; ~15 sibling tests set those to a `TempDir` under `#[serial]` and drop it on the way out.

Observed failing once in ~37 full-workspace runs; it did **not** reproduce in 30 further runs, so the exact interleaving is read from the code rather than from a captured one. The exposure isn't in question either way: the test depends on state every other test that writes it treats as requiring the lock. `render_windows_task_spec` reads no environment and the launchd tests go through `render_launchd_spec_for_home`, so neither needs the same treatment.

## 3. `chore(gitignore)`: ignore TUI exports wherever they are written

The rule was `crates/tokscale-cli/tokscale-export-*.json`, but `export_to_json` (`tui/app.rs`) writes a bare relative filename, so the file lands in the process's cwd. `cargo test` runs from the workspace root, so exercising that path leaves untracked `tokscale-export-<timestamp>.json` files in the repo root — where the scoped pattern doesn't match them. Dropping the prefix covers both, and also the user-facing case: tokscale is a developer tool, so the export key is routinely pressed with a repo as the cwd.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy --locked --workspace --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features --no-fail-fast` — all green; core goes 1808 → 1812 with the four new DSH tests
- **Non-vacuity check:** with the `compaction/summary` arm reverted, 3 of the 4 new tests fail. The fourth (`compaction_summary_without_usage_is_skipped`) is a negative test and only carries meaning with the arm present.

One pre-existing test, `test_empty_parse_results_are_not_cached_for_optional_file_sources`, fails in my environment only because it runs as `uid 0`: it `chmod 000`s a fixture and expects the parse to fail, but root bypasses the permission (verified directly — root reads a `0o000` file here). It is unrelated to this diff and passes under CI's non-root runner. The author of #1154 hit the same thing independently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMvHeQhUCLUApYBnMhYaxH)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Counts DSH `compaction/summary` usage that was previously ignored, without stealing a turn or colliding with replies; bumps the DSH parser to rebuild caches. Also stabilizes an autosubmit test and ignores TUI export files at the repo root.

- DSH parsing (`tokscale-core`): treat `compaction/summary` like an assistant call; never mark a turn start; namespace the dedup key to avoid reply collisions; skip events with no `usage`; fork seed-prefix rules unchanged.
- Cache version (`tokscale-core`): DSH parser 1 → 2 so caches rebuild and counts correct; no manual migration; limited to builds from `main`.
- Tests: serialize `systemd_spec_uses_autosubmit_run` with `serial_test::serial` to avoid racy env reads; no behavior changes.
- Ignore rule: add `tokscale-export-*.json` at repo root so TUI exports aren’t tracked; affects `.gitignore` used by `tokscale-cli` workflows.

<sup>Written for commit 3d0836029ff27fde39ba660b0900213a869930c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

