### PR TITLE
fix(scanner): remove nested par_bridge to prevent futex deadlock on large directories

### DIFF
--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -382,7 +382,6 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
 
     let mut paths: Vec<PathBuf> = WalkDir::new(root)
         .into_iter()
-        .par_bridge()
         .filter_map(|e| e.ok())
         .filter(|e| {
             let path = e.path();


### PR DESCRIPTION
## Summary
    Refs #1153 where `tokscale submit` intermittently hangs (futex_wait_queue, ~0% CPU) when scanning large directories like `~/.config/Code/logs`.

    ### Description
    The directory scanner (`scan_directory`) used `.par_bridge()` on the `WalkDir` iterator. Because `scan_directory` is already called from within a parallel iterator (`.into_par_iter()`)
  mapping across multiple scan roots, this created nested parallelism.

    `par_bridge()` on a sequential iterator uses a mutex to synchronize thread access. When tens of thousands of files are discovered in a single directory, the Rayon thread pool becomes
  starved and deadlocks waiting on this mutex, hanging the scan entirely.

    Removing `.par_bridge()` from `scan_directory` resolves the deadlock by making the file tree walk sequential per root, while the roots themselves are still processed concurrently. Since
  `WalkDir` reads entry types without triggering a `stat()` syscall on Linux/Windows, the sequential filter is extremely fast and the overhead of `.par_bridge()` was unnecessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `.par_bridge()` from the directory scanner to stop futex deadlocks on large directory trees. Before: `WalkDir` used `.par_bridge()` inside a parallel root iterator; after: each root walks sequentially while roots still run in parallel.

- Fixes #1153 causing intermittent hangs in `tokscale submit` on very large trees (e.g., `~/.config/Code/logs`).
- Scope: only `scan_directory`; no API or CLI changes.
- Impact: eliminates deadlocks; performance impact is expected to be negligible.

<sup>Written for commit 8076c7e210713e9c2ce7ed4bab45c267d72c22a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

