### PR TITLE
chore(cache): delete the pre-v2 monolith once the shard cache is in use

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -34,6 +34,11 @@ const LEGACY_CACHE_FORMAT_VERSION: u32 = 4;
 // the monolith did not record a trustworthy parser owner for migration.
 const CACHE_SHARD_DIRNAME: &str = "source-message-cache-v2";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
+/// The pre-v2 monolith (`CACHE_FILENAME` in #327, dropped by #856).
+///
+/// Never read since v2 landed, and nothing rewrites it, so it is dead weight
+/// that only grows stale -- a real profile still had 155 MB of it from April.
+const LEGACY_MONOLITH_CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_SHARD_COUNT: usize = 256;
 const MAX_CACHE_SHARD_BYTES: u64 = 256 * 1024 * 1024;
 const FINGERPRINT_SAMPLE_BYTES: usize = 4096;
@@ -62,6 +67,39 @@ fn cache_shard_dir() -> Option<PathBuf> {
 
 fn cache_lock_path() -> Option<PathBuf> {
     Some(cache_dir()?.join(CACHE_LOCK_FILENAME))
+}
+
+/// Deletes the pre-v2 monolithic cache file, once per process.
+///
+/// V2 deliberately never reads it (see the note on `CACHE_SHARD_DIRNAME`), so
+/// once the shard directory is in use the monolith is unreachable bytes. It is
+/// checked in all three historic homes because #473 moved the cache root and
+/// the old copies were left where they were.
+///
+/// Best-effort on purpose: a read-only cache dir, a permission problem, or a
+/// concurrent tokscale winning the race all just leave the file alone. The lock
+/// file sharing its stem is still live and is never touched here.
+///
+/// The `legacy_*` probes return `None` under `TOKSCALE_CONFIG_DIR`, so an
+/// isolated profile never reaches into the real cache locations to delete
+/// anything.
+fn remove_legacy_monolith_cache() {
+    let candidates = [
+        cache_dir(),
+        crate::paths::legacy_dirs_cache_dir(),
+        crate::paths::legacy_dot_cache_tokscale_dir(),
+    ];
+    for dir in candidates.into_iter().flatten() {
+        let _ = fs::remove_file(dir.join(LEGACY_MONOLITH_CACHE_FILENAME));
+    }
+}
+
+/// `Once` wrapper for the hot path. Split from the body above so tests can
+/// exercise the removal itself -- a process-wide `Once` fires for whichever
+/// test runs first and is invisible to every other one.
+fn remove_legacy_monolith_cache_once() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(remove_legacy_monolith_cache);
 }
 
 fn fallback_cache_dir() -> Option<PathBuf> {
@@ -1622,6 +1660,10 @@ impl SourceMessageCache {
             );
             return;
         }
+        // The shard directory is now known-usable, which is the point at which
+        // the v1 monolith is provably unreachable. Doing it here rather than at
+        // startup keeps it off the path of runs that never touch the cache.
+        remove_legacy_monolith_cache_once();
         let lock_file = match OpenOptions::new()
             .read(true)
             .write(true)
