### PR TITLE
fix(dsh): attribute usage to the served model, not the configured one

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1119,6 +1119,13 @@ fn parser_version(client: ClientId) -> u32 {
         // them. v6 entries carry a count on every record, which `sessionize`
         // reads as one session per record.
         ClientId::Droid => 7,
+        // v1->v2: usage now attributes to the model the provider actually
+        // served (`replayState.response.responseModel`) instead of the
+        // configured `source.model`. DSH transcripts are append-only and a
+        // cached entry otherwise outlives the fix, so unchanged files keep
+        // reporting the requested model (70% of rows on a real tree) and the
+        // alias-priced cost that came with it.
+        ClientId::Dsh => 2,
         // First version of the fx (vercel-labs) usage-v2.json parser. Entries
         // are versioned from the start so later parser changes have an
         // obvious local counter to bump, like every other client here.

--- a/crates/tokscale-core/src/sessions/dsh.rs
+++ b/crates/tokscale-core/src/sessions/dsh.rs
@@ -15,7 +15,11 @@
 //!   for messages whose `source` is absent).
 //! - `assistant/message`: authoritative per-call usage on `data.usage`
 //!   (`inputTokens`, `outputTokens`, `cacheReadTokens`, ...) plus the serving
-//!   provider/model on `data.message.source`.
+//!   provider and model on `data.message.source`. `source.model` is the model
+//!   the session was configured to request; when the provider serves a
+//!   different one the LLM client records the API-reported model as
+//!   `source.replayState.response.responseModel`, and that field wins for
+//!   attribution and pricing (see [`served_model`]).
 //!
 //! DSH never embeds a cost, so every message leaves the parser at `0.0` and
 //! pricing is its only cost source — the generic source cache is safe here.
@@ -171,9 +175,7 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
                 }
 
                 let source = value.pointer("/data/message/source");
-                let model_id = source
-                    .and_then(|s| s.get("model"))
-                    .and_then(Value::as_str)
+                let model_id = served_model(source)
                     .or(fallback_model.as_deref())
                     .unwrap_or("unknown")
                     .to_string();
@@ -246,6 +248,30 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
     }
 
     messages
