### PR TITLE
feat(kimi): discover Kimi Work sessions natively

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -73,7 +73,7 @@
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/` (`SENPI_CODING_AGENT_DIR` でオーバーライド可能) |
 | <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/`（`KIMCHI_CODING_AGENT_DIR` でオーバーライド可能） |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Reasonix" /> | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | `~/.reasonix/stats/*.jsonl`（`REASONIX_STATE_HOME` または `REASONIX_HOME` でオーバーライド可能） |
-| <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/` (`KIMI_CODE_HOME` でオーバーライド可能) |
+| <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/` (`KIMI_CODE_HOME` でオーバーライド可能) kimi-work: デスクトップ app-data ルート（自動検出） |
 | <img width="48px" src=".github/assets/client-qwen.png" alt="Qwen" /> | [Qwen CLI](https://github.com/QwenLM/qwen-cli) | `~/.qwen/projects/` |
 | <img width="48px" src=".github/assets/client-roocode.png" alt="Roo Code" /> | [Roo Code](https://github.com/RooCodeInc/Roo-Code) | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/`) |
 | <img width="48px" src=".github/assets/client-kilocode.png" alt="Kilo" /> | [Kilo](https://github.com/Kilo-Org/kilocode) | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/kilocode.kilo-code/tasks/`) |
@@ -179,7 +179,7 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
   - 設定可能なカラーテーマのGitHubスタイル貢献グラフ
   - リアルタイムフィルタリングとソート
   - ゼロフリッカーレンダリング
-- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Prime Agent、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic、Cherry Studio、fxの使用量を追跡
+- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Prime Agent、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Kimi Work、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic、Cherry Studio、fxの使用量を追跡
 - **リアルタイム価格** - 1時間ディスクキャッシュ付きでLiteLLMから現在の価格を取得；OpenRouter自動フォールバックと新規モデル向けCursor価格サポート
 - **詳細な内訳** - 入力、出力、キャッシュ読み書き、推論トークン追跡
 - **ネイティブRustコア** - 10倍高速な処理のため、すべての解析と集計をRustで実行
@@ -1455,6 +1455,7 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 | Kimchi Coding | `~/.config/kimchi/harness/sessions/` | `%USERPROFILE%\.config\kimchi\harness\sessions\` | `KIMCHI_CODING_AGENT_DIR` 環境変数でオーバーライド可能；Pi互換のJSONLセッション |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | すべてのプラットフォームで同じパス |
 | Kimi Code | `~/.kimi-code/` | `%USERPROFILE%\.kimi-code\` | すべてのプラットフォームで同じパス |
+| Kimi Work (desktop) | `~/Library/Application Support/kimi-desktop/` | `%APPDATA%\kimi-desktop\` | Linux ビルドなし |
 | Qwen CLI | `~/.qwen/` | `%USERPROFILE%\.qwen\` | すべてのプラットフォームで同じパス |
 | Roo Code | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\` | VS Code globalStorageタスクログ |
 | Kilo | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\kilocode.kilo-code\tasks\` | VS Code globalStorageタスクログ |

--- a/README.ko.md
+++ b/README.ko.md
@@ -73,7 +73,7 @@
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/` (`SENPI_CODING_AGENT_DIR`로 오버라이드 가능) |
 | <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/` (`KIMCHI_CODING_AGENT_DIR`로 오버라이드 가능) |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Reasonix" /> | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | `~/.reasonix/stats/*.jsonl` (`REASONIX_STATE_HOME` 또는 `REASONIX_HOME`으로 오버라이드 가능) |
-| <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/` (override via `KIMI_CODE_HOME`) |
+| <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/` (override via `KIMI_CODE_HOME`) kimi-work: desktop app-data root (auto-discovered) |
 | <img width="48px" src=".github/assets/client-qwen.png" alt="Qwen" /> | [Qwen CLI](https://github.com/QwenLM/qwen-cli) | `~/.qwen/projects/` |
 | <img width="48px" src=".github/assets/client-roocode.png" alt="Roo Code" /> | [Roo Code](https://github.com/RooCodeInc/Roo-Code) | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/`) |
 | <img width="48px" src=".github/assets/client-kilocode.png" alt="Kilo" /> | [Kilo](https://github.com/Kilo-Org/kilocode) | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/kilocode.kilo-code/tasks/`) |
@@ -177,7 +177,7 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
   - 설정 가능한 색상 테마의 GitHub 스타일 기여 그래프
   - 실시간 필터링 및 정렬
   - 깜빡임 없는 렌더링
-- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Prime Agent, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic, Cherry Studio, fx 사용량 통합 추적
+- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Prime Agent, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Kimi Work, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic, Cherry Studio, fx 사용량 통합 추적
 - **실시간 가격 반영** - LiteLLM에서 최신 가격을 가져와(디스크 캐시 1시간) 비용 계산; OpenRouter 자동 폴백 및 신규 모델용 Cursor 가격 지원
 - **상세 분석** - 입력, 출력, 캐시 읽기/쓰기, 추론 토큰까지 추적
 - **네이티브 Rust 코어** - 모든 파싱과 집계를 Rust로 처리해 최대 10배 빠른 성능
@@ -1456,6 +1456,7 @@ AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장�
 | Kimchi Coding | `~/.config/kimchi/harness/sessions/` | `%USERPROFILE%\.config\kimchi\harness\sessions\` | `KIMCHI_CODING_AGENT_DIR` 환경변수로 오버라이드 가능; Pi 호환 JSONL 세션 |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | 모든 플랫폼에서 동일한 경로 |
 | Kimi Code | `~/.kimi-code/` | `%USERPROFILE%\.kimi-code\` | 모든 플랫폼에서 동일한 경로 |
+| Kimi Work (desktop) | `~/Library/Application Support/kimi-desktop/` | `%APPDATA%\kimi-desktop\` | Linux 빌드 없음 |
 | Qwen CLI | `~/.qwen/` | `%USERPROFILE%\.qwen\` | 모든 플랫폼에서 동일한 경로 |
 | Roo Code | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\` | VS Code globalStorage 작업 로그 |
 | Kilo | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\kilocode.kilo-code\tasks\` | VS Code globalStorage 작업 로그 |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/` (override via `SENPI_CODING_AGENT_DIR`) |
 | <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/` (override via `KIMCHI_CODING_AGENT_DIR`) |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Reasonix" /> | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | `~/.reasonix/stats/*.jsonl` (override via `REASONIX_STATE_HOME` or `REASONIX_HOME`) |
-| <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/` (override via `KIMI_CODE_HOME`) |
+| <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/` (override via `KIMI_CODE_HOME`) kimi-work: desktop app-data root (auto-discovered) |
 | <img width="48px" src=".github/assets/client-qwen.png" alt="Qwen" /> | [Qwen CLI](https://github.com/QwenLM/qwen-cli) | `~/.qwen/projects/` |
 | <img width="48px" src=".github/assets/client-roocode.png" alt="Roo Code" /> | [Roo Code](https://github.com/RooCodeInc/Roo-Code) | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/`) |
 | <img width="48px" src=".github/assets/client-kilocode.png" alt="Kilo" /> | [Kilo](https://github.com/Kilo-Org/kilocode) | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/kilocode.kilo-code/tasks/`) |
@@ -177,7 +177,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with configurable color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Prime Agent, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic, Cherry Studio, and fx
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Prime Agent, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Kimi Work, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic, Cherry Studio, and fx
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -1493,6 +1493,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Kimchi Coding | `~/.config/kimchi/harness/sessions/` | `%USERPROFILE%\.config\kimchi\harness\sessions\` | Configurable via `KIMCHI_CODING_AGENT_DIR` env var; Pi-compatible JSONL sessions |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | Same path on all platforms |
 | Kimi Code | `~/.kimi-code/` | `%USERPROFILE%\.kimi-code\` | Same path on all platforms |
+| Kimi Work (desktop) | `~/Library/Application Support/kimi-desktop/` | `%APPDATA%\kimi-desktop\` | No Linux build |
 | Qwen CLI | `~/.qwen/` | `%USERPROFILE%\.qwen\` | Same path on all platforms |
 | Roo Code | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\` | VS Code globalStorage task logs |
 | Kilo | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\kilocode.kilo-code\tasks\` | VS Code globalStorage task logs |

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -74,7 +74,7 @@
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/`（通过 `SENPI_CODING_AGENT_DIR` 覆盖） |
 | <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/`（可通过 `KIMCHI_CODING_AGENT_DIR` 覆盖） |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Reasonix" /> | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | `~/.reasonix/stats/*.jsonl`（可通过 `REASONIX_STATE_HOME` 或 `REASONIX_HOME` 覆盖） |
-| <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/`（可通过 `KIMI_CODE_HOME` 覆盖） |
+| <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/`（可通过 `KIMI_CODE_HOME` 覆盖）kimi-work：桌面端 app-data 根目录（自动发现） |
 | <img width="48px" src=".github/assets/client-qwen.png" alt="Qwen" /> | [Qwen CLI](https://github.com/QwenLM/qwen-cli) | `~/.qwen/projects/` |
 | <img width="48px" src=".github/assets/client-roocode.png" alt="Roo Code" /> | [Roo Code](https://github.com/RooCodeInc/Roo-Code) | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/`) |
 | <img width="48px" src=".github/assets/client-kilocode.png" alt="Kilo" /> | [Kilo](https://github.com/Kilo-Org/kilocode) | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/kilocode.kilo-code/tasks/`) |
@@ -177,7 +177,7 @@
   - 支持可配置颜色主题的 GitHub 风格贡献图
   - 实时筛选和排序
   - 零闪烁渲染
-- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Prime Agent、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic、Cherry Studio 和 fx 的使用情况
+- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Prime Agent、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Kimi Work、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic、Cherry Studio 和 fx 的使用情况
 - **实时定价** - 从 LiteLLM 获取当前价格，带 1 小时磁盘缓存；OpenRouter 自动回退和新模型的 Cursor 定价支持
 - **详细分解** - 输入、输出、缓存读写和推理 Token 跟踪
 - **原生 Rust 核心** - 所有解析和聚合在 Rust 中完成，处理速度提升 10 倍
@@ -1455,6 +1455,7 @@ AI 编程工具将会话数据存储在跨平台位置。大多数工具在所�
 | Kimchi Coding | `~/.config/kimchi/harness/sessions/` | `%USERPROFILE%\.config\kimchi\harness\sessions\` | 可通过 `KIMCHI_CODING_AGENT_DIR` 环境变量覆盖；Pi 兼容的 JSONL 会话 |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | 所有平台使用相同路径 |
 | Kimi Code | `~/.kimi-code/` | `%USERPROFILE%\.kimi-code\` | 所有平台使用相同路径 |
+| Kimi Work（桌面端） | `~/Library/Application Support/kimi-desktop/` | `%APPDATA%\kimi-desktop\` | 无 Linux 版本 |
 | Qwen CLI | `~/.qwen/` | `%USERPROFILE%\.qwen\` | 所有平台使用相同路径 |
 | Roo Code | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\` | VS Code globalStorage 任务日志 |
 | Kilo | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\kilocode.kilo-code\tasks\` | VS Code globalStorage 任务日志 |

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -8693,6 +8693,61 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    fn test_parse_local_clients_kimi_work_uses_kimi_code_parser() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+
+        let work_root = if cfg!(target_os = "macos") {
+            source_home
+                .path()
+                .join("Library")
+                .join("Application Support")
+        } else {
+            source_home.path().join("AppData").join("Roaming")
+        };
+        let wire = work_root
+            .join("kimi-desktop")
+            .join("daimon-share")
+            .join("daimon")
+            .join("runtime")
+            .join("kimi-code")
+            .join("home")
+            .join("sessions")
+            .join("wd_workspace_c107cac82a87")
+            .join("conv-4e171339d10b9954d0fc24da")
+            .join("agents")
+            .join("main")
+            .join("wire.jsonl");
+        std::fs::create_dir_all(wire.parent().unwrap()).unwrap();
+        std::fs::write(
+            &wire,
+            r#"{"type":"usage.record","model":"k2d6-agent","usage":{"inputOther":100,"output":10,"inputCacheRead":20,"inputCacheCreation":0},"usageScope":"turn","time":1780319377010}"#,
+        )
+        .unwrap();
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(source_home.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["kimi".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+
+        assert_eq!(parsed.counts.get(ClientId::Kimi), 1);
+        assert_eq!(parsed.messages.len(), 1);
+        let message = &parsed.messages[0];
+        assert_eq!(message.session_id, "conv-4e171339d10b9954d0fc24da");
+        assert_eq!(message.model_id, "k2d6-agent");
+        assert_eq!(message.input, 100);
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn test_kimchi_deduplicates_same_message_across_scan_roots() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -1194,8 +1194,9 @@ fn kimi_work_share_dir_root(app_data: &Path) -> Option<PathBuf> {
 /// Candidate Kimi Work session roots (Kimi Desktop's embedded daimon runtime).
 ///
 /// The suffix is the fixed on-disk layout of the desktop app. There is no Work
-/// build for Linux, so only the macOS app-data root and the Windows
-/// `%APPDATA%`/literal pair are produced.
+/// build for Linux. On macOS the app-data root is used; on Windows the
+/// home-relative root is always included, while the environment-derived root
+/// uses a valid `shareDir` or falls back to `%APPDATA%`.
 /// The Windows environment root is only consulted when env roots are enabled,
 /// matching the Kiro/Cline root helpers.
 fn kimi_work_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
@@ -5586,8 +5587,8 @@ mod tests {
         assert!(kimi_files.contains(&ctitle));
     }
 
-    /// The literal Work root is always included; the `%APPDATA%` root is only
-    /// included for normal scans where environment roots are enabled.
+    /// The home-relative Work root is always included; the environment-selected
+    /// root is only included for normal scans where environment roots are enabled.
     #[test]
     #[serial]
     #[cfg(target_os = "windows")]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -5698,6 +5698,9 @@ mod tests {
         kimi_work_wire_from_root(app_data, session_id)
     }
 
+    // Both callers are gated to macos/windows, so without a matching gate this
+    // helper is compiled with zero callers on linux and warns there.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     fn kimi_work_wire_from_root(root: &std::path::Path, session_id: &str) -> PathBuf {
         super::join_native_path(
             root,

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -601,11 +601,17 @@ pub fn extra_scan_paths_for(
 /// produces. `Path::join` only normalizes the junction, so the relative half's
 /// own `/` separators would survive untouched on Windows (#1048).
 fn join_native(root: &str, relative: &str) -> String {
-    let mut path = std::path::PathBuf::from(root);
+    join_native_path(std::path::Path::new(root), relative)
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn join_native_path(root: &std::path::Path, relative: &str) -> std::path::PathBuf {
+    let mut path = root.to_path_buf();
     for component in std::path::Path::new(relative).components() {
         path.push(component.as_os_str());
     }
-    path.to_string_lossy().into_owned()
+    path
 }
 
 pub fn built_in_extra_scan_paths_for(
@@ -1169,6 +1175,42 @@ fn push_grok_dual_source_scan_tasks(
     );
 }
 
+/// Candidate Kimi Work session roots (Kimi Desktop's embedded daimon runtime).
+///
+/// The suffix is the fixed on-disk layout of the desktop app. There is no Work
+/// build for Linux, so only the macOS app-data root and the Windows
+/// `%APPDATA%`/literal pair are produced.
+/// The Windows environment root is only consulted when env roots are enabled,
+/// matching the Kiro/Cline root helpers.
+fn kimi_work_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
+    const KIMI_WORK_SUFFIX: &str =
+        "kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions";
+
+    if cfg!(target_os = "macos") {
+        return vec![PathBuf::from(join_native(
+            home_dir,
+            &format!("Library/Application Support/{KIMI_WORK_SUFFIX}"),
+        ))];
+    }
+    if cfg!(target_os = "windows") {
+        let mut roots = vec![PathBuf::from(join_native(
+            home_dir,
+            &format!("AppData/Roaming/{KIMI_WORK_SUFFIX}"),
+        ))];
+        if use_env_roots {
+            if let Some(app_data) = std::env::var_os("APPDATA").filter(|value| !value.is_empty()) {
+                roots.push(join_native_path(
+                    std::path::Path::new(&app_data),
+                    KIMI_WORK_SUFFIX,
+                ));
+            }
+        }
+        return roots;
+    }
+
+    Vec::new()
+}
+
 fn kiro_global_storage_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
     let mut roots = vec![
         PathBuf::from(format!(
@@ -1681,6 +1723,12 @@ fn scan_all_clients_with_env_strategy_inner(
             ClientId::Kimi,
             kimi_code_path,
         );
+
+        // Kimi Work (Kimi Desktop / daimon runtime): same wire.jsonl protocol
+        // under the desktop app-data tree; no Work build for Linux.
+        for work_root in kimi_work_roots(home_dir, use_env_roots) {
+            push_unique_scan_task(&mut tasks, &mut seen_scan_roots, ClientId::Kimi, work_root);
+        }
     }
 
     if enabled.contains(&ClientId::Codex) {
@@ -5487,6 +5535,133 @@ mod tests {
         );
 
         assert_eq!(result.get(ClientId::Kimi), &vec![wire]);
+    }
+
+    /// Kimi Work uses the same wire protocol under the desktop app-data tree,
+    /// with both conversation and title-generation sessions preserved as
+    /// separate files.
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    fn test_scan_all_clients_kimi_work_discovers_conv_and_ctitle_sessions() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let conv = kimi_work_test_wire(home, "conv-4e171339d10b9954d0fc24da");
+        let ctitle = kimi_work_test_wire(home, "ctitle-01a01fe5-e170-765c-a1b3-c4daad0cda13");
+        let wire = concat!(
+            "{\"type\":\"llm.request\",\"model\":\"k2d6-agent\",\"time\":1780319377000}\n",
+            "{\"type\":\"usage.record\",\"model\":\"k2d6-agent\",\"usage\":{\"inputOther\":100,\"output\":10,\"inputCacheRead\":0,\"inputCacheCreation\":0},\"usageScope\":\"turn\",\"time\":1780319377010}\n"
+        );
+        for path in [&conv, &ctitle] {
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, wire).unwrap();
+        }
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["kimi".to_string()],
+            false,
+        );
+        let kimi_files = result.get(ClientId::Kimi);
+        assert_eq!(kimi_files.len(), 2);
+        assert!(kimi_files.contains(&conv));
+        assert!(kimi_files.contains(&ctitle));
+    }
+
+    /// The literal Work root is always included; the `%APPDATA%` root is only
+    /// included for normal scans where environment roots are enabled.
+    #[test]
+    #[serial]
+    #[cfg(target_os = "windows")]
+    fn test_scan_all_clients_kimi_work_respects_env_roots() {
+        let mut env = EnvGuard::capture(&[
+            "APPDATA",
+            "KIMI_CODE_HOME",
+            "TOKSCALE_EXTRA_DIRS",
+            "TOKSCALE_HEADLESS_DIR",
+        ]);
+        env.remove("KIMI_CODE_HOME");
+        env.remove("TOKSCALE_EXTRA_DIRS");
+        env.remove("TOKSCALE_HEADLESS_DIR");
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().join("home");
+        let work_literal = kimi_work_test_wire(&home, "conv-session-work-1");
+        fs::create_dir_all(work_literal.parent().unwrap()).unwrap();
+        File::create(&work_literal).unwrap();
+
+        let conflicting = dir.path().join("conflicting-appdata");
+        let conflict_wire = kimi_work_appdata_test_wire(&conflicting, "ctitle-session-work-2");
+        fs::create_dir_all(conflict_wire.parent().unwrap()).unwrap();
+        File::create(&conflict_wire).unwrap();
+        env.set("APPDATA", &conflicting);
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["kimi".to_string()],
+            false,
+        );
+        let kimi_files = result.get(ClientId::Kimi);
+        assert_eq!(kimi_files.len(), 1);
+        assert!(kimi_files.contains(&work_literal));
+        assert!(
+            !kimi_files.contains(&conflict_wire),
+            "APPDATA-driven Work root must be ignored when --home is authoritative"
+        );
+
+        let result =
+            scan_all_clients_with_env_strategy(home.to_str().unwrap(), &["kimi".to_string()], true);
+        let kimi_files = result.get(ClientId::Kimi);
+        assert_eq!(kimi_files.len(), 2);
+        assert!(kimi_files.contains(&work_literal));
+        assert!(kimi_files.contains(&conflict_wire));
+    }
+
+    /// Kimi Work ships as a desktop-only build; a Linux home must not cause a
+    /// similarly named application-data tree to be scanned as Kimi Work.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_scan_all_clients_kimi_work_is_not_discovered_on_linux() {
+        let dir = TempDir::new().unwrap();
+        let wire = dir.path().join(
+            "Library/Application Support/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/wd_workspace_c107cac82a87/conv-linux-session/agents/main/wire.jsonl",
+        );
+        fs::create_dir_all(wire.parent().unwrap()).unwrap();
+        File::create(&wire).unwrap();
+
+        let result = scan_all_clients_with_env_strategy(
+            dir.path().to_str().unwrap(),
+            &["kimi".to_string()],
+            false,
+        );
+
+        assert!(result.get(ClientId::Kimi).is_empty());
+    }
+
+    /// Kimi Work lays sessions out under the desktop app-data root exactly like
+    /// Kimi Code: `<work-root>/wd_<workspace>_<hash>/<conv-*|ctitle-*>/agents/main/wire.jsonl`.
+    /// `<work-root>` is the platform app-data location produced by
+    /// [`kimi_work_roots`] for a home-relative scan.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    fn kimi_work_test_wire(home: &std::path::Path, session_id: &str) -> PathBuf {
+        let work_root = if cfg!(target_os = "macos") {
+            home.join("Library").join("Application Support")
+        } else {
+            home.join("AppData").join("Roaming")
+        };
+        kimi_work_wire_from_root(&work_root, session_id)
+    }
+
+    #[cfg(target_os = "windows")]
+    fn kimi_work_appdata_test_wire(app_data: &std::path::Path, session_id: &str) -> PathBuf {
+        kimi_work_wire_from_root(app_data, session_id)
+    }
+
+    fn kimi_work_wire_from_root(root: &std::path::Path, session_id: &str) -> PathBuf {
+        super::join_native_path(
+            root,
+            &format!(
+                "kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/wd_workspace_c107cac82a87/{session_id}/agents/main/wire.jsonl"
+            ),
+        )
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -1175,6 +1175,22 @@ fn push_grok_dual_source_scan_tasks(
     );
 }
 
+/// Read Kimi Desktop's optional relocated Work share directory.
+fn kimi_work_share_dir_root(app_data: &Path) -> Option<PathBuf> {
+    let config_path = app_data.join("kimi-desktop").join("daimon-storage.json");
+    let content = std::fs::read_to_string(config_path).ok()?;
+    let config: Value = serde_json::from_str(&content).ok()?;
+    let share_dir = config.get("shareDir")?.as_str()?;
+    if share_dir.trim().is_empty() {
+        return None;
+    }
+
+    Some(join_native_path(
+        Path::new(share_dir),
+        "daimon/runtime/kimi-code/home/sessions",
+    ))
+}
+
 /// Candidate Kimi Work session roots (Kimi Desktop's embedded daimon runtime).
 ///
 /// The suffix is the fixed on-disk layout of the desktop app. There is no Work
@@ -1199,10 +1215,11 @@ fn kimi_work_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
         ))];
         if use_env_roots {
             if let Some(app_data) = std::env::var_os("APPDATA").filter(|value| !value.is_empty()) {
-                roots.push(join_native_path(
-                    std::path::Path::new(&app_data),
-                    KIMI_WORK_SUFFIX,
-                ));
+                let app_data = PathBuf::from(app_data);
+                roots.push(
+                    kimi_work_share_dir_root(&app_data)
+                        .unwrap_or_else(|| join_native_path(&app_data, KIMI_WORK_SUFFIX)),
+                );
             }
         }
         return roots;
@@ -5450,7 +5467,8 @@ mod tests {
     #[test]
     #[serial]
     fn test_scan_all_clients_kimi_code_home_override() {
-        let mut env = EnvGuard::capture(&["KIMI_CODE_HOME"]);
+        let mut env = EnvGuard::capture(&["KIMI_CODE_HOME", "APPDATA"]);
+        env.remove("APPDATA");
         let dir = TempDir::new().unwrap();
         let home = dir.path().join("home");
         let custom_root = dir.path().join("custom-kimi-code");
@@ -5498,7 +5516,8 @@ mod tests {
     #[serial]
     fn test_scan_all_clients_kimi_code_home_blank_falls_back_to_home() {
         for blank in ["", "   ", "\t\n"] {
-            let mut env = EnvGuard::capture(&["KIMI_CODE_HOME"]);
+            let mut env = EnvGuard::capture(&["KIMI_CODE_HOME", "APPDATA"]);
+            env.remove("APPDATA");
             let dir = TempDir::new().unwrap();
             let home = dir.path();
             let wire = setup_mock_kimi_code_dir(&home.join(".kimi-code"));
@@ -5613,6 +5632,30 @@ mod tests {
         assert_eq!(kimi_files.len(), 2);
         assert!(kimi_files.contains(&work_literal));
         assert!(kimi_files.contains(&conflict_wire));
+
+        let share_dir = dir.path().join("custom-share");
+        let config_path = conflicting.join("kimi-desktop").join("daimon-storage.json");
+        fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        fs::write(
+            &config_path,
+            serde_json::json!({"shareDir": share_dir.to_string_lossy()}).to_string(),
+        )
+        .unwrap();
+
+        let configured_wire = super::join_native_path(
+            &share_dir,
+            "daimon/runtime/kimi-code/home/sessions/wd_workspace_c107cac82a87/conv-configured-share/agents/main/wire.jsonl",
+        );
+        fs::create_dir_all(configured_wire.parent().unwrap()).unwrap();
+        File::create(&configured_wire).unwrap();
+
+        let result =
+            scan_all_clients_with_env_strategy(home.to_str().unwrap(), &["kimi".to_string()], true);
+        let kimi_files = result.get(ClientId::Kimi);
+        assert_eq!(kimi_files.len(), 2);
+        assert!(kimi_files.contains(&work_literal));
+        assert!(kimi_files.contains(&configured_wire));
+        assert!(!kimi_files.contains(&conflict_wire));
     }
 
     /// Kimi Work ships as a desktop-only build; a Linux home must not cause a


### PR DESCRIPTION
## Summary

- Discover Kimi Work sessions natively on macOS and Windows, without requiring `TOKSCALE_EXTRA_DIRS`.
- On Windows, honor Kimi Desktop's optional `shareDir` in `kimi-desktop/daimon-storage.json` when the app has relocated its data directory.
- Fall back to the platform default Work directory when the configuration is absent or invalid, while keeping explicit `--home` scans isolated from the current user's environment roots.
- Reuse the existing Kimi Code wire parser and pricing path; no new client ID or private session fixture is introduced.

This implements the native Kimi Work discovery follow-up identified in #1145. The model aliases themselves were already landed in #1147; this branch adds the broader discovery feature, with Windows relocated-share handling as one compatibility case for real Kimi Desktop installations.

### Windows root selection

On Windows, the home-relative Work root is always retained. For normal scans, a valid `shareDir` is used as the environment-derived root; the legacy `%APPDATA%` root is used only when the configuration is missing, unreadable, invalid, or blank. A valid `shareDir` intentionally replaces that fallback rather than merging both. Explicit `--home` scans disable environment roots.

## Implementation

- Registers Kimi Work roots inside the existing Kimi scanner branch.
- Reads the optional Windows `shareDir` configuration and appends `daimon/runtime/kimi-code/home/sessions` using native path components.
- Keeps the home-relative Work root and selects the configured `shareDir` or legacy `%APPDATA%` as the environment-root candidate.
- Preserves canonical root/file de-duplication.
- Adds regression coverage for `conv-*`, `ctitle-*`, environment-root isolation, configured `shareDir`, and Linux exclusion.
- Keeps the four maintained README translations synchronized.

## Validation

Windows validation was performed against real local Kimi Work data without including private paths, session IDs, prompts, or logs in this PR:

### Windows before/after

The relocated-share case was reproduced with real local Kimi Work data; only aggregate counts and behavior are reported here:

- Before `aa7c3ad0`, the default scan found 0 Kimi Work files, while an explicit extra scan root found 4.
- After `aa7c3ad0`, the default scan followed the configured `shareDir`, found all 4 files, and produced non-zero priced usage through the existing Kimi Code parser and pricing path.

- `cargo test -p tokscale-core kimi_work --lib -- --nocapture`: 4 passed
- `cargo test -p tokscale-core kimi --lib -- --nocapture`: 53 passed
- The Windows full core suite had one unrelated pre-existing symlink test failure because the account lacked the privilege required to create directory symlinks (OS error 1314); excluding only that test, 1816 passed and 0 failed.

Additional local validation:

- `cargo test --locked --workspace --all-features --quiet`: passed
- `cargo clippy --locked --workspace --all-features -- -D warnings`: passed
- Changed-file rustfmt and `git diff --check`: passed

The repository-wide format check still reports pre-existing formatting in `crates/tokscale-core/src/sessions/opencode.rs`, which is outside this PR.

Closes #1171
Related to #1145