@@ -2632,6 +2674,46 @@ mod tests {
             temp_home.join(".config").join("tokscale"),
         );
         env
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn legacy_monolith_cache_is_removed_but_the_live_lock_is_not() {
+        let temp_home = TempDir::new().unwrap();
+        let _env = sandbox_cache_env(temp_home.path());
+
+        let dir = cache_dir().expect("sandboxed cache dir");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let monolith = dir.join(LEGACY_MONOLITH_CACHE_FILENAME);
+        // The lock shares the stem with the monolith and is still live, so the
+        // cleanup has to be able to tell them apart.
+        let lock = dir.join(CACHE_LOCK_FILENAME);
+        let shards = dir.join(CACHE_SHARD_DIRNAME);
+        std::fs::write(&monolith, b"v1 monolith payload").unwrap();
+        std::fs::write(&lock, b"").unwrap();
+        std::fs::create_dir_all(&shards).unwrap();
+
+        remove_legacy_monolith_cache();
+
+        assert!(!monolith.exists(), "the v1 monolith must be deleted");
+        assert!(lock.exists(), "the live lock file must survive");
+        assert!(shards.exists(), "the v2 shard directory must survive");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn removing_the_legacy_monolith_is_idempotent_and_survives_a_missing_dir() {
+        // Runs on every cache load, so the common case is that there is nothing
+        // to delete -- and the cache dir may not exist yet on a first run.
+        let temp_home = TempDir::new().unwrap();
+        let _env = sandbox_cache_env(temp_home.path());
+
+        remove_legacy_monolith_cache();
+        remove_legacy_monolith_cache();
+
+        let dir = cache_dir().expect("sandboxed cache dir");
+        assert!(!dir.join(LEGACY_MONOLITH_CACHE_FILENAME).exists());
     }
 
     fn write_temp_file(content: &[u8]) -> NamedTempFile {


### PR DESCRIPTION
## 문제

#856이 소스 캐시를 샤드 방식으로 옮기면서 `source-message-cache.bin`을 **의도적으로 남겨뒀습니다** — 모놀리스가 마이그레이션에 쓸 만한 파서 소유자를 기록하지 않았기 때문입니다 (`message_cache.rs:33`).

그 뒤로 **아무도 읽지 않고, 아무도 다시 쓰지 않습니다.** 그래서 영원히 남습니다. 실제 프로파일에서 **4월 30일자 155MB**가 그대로 있었고, `~/Library/Caches/tokscale` 156MB 중 실제로 살아있는 건 1.2MB뿐이었습니다.

죽은 파일이라는 근거:
- `rg`로 전수 확인 — `source-message-cache`를 읽는 코드 경로 없음. 남은 참조는 문서 주석, v2 디렉터리명, **현역 락 파일명**, 그리고 원자적 샤드 쓰기의 임시파일 이름 fallback뿐
- git 히스토리: `#327`(e6a80fce)이 `const CACHE_FILENAME: &str = "source-message-cache.bin"` 도입 → `#856`(ae36db5c)이 v2 샤드로 넘어가며 그 상수 제거

## 해결

샤드 디렉터리 사용이 확정된 직후 삭제합니다. 위치 3곳을 모두 훑습니다 — `#473`이 캐시 루트를 옮겼고 구 위치의 사본은 그대로 남았기 때문입니다:

```rust
let candidates = [
    cache_dir(),
    crate::paths::legacy_dirs_cache_dir(),          // ~/Library/Caches/tokscale
    crate::paths::legacy_dot_cache_tokscale_dir(),  // ~/.cache/tokscale
];
```

이미 있던 헬퍼를 재사용했고, 이 헬퍼들은 `TOKSCALE_CONFIG_DIR`이 설정되면 `None`을 반환합니다 — **격리된 프로파일이 실제 캐시 위치를 건드리지 않는다**는 `paths.rs`의 기존 계약이 그대로 유지됩니다.

## 설계 결정

- **best-effort** — 읽기전용 FS, 권한 문제, 동시 실행 경합 모두 그냥 파일을 남겨둡니다. 다음 실행에서 다시 시도합니다.
- **락 파일 절대 불가침** — `source-message-cache.lock`은 같은 stem을 공유하지만 현역입니다. 테스트로 고정했습니다.
- **훅 위치는 캐시 로드 경로** — 시작 시점이 아니라, 캐시를 실제로 쓰는 실행에서만 비용이 발생합니다.
- **`Once` 래퍼와 본체 분리** — 프로세스 전역 `Once`는 첫 테스트에서만 발동돼 나머지 테스트가 관찰할 수 없으므로, 본체를 따로 빼서 테스트 가능하게 했습니다.

## 실제 파일 검증

| | 전 | 후 |
|---|---|---|
| `~/Library/Caches/tokscale` | 156M | **1.2M** |
| `Library/…/source-message-cache.bin` | 162,209,683 B | 삭제 |
| `.config/…/source-message-cache.bin` | 285 B | 삭제 |
| `source-message-cache.lock` | 있음 | **생존** |
| v2 샤드 트리 | 375M | **375M** |

## 검증

- `cargo fmt --all -- --check` → 0
- `cargo clippy --locked --workspace --all-features -- -D warnings` → 0
- `cargo test --workspace` → **3153 passed, 0 failed**
- 새 테스트 2개: 모놀리스 삭제 + 락/샤드 생존, 멱등성 + 디렉터리 부재 시 안전

한 번의 전체 실행에서 `trae::sync::tests::test_losing_contender_leaves_no_orphan_after_release`가 실패했는데, 이 변경과 무관한 기존 flake입니다: 단독 실행 시 main·이 브랜치 양쪽에서 3/3 통과하고, 해당 테스트는 자체 `TempDir`의 `sync.lock`만 사용해 접점이 없습니다. 재실행에서 3153개 전부 통과했습니다.

## 참고: 별건으로 찾은 것

이 조사 중에 `tokscale models` 186초의 내역을 프로파일링했는데, 초반 **약 45초가 단일 스레드**(96% 유저공간 CPU)였습니다. 원인은 `message_cache.rs:1661`의 직렬 `for` 루프가 **1,877개 샤드 / 378MB를 하나씩 bincode 역직렬화**하는 것입니다. 병렬화하면 전체의 20% 정도 단축될 것으로 보이나, 별도 변경이라 이 PR에는 넣지 않았습니다.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the pre‑v2 monolithic cache file once the shard cache is active to reclaim disk space and avoid stale data. Previously we left `source-message-cache.bin` in place and never read it; now we delete it after confirming the shard directory is usable.

- Delete only `source-message-cache.bin` in the current cache root and two legacy roots; never touch `source-message-cache.lock` or the v2 shard directory.
- Run the cleanup on the cache load path (not at startup), once per process, and as best‑effort (permission or race issues leave the file for a later run).
- Respect `TOKSCALE_CONFIG_DIR`; isolated profiles do not reach into real cache locations.

<sup>Written for commit 9a8e81c803433548df836ce5565265d610109358. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