+}
+
+/// Resolve the model a call was actually served by.
+///
+/// `source.model` is the model the session was configured to request, and the
+/// provider does not always honor it: a floating alias (`~x-ai/grok-latest`)
+/// resolves server-side to a concrete model, and a pinned name can be
+/// superseded outright (glm-5.2 requests served by glm-5.3). The LLM client
+/// therefore copies the API-reported model into
+/// `source.replayState.response.responseModel`, and only when it differs from
+/// the request (`pi-ai/dist/api/openai-completions.js` guards the assignment
+/// with `chunk.model !== model.id`), so it is the authoritative attribution
+/// when present and `source.model` remains the fallback for the rows without
+/// it. Billing the configured name instead is not cosmetic: pricing the alias
+/// `~x-ai/grok-latest` resolves only a fuzzy "model_part (estimate only)"
+/// match onto another provider's listing, while the served `x-ai/grok-4.6`
+/// resolves exactly.
+fn served_model(source: Option<&Value>) -> Option<&str> {
+    source
+        .and_then(|s| s.pointer("/replayState/response/responseModel"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .or_else(|| source.and_then(|s| s.get("model")).and_then(Value::as_str))
 }
 
 /// Split DSH's usage row into Tokscale's five additive buckets.
@@ -327,6 +353,70 @@ mod tests {
 
         // Same turn, later step: not a turn start.
         assert!(!messages[1].is_turn_start);
+    }
+
+    #[test]
+    fn attributes_usage_to_the_served_model_when_the_provider_substitutes_one() {
+        // given: `source.model` is the model the session requested, but the
+        // provider served a different one and the LLM client recorded the
+        // API-reported model as `replayState.response.responseModel` (set only
+        // when the reported model differs from the request). Real shape from a
+        // live transcript: a glm-5.2 request served by glm-5.3.
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-served","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"assistant/message","time":1787122684043,"data":{"turn":1,"message":{"id":"m-served","source":{"kind":"model","provider":"zai-coding-cn","model":"glm-5.2","replayState":{"response":{"kind":"pi-ai","version":2,"api":"openai-completions","provider":"zai-coding-cn","model":"glm-5.2","responseModel":"glm-5.3","responseId":"20260819145800e496ad89a4914f88","stopReason":"toolUse"},"blocks":[{"type":"tool-call"}]}}},"usage":{"inputTokens":8425,"outputTokens":207,"cacheReadTokens":576}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "glm-5.3");
+        assert_eq!(messages[0].provider_id, "zai-coding-cn");
+        // The served model also defines the dedup key's model slot, so a
+        // seeded copy attributes (and collapses) under what served the call.
+        assert!(messages[0]
+            .dedup_key
+            .as_deref()
+            .unwrap()
+            .contains(":zai-coding-cn:glm-5.3:"));
+    }
+
+    #[test]
+    fn resolves_floating_model_aliases_through_the_served_model() {
+        // given: a floating alias such as `~x-ai/grok-latest` has no stable
+        // identity of its own — which model it resolved to is only recorded in
+        // the response. Pricing the alias only fuzzy-matches another
+        // provider's "estimate only" listing, while the served
+        // `x-ai/grok-4.6` resolves exactly (OpenRouter, submission-safe).
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-alias","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"assistant/message","time":1787122684043,"data":{"turn":1,"message":{"id":"m-alias","source":{"kind":"model","provider":"openrouter","model":"~x-ai/grok-latest","replayState":{"response":{"kind":"pi-ai","version":2,"api":"openai-completions","provider":"openrouter","model":"~x-ai/grok-latest","responseModel":"x-ai/grok-4.6","stopReason":"stop"}}}},"usage":{"inputTokens":100,"outputTokens":20}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "x-ai/grok-4.6");
+        assert_eq!(messages[0].provider_id, "openrouter");
+    }
+
+    #[test]
+    fn falls_back_to_the_configured_model_without_replay_state() {
+        // given: rows without `replayState` (observed on a third of live
+        // transcripts) keep the configured `source.model` — same when the
+        // response echoed the request verbatim and `responseModel` was never
+        // set. Both spellings must attribute to the configured model.
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-noreplay","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"assistant/message","time":1787122684043,"data":{"turn":1,"message":{"id":"m-1","source":{"kind":"model","provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":10,"outputTokens":20}}}"#,
+            r#"{"type":"assistant/message","time":1787122684044,"data":{"turn":1,"message":{"id":"m-2","source":{"kind":"model","provider":"deepseek","model":"deepseek-reasoner","replayState":{"response":{"kind":"pi-ai","version":2,"api":"openai-completions","provider":"deepseek","model":"deepseek-reasoner","stopReason":"stop"}}}},"usage":{"inputTokens":11,"outputTokens":21}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].model_id, "deepseek-reasoner");
+        assert_eq!(messages[1].model_id, "deepseek-reasoner");
     }
 
     #[test]


### PR DESCRIPTION
DSH support landed in #1126 attributing every `assistant/message` row to `data.message.source.model` — but that field is the model the session was **configured to request**, not necessarily the model that served the call. When the provider substitutes a different one, the LLM client (pi-ai) copies the API-reported model into `source.replayState.response.responseModel`, and it does so **only when the two differ** (`pi-ai/dist/api/openai-completions.js` guards the assignment with `chunk.model !== model.id`), which makes it the precise "provider substituted the model" signal.

## Measured on live transcripts

Across a real `~/.dsh` tree (1,762 `assistant/message` rows with usage): **1,231 rows (70%) were served by a different model than configured**:

| configured `source.model` | served `responseModel` | rows |
|---|---|---|
| `glm-5.2` | `glm-5.3` | 1190 |
| `~x-ai/grok-latest` | `x-ai/grok-4.6` | 38 |
| `~deepseek/deepseek-v4-flash-latest` | `deepseek/deepseek-v4-flash-0731` | 3 |

The remaining 531 rows carry no `responseModel` (no `replayState`, or the response echoed the request verbatim) and keep the configured model unchanged.

## Why attribution is wrong today, not just cosmetically

`tokscale pricing '~x-ai/grok-latest'` fuzzy-resolves to `edenai/xai/grok-latest` — another provider's listing, `model_part (estimate only)` — while the served `x-ai/grok-4.6` resolves **exactly** via OpenRouter (submission-safe). A floating alias has no stable identity of its own; which concrete model it resolved to is only recorded in the response.

## Change

- `sessions/dsh.rs` gains a `served_model()` helper: prefer `replayState.response.responseModel` (trimmed, non-empty), fall back to `source.model`, then to the `request/header` config as before. The dedup key's model slot follows automatically, so seeded fork copies still collapse against the parent under the model that served the call.
- `message_cache.rs` bumps `ClientId::Dsh` to parser version 2, per the file's own convention that "parser-only changes belong in `parser_version()`". Without it the fix never reaches existing users: DSH transcripts are append-only, so a cached entry outlives the parser change and unchanged files keep reporting the requested model with the alias-priced cost. Measured on the same tree, the pre-fix report showed glm-5.2 with 1,190 messages / 3.28M input and a `~x-ai/grok-latest` row priced off the EdenAI estimate; after the bump (cold reparse) glm-5.2 disappears into glm-5.3 (1,717 msgs / 4.86M input) and the grok aggregate (833,087 in / 37,122 out) moves wholesale to the exactly-priced `x-ai/grok-4.6`.

Three new tests in `sessions/dsh.rs` cover the substitution (real transcript shape, glm-5.2 → glm-5.3), the floating-alias resolution (`~x-ai/grok-latest` → `x-ai/grok-4.6`), and the no-replay-state fallback; all 17 `sessions::dsh` tests and the full `tokscale-core` suite pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes DSH usage to the model that actually served the call, not the model that was configured. Previously we used `source.model`; now we prefer `replayState.response.responseModel` when present, falling back to the configured model, which fixes pricing and dedup when providers substitute models or floating aliases resolve server-side.

- In crates/tokscale-core/src/sessions/dsh.rs, add `served_model()` and use it for attribution; dedup keys now reflect the served model.
- In crates/tokscale-core/src/message_cache.rs, bump the DSH parser version to 2 to invalidate caches so append-only transcripts reparse; no user action required.
- Add tests for model substitution, floating-alias resolution, and no-replay-state fallback. Pricing now resolves to exact served models (e.g., `x-ai/grok-4.6`) instead of alias estimates.

<sup>Written for commit 483abce5aceb5e3675121e6c9efbf300f92c6e6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

