### PR TITLE
fix(tui): rebuild the aggregate cache when the parser generation changes

### DIFF
--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -86,6 +86,17 @@ fn legacy_cache_files() -> Vec<PathBuf> {
 struct CachedTUIData {
     #[serde(default)]
     schema_version: u32,
+    /// `parser_generation()` at write time.
+    ///
+    /// `schema_version` covers the shape of this file; this covers the shape of
+    /// the *numbers inside it*. A parser fix changes totals without changing
+    /// either the file layout or any of the keys below, so without this a
+    /// pre-fix aggregate is indistinguishable from a current one.
+    ///
+    /// Defaults to 0 for files written before this field existed, which never
+    /// matches a real generation, so those are rebuilt once.
+    #[serde(default)]
+    parser_generation: u64,
     timestamp: u64,
     enabled_clients: Vec<String>,
     #[serde(default)]
@@ -778,6 +789,13 @@ fn classify_cached_payload(
     if cached.schema_version > CACHE_SCHEMA_VERSION {
         return CacheResult::Miss;
     }
+    // Miss, not Stale. Everything below can still hand back `Stale`, and
+    // `decide_initial_data` paints `Stale` exactly like `Fresh` -- so treating a
+    // parser change as merely stale would show the pre-fix totals anyway, which
+    // is the whole thing this guards against.
+    if cached.parser_generation != tokscale_core::parser_generation() {
+        return CacheResult::Miss;
+    }
     let schema_outdated = cached.schema_version < CACHE_SCHEMA_VERSION;
     let cached_group_by = cached
         .group_by
@@ -942,6 +960,7 @@ pub fn save_cached_data(
 
     let cached = CachedTUIData {
         schema_version: CACHE_SCHEMA_VERSION,
+        parser_generation: tokscale_core::parser_generation(),
         timestamp,
         enabled_clients: clients_vec,
         include_synthetic,
@@ -982,6 +1001,21 @@ pub fn save_cached_data(
 
 #[cfg(test)]
 mod tests {
+
+    /// Stamps the current parser generation into a hand-written cache fixture.
+    ///
+    /// The fixtures below are raw JSON on purpose -- they pin legacy on-disk
+    /// shapes that no current writer produces. `parserGeneration` is the one
+    /// field that cannot be pinned: it is computed from every client's
+    /// `parser_version`, so hardcoding it would make each of these files need
+    /// editing on every parser bump. Tests that are about generation
+    /// mismatch set it themselves instead of going through this.
+    fn with_current_generation(json: &str) -> String {
+        let mut value: serde_json::Value =
+            serde_json::from_str(json).expect("fixture is valid JSON");
+        value["parserGeneration"] = serde_json::json!(tokscale_core::parser_generation());
+        value.to_string()
+    }
     use super::*;
     use serial_test::serial;
     use std::ffi::OsString;
@@ -1227,6 +1261,68 @@ mod tests {
     }
 
     #[test]
+    fn a_cache_from_a_different_parser_generation_misses() {
+        // The point of the field. A parser fix changes the totals without
+        // changing the file layout, the group_by, the scope or the client set,
+        // so every other check here passes and the pre-fix numbers get handed
+        // back. Same payload as the fresh case, only the generation differs.
+        let mut value: serde_json::Value =
+            serde_json::from_str(&with_current_generation(LEGACY_FALLBACK_PAYLOAD)).unwrap();
+        value["parserGeneration"] =
+            serde_json::json!(tokscale_core::parser_generation().wrapping_add(1));
+
+        let payload: CachedTUIData = serde_json::from_value(value).unwrap();
+        let clients = make_filters(&[ClientFilter::Claude], false);
+        let result = classify_cached_payload(
+            payload,
+            &clients,
+            &GroupBy::Model,
+            &CacheReportScope::default(),
+        );
+        assert!(
+            matches!(result, CacheResult::Miss),
+            "a stale parser generation must Miss, not Stale -- Stale is painted just like Fresh; got {}",
+            other_variant_name(&result)
+        );
+    }
+
+    #[test]
+    fn a_cache_written_before_the_generation_field_misses() {
+        // Migration path. Files written before the field existed deserialize to
+        // 0, which no real generation equals, so they rebuild once on their own
+        // -- no schema bump needed to evict them.
+        let payload: CachedTUIData = serde_json::from_str(LEGACY_FALLBACK_PAYLOAD).unwrap();
+        assert_eq!(payload.parser_generation, 0, "pre-field files default to 0");
+
+        let clients = make_filters(&[ClientFilter::Claude], false);
+        let result = classify_cached_payload(
+            payload,
+            &clients,
+            &GroupBy::Model,
+            &CacheReportScope::default(),
+        );
+        assert!(
+            matches!(result, CacheResult::Miss),
+            "a cache predating the field must rebuild; got {}",
+            other_variant_name(&result)
+        );
+    }
+
+    #[test]
+    fn parser_generation_is_stable_and_non_zero() {
+        // The value is persisted, so it must not vary between calls. This
+        // deliberately does not pin a literal: that would need editing on every
+        // parser bump, which is the maintenance burden the field removes.
+        assert_eq!(
+            tokscale_core::parser_generation(),
+            tokscale_core::parser_generation()
+        );
+        // 0 is the serde default for pre-field files, so a real generation must
+        // never collide with it.
+        assert_ne!(tokscale_core::parser_generation(), 0);
+    }
+
+    #[test]
     #[serial]
     fn load_cache_misses_when_report_scope_differs() {
         let temp_dir = TempDir::new().unwrap();
@@ -1236,7 +1332,8 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(
             &cache_path,
-            r#"{
+            with_current_generation(
+                r#"{
   "schemaVersion": 10,
   "timestamp": 9999999999999,
   "enabledClients": ["claude"],
@@ -1259,6 +1356,7 @@ mod tests {
     "longestStreak": 0
   }
 }"#,
+            ),
         )
         .unwrap();
 
@@ -1318,7 +1416,8 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(
             &cache_path,
-            r#"{
+            with_current_generation(
+                r#"{
   "schemaVersion": 8,
   "timestamp": 9999999999999,
   "enabledClients": ["claude"],
@@ -1336,6 +1435,7 @@ mod tests {
     "longestStreak": 0
   }
 }"#,
+            ),
         )
         .unwrap();
 
@@ -1362,7 +1462,8 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(
             &cache_path,
-            r#"{
+            with_current_generation(
+                r#"{
   "timestamp": 9999999999999,
   "enabledClients": ["claude"],
   "includeSynthetic": false,
@@ -1376,6 +1477,7 @@ mod tests {
     "longestStreak": 0
   }
 }"#,
+            ),
         )
         .unwrap();
 
@@ -1396,7 +1498,8 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(
             &cache_path,
-            r#"{
+            with_current_generation(
+                r#"{
   "schemaVersion": 4,
   "timestamp": 9999999999999,
   "enabledClients": ["claude"],
@@ -1412,6 +1515,7 @@ mod tests {
     "longestStreak": 0
   }
 }"#,
+            ),
         )
         .unwrap();
 
@@ -1436,7 +1540,8 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(
             &cache_path,
-            r#"{
+            with_current_generation(
+                r#"{
   "schemaVersion": 3,
   "timestamp": 9999999999999,
   "enabledClients": ["claude"],
@@ -1477,6 +1582,7 @@ mod tests {
     "longestStreak": 1
   }
 }"#,
+            ),
         )
         .unwrap();
 
@@ -1505,7 +1611,8 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(
             &cache_path,
-            r#"{
+            with_current_generation(
+                r#"{
   "schemaVersion": 10,
   "timestamp": 9999999999999,
   "enabledClients": ["claude", "cursor"],
@@ -1589,6 +1696,7 @@ mod tests {
     "longestStreak": 1
   }
 }"#,
+            ),
         )
         .unwrap();
 
@@ -1618,7 +1726,8 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(
             &cache_path,
-            r#"{
+            with_current_generation(
+                r#"{
   "schemaVersion": 5,
   "timestamp": 9999999999999,
   "enabledClients": ["claude"],
@@ -1662,6 +1771,7 @@ mod tests {
     "longestStreak": 1
   }
 }"#,
+            ),
         )
         .unwrap();
 
@@ -1686,7 +1796,8 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(
             &cache_path,
-            r#"{
+            with_current_generation(
+                r#"{
   "schemaVersion": 3,
   "timestamp": 9999999999999,
   "enabledClients": ["claude"],
@@ -1727,6 +1838,7 @@ mod tests {
     "longestStreak": 1
   }
 }"#,
+            ),
         )
         .unwrap();
 
