### PR TITLE
chore: resolve strict Clippy warnings

### DIFF
--- a/crates/tokscale-cli/src/paths.rs
+++ b/crates/tokscale-cli/src/paths.rs
@@ -38,7 +38,9 @@ pub fn legacy_macos_config_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_os = "macos")]
     use serial_test::serial;
+    #[cfg(target_os = "macos")]
     use std::env;
 
     #[test]

--- a/crates/tokscale-core/src/sessions/cherrystudio.rs
+++ b/crates/tokscale-core/src/sessions/cherrystudio.rs
@@ -745,7 +745,7 @@ mod tests {
         println!("去重后总消息数: {}", total_messages);
         println!("去重后总 token: {}", total_tokens);
         let mut models: Vec<_> = by_model.into_iter().collect();
-        models.sort_by(|a, b| b.1 .1.cmp(&a.1 .1));
+        models.sort_by_key(|a| std::cmp::Reverse(a.1 .1));
         for (m, (c, t)) in models {
             println!("  {m:<24} msgs={c:>6}  tokens={t:>14}");
         }


### PR DESCRIPTION
### Summary
    Resolves a couple of strict Clippy warnings triggered under `-D warnings`.

    ### Description
    - **`tokscale-cli/src/paths.rs`**: Added `#[cfg(target_os = "macos")]` to `std::env` and `serial_test::serial` imports. These were
  only used in macOS-specific tests, causing an `unused_imports` warning on Linux builds.
    - **`tokscale-core/src/sessions/cherrystudio.rs`**: Refactored the token sorting logic to use `sort_by_key` with `std::cmp::Reverse`
  instead of `sort_by`, resolving the `unnecessary_sort_by` warning. This makes the code more idiomatic.

    Verified locally with `cargo clippy --workspace --all-targets -- -D warnings` passing cleanly.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes strict Clippy warnings so `cargo clippy --workspace --all-targets -- -D warnings` passes on all platforms. No runtime behavior changes.

- Gate `serial_test::serial` and `std::env` imports in macOS-only tests with `#[cfg(target_os = "macos")]` to remove `unused_imports` on Linux.
- Replace `sort_by` with `sort_by_key(std::cmp::Reverse(...))` to resolve `unnecessary_sort_by` and keep the same sorting order.

<sup>Written for commit efd4d0b451674ff5485cfdd032cfff7e65e24769. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

