### PR TITLE
feat(submit): print a fix hint after unpriced-exclusion warnings

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5689,6 +5689,23 @@ fn report_unpriced_submission_exclusions(
             .yellow()
         );
     }
+
+    // Homebrew-style follow-up: the warnings above name the gap, but nothing
+    // told the user the fix is one file away. #1021/#1035 reporters (and the
+    // custom-pricing docs added after them) all had to read core sources to
+    // discover that an exact-match entry in custom-pricing.json — including
+    // explicit 0 rates for free models and routing labels — is the supported fix.
+    if !excluded.is_empty() {
+        let pricing_path = crate::paths::get_config_dir().join("custom-pricing.json");
+        println!(
+            "{}",
+            format!(
+                "  Hint: excluded models stay unsubmitted until priced. Add exact-match entries to\n          {}\n          (an explicit 0 declares a free model or a known routing-label rate), then re-check with\n          `tokscale submit --dry-run` and `tokscale pricing <model-id>`.",
+                pricing_path.display(),
+            )
+            .bright_black()
+        );
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5700,7 +5700,7 @@ fn report_unpriced_submission_exclusions(
         println!(
             "{}",
             format!(
-                "  Hint: excluded models stay unsubmitted until priced. Add exact-match entries to\n          {}\n          (an explicit 0 declares a free model or a known routing-label rate), then re-check with\n          `tokscale submit --dry-run` and `tokscale pricing <model-id>`.",
+                "  Hint: excluded models stay unsubmitted until priced. Add exact-match entries to\n          {}\n          keyed by the model id alone (the `model` half of the `provider/model` above),\n          where an explicit 0 declares a free model or a known routing-label rate, then\n          re-check with `tokscale submit --dry-run` and `tokscale pricing <model-id>`.",
                 pricing_path.display(),
             )
             .bright_black()

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -4776,6 +4776,18 @@ fn test_submit_excludes_unpriced_usage_and_keeps_the_rest() {
         "the warning must say covered usage remains: {stdout}"
     );
     assert!(
+        stdout.contains("Hint: excluded models stay unsubmitted until priced"),
+        "the exclusion must be followed by a fix hint: {stdout}"
+    );
+    assert!(
+        stdout.contains("custom-pricing.json"),
+        "the hint must name the custom pricing file: {stdout}"
+    );
+    assert!(
+        stdout.contains("submit --dry-run"),
+        "the hint must point at the verification command: {stdout}"
+    );
+    assert!(
         stdout.contains("Dry run - not submitting data."),
         "dry-run must complete without submitting: {stdout}"
     );

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -4784,6 +4784,10 @@ fn test_submit_excludes_unpriced_usage_and_keeps_the_rest() {
         "the hint must name the custom pricing file: {stdout}"
     );
     assert!(
+        stdout.contains("keyed by the model id alone"),
+        "the hint must state the key format, since the warning above prints provider/model but CustomPricing::lookup keys on the model id: {stdout}"
+    );
+    assert!(
         stdout.contains("submit --dry-run"),
         "the hint must point at the verification command: {stdout}"
     );

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -418,8 +418,14 @@ mod tests {
             msg.workspace_key.as_deref(),
             Some("/Users/alice/current-opencode-repo")
         );
-        assert_eq!(msg.workspace_label.as_deref(), Some("current-opencode-repo"));
-        assert_eq!(msg.session_title.as_deref(), Some("Current OpenCode session"));
+        assert_eq!(
+            msg.workspace_label.as_deref(),
+            Some("current-opencode-repo")
+        );
+        assert_eq!(
+            msg.session_title.as_deref(),
+            Some("Current OpenCode session")
+        );
         assert_eq!(msg.dedup_key.as_deref(), Some("msg_current_v2"));
     }
 
@@ -450,7 +456,11 @@ mod tests {
         drop(conn);
 
         let messages = parse_opencode_sqlite(&db_path);
-        assert_eq!(messages.len(), 1, "usage should parse without session metadata");
+        assert_eq!(
+            messages.len(),
+            1,
+            "usage should parse without session metadata"
+        );
         assert_eq!(messages[0].workspace_key, None);
         assert_eq!(messages[0].session_title, None);
         assert_eq!(


### PR DESCRIPTION
## Summary

When `tokscale submit` excludes unpriced usage, it prints the per-model warnings and stops there. This PR follows the warning list with a homebrew-style hint naming the remedy:

```
  Warning: excluded 1372 unpriced nous/meituan/longcat-2.0:free message(s) (87,391,743 tokens): no authoritative model-to-price mapping. Remaining priced usage will be submitted.
  Hint: excluded models stay unsubmitted until priced. Add exact-match entries to
          /Users/me/.config/tokscale/custom-pricing.json
          (an explicit 0 declares a free model or a known routing-label rate), then re-check with
          `tokscale submit --dry-run` and `tokscale pricing <model-id>`.
```

- Path is resolved via the same `get_config_dir()` the loader uses, so `TOKSCALE_CONFIG_DIR` overrides are reflected.
- Printed only when exclusions exist; styled like the other auxiliary output (`bright_black`).

## Motivation

#1021 and #1035 are users who hit these warnings and could not tell what to do next; the README section documenting the fix only landed in #1167. Even with docs, the moment of failure is the right place to teach the escape hatch — the custom-pricing mechanism (exact match, explicit-0 free models, routing-label override) is otherwise discoverable only by reading core sources.

## Verification

- New assertions in `test_submit_excludes_unpriced_usage_and_keeps_the_rest` (hint present, names `custom-pricing.json`, points at `submit --dry-run`).
- `cargo test -p tokscale-cli --test cli_tests test_submit_excludes_unpriced_usage_and_keeps_the_rest test_submit_offline_without_pricing_cache_fails` passes; `cargo fmt --check` clean.
- Manually exercised against real local data: hint renders under 26 exclusion rows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prints a follow-up fix hint after unpriced-usage exclusion warnings in `tokscale submit`, so users know how to price and re-verify; previously we only printed per-model warnings. The hint now also states that custom-pricing entries are keyed by the model id alone, preventing silent mismatches. Submission behavior is unchanged.

- Prints the hint only when exclusions exist; styling matches other auxiliary output.
- Resolves the path via `get_config_dir()` and honors `TOKSCALE_CONFIG_DIR`, naming `custom-pricing.json`.
- Instructs users to add exact-match entries keyed by the model id (explicit 0 for free models or routing labels) and to verify with `tokscale submit --dry-run` and `tokscale pricing <model-id>`.
- Extends `test_submit_excludes_unpriced_usage_and_keeps_the_rest` to assert the hint, including the key format; no changes to priced submission logic.
- Chore: applies `cargo fmt` to OpenCode session tests only.

<sup>Written for commit 0c0512774ff5809c620f7803d7283f02718e0070. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

