### PR TITLE
fix: close two hang/double-count gaps found by adversarial review

### DIFF
--- a/crates/tokscale-cli/src/bin/fake_codex.rs
+++ b/crates/tokscale-cli/src/bin/fake_codex.rs
@@ -50,6 +50,30 @@ fn emit(text: &str) {
     stdout.flush().expect("failed to flush stdout");
 }
 
+/// Spawns a grandchild that inherits stdout and outlives this process, so the
+/// write end of the parent's pipe stays open after this process is gone.
+///
+/// Deliberately never waited on -- reaping it would close the write end and
+/// destroy the condition under test. The PID is published to
+/// `TOKSCALE_FAKE_CODEX_PIDFILE` when set so the test can reap it in teardown
+/// rather than leaving it to age out on its own.
+fn spawn_stdout_holder() {
+    let exe = std::env::current_exe().expect("current_exe");
+    #[allow(clippy::zombie_processes)]
+    let holder = std::process::Command::new(exe)
+        .env("TOKSCALE_FAKE_CODEX_MODE", "slow")
+        .env_remove("TOKSCALE_FAKE_CODEX_PIDFILE")
+        .stdout(std::process::Stdio::inherit())
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to spawn stdout holder");
+
+    if let Ok(path) = std::env::var("TOKSCALE_FAKE_CODEX_PIDFILE") {
+        let _ = std::fs::write(path, holder.id().to_string());
+    }
+}
+
 fn main() {
     let mode = std::env::var("TOKSCALE_FAKE_CODEX_MODE").unwrap_or_default();
 
@@ -70,21 +94,20 @@ fn main() {
         // test's own upper bound, not merely the parent's deadline: a parent
         // that waits for EOF unboundedly has to look *slower than the bound*,
         // or the test cannot tell it apart from a parent that drained promptly.
+        // The direct child is killed at the deadline while the holder keeps the
+        // pipe open: the timeout branch of the drain.
         "descendant" => {
-            let exe = std::env::current_exe().expect("current_exe");
-            // Deliberately never waited on: outliving this process, still
-            // holding the inherited stdout pipe, is the entire point of the
-            // fixture. Reaping it here would close the write end and destroy
-            // the condition under test.
-            #[allow(clippy::zombie_processes)]
-            let _descendant = std::process::Command::new(exe)
-                .env("TOKSCALE_FAKE_CODEX_MODE", "slow")
-                .stdout(std::process::Stdio::inherit())
-                .stdin(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .spawn()
-                .expect("failed to spawn descendant");
+            spawn_stdout_holder();
             std::thread::sleep(std::time::Duration::from_secs(FAKE_CODEX_SLOW_SLEEP_SECS));
+        }
+        // The direct child exits *successfully and immediately* while the holder
+        // keeps the pipe open, so `try_wait` observes a normal exit and
+        // `timed_out` stays false: the non-timeout branch of the drain. The
+        // parent has no deadline to fall back on here, which is what makes this
+        // shape distinct from `descendant`.
+        "descendant-exit" => {
+            spawn_stdout_holder();
+            emit("captured partial");
         }
         _ => {
             eprintln!("unknown TOKSCALE_FAKE_CODEX_MODE");

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -6517,9 +6517,35 @@ fn run_capture_command(
         // timeout, and the partial file is best-effort by definition.
         let _ = pump_done_rx.recv_timeout(STDOUT_DRAIN_GRACE);
     } else {
-        pump_done_rx
-            .recv()
-            .map_err(|_| anyhow::anyhow!("Subprocess stdout reader thread panicked"))??;
+        // The child exited on its own, but that does NOT mean the pipe is closed:
+        // a descendant it spawned can still hold the write end, and then the pump
+        // never reaches EOF. This branch has no deadline behind it -- `timed_out`
+        // is false precisely because the deadline was never reached -- so an
+        // unbounded wait here hangs forever with nothing to rescue it. That was
+        // true of the original unconditional join too, and #1166 only bounded the
+        // timeout branch, so it survived both.
+        //
+        // Bound it by whatever is left of the caller's own deadline, plus the same
+        // drain grace. Total wall time therefore stays within the configured
+        // timeout plus the grace, whichever path is taken.
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match pump_done_rx.recv_timeout(remaining + STDOUT_DRAIN_GRACE) {
+            Ok(pump_result) => pump_result?,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                // Report rather than silently truncate: the child succeeded, so
+                // returning Ok here would present a capture file we cannot show
+                // is complete.
+                return Err(anyhow::anyhow!(
+                    "Subprocess '{}' exited but its stdout stayed open past the capture deadline, \
+                     which happens when it leaves a background process holding the pipe. \
+                     The output file may be incomplete.",
+                    command
+                ));
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(anyhow::anyhow!("Subprocess stdout reader thread panicked"));
+            }
+        }
     }
 
     Ok(CaptureCommandOutcome {

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -494,6 +494,76 @@ fn headless_capture_descendant_holding_stdout_still_times_out() {
     );
 }
 
+/// Reaps the stdout holder `fake_codex` publishes to `TOKSCALE_FAKE_CODEX_PIDFILE`.
+///
+/// The holder deliberately outlives the direct child, so without this it would
+/// sit in the process table for the rest of its 120s sleep. Parallel and retried
+/// CI runs accumulate those, so teardown kills it rather than waiting it out.
+#[cfg(unix)]
+struct HolderReaper {
+    pidfile: std::path::PathBuf,
+}
+
+#[cfg(unix)]
+impl Drop for HolderReaper {
+    fn drop(&mut self) {
+        let Ok(raw) = std::fs::read_to_string(&self.pidfile) else {
+            return;
+        };
+        let Ok(pid) = raw.trim().parse::<i32>() else {
+            return;
+        };
+        // Shelling out to kill(1) keeps this dependency-free -- tokscale-cli does
+        // not depend on libc, and pulling it in for one test teardown is not
+        // worth it. An already-exited pid just makes kill exit non-zero.
+        let _ = std::process::Command::new("kill")
+            .arg("-9")
+            .arg(pid.to_string())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+}
+
+/// The other half of #1049: the direct child exits *successfully* before the
+/// deadline while a descendant keeps stdout open.
+///
+/// `try_wait` sees a normal exit, so `timed_out` stays false and the drain takes
+/// the non-timeout branch. That branch waited unboundedly -- both before #1166
+/// (an unconditional `join`) and after it -- so this hung forever with no
+/// deadline to rescue it. The timeout branch's `STDOUT_DRAIN_GRACE` does not
+/// apply here, which is exactly why this needs its own test.
+#[test]
+#[cfg(unix)]
+fn headless_capture_descendant_after_clean_exit_does_not_hang() {
+    let fake_bin = create_fake_codex_bin();
+    let output_path = fake_bin.path().join("descendant-exit.jsonl");
+    let pidfile = fake_bin.path().join("holder.pid");
+    let _reaper = HolderReaper {
+        pidfile: pidfile.clone(),
+    };
+
+    let started = Instant::now();
+    headless_capture_command(
+        fake_bin.path(),
+        &output_path,
+        "descendant-exit",
+        HEADLESS_SLOW_TIMEOUT_MS,
+    )
+    .env("TOKSCALE_FAKE_CODEX_PIDFILE", &pidfile)
+    .assert()
+    .failure();
+    let elapsed = started.elapsed();
+
+    // The bound is the assertion. The holder sleeps 120s, so anything that waits
+    // for EOF cannot return before then; finishing inside the 60s ceiling proves
+    // the wait is bounded rather than merely slow.
+    assert!(
+        elapsed < HEADLESS_SLOW_MAX_ELAPSED,
+        "a descendant holding stdout after a clean child exit must not hang: {elapsed:?}"
+    );
+}
+
 /// How far the measured deadline may sit from the configured one in
 /// `headless_capture_timeout_fires_near_its_deadline`.
 ///

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1124,7 +1124,11 @@ fn parser_version(client: ClientId) -> u32 {
         // entries undercount every session that compacted (#1152). DSH has not
         // shipped in a release, so this only rebuilds caches written by builds
         // from main.
-        ClientId::Dsh => 2,
+        // v2->v3: idless rows (which is every summary) fell back to a
+        // session-scoped dedup key, so a fork without `seedLength` counted the
+        // copied summary twice. The key now falls back to `seq`, so v2 entries
+        // carry keys that no longer match and must be reparsed.
+        ClientId::Dsh => 3,
         // First version of the fx (vercel-labs) usage-v2.json parser. Entries
         // are versioned from the start so later parser changes have an
         // obvious local counter to bump, like every other client here.

--- a/crates/tokscale-core/src/sessions/dsh.rs
+++ b/crates/tokscale-core/src/sessions/dsh.rs
@@ -224,12 +224,32 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
                 // key: a sanitized or otherwise non-unique id then still
                 // separates calls that differ in time, routing or usage
                 // instead of silently folding them into one.
+                // Falling back to the session id breaks the very case the
+                // paragraph above describes. A `compaction/summary` carries no
+                // `message.id`, so a fork that lost its `seedLength` copies the
+                // summary into a file with a *different* session id, the two
+                // keys differ, and the cross-file pass -- which only collapses
+                // identical keys -- bills the summarize call twice.
+                //
+                // `seq` is the other field a fork copies verbatim (see the
+                // boundary check above), so it stands in for the missing id and
+                // stays identical across the copy. It is unique within a file,
+                // and pairing it with the timestamp, routing and buckets already
+                // in the key means an accidental merge would need two unrelated
+                // sessions to agree on all of them at millisecond resolution.
                 let identity = value
                     .pointer("/data/message/id")
                     .and_then(Value::as_str)
                     .map(str::trim)
                     .filter(|id| !id.is_empty())
-                    .map_or_else(|| format!("sid:{sid}"), |id| format!("msg:{id}"));
+                    .map(|id| format!("msg:{id}"))
+                    .or_else(|| {
+                        value
+                            .get("seq")
+                            .and_then(Value::as_i64)
+                            .map(|seq| format!("seq:{seq}"))
+                    })
+                    .unwrap_or_else(|| format!("sid:{sid}"));
                 // Namespace the summary so it can never collapse against a loop
                 // step: a summary carries no `message.id` of its own, so both
                 // fall back to `sid:` and a summary that happened to match a
@@ -345,11 +365,16 @@ mod tests {
         assert!(first.is_turn_start);
         assert_eq!(first.workspace_key.as_deref(), Some("E:/repo/proj"));
         assert_eq!(first.workspace_label.as_deref(), Some("proj"));
-        assert!(first
-            .dedup_key
-            .as_deref()
-            .unwrap()
-            .starts_with("dsh:sid:session-abc:"));
+        // This row carries no `message.id`, so the key falls back to `seq`
+        // rather than the session id: a fork copies `seq` verbatim, so the key
+        // survives the copy and the cross-file pass can collapse the two.
+        // This row carries no `message.id`, so the key falls back to `seq`
+        // rather than the session id: a fork copies `seq` verbatim, so the key
+        // survives the copy and the cross-file pass can still collapse the two.
+        assert_eq!(
+            first.dedup_key.as_deref(),
+            Some("dsh:seq:301:1786669454772:irix:deepseek-v4-flash:130:159:13824:0:0")
+        );
 
         // Same turn, later step: not a turn start.
         assert!(!messages[1].is_turn_start);
@@ -595,6 +620,44 @@ mod tests {
         assert_eq!(child_messages.len(), 1);
         assert_eq!(child_messages[0].timestamp, 1786358035361);
         assert_eq!(child_messages[0].tokens.input, 97);
+    }
+
+    #[test]
+    fn a_copied_summary_shares_its_key_across_a_fork_that_lost_seedlength() {
+        // The sibling test above covers the same shape for an assistant row,
+        // which survives on its `message.id`. A `compaction/summary` has none,
+        // so before the `seq` fallback the two files produced
+        // `dsh:summary:sid:parent...` and `dsh:summary:sid:child...`; the
+        // cross-file pass only collapses identical keys, so the summarize call
+        // was billed twice.
+        let row = r#"{"type":"compaction/summary","seq":4,"time":1786669450002,"data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20}}}"#;
+        let parent = write_zstd_session(&[
+            r#"{"type":"session","id":"96cf59c9-b347-48b9-b234-a5200913ad05","createdAt":1,"cwd":"/work"}"#,
+            row,
+        ]);
+        // No `seedLength`, so the seq boundary never fires and the copy is parsed.
+        let child = write_zstd_session(&[
+            r#"{"type":"session","id":"ada8966c-9fa3-441b-8721-37ff1e795e6a","createdAt":2,"cwd":"/work","parentSession":"96cf59c9-b347-48b9-b234-a5200913ad05"}"#,
+            row,
+        ]);
+
+        let parent_messages = parse_dsh_file(parent.path());
+        let child_messages = parse_dsh_file(child.path());
+
+        assert_eq!(parent_messages.len(), 1);
+        assert_eq!(child_messages.len(), 1);
+        assert_ne!(
+            parent_messages[0].session_id, child_messages[0].session_id,
+            "the two files must be distinct sessions for this to test anything"
+        );
+        assert_eq!(
+            parent_messages[0].dedup_key.as_deref(),
+            Some("dsh:summary:seq:4:1786669450002:p:m:10:20:0:0:0")
+        );
+        assert_eq!(
+            parent_messages[0].dedup_key, child_messages[0].dedup_key,
+            "a copied summary must collapse across the fork, or its cost is counted twice"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-ups from an adversarial review of `b069c85d..HEAD` (the six PRs merged today). Both were verified by reproducing them first, not by reading the diff.

## 1. Headless capture could still hang after a clean child exit

#1166 bounded the stdout drain on the timeout path, but the other branch still waited unboundedly — and that branch has no deadline behind it, since `timed_out` is false precisely because the deadline was never reached. A child that exits **successfully** while a descendant keeps the stdout pipe open hung forever. The original unconditional `join()` had the same hole, so it survived both.

Now bounded by whatever remains of the caller's deadline plus `STDOUT_DRAIN_GRACE`, so total wall time stays within the configured timeout either way. On expiry it returns an error rather than `Ok`: the child succeeded, so returning success would present a capture file we cannot show is complete.

`fake_codex` gains `descendant-exit` (spawn a stdout holder, then exit 0). The existing `descendant` fixture keeps the direct child alive to the deadline, so it only ever exercised the timeout branch.

**Verified discriminating:** the new test **fails at 122.47s** against the unbounded wait and **passes at 14.35s** with the bound.

Both fixtures now publish the holder pid to `TOKSCALE_FAKE_CODEX_PIDFILE` and teardown kills it, instead of leaving a 120s orphan per run for parallel and retried CI to accumulate. Verified 0 leaked processes after the suite.

## 2. A fork could double-count a DSH summarize call

A `compaction/summary` carries no `data.message.id`, so its dedup key fell back to the session id. A fork whose header lost `seedLength` copies the summary into a file under a different session id, the seq boundary never fires, and the keys diverge:

```
parent  dsh:summary:sid:parentAAA:1786669450002:p:m:10:20:0:0:0
child   dsh:summary:sid:childBBB:1786669450002:p:m:10:20:0:0:0
```

The cross-file pass only collapses identical keys, so 30 tokens are counted as 60. `msg:{id}` exists to cover exactly this case — the comment there says so — but a summary has no id to key on.

The key now falls back to `seq` before the session id. A fork copies `seq` verbatim (the same property the boundary check relies on), and it is unique within a file; paired with the timestamp, routing and buckets already in the key, an accidental merge would need two unrelated sessions to agree on all of them at millisecond resolution.

DSH `parser_version` goes 2 → 3 so v2 entries, whose keys no longer match, are reparsed.

`parses_assistant_messages_with_usage` now pins `dsh:seq:301:...` — that row has no `message.id` either, so its key legitimately changed shape.

## Validation

- `cargo fmt --all -- --check` → 0
- `cargo clippy --locked --workspace --all-features -- -D warnings` → 0
- `cargo test --workspace` → **1113 passed, 0 failed**
- Both descendant tests are `#[cfg(unix)]`: the holder is the fixture binary and Windows locks a running image, which would strand the fixture's TempDir.

## Not included

A third finding — the DSH parser bump does not invalidate the derived TUI aggregate cache (`CACHE_SCHEMA_VERSION` is still 10, and `mod.rs:53` displays `Stale` as well as `Fresh`) — is real in mechanism but narrower in impact, since DSH has not shipped in a release. Bumping the schema alone would not fix it either: an outdated schema classifies as `Stale`, which is still displayed, so it needs a generation that returns `Miss`. Left for a separate decision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two adversarially discovered gaps: bounds the `tokscale-cli` headless capture stdout drain after a clean child exit to avoid hangs, and prevents double-counting DSH summaries by keying idless rows on `seq`; DSH `parser_version` bumps to reparse caches.

- Old CLI behavior: draining stdout after a normal child exit could wait forever if a descendant kept the pipe open. New: drain waits up to the remaining deadline plus `STDOUT_DRAIN_GRACE`; on expiry it returns an error because the output may be incomplete. Adds a `descendant-exit` fixture and a Unix-only test that reaps the stdout holder via `TOKSCALE_FAKE_CODEX_PIDFILE`.
- Old DSH behavior: idless rows (e.g., `compaction/summary`) fell back to session-scoped keys, so a fork without `seedLength` billed a copied summary twice. New: fallback to `seq` before the session id so the cross-file pass collapses the copy. Bumps DSH `parser_version` 2 → 3 in `tokscale-core`; v2 cache entries are reparsed automatically.

<sup>Written for commit 107c9c864032a90d31c1d4a8d1f81a5a3f6c18be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