@@ -1789,7 +1901,7 @@ mod tests {
         let legacy = temp_dir.path().join(".cache/tokscale/tui-data-cache.json");
         fs::create_dir_all(canonical.parent().unwrap()).unwrap();
         fs::create_dir_all(legacy.parent().unwrap()).unwrap();
-        fs::write(&legacy, LEGACY_FALLBACK_PAYLOAD).unwrap();
+        fs::write(&legacy, with_current_generation(LEGACY_FALLBACK_PAYLOAD)).unwrap();
 
         let clients = make_filters(&[ClientFilter::Claude], false);
         let scope = CacheReportScope::default();

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod wiki;
 pub use aggregator::*;
 pub use bucket_tz::BucketTimezone;
 pub use clients::{ClientCounts, ClientDef, ClientId, PathRoot};
+pub use message_cache::parser_generation;
 pub use model_alias::ModelAliasMap;
 pub use parser::*;
 pub use scanner::*;

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -942,6 +942,36 @@ impl CacheIdentity {
     }
 }
 
+/// One value identifying the parser generation of every client at once.
+///
+/// Derived caches store this so a `parser_version` bump invalidates them too.
+/// The source cache versions each client independently, but anything folded on
+/// top of it -- the TUI aggregate cache -- mixes all clients into one set of
+/// totals, so it cannot say which client a given number came from and has to
+/// rebuild whenever any of them changes.
+///
+/// Deliberately covers `ClientId::ALL` rather than only the enabled set. A
+/// derived cache that reads this is rebuilt in the background anyway (see
+/// `decide_initial_data`), so an unnecessary rebuild costs one first paint,
+/// while a missed one shows numbers we already know are wrong. Reordering
+/// `define_clients!` also changes the value; that is the same cheap trade.
+///
+/// FNV-1a rather than `DefaultHasher`: this value is persisted, and
+/// `DefaultHasher`'s output is explicitly not stable across Rust releases.
+pub fn parser_generation() -> u64 {
+    const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    let mut acc = FNV_OFFSET_BASIS;
+    for client in ClientId::ALL {
+        for byte in parser_version(client).to_le_bytes() {
+            acc ^= u64::from(byte);
+            acc = acc.wrapping_mul(FNV_PRIME);
+        }
+    }
+    acc
+}
+
 fn parser_version(client: ClientId) -> u32 {
     match client {
         // These clients accumulated parser-only invalidations under the old


### PR DESCRIPTION
마지막 남은 adversarial review 지적(MEDIUM) 처리입니다.

## 문제

캐시가 두 겹인데 무효화 축이 연결돼 있지 않았습니다.

- **소스 캐시** (`message_cache.rs`, 155MB) — 클라이언트별 `parser_version`. 파서가 바뀌면 재파싱. ✅
- **TUI 집계 캐시** (`tui/cache.rs`, 165KB) — 그 위에 접은 결과. `schema_version`만 있고 **파서 세대를 담을 필드가 없었음**. ❌

그래서 #1162 이후에도 예전 집계가 그대로 통과했습니다. `schema_version`은 10으로 같고, `group_by`·`report_scope`·클라이언트 목록도 다 맞으니까요. `decide_initial_data`는 `Fresh`와 `Stale`을 **똑같이** 화면에 올리므로(`tui/mod.rs:53`) 사용자는 DSH 과소집계를 봤고, 그 창에서 `e`를 누르면 그 숫자가 **파일로 남습니다** — 화면은 백그라운드 리프레시가 고쳐주지만 파일은 안 고쳐집니다.

`CACHE_SCHEMA_VERSION`만 올리는 걸로는 안 됩니다. 낡은 스키마는 `Miss`가 아니라 `Stale`을 리턴하고(`cache.rs:815`), `Stale`은 표시됩니다.

## 해결

`CachedTUIData`에 `parser_generation: u64`를 추가하고, 불일치 시 **`Stale`이 아니라 `Miss`**를 리턴합니다. 검사는 `Stale`을 리턴할 수 있는 모든 경로보다 **앞에** 둡니다.

`parser_generation()`은 모든 클라이언트의 `parser_version`을 접습니다. 앞으로 어느 파서를 고치든 자동으로 따라옵니다 — 이번에 아무도 기억 못 한 게 정확히 그 문제였습니다.

`#[serde(default)]` 덕분에 **스키마 범프가 필요 없습니다.** 필드 이전 파일은 `0`으로 역직렬화되고, 실제 세대값은 절대 0이 아니므로 자동으로 한 번 재생성됩니다.

## 설계 결정

- **FNV-1a, `DefaultHasher` 아님.** 이 값은 디스크에 영구 저장되는데 `DefaultHasher` 출력은 Rust 릴리스 간 안정성이 보장되지 않습니다. 툴체인만 올려도 캐시가 날아갈 수 있습니다.
- **`ClientId::ALL`, 활성 클라이언트만이 아님.** `decide_initial_data`가 항상 백그라운드 로드를 걸므로 불필요한 `Miss`의 비용은 첫 페인트 한 번뿐입니다. 반대로 놓친 `Miss`는 이미 틀린 걸 아는 숫자를 보여줍니다. 비대칭이라 보수적으로 갔습니다.
- **`CacheResult` 변형 추가 안 함.** `Stale`은 "낡았지만 보여줄 만함", 지금 필요한 건 "보여주면 안 됨"인데 그건 `Miss`가 이미 의미합니다.

## 테스트

기존 픽스처 9개가 세대값이 없어서 전부 `Miss`가 났습니다 — 가드가 동작한다는 증거였습니다. `with_current_generation()` 헬퍼로 스탬프를 찍어 각 테스트가 자기 변수만 검증하도록 되돌렸습니다. 세대값을 리터럴로 박지 않은 건 의도적입니다(파서 범프마다 픽스처를 고쳐야 하는 부담이 바로 이 필드가 없애려는 것).

추가한 3개:
- 세대 불일치 → `Miss` (다른 조건은 전부 통과하는 상태에서)
- 필드 이전 파일 → `Miss` (마이그레이션 경로)
- 세대값이 호출 간 안정적이고 0이 아님

## 검증

- `cargo fmt --all -- --check` → 0
- `cargo clippy --locked --workspace --all-features -- -D warnings` → 0
- `cargo test --workspace` → **3151 passed, 0 failed** (`tui::cache` 29개 포함)

## 참고: 이 캐시가 필요한 이유 (실측)

둘 다 있어야 하는지 확인차 재봤습니다. 이 데이터셋에서 `tokscale models`(소스 → 집계 경로)는 **cold 195초 / warm 211초**입니다. 165KB짜리 집계 캐시가 없으면 TUI를 켤 때마다 3분 넘게 빈 화면을 봐야 합니다. 계층을 합치는 게 아니라 의존 관계를 명시하는 게 맞는 방향이라는 근거입니다.

(별건: warm이 cold보다 느린 건 그 자체로 이상합니다. #1153과 같은 데이터셋이라 따로 볼 가치가 있어 보입니다.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the TUI aggregate cache when the parser generation changes so the UI and exports never show pre-fix totals. Previously, the aggregate cache ignored parser changes and could classify old data as Fresh/Stale; now a generation mismatch returns Miss and forces a rebuild.

- Adds `parser_generation: u64` to the TUI cache payload and stamps it on write. Deserialization defaults to 0 for pre-field files, so old caches Miss once without a schema bump.
- Compares `cached.parser_generation` to `tokscale_core::parser_generation()` before any path that can return Stale; on mismatch, returns Miss.
- Introduces `tokscale_core::parser_generation()` (FNV-1a over every client’s `parser_version`, i.e., `ClientId::ALL`) and re-exports it from `tokscale-core`. Uses a stable hash since the value is persisted.
- Updates tests: helper stamps the current generation; adds checks for mismatch Miss, pre-field migration, and generation stability.

**Rollout**
- No migrations required. Expect a one-time Miss and rebuild for existing caches written before this field.

<sup>Written for commit e7f5905029462bdb5b16fa21a71947158a79c95c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

