### PR TITLE
fix(cli): do not wait on stdout pump thread if headless capture times out

### DIFF
--- a/crates/tokscale-cli/src/bin/fake_codex.rs
+++ b/crates/tokscale-cli/src/bin/fake_codex.rs
@@ -64,6 +64,23 @@ fn main() {
         // so the parent's timeout always wins by a margin the runner cannot eat
         // into. See `FAKE_CODEX_SLOW_SLEEP_SECS`.
         "slow" => std::thread::sleep(std::time::Duration::from_secs(FAKE_CODEX_SLOW_SLEEP_SECS)),
+        // #1049's shape. A grandchild inherits the stdout pipe and outlives the
+        // direct child, so killing the child does not close the write end and
+        // the parent's pump never reaches EOF. The grandchild must outlast the
+        // test's own upper bound, not merely the parent's deadline: a parent
+        // that waits for EOF unboundedly has to look *slower than the bound*,
+        // or the test cannot tell it apart from a parent that drained promptly.
+        "descendant" => {
+            let exe = std::env::current_exe().expect("current_exe");
+            std::process::Command::new(exe)
+                .env("TOKSCALE_FAKE_CODEX_MODE", "slow")
+                .stdout(std::process::Stdio::inherit())
+                .stdin(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .expect("failed to spawn descendant");
+            std::thread::sleep(std::time::Duration::from_secs(FAKE_CODEX_SLOW_SLEEP_SECS));
+        }
         _ => {
             eprintln!("unknown TOKSCALE_FAKE_CODEX_MODE");
             std::process::exit(2);

--- a/crates/tokscale-cli/src/bin/fake_codex.rs
+++ b/crates/tokscale-cli/src/bin/fake_codex.rs
@@ -72,7 +72,12 @@ fn main() {
         // or the test cannot tell it apart from a parent that drained promptly.
         "descendant" => {
             let exe = std::env::current_exe().expect("current_exe");
-            std::process::Command::new(exe)
+            // Deliberately never waited on: outliving this process, still
+            // holding the inherited stdout pipe, is the entire point of the
+            // fixture. Reaping it here would close the write end and destroy
+            // the condition under test.
+            #[allow(clippy::zombie_processes)]
+            let _descendant = std::process::Command::new(exe)
                 .env("TOKSCALE_FAKE_CODEX_MODE", "slow")
                 .stdout(std::process::Stdio::inherit())
                 .stdin(std::process::Stdio::null())

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -6401,6 +6401,15 @@ struct CaptureCommandOutcome {
     timed_out: bool,
 }
 
+/// How long the stdout pump gets to finish draining a killed child's pipe.
+///
+/// Bounded because a *descendant* of the child may still hold the write end, in
+/// which case the pump never reaches EOF and an unbounded wait hangs the whole
+/// timeout (#1049). Two seconds because the ordinary case -- the pipe closing
+/// with the child -- only has to move at most one pipe buffer, so anything past
+/// a few milliseconds already means a descendant is holding it open.
+const STDOUT_DRAIN_GRACE: Duration = Duration::from_secs(2);
+
 fn run_capture_command(
     command: &str,
     args: &[String],
@@ -6433,23 +6442,30 @@ fn run_capture_command(
         )
     })?;
 
-    let output_handle = thread::spawn(move || -> Result<()> {
-        let mut reader = std::io::BufReader::new(stdout);
-        let mut buffer = [0; 8192];
-        loop {
-            match reader.read(&mut buffer) {
-                Ok(0) => return Ok(()),
-                Ok(n) => output_file
-                    .write_all(&buffer[..n])
-                    .map_err(|e| anyhow::anyhow!("Failed to write to output file: {}", e))?,
-                Err(e) => {
-                    return Err(anyhow::anyhow!(
-                        "Failed to read from subprocess stdout: {}",
-                        e
-                    ));
+    // The pump reports completion over a channel rather than only through its
+    // JoinHandle, so the timeout path below can wait for it with a bound.
+    let (pump_done_tx, pump_done_rx) = std::sync::mpsc::channel::<Result<()>>();
+    thread::spawn(move || {
+        let result = (|| -> Result<()> {
+            let mut reader = std::io::BufReader::new(stdout);
+            let mut buffer = [0; 8192];
+            loop {
+                match reader.read(&mut buffer) {
+                    Ok(0) => return Ok(()),
+                    Ok(n) => output_file
+                        .write_all(&buffer[..n])
+                        .map_err(|e| anyhow::anyhow!("Failed to write to output file: {}", e))?,
+                    Err(e) => {
+                        return Err(anyhow::anyhow!(
+                            "Failed to read from subprocess stdout: {}",
+                            e
+                        ));
+                    }
                 }
             }
-        }
+        })();
+        // A panic drops the sender instead, surfacing as RecvError below.
+        let _ = pump_done_tx.send(result);
     });
 
     let deadline = Instant::now() + timeout;
@@ -6473,11 +6489,20 @@ fn run_capture_command(
         thread::sleep(Duration::from_millis(25));
     };
 
-    if !timed_out {
-        let output_result = output_handle
-            .join()
-            .map_err(|_| anyhow::anyhow!("Subprocess stdout reader thread panicked"))?;
-        output_result?;
+    if timed_out {
+        // Wait, but with a bound. An unbounded wait hangs whenever a descendant
+        // holds the pipe open (#1049); no wait at all loses output, because the
+        // caller prints "Partial output saved" and then calls process::exit,
+        // which does not wait for threads -- so anything the child had already
+        // written but the pump had not yet copied would be dropped.
+        //
+        // A drain error is deliberately ignored: the run already failed on the
+        // timeout, and the partial file is best-effort by definition.
+        let _ = pump_done_rx.recv_timeout(STDOUT_DRAIN_GRACE);
+    } else {
+        pump_done_rx
+            .recv()
+            .map_err(|_| anyhow::anyhow!("Subprocess stdout reader thread panicked"))??;
     }
 
     Ok(CaptureCommandOutcome {

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -6473,10 +6473,10 @@ fn run_capture_command(
         thread::sleep(Duration::from_millis(25));
     };
 
-    let output_result = output_handle
-        .join()
-        .map_err(|_| anyhow::anyhow!("Subprocess stdout reader thread panicked"))?;
     if !timed_out {
+        let output_result = output_handle
+            .join()
+            .map_err(|_| anyhow::anyhow!("Subprocess stdout reader thread panicked"))?;
         output_result?;
     }
 

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -447,12 +447,50 @@ fn headless_capture_slow_command_times_out() {
     // faster means the parent gave up early.
     //
     // Note this test cannot catch #1049: the stand-in spawns nothing, so its pipe
-    // closes the moment it is killed, and the unbounded `output_handle.join()`
-    // after the kill is never exercised. Widening the gap does not hide that —
-    // it was never covered.
+    // closes the moment it is killed, and the drain after the kill returns at
+    // once instead of waiting out `STDOUT_DRAIN_GRACE`. Widening the gap does not
+    // hide that — it was never covered here. The descendant shape that #1049
+    // actually reports is covered by
+    // `headless_capture_descendant_holding_stdout_still_times_out` below.
     assert!(
         elapsed >= HEADLESS_SLOW_MIN_ELAPSED && elapsed < HEADLESS_SLOW_MAX_ELAPSED,
         "slow command timeout duration was unexpected: {elapsed:?}"
+    );
+}
+
+/// The #1049 shape: the child is killed at the deadline but a *descendant* still
+/// holds the write end of the stdout pipe, so the pump never sees EOF.
+///
+/// Unix-only. The grandchild is the stand-in binary itself, and Windows keeps a
+/// running image locked, which would leave the fixture's TempDir undeletable for
+/// the two minutes the grandchild lives. #1049 is a Linux report and
+/// `run_capture_command` is ordinary `std::process` code, so ubuntu and macOS
+/// coverage is what this needs to be worth its cost.
+///
+/// The bound this asserts is the point: a parent that waits for EOF without one
+/// cannot finish before the grandchild's 120s sleep, well past
+/// `HEADLESS_SLOW_MAX_ELAPSED`.
+#[test]
+#[cfg(unix)]
+fn headless_capture_descendant_holding_stdout_still_times_out() {
+    let fake_bin = create_fake_codex_bin();
+    let output_path = fake_bin.path().join("descendant.jsonl");
+
+    let started = Instant::now();
+    headless_capture_command(
+        fake_bin.path(),
+        &output_path,
+        "descendant",
+        HEADLESS_SLOW_TIMEOUT_MS,
+    )
+    .assert()
+    .failure()
+    .code(124);
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed >= HEADLESS_SLOW_MIN_ELAPSED && elapsed < HEADLESS_SLOW_MAX_ELAPSED,
+        "a descendant holding stdout must not extend the timeout: {elapsed:?}"
     );
 }
 


### PR DESCRIPTION
  ### Summary
    Fixes #1049 where `tokscale headless` hangs past its timeout if the child process leaves a descendant holding the stdout pipe.

    ### Description
    In `run_capture_command`, if a timeout occurs, the direct child is killed. However, if a grandchild process inherited the stdout pipe and survives the parent's death, the pipe remains
  open. 

    Previously, the main thread unconditionally called `output_handle.join()`, causing it to block indefinitely on the pump thread's `read()` until the grandchild eventually exited. This
  defeated the purpose of the timeout.

    This fix changes the logic so that if the deadline has expired (`timed_out` is true), we do not wait for the pump thread to join. The function immediately returns the timeout outcome,
  which results in a `std::process::exit(124)`, tearing down the blocked background thread and correctly terminating the command.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds stdout draining on timeout to prevent `tokscale headless` from hanging when a descendant holds the pipe, while preserving already-written output. Previously we joined the stdout pump unbounded and could hang; now we wait up to 2s and then exit 124.

- On timeout, wait up to 2s (`STDOUT_DRAIN_GRACE`) for the stdout pump via a channel; normal completion still waits and propagates errors.
- Avoids hangs from descendants holding stdout and reduces dropped output compared to skipping the drain entirely; any remaining stdout after the grace period is discarded.
- Adds `descendant` mode to the `fake_codex` stand-in and a Unix-only test covering #1049; suppresses `clippy::zombie_processes` in `fake_codex` to allow the deliberately unreaped grandchild.

<sup>Written for commit 3583a4feae5c278a9fb045bf81a60dbb0c549c21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



