### PR TITLE
feat(embed): add weekly and monthly stats and ranks

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1124,7 +1124,7 @@ GitHubプロフィールREADMEにTokscaleの公開統計を直接埋め込むこ
 | `template` | `classic`（デフォルト）· `minimal` · `terminal` · `graph` · `orbit` · `vitals` · `blueprint` · `receipt` | カードデザイン |
 | `color` | `blue` · `green` · `teal` · `purple` · `pink` · `orange` · `monochrome` · `halloween` · `YlGnBu` | アクセントカラーと貢献グラフのパレット |
 | `theme` | `dark`（デフォルト）· `light` | ライトまたはダークのカード |
-| `period` | `all`（デフォルト）· `month`（直近30日）· `week`（直近7日） | トークン、コスト、貢献アクティビティの期間。ランクと送信回数はライフタイムのまま |
+| `period` | `all`（デフォルト）· `month`（直近30日）· `week`（直近7日） | トークン、コスト、貢献アクティビティ、ランクの期間。送信回数はライフタイムのまま |
 | `sort` | `tokens`（デフォルト）· `cost` | ランクを取得するリーダーボード |
 | `tokens`, `cost` | `compact` · `full` | 数値フォーマット、個別に設定可能 — `20.9B` か `20,941,000,000` |
 | `rank` | `plain`（デフォルト、`#134`）· `percent`（`top 12%`）· `total`（`#134 / 1,174`） | リーダーボードのランクの表示方法 |

--- a/README.ja.md
+++ b/README.ja.md
@@ -1124,6 +1124,7 @@ GitHubプロフィールREADMEにTokscaleの公開統計を直接埋め込むこ
 | `template` | `classic`（デフォルト）· `minimal` · `terminal` · `graph` · `orbit` · `vitals` · `blueprint` · `receipt` | カードデザイン |
 | `color` | `blue` · `green` · `teal` · `purple` · `pink` · `orange` · `monochrome` · `halloween` · `YlGnBu` | アクセントカラーと貢献グラフのパレット |
 | `theme` | `dark`（デフォルト）· `light` | ライトまたはダークのカード |
+| `period` | `all`（デフォルト）· `month`（直近30日）· `week`（直近7日） | トークン、コスト、貢献アクティビティの期間。ランクと送信回数はライフタイムのまま |
 | `sort` | `tokens`（デフォルト）· `cost` | ランクを取得するリーダーボード |
 | `tokens`, `cost` | `compact` · `full` | 数値フォーマット、個別に設定可能 — `20.9B` か `20,941,000,000` |
 | `rank` | `plain`（デフォルト、`#134`）· `percent`（`top 12%`）· `total`（`#134 / 1,174`） | リーダーボードのランクの表示方法 |
@@ -1137,6 +1138,7 @@ GitHubプロフィールREADMEにTokscaleの公開統計を直接埋め込むこ
 ![](https://tokscale.ai/api/embed/<username>/svg?template=orbit&color=pink&rank=percent)
 ![](https://tokscale.ai/api/embed/<username>/svg?template=terminal&color=green&theme=light)
 ![](https://tokscale.ai/api/embed/<username>/svg?template=receipt&color=YlGnBu&graph=1)
+![](https://tokscale.ai/api/embed/<username>/svg?period=week&graph=1)
 ```
 
 ### GitHubプロフィールバッジ

--- a/README.ko.md
+++ b/README.ko.md
@@ -1125,6 +1125,7 @@ GitHub 프로필 README에 Tokscale 공개 통계를 직접 임베드할 수 있
 | `template` | `classic` (기본값) · `minimal` · `terminal` · `graph` · `orbit` · `vitals` · `blueprint` · `receipt` | 카드 디자인 |
 | `color` | `blue` · `green` · `teal` · `purple` · `pink` · `orange` · `monochrome` · `halloween` · `YlGnBu` | 강조 색상 및 기여 그래프 팔레트 |
 | `theme` | `dark` (기본값) · `light` | 라이트 또는 다크 카드 |
+| `period` | `all` (기본값) · `month` (최근 30일) · `week` (최근 7일) | 토큰, 비용 및 기여 활동 기간. 랭크와 제출 횟수는 전체 기간 기준 |
 | `sort` | `tokens` (기본값) · `cost` | 랭크를 가져올 리더보드 기준 |
 | `tokens`, `cost` | `compact` · `full` | 숫자 형식, 독립적으로 설정 — `20.9B` vs `20,941,000,000` |
 | `rank` | `plain` (기본값, `#134`) · `percent` (`top 12%`) · `total` (`#134 / 1,174`) | 리더보드 랭크 표시 방식 |
@@ -1138,6 +1139,7 @@ GitHub 프로필 README에 Tokscale 공개 통계를 직접 임베드할 수 있
 ![](https://tokscale.ai/api/embed/<username>/svg?template=orbit&color=pink&rank=percent)
 ![](https://tokscale.ai/api/embed/<username>/svg?template=terminal&color=green&theme=light)
 ![](https://tokscale.ai/api/embed/<username>/svg?template=receipt&color=YlGnBu&graph=1)
+![](https://tokscale.ai/api/embed/<username>/svg?period=week&graph=1)
 ```
 
 ### GitHub 프로필 뱃지

--- a/README.ko.md
+++ b/README.ko.md
@@ -1125,7 +1125,7 @@ GitHub 프로필 README에 Tokscale 공개 통계를 직접 임베드할 수 있
 | `template` | `classic` (기본값) · `minimal` · `terminal` · `graph` · `orbit` · `vitals` · `blueprint` · `receipt` | 카드 디자인 |
 | `color` | `blue` · `green` · `teal` · `purple` · `pink` · `orange` · `monochrome` · `halloween` · `YlGnBu` | 강조 색상 및 기여 그래프 팔레트 |
 | `theme` | `dark` (기본값) · `light` | 라이트 또는 다크 카드 |
-| `period` | `all` (기본값) · `month` (최근 30일) · `week` (최근 7일) | 토큰, 비용 및 기여 활동 기간. 랭크와 제출 횟수는 전체 기간 기준 |
+| `period` | `all` (기본값) · `month` (최근 30일) · `week` (최근 7일) | 토큰, 비용, 기여 활동 및 랭크 기간. 제출 횟수는 전체 기간 기준 |
 | `sort` | `tokens` (기본값) · `cost` | 랭크를 가져올 리더보드 기준 |
 | `tokens`, `cost` | `compact` · `full` | 숫자 형식, 독립적으로 설정 — `20.9B` vs `20,941,000,000` |
 | `rank` | `plain` (기본값, `#134`) · `percent` (`top 12%`) · `total` (`#134 / 1,174`) | 리더보드 랭크 표시 방식 |

--- a/README.md
+++ b/README.md
@@ -1160,7 +1160,7 @@ customize the design.
 | `template` | `classic` (default) · `minimal` · `terminal` · `graph` · `orbit` · `vitals` · `blueprint` · `receipt` | Card design |
 | `color` | `blue` · `green` · `teal` · `purple` · `pink` · `orange` · `monochrome` · `halloween` · `YlGnBu` | Accent color and contribution-graph palette |
 | `theme` | `dark` (default) · `light` | Light or dark card |
-| `period` | `all` (default) · `month` (trailing 30 days) · `week` (trailing 7 days) | Token, cost, and contribution window; rank and submission count stay lifetime |
+| `period` | `all` (default) · `month` (trailing 30 days) · `week` (trailing 7 days) | Token, cost, contribution, and rank window; submission count stays lifetime |
 | `sort` | `tokens` (default) · `cost` | Which leaderboard the rank is taken from |
 | `tokens`, `cost` | `compact` · `full` | Number format, set independently — `20.9B` vs `20,941,000,000` |
 | `rank` | `plain` (default, `#134`) · `percent` (`top 12%`) · `total` (`#134 / 1,174`) | How the leaderboard rank is shown |

--- a/README.md
+++ b/README.md
@@ -1160,6 +1160,7 @@ customize the design.
 | `template` | `classic` (default) · `minimal` · `terminal` · `graph` · `orbit` · `vitals` · `blueprint` · `receipt` | Card design |
 | `color` | `blue` · `green` · `teal` · `purple` · `pink` · `orange` · `monochrome` · `halloween` · `YlGnBu` | Accent color and contribution-graph palette |
 | `theme` | `dark` (default) · `light` | Light or dark card |
+| `period` | `all` (default) · `month` (trailing 30 days) · `week` (trailing 7 days) | Token, cost, and contribution window; rank and submission count stay lifetime |
 | `sort` | `tokens` (default) · `cost` | Which leaderboard the rank is taken from |
 | `tokens`, `cost` | `compact` · `full` | Number format, set independently — `20.9B` vs `20,941,000,000` |
 | `rank` | `plain` (default, `#134`) · `percent` (`top 12%`) · `total` (`#134 / 1,174`) | How the leaderboard rank is shown |
@@ -1175,6 +1176,7 @@ Examples:
 ![](https://tokscale.ai/api/embed/<username>/svg?template=terminal&color=green&theme=light)
 ![](https://tokscale.ai/api/embed/<username>/svg?template=receipt&color=YlGnBu&graph=1)
 ![](https://tokscale.ai/api/embed/<username>/svg?view=3d&compact=1)
+![](https://tokscale.ai/api/embed/<username>/svg?period=week&graph=1)
 ```
 
 ### GitHub Profile Badge

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1126,6 +1126,7 @@ Tokscale 包含一个社交平台，您可以在其中分享使用数据并与�
 | `template` | `classic`（默认）· `minimal` · `terminal` · `graph` · `orbit` · `vitals` · `blueprint` · `receipt` | 卡片设计 |
 | `color` | `blue` · `green` · `teal` · `purple` · `pink` · `orange` · `monochrome` · `halloween` · `YlGnBu` | 强调色和贡献图配色 |
 | `theme` | `dark`（默认）· `light` | 浅色或深色卡片 |
+| `period` | `all`（默认）· `month`（最近30天）· `week`（最近7天） | 令牌、成本和贡献活动的统计区间；排名和提交次数仍为全时段 |
 | `sort` | `tokens`（默认）· `cost` | 排名取自哪个排行榜 |
 | `tokens`、`cost` | `compact` · `full` | 数字格式，可分别设置 —— `20.9B` 对比 `20,941,000,000` |
 | `rank` | `plain`（默认，`#134`）· `percent`（`top 12%`）· `total`（`#134 / 1,174`） | 排行榜名次的显示方式 |
@@ -1139,6 +1140,7 @@ Tokscale 包含一个社交平台，您可以在其中分享使用数据并与�
 ![](https://tokscale.ai/api/embed/<username>/svg?template=orbit&color=pink&rank=percent)
 ![](https://tokscale.ai/api/embed/<username>/svg?template=terminal&color=green&theme=light)
 ![](https://tokscale.ai/api/embed/<username>/svg?template=receipt&color=YlGnBu&graph=1)
+![](https://tokscale.ai/api/embed/<username>/svg?period=week&graph=1)
 ```
 
 ### GitHub 个人资料徽章

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1126,7 +1126,7 @@ Tokscale 包含一个社交平台，您可以在其中分享使用数据并与�
 | `template` | `classic`（默认）· `minimal` · `terminal` · `graph` · `orbit` · `vitals` · `blueprint` · `receipt` | 卡片设计 |
 | `color` | `blue` · `green` · `teal` · `purple` · `pink` · `orange` · `monochrome` · `halloween` · `YlGnBu` | 强调色和贡献图配色 |
 | `theme` | `dark`（默认）· `light` | 浅色或深色卡片 |
-| `period` | `all`（默认）· `month`（最近30天）· `week`（最近7天） | 令牌、成本和贡献活动的统计区间；排名和提交次数仍为全时段 |
+| `period` | `all`（默认）· `month`（最近30天）· `week`（最近7天） | 令牌、成本、贡献活动和排名的统计区间；提交次数仍为全时段 |
 | `sort` | `tokens`（默认）· `cost` | 排名取自哪个排行榜 |
 | `tokens`、`cost` | `compact` · `full` | 数字格式，可分别设置 —— `20.9B` 对比 `20,941,000,000` |
 | `rank` | `plain`（默认，`#134`）· `percent`（`top 12%`）· `total`（`#134 / 1,174`） | 排行榜名次的显示方式 |

--- a/packages/frontend/__tests__/api/embedSvgRoute.test.ts
+++ b/packages/frontend/__tests__/api/embedSvgRoute.test.ts
@@ -54,6 +54,8 @@ let GET: ModuleExports["GET"];
 
 function statsFor(username: string) {
   return {
+    period: "all" as const,
+    dateRange: null,
     user: {
       id: "user-1",
       username,
@@ -185,6 +187,44 @@ describe("GET /api/embed/[username]/svg", () => {
     expect(renderMinimalEmbedSvg).not.toHaveBeenCalled();
     expectPublicSvgHeaders(response);
     await expect(response.text()).resolves.toBe("<svg>classic</svg>");
+  });
+
+  it("applies a finite period to stats and contribution data", async () => {
+    const dateRange = { start: "2026-03-01", end: "2026-03-07" };
+    getUserEmbedStats.mockResolvedValue({
+      ...statsFor("octocat"),
+      period: "week",
+      dateRange,
+    });
+
+    const response = await request("?template=graph&period=week");
+
+    expect(response.status).toBe(200);
+    expect(getUserEmbedStats).toHaveBeenCalledWith(
+      "octocat",
+      "tokens",
+      "week",
+    );
+    expect(getUserEmbedContributions).toHaveBeenCalledWith(
+      "octocat",
+      dateRange,
+    );
+    expect(renderGraphEmbedSvg).toHaveBeenCalledWith(
+      expect.objectContaining({ period: "week", dateRange }),
+      expect.objectContaining({ contributions: [] }),
+    );
+  });
+
+  it("falls back to lifetime stats for an unknown period", async () => {
+    getUserEmbedStats.mockResolvedValue(statsFor("octocat"));
+
+    await request("?period=quarter");
+
+    expect(getUserEmbedStats).toHaveBeenCalledWith(
+      "octocat",
+      "tokens",
+      "all",
+    );
   });
 
   it.each([

--- a/packages/frontend/__tests__/components/profileEmbedDialogOptions.test.ts
+++ b/packages/frontend/__tests__/components/profileEmbedDialogOptions.test.ts
@@ -11,6 +11,7 @@ const defaults: EmbedDialogOptions = {
   compact: false,
   costFormat: "compact",
   graph: false,
+  period: "all",
   rankFormat: "plain",
   sortBy: "tokens",
   template: "classic",
@@ -117,6 +118,21 @@ describe("profile embed dialog options", () => {
       tokens: "full",
       cost: "full",
     });
+  });
+
+  it("keeps the selected stats period in the embed and profile links", () => {
+    const links = buildProfileEmbedLinks("octocat", {
+      ...defaults,
+      period: "month",
+    });
+    const embedUrl = new URL(links.embedUrl);
+
+    expect(embedUrl.searchParams.get("period")).toBe("month");
+    expect(links.profileUrl).toBe(
+      "https://tokscale.ai/u/octocat?period=month",
+    );
+    expect(links.markdownSnippet).toContain("period=month");
+    expect(links.htmlSnippet).toContain("period=month");
   });
 
   it("does not show a redundant graph toggle for graph-first templates", () => {

--- a/packages/frontend/__tests__/lib/embedTemplates.test.ts
+++ b/packages/frontend/__tests__/lib/embedTemplates.test.ts
@@ -6,6 +6,8 @@ import type {
 import {
   THEMES,
   applyEmbedColor,
+  getEmbedPeriodDateRange,
+  parseEmbedPeriod,
   parseEmbedTemplate,
   parseEmbedColor,
   parseNumberFormat,
@@ -103,6 +105,8 @@ function isometricCubeGeometry(svg: string): string[] {
 }
 
 const mockStats: UserEmbedStats = {
+  period: "all",
+  dateRange: null,
   user: {
     id: "user-id",
     username: "octocat",
@@ -145,6 +149,29 @@ describe("parseEmbedTemplate", () => {
   it("falls back to classic for unknown or missing values", () => {
     expect(parseEmbedTemplate("fancy")).toBe("classic");
     expect(parseEmbedTemplate(null)).toBe("classic");
+  });
+});
+
+describe("embed period", () => {
+  it("accepts profile periods and falls back to lifetime", () => {
+    expect(parseEmbedPeriod("week")).toBe("week");
+    expect(parseEmbedPeriod("month")).toBe("month");
+    expect(parseEmbedPeriod("quarter")).toBe("all");
+    expect(parseEmbedPeriod(null)).toBe("all");
+  });
+
+  it("anchors finite ranges to submitted dates ahead of UTC today", () => {
+    const now = new Date("2026-03-12T12:00:00.000Z");
+
+    expect(getEmbedPeriodDateRange("week", "2026-03-14", now)).toEqual({
+      start: "2026-03-08",
+      end: "2026-03-14",
+    });
+    expect(getEmbedPeriodDateRange("month", null, now)).toEqual({
+      start: "2026-02-11",
+      end: "2026-03-12",
+    });
+    expect(getEmbedPeriodDateRange("all", "2026-03-14", now)).toBeNull();
   });
 });
 
@@ -223,6 +250,19 @@ describe("renderMinimalEmbedSvg", () => {
     expect(svg).toContain("<svg");
     expect(svg).toContain("@octocat");
     expect(svg).toContain("Total tokens");
+  });
+
+  it("labels finite stats and lifetime rank without mixing their scopes", () => {
+    const svg = renderMinimalEmbedSvg({
+      ...mockStats,
+      period: "month",
+      dateRange: { start: "2026-01-26", end: "2026-02-24" },
+    });
+
+    expect(svg).toContain("Tokscale · 30d");
+    expect(svg).toContain("Tokens · 30d");
+    expect(svg).toContain("Cost · 30d");
+    expect(svg).toContain("Rank · lifetime");
   });
 
   it("honors the token number format", () => {
@@ -423,6 +463,8 @@ describe("embed renderer root contracts", () => {
 describe("embed text fitting", () => {
   const username = "u".repeat(39);
   const extremeStats: UserEmbedStats = {
+    period: "all",
+    dateRange: null,
     user: {
       ...mockStats.user,
       username,

--- a/packages/frontend/__tests__/lib/embedTemplates.test.ts
+++ b/packages/frontend/__tests__/lib/embedTemplates.test.ts
@@ -252,7 +252,7 @@ describe("renderMinimalEmbedSvg", () => {
     expect(svg).toContain("Total tokens");
   });
 
-  it("labels finite stats and lifetime rank without mixing their scopes", () => {
+  it("labels finite stats and rank with the selected scope", () => {
     const svg = renderMinimalEmbedSvg({
       ...mockStats,
       period: "month",
@@ -262,7 +262,7 @@ describe("renderMinimalEmbedSvg", () => {
     expect(svg).toContain("Tokscale · 30d");
     expect(svg).toContain("Tokens · 30d");
     expect(svg).toContain("Cost · 30d");
-    expect(svg).toContain("Rank · lifetime");
+    expect(svg).toContain("Rank · 30d");
   });
 
   it("honors the token number format", () => {

--- a/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
+++ b/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
@@ -290,7 +290,7 @@ describe("user embed data", () => {
     ).toBe(true);
   });
 
-  it("scopes embed totals to an anchored trailing seven-day window", async () => {
+  it("scopes embed totals and rank to an anchored trailing seven-day window", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-12T12:00:00.000Z"));
 
@@ -308,8 +308,8 @@ describe("user embed data", () => {
           updatedAt: new Date("2026-03-14T09:00:00.000Z"),
         },
       ]);
-      mockState.pushExecuteResult([{ rank: 2, total: 10 }]);
       mockState.pushExecuteResult([{ totalTokens: 700, totalCost: 7 }]);
+      mockState.pushExecuteResult([{ rank: 2, total: 10 }]);
 
       const stats = await getUserEmbedStats("alice", "tokens", "week");
       const sqlTexts = serializeSqlCalls();
@@ -328,6 +328,9 @@ describe("user embed data", () => {
       expect(
         sqlTexts.some(
           (text) =>
+            text.includes("WITH rankable AS") &&
+            text.includes("FROM daily_breakdown d") &&
+            text.includes("RANK() OVER") &&
             text.includes("d.date >= 2026-03-08") &&
             text.includes("d.date <= 2026-03-14"),
         ),

--- a/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
+++ b/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
@@ -33,6 +33,7 @@ const mockState = vi.hoisted(() => {
   const eq = vi.fn(() => "eq");
   const and = vi.fn(() => "and");
   const gte = vi.fn(() => "gte");
+  const lte = vi.fn(() => "lte");
   const sql = Object.assign(
     vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
       strings: Array.from(strings),
@@ -72,6 +73,7 @@ const mockState = vi.hoisted(() => {
     eq,
     and,
     gte,
+    lte,
     sql,
     reset() {
       awaitedResults.length = 0;
@@ -82,6 +84,7 @@ const mockState = vi.hoisted(() => {
       eq.mockClear();
       and.mockClear();
       gte.mockClear();
+      lte.mockClear();
       sql.mockClear();
       sql.raw.mockClear();
     },
@@ -130,6 +133,7 @@ vi.mock("drizzle-orm", () => ({
   eq: mockState.eq,
   and: mockState.and,
   gte: mockState.gte,
+  lte: mockState.lte,
   sql: mockState.sql,
 }));
 
@@ -284,6 +288,77 @@ describe("user embed data", () => {
         text.toLowerCase().includes("lower(users.username) = imlunahey"),
       ),
     ).toBe(true);
+  });
+
+  it("scopes embed totals to an anchored trailing seven-day window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-12T12:00:00.000Z"));
+
+    try {
+      mockState.pushAwaitedResult([
+        {
+          id: "user-alice",
+          username: "alice",
+          displayName: "Alice",
+          avatarUrl: null,
+          totalTokens: 3000,
+          totalCost: 40,
+          submissionCount: 3,
+          latestDate: "2026-03-14",
+          updatedAt: new Date("2026-03-14T09:00:00.000Z"),
+        },
+      ]);
+      mockState.pushExecuteResult([{ rank: 2, total: 10 }]);
+      mockState.pushExecuteResult([{ totalTokens: 700, totalCost: 7 }]);
+
+      const stats = await getUserEmbedStats("alice", "tokens", "week");
+      const sqlTexts = serializeSqlCalls();
+
+      expect(stats).toMatchObject({
+        period: "week",
+        dateRange: { start: "2026-03-08", end: "2026-03-14" },
+        stats: {
+          totalTokens: 700,
+          totalCost: 7,
+          submissionCount: 3,
+          rank: 2,
+          rankTotal: 10,
+        },
+      });
+      expect(
+        sqlTexts.some(
+          (text) =>
+            text.includes("d.date >= 2026-03-08") &&
+            text.includes("d.date <= 2026-03-14"),
+        ),
+      ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds contribution queries to a finite stats window", async () => {
+    const dateRange = { start: "2026-03-01", end: "2026-03-07" };
+    mockState.pushAwaitedResult([{ id: "user-alice" }]);
+    mockState.pushAwaitedResult([
+      { date: "2026-03-01", tokens: 10, cost: 1 },
+      { date: "2026-03-07", tokens: 100, cost: 10 },
+    ]);
+
+    const contributions = await getUserEmbedContributions(
+      "alice",
+      dateRange,
+    );
+
+    expect(mockState.gte).toHaveBeenCalledWith(
+      mockState.tables.dailyBreakdown.date,
+      dateRange.start,
+    );
+    expect(mockState.lte).toHaveBeenCalledWith(
+      mockState.tables.dailyBreakdown.date,
+      dateRange.end,
+    );
+    expect(contributions?.map(({ intensity }) => intensity)).toEqual([1, 4]);
   });
 
   it("derives contribution intensity from max-relative tokens even when cost is zero", async () => {

--- a/packages/frontend/__tests__/lib/renderIsometric3DSvg.test.ts
+++ b/packages/frontend/__tests__/lib/renderIsometric3DSvg.test.ts
@@ -9,6 +9,8 @@ import type {
 } from "../../src/lib/embed/getUserEmbedStats";
 
 const mockStats: UserEmbedStats = {
+  period: "all",
+  dateRange: null,
   user: {
     id: "user-id",
     username: "octocat",

--- a/packages/frontend/__tests__/lib/renderProfileBadgeSvg.test.ts
+++ b/packages/frontend/__tests__/lib/renderProfileBadgeSvg.test.ts
@@ -6,6 +6,8 @@ import {
 import type { UserEmbedStats } from "../../src/lib/embed/getUserEmbedStats";
 
 const mockStats: UserEmbedStats = {
+  period: "all",
+  dateRange: null,
   user: {
     id: "user-id",
     username: "octocat",

--- a/packages/frontend/__tests__/lib/renderProfileEmbedSvg.test.ts
+++ b/packages/frontend/__tests__/lib/renderProfileEmbedSvg.test.ts
@@ -6,6 +6,8 @@ import {
 import type { UserEmbedStats } from "../../src/lib/embed/getUserEmbedStats";
 
 const mockStats: UserEmbedStats = {
+  period: "all",
+  dateRange: null,
   user: {
     id: "user-id",
     username: "octocat",

--- a/packages/frontend/src/app/api/embed/[username]/svg/route.ts
+++ b/packages/frontend/src/app/api/embed/[username]/svg/route.ts
@@ -20,8 +20,11 @@ import {
   type EmbedTemplate,
   type EmbedColorName,
   type EmbedNumberFormat,
+  type EmbedPeriod,
+  type EmbedPeriodDateRange,
   parseEmbedTemplate,
   parseEmbedColor,
+  parseEmbedPeriod,
   parseNumberFormat,
   parseRankFormat,
 } from "@/lib/embed/embedShared";
@@ -81,9 +84,10 @@ interface RouteParams {
 async function getContributionsWithEvidence(
   username: string,
   template: EmbedTemplate | "3d",
+  dateRange: EmbedPeriodDateRange | null,
 ) {
   try {
-    return await getUserEmbedContributions(username);
+    return await getUserEmbedContributions(username, dateRange);
   } catch (error) {
     console.warn("[embed-svg] contribution fetch failed", {
       username,
@@ -117,6 +121,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   const theme = parseTheme(searchParams);
   const compact = parseCompact(searchParams);
   const sortBy = parseSort(searchParams);
+  const period: EmbedPeriod = parseEmbedPeriod(searchParams.get("period"));
   const showGraph = parseGraph(searchParams);
   const view = parseView(searchParams);
   const template: EmbedTemplate = parseEmbedTemplate(
@@ -146,7 +151,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   }
 
   try {
-    const data = await getUserEmbedStats(username, sortBy);
+    const data = await getUserEmbedStats(username, sortBy, period);
 
     if (!data) {
       const svg =
@@ -169,7 +174,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     if (view === "3d") {
-      const contributions = await getContributionsWithEvidence(username, "3d");
+      const contributions = await getContributionsWithEvidence(
+        username,
+        "3d",
+        data.dateRange,
+      );
 
       if (!contributions) {
         const svg = renderIsometric3DErrorSvg(
@@ -192,6 +201,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         status: 200,
         durationMs: Date.now() - startedAt,
         sortBy,
+        period,
         theme,
         compact,
       });
@@ -209,7 +219,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       template === "orbit" ||
       template === "receipt";
     const contributions = wantsContributions
-      ? await getContributionsWithEvidence(username, template)
+      ? await getContributionsWithEvidence(
+          username,
+          template,
+          data.dateRange,
+        )
       : null;
 
     if (contributionDataRequired && !contributions) {
@@ -272,6 +286,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       color,
       compact,
       sortBy,
+      period,
       theme,
       graph: showGraph,
     });

--- a/packages/frontend/src/components/profile/ProfileEmbedDialog.tsx
+++ b/packages/frontend/src/components/profile/ProfileEmbedDialog.tsx
@@ -15,6 +15,7 @@ import {
   buildProfileEmbedLinks,
   getEmbedDialogCapabilities,
   type EmbedNumberFormat,
+  type EmbedPeriod,
   type EmbedRankFormat,
   type EmbedSortBy,
   type EmbedTheme,
@@ -51,6 +52,7 @@ export function ProfileEmbedDialog({
 }: ProfileEmbedDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
   const [theme, setTheme] = useState<EmbedTheme>("dark");
+  const [period, setPeriod] = useState<EmbedPeriod>("all");
   const [sortBy, setSortBy] = useState<EmbedSortBy>("tokens");
   const [layoutCompact, setLayoutCompact] = useState(false);
   const [threeDCompact, setThreeDCompact] = useState(false);
@@ -148,6 +150,7 @@ export function ProfileEmbedDialog({
         compact,
         costFormat,
         graph,
+        period,
         rankFormat,
         sortBy,
         template,
@@ -160,6 +163,7 @@ export function ProfileEmbedDialog({
       compact,
       costFormat,
       graph,
+      period,
       rankFormat,
       sortBy,
       template,
@@ -303,6 +307,32 @@ export function ProfileEmbedDialog({
                 >
                   Light
                 </SegmentButton>
+              </SegmentedControl>
+            </OptionGroup>
+
+            <OptionGroup>
+              <OptionLabel id="embed-period-label">Time range</OptionLabel>
+              <SegmentedControl
+                role="group"
+                aria-labelledby="embed-period-label"
+              >
+                {(
+                  [
+                    ["all", "Lifetime"],
+                    ["month", "30d"],
+                    ["week", "7d"],
+                  ] as const
+                ).map(([value, label]) => (
+                  <SegmentButton
+                    key={value}
+                    type="button"
+                    $active={period === value}
+                    aria-pressed={period === value}
+                    onClick={() => setPeriod(value)}
+                  >
+                    {label}
+                  </SegmentButton>
+                ))}
               </SegmentedControl>
             </OptionGroup>
 

--- a/packages/frontend/src/components/profile/embedDialogOptions.ts
+++ b/packages/frontend/src/components/profile/embedDialogOptions.ts
@@ -1,7 +1,11 @@
-import type { EmbedTemplate } from "@/lib/embed/embedShared";
+import type {
+  EmbedPeriod as SharedEmbedPeriod,
+  EmbedTemplate,
+} from "@/lib/embed/embedShared";
 import type { ColorPaletteName } from "@/lib/themes";
 
 export type EmbedTheme = "dark" | "light";
+export type EmbedPeriod = SharedEmbedPeriod;
 export type EmbedSortBy = "tokens" | "cost";
 export type EmbedView = "2d" | "3d";
 export type EmbedNumberFormat = "compact" | "full";
@@ -12,6 +16,7 @@ export interface EmbedDialogOptions {
   compact: boolean;
   costFormat: EmbedNumberFormat;
   graph: boolean;
+  period: EmbedPeriod;
   rankFormat: EmbedRankFormat;
   sortBy: EmbedSortBy;
   template: EmbedTemplate;
@@ -86,6 +91,7 @@ export function buildProfileEmbedLinks(
   if (options.view === "3d") params.set("view", "3d");
   if (options.theme !== "dark") params.set("theme", options.theme);
   if (options.sortBy !== "tokens") params.set("sort", options.sortBy);
+  if (options.period !== "all") params.set("period", options.period);
 
   if (options.view === "3d") {
     if (options.compact) params.set("compact", "1");
@@ -110,7 +116,9 @@ export function buildProfileEmbedLinks(
   const escapedUsername = escapeHtmlAttribute(username);
   const baseEmbedUrl = `${TOKSCALE_URL}/api/embed/${encodedUsername}/svg`;
   const embedUrl = query ? `${baseEmbedUrl}?${query}` : baseEmbedUrl;
-  const profileUrl = `${TOKSCALE_URL}/u/${encodedUsername}`;
+  const profileUrl = `${TOKSCALE_URL}/u/${encodedUsername}${
+    options.period === "all" ? "" : `?period=${options.period}`
+  }`;
 
   return {
     embedUrl,

--- a/packages/frontend/src/lib/embed/embedShared.ts
+++ b/packages/frontend/src/lib/embed/embedShared.ts
@@ -19,6 +19,7 @@ import {
 export { escapeXml };
 
 export type EmbedTheme = "dark" | "light";
+export type EmbedPeriod = "all" | "month" | "week";
 export type EmbedTemplate =
   | "classic"
   | "minimal"
@@ -31,6 +32,11 @@ export type EmbedTemplate =
 export type EmbedNumberFormat = "compact" | "full";
 export type EmbedRankFormat = "plain" | "percent" | "total";
 export type EmbedColorName = ColorPaletteName;
+
+export interface EmbedPeriodDateRange {
+  start: string;
+  end: string;
+}
 
 export interface ThemePalette {
   scheme: EmbedTheme;
@@ -126,6 +132,76 @@ export const EMBED_TEMPLATES: EmbedTemplate[] = [
   "blueprint",
   "receipt",
 ];
+
+const EMBED_PERIODS: EmbedPeriod[] = ["all", "month", "week"];
+const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Parse the `period` query param, falling back to lifetime stats. */
+export function parseEmbedPeriod(value: string | null): EmbedPeriod {
+  return EMBED_PERIODS.includes(value as EmbedPeriod)
+    ? (value as EmbedPeriod)
+    : "all";
+}
+
+/** Short label used anywhere an embed needs to identify its stats window. */
+export function getEmbedPeriodLabel(
+  period: EmbedPeriod | undefined,
+): "lifetime" | "30d" | "7d" {
+  if (period === "month") return "30d";
+  if (period === "week") return "7d";
+  return "lifetime";
+}
+
+/** Number of calendar days in a finite embed window. */
+export function getEmbedPeriodDayCount(
+  period: EmbedPeriod | undefined,
+): 7 | 30 | null {
+  if (period === "month") return 30;
+  if (period === "week") return 7;
+  return null;
+}
+
+function parseDateKey(value: string | null | undefined): Date | null {
+  if (!value || !DATE_KEY_PATTERN.test(value)) return null;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/**
+ * Resolve the same trailing 7d/30d window as the public profile. The newest
+ * submitted calendar day wins when it is ahead of UTC today, which keeps data
+ * reported from timezones east of UTC inside the requested window.
+ */
+export function getEmbedPeriodDateRange(
+  period: EmbedPeriod,
+  latestDate: string | null | undefined,
+  now: Date = new Date(),
+): EmbedPeriodDateRange | null {
+  const dayCount = getEmbedPeriodDayCount(period);
+  if (!dayCount) return null;
+
+  const utcToday = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  const latest = parseDateKey(latestDate);
+  const end = latest && latest > utcToday ? latest : utcToday;
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (dayCount - 1));
+
+  return {
+    start: start.toISOString().slice(0, 10),
+    end: end.toISOString().slice(0, 10),
+  };
+}
+
+/** Use a finite period's anchored end date when laying out its graph. */
+export function getEmbedPeriodReferenceDate(
+  period: EmbedPeriod | undefined,
+  dateRange: EmbedPeriodDateRange | null | undefined,
+): Date | undefined {
+  if (period === "all" || !dateRange) return undefined;
+  return parseDateKey(dateRange.end) ?? undefined;
+}
 
 /** Parse the `template` query param, falling back to the classic card. */
 export function parseEmbedTemplate(value: string | null): EmbedTemplate {
@@ -326,8 +402,9 @@ export function getContributionWindow<T extends ContributionDay>(
  */
 export function layoutContributions(
   contributions: ContributionDay[],
+  referenceDate: Date = new Date(),
 ): ContributionLayout {
-  const window = getContributionWindow(contributions);
+  const window = getContributionWindow(contributions, referenceDate);
   const hasTokenTotals = window.days.some(
     ({ totalTokens }) => typeof totalTokens === "number",
   );
@@ -481,13 +558,16 @@ export interface CardHeaderOptions {
   x: number;
   y: number;
   right: number;
+  period?: EmbedPeriod;
 }
 
 /** Compact identity header shared by every 2D widget. */
 export function cardHeader(options: CardHeaderOptions): string {
-  const { username, displayName, palette, x, y, right } = options;
+  const { username, displayName, palette, x, y, right, period } = options;
   const identityWidth = Math.max(80, right - x - 92);
   const headline = displayName?.trim() || `@${username}`;
+  const periodLabel = getEmbedPeriodLabel(period);
+  const brand = periodLabel === "lifetime" ? "Tokscale" : `Tokscale · ${periodLabel}`;
 
   return [
     fittedText({
@@ -511,7 +591,7 @@ export function cardHeader(options: CardHeaderOptions): string {
           minFontSize: 8,
         })
       : "",
-    `<text x="${right}" y="${y}" fill="${palette.muted}" font-size="11" font-weight="600" text-anchor="end" font-family="${FIGTREE_FONT_STACK}">Tokscale</text>`,
+    `<text x="${right}" y="${y}" fill="${palette.muted}" font-size="11" font-weight="600" text-anchor="end" font-family="${FIGTREE_FONT_STACK}">${brand}</text>`,
   ]
     .filter(Boolean)
     .join("\n  ");
@@ -567,6 +647,7 @@ export interface ContributionPanelOptions {
   showLegend?: boolean;
   mono?: boolean;
   heading?: string;
+  referenceDate?: Date;
 }
 
 export interface ContributionPanelResult {
@@ -592,8 +673,9 @@ export function contributionPanel(
     showLegend = false,
     mono = false,
     heading = "Contribution activity",
+    referenceDate,
   } = options;
-  const layout = layoutContributions(contributions);
+  const layout = layoutContributions(contributions, referenceDate);
   const colors = gradeColors(palette);
   const font = mono ? MONO_FONT_STACK : FIGTREE_FONT_STACK;
   const dayLabelWidth = showDayLabels ? 30 : 0;

--- a/packages/frontend/src/lib/embed/getUserEmbedStats.ts
+++ b/packages/frontend/src/lib/embed/getUserEmbedStats.ts
@@ -6,8 +6,14 @@ import {
   normalizeUsernameCacheKey,
   usernameEqualsIgnoreCase,
 } from "@/lib/db/usernameLookup";
-import { eq, sql, and, gte } from "drizzle-orm";
-import { getContributionIntensity, getContributionWindow } from "./embedShared";
+import { eq, sql, and, gte, lte } from "drizzle-orm";
+import {
+  getContributionIntensity,
+  getContributionWindow,
+  getEmbedPeriodDateRange,
+  type EmbedPeriod,
+  type EmbedPeriodDateRange,
+} from "./embedShared";
 
 export type EmbedSortBy = "tokens" | "cost";
 
@@ -19,6 +25,8 @@ export interface EmbedContributionDay {
 }
 
 export interface UserEmbedStats {
+  period: EmbedPeriod;
+  dateRange: EmbedPeriodDateRange | null;
   user: {
     id: string;
     username: string;
@@ -41,6 +49,7 @@ export interface UserEmbedStats {
 async function fetchUserEmbedStats(
   username: string,
   sortBy: EmbedSortBy,
+  period: EmbedPeriod,
 ): Promise<UserEmbedStats | null> {
   const matchingUsers = await db
     .select({
@@ -51,6 +60,7 @@ async function fetchUserEmbedStats(
       totalTokens: sql<number>`COALESCE(${submissions.totalTokens}, 0)`,
       totalCost: sql<number>`COALESCE(CAST(${submissions.totalCost} AS DECIMAL(18,4)), 0)`,
       submissionCount: sql<number>`COALESCE(${submissions.submitCount}, 0)`,
+      latestDate: submissions.dateEnd,
       updatedAt: submissions.updatedAt,
       hasBackfill: sql<boolean>`COALESCE(${submissions.hasBackfill}, false)`,
     })
@@ -66,6 +76,7 @@ async function fetchUserEmbedStats(
 
   let rank: number | null = null;
   let rankTotal: number | null = null;
+  const dateRange = getEmbedPeriodDateRange(period, result.latestDate);
 
   const rankingValue =
     sortBy === "cost"
@@ -114,7 +125,31 @@ async function fetchUserEmbedStats(
     rankTotal = Number(rankRow?.total) || null;
   }
 
+  let totalTokens = Number(result.totalTokens) || 0;
+  let totalCost = Number(result.totalCost) || 0;
+
+  if (dateRange) {
+    const periodResult = await db.execute<{
+      totalTokens: number;
+      totalCost: number;
+    }>(sql`
+      SELECT
+        COALESCE(SUM(d.tokens), 0) AS "totalTokens",
+        COALESCE(SUM(CAST(d.cost AS DECIMAL(18,4))), 0) AS "totalCost"
+      FROM daily_breakdown d
+      INNER JOIN submissions s ON d.submission_id = s.id
+      WHERE s.user_id = ${result.id}
+        AND d.date >= ${dateRange.start}
+        AND d.date <= ${dateRange.end}
+    `);
+    const periodRow = periodResult[0];
+    totalTokens = Number(periodRow?.totalTokens) || 0;
+    totalCost = Number(periodRow?.totalCost) || 0;
+  }
+
   return {
+    period,
+    dateRange,
     user: {
       id: result.id,
       username: result.username,
@@ -122,8 +157,8 @@ async function fetchUserEmbedStats(
       avatarUrl: result.avatarUrl,
     },
     stats: {
-      totalTokens: Number(result.totalTokens) || 0,
-      totalCost: Number(result.totalCost) || 0,
+      totalTokens,
+      totalCost,
       submissionCount: Number(result.submissionCount) || 0,
       rank,
       rankTotal,
@@ -136,17 +171,19 @@ async function fetchUserEmbedStats(
 export function getUserEmbedStats(
   username: string,
   sortBy: EmbedSortBy = "tokens",
+  period: EmbedPeriod = "all",
 ): Promise<UserEmbedStats | null> {
   const usernameCacheKey = normalizeUsernameCacheKey(username);
 
   return unstable_cache(
-    () => fetchUserEmbedStats(username, sortBy),
-    [`embed-user:${usernameCacheKey}:${sortBy}`],
+    () => fetchUserEmbedStats(username, sortBy, period),
+    [`embed-user:${usernameCacheKey}:${sortBy}:${period}`],
     {
       tags: [
         `user:${usernameCacheKey}`,
         `embed-user:${usernameCacheKey}`,
         `embed-user:${usernameCacheKey}:${sortBy}`,
+        `embed-user:${usernameCacheKey}:${sortBy}:${period}`,
       ],
       revalidate: 60,
     },
@@ -155,6 +192,7 @@ export function getUserEmbedStats(
 
 async function fetchUserEmbedContributions(
   username: string,
+  dateRange: EmbedPeriodDateRange | null,
 ): Promise<EmbedContributionDay[] | null> {
   const matchingUsers = await db
     .select({ id: users.id })
@@ -165,18 +203,31 @@ async function fetchUserEmbedContributions(
 
   if (!user) return null;
 
-  // Use UTC-based date and include a 7-day buffer before "one year ago"
-  // so that all dates visible in the first week of the contribution grid are included.
-  const today = new Date();
-  const cutoffDate = new Date(
-    Date.UTC(
-      today.getUTCFullYear() - 1,
-      today.getUTCMonth(),
-      today.getUTCDate(),
-    ),
-  );
-  cutoffDate.setUTCDate(cutoffDate.getUTCDate() - 7);
-  const cutoff = cutoffDate.toISOString().split("T")[0];
+  let cutoff: string;
+  if (dateRange) {
+    cutoff = dateRange.start;
+  } else {
+    // Use UTC-based date and include a 7-day buffer before "one year ago"
+    // so that all dates visible in the first week of the contribution grid are included.
+    const today = new Date();
+    const cutoffDate = new Date(
+      Date.UTC(
+        today.getUTCFullYear() - 1,
+        today.getUTCMonth(),
+        today.getUTCDate(),
+      ),
+    );
+    cutoffDate.setUTCDate(cutoffDate.getUTCDate() - 7);
+    cutoff = cutoffDate.toISOString().split("T")[0];
+  }
+
+  const contributionFilter = dateRange
+    ? and(
+        eq(submissions.userId, user.id),
+        gte(dailyBreakdown.date, dateRange.start),
+        lte(dailyBreakdown.date, dateRange.end),
+      )
+    : and(eq(submissions.userId, user.id), gte(dailyBreakdown.date, cutoff));
 
   const rows = await db
     .select({
@@ -186,9 +237,7 @@ async function fetchUserEmbedContributions(
     })
     .from(dailyBreakdown)
     .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))
-    .where(
-      and(eq(submissions.userId, user.id), gte(dailyBreakdown.date, cutoff)),
-    )
+    .where(contributionFilter)
     .groupBy(dailyBreakdown.date)
     .orderBy(dailyBreakdown.date);
 
@@ -200,7 +249,13 @@ async function fetchUserEmbedContributions(
     totalCost: Number(row.cost) || 0,
     intensity: 0,
   }));
-  const contributionWindow = getContributionWindow(contributions);
+  const referenceDate = dateRange
+    ? new Date(`${dateRange.end}T00:00:00.000Z`)
+    : new Date();
+  const contributionWindow = getContributionWindow(
+    contributions,
+    referenceDate,
+  );
   const scopedDates = new Set(contributionWindow.days.map(({ date }) => date));
   const maxTokens = Math.max(
     0,
@@ -219,14 +274,22 @@ async function fetchUserEmbedContributions(
 
 export function getUserEmbedContributions(
   username: string,
+  dateRange: EmbedPeriodDateRange | null = null,
 ): Promise<EmbedContributionDay[] | null> {
   const usernameCacheKey = normalizeUsernameCacheKey(username);
+  const rangeKey = dateRange
+    ? `${dateRange.start}:${dateRange.end}`
+    : "all";
 
   return unstable_cache(
-    () => fetchUserEmbedContributions(username),
-    [`embed-contrib:${usernameCacheKey}`],
+    () => fetchUserEmbedContributions(username, dateRange),
+    [`embed-contrib:${usernameCacheKey}:${rangeKey}`],
     {
-      tags: [`user:${usernameCacheKey}`, `embed-contrib:${usernameCacheKey}`],
+      tags: [
+        `user:${usernameCacheKey}`,
+        `embed-contrib:${usernameCacheKey}`,
+        `embed-contrib:${usernameCacheKey}:${rangeKey}`,
+      ],
       revalidate: 60,
     },
   )();

--- a/packages/frontend/src/lib/embed/getUserEmbedStats.ts
+++ b/packages/frontend/src/lib/embed/getUserEmbedStats.ts
@@ -78,53 +78,6 @@ async function fetchUserEmbedStats(
   let rankTotal: number | null = null;
   const dateRange = getEmbedPeriodDateRange(period, result.latestDate);
 
-  const rankingValue =
-    sortBy === "cost"
-      ? Number(result.totalCost) || 0
-      : Number(result.totalTokens) || 0;
-
-  if (rankingValue > 0) {
-    // Both the rank and the "of N" denominator count rankable users only, so a
-    // hidden account neither holds a position nor inflates the total. A hidden
-    // user is absent from the CTE, so this returns no row and rank stays null.
-    const rankResult = await db.execute<{ rank: number; total: number }>(sql`
-      WITH rankable AS (
-        SELECT s.*
-        FROM submissions s
-        JOIN users u ON u.id = s.user_id
-        WHERE u.leaderboard_hidden = false
-      ),
-      ranked AS (
-        SELECT
-          user_id,
-          RANK() OVER (
-            ORDER BY
-              ${
-                sortBy === "cost"
-                  ? sql`CAST(total_cost AS DECIMAL(18,4)) DESC`
-                  : sql`total_tokens DESC`
-              }
-          ) AS rank
-        FROM rankable
-      )
-      SELECT rank, (SELECT COUNT(*)::int FROM rankable) AS total
-      FROM ranked WHERE user_id = ${result.id}
-    `);
-
-    const rankRow = (
-      rankResult as unknown as { rank: number; total: number }[]
-    )[0];
-    // Coerced because RANK() is a Postgres bigint, which postgres-js hands
-    // back as a string — so without this the returned value is "1", not 1, and
-    // the `number | null` on UserEmbedStats is wrong. publicProfileData.ts
-    // compensates for the same thing at its call site.
-    //
-    // Number(undefined) is NaN and falls through to null, so a missing row
-    // behaves as before.
-    rank = Number(rankRow?.rank) || null;
-    rankTotal = Number(rankRow?.total) || null;
-  }
-
   let totalTokens = Number(result.totalTokens) || 0;
   let totalCost = Number(result.totalCost) || 0;
 
@@ -145,6 +98,77 @@ async function fetchUserEmbedStats(
     const periodRow = periodResult[0];
     totalTokens = Number(periodRow?.totalTokens) || 0;
     totalCost = Number(periodRow?.totalCost) || 0;
+  }
+
+  const rankingValue = sortBy === "cost" ? totalCost : totalTokens;
+
+  if (rankingValue > 0) {
+    // Both the rank and the "of N" denominator count rankable users only, so a
+    // hidden account neither holds a position nor inflates the total. A hidden
+    // user is absent from the CTE, so this returns no row and rank stays null.
+    const rankResult = dateRange
+      ? await db.execute<{ rank: number; total: number }>(sql`
+          WITH rankable AS (
+            SELECT
+              s.user_id,
+              SUM(d.tokens) AS total_tokens,
+              SUM(CAST(d.cost AS DECIMAL(18,4))) AS total_cost
+            FROM daily_breakdown d
+            INNER JOIN submissions s ON d.submission_id = s.id
+            INNER JOIN users u ON u.id = s.user_id
+            WHERE u.leaderboard_hidden = false
+              AND d.date >= ${dateRange.start}
+              AND d.date <= ${dateRange.end}
+            GROUP BY s.user_id
+          ),
+          ranked AS (
+            SELECT
+              user_id,
+              RANK() OVER (
+                ORDER BY
+                  ${
+                    sortBy === "cost"
+                      ? sql`total_cost DESC`
+                      : sql`total_tokens DESC`
+                  }
+              ) AS rank
+            FROM rankable
+          )
+          SELECT rank, (SELECT COUNT(*)::int FROM rankable) AS total
+          FROM ranked WHERE user_id = ${result.id}
+        `)
+      : await db.execute<{ rank: number; total: number }>(sql`
+          WITH rankable AS (
+            SELECT s.*
+            FROM submissions s
+            JOIN users u ON u.id = s.user_id
+            WHERE u.leaderboard_hidden = false
+          ),
+          ranked AS (
+            SELECT
+              user_id,
+              RANK() OVER (
+                ORDER BY
+                  ${
+                    sortBy === "cost"
+                      ? sql`CAST(total_cost AS DECIMAL(18,4)) DESC`
+                      : sql`total_tokens DESC`
+                  }
+              ) AS rank
+            FROM rankable
+          )
+          SELECT rank, (SELECT COUNT(*)::int FROM rankable) AS total
+          FROM ranked WHERE user_id = ${result.id}
+        `);
+
+    const rankRow = (
+      rankResult as unknown as { rank: number; total: number }[]
+    )[0];
+    // Coerced because RANK() is a Postgres bigint, which postgres-js hands
+    // back as a string. Number(undefined) is NaN and falls through to null, so
+    // a missing row behaves as before.
+    rank = Number(rankRow?.rank) || null;
+    rankTotal = Number(rankRow?.total) || null;
   }
 
   return {

--- a/packages/frontend/src/lib/embed/renderBlueprintEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderBlueprintEmbedSvg.ts
@@ -16,6 +16,8 @@ import {
   fittedText,
   formatRank,
   getContributionWindow,
+  getEmbedPeriodLabel,
+  getEmbedPeriodReferenceDate,
   getRankColor,
   layoutContributions,
   resolvePalette,
@@ -42,7 +44,17 @@ export function renderBlueprintEmbedSvg(
   const theme: EmbedTheme = options.theme === "light" ? "light" : "dark";
   const palette = resolvePalette(theme, options.color ?? null);
   const contributionDays = options.contributions ?? [];
-  const scopedContributionDays = getContributionWindow(contributionDays).days;
+  const periodLabel = getEmbedPeriodLabel(data.period);
+  const activityPeriodLabel =
+    periodLabel === "lifetime" ? "1y" : periodLabel;
+  const referenceDate = getEmbedPeriodReferenceDate(
+    data.period,
+    data.dateRange,
+  );
+  const scopedContributionDays = getContributionWindow(
+    contributionDays,
+    referenceDate,
+  ).days;
   const contributions = options.graph ? contributionDays : null;
   const right = W - PAD;
   const innerWidth = W - PAD * 2;
@@ -55,7 +67,7 @@ export function renderBlueprintEmbedSvg(
         options.rankFormat,
       )
     : "Unranked";
-  const activity = layoutContributions(contributionDays);
+  const activity = layoutContributions(contributionDays, referenceDate);
   const yearTokens = scopedContributionDays.reduce(
     (total, day) => total + Math.max(0, day.totalTokens || 0),
     0,
@@ -81,51 +93,72 @@ export function renderBlueprintEmbedSvg(
     {
       id: "total-tokens",
       value: formatNumber(data.stats.totalTokens, tokensCompact),
-      label: "Tokens · lifetime",
+      label: `Tokens · ${periodLabel}`,
       color: palette.brand,
     },
     {
       id: "total-cost",
       value: formatCurrency(data.stats.totalCost, costCompact),
-      label: "Cost · lifetime",
+      label: `Cost · ${periodLabel}`,
       color: palette.cost,
     },
     {
       id: "rank",
       value: rank,
-      label: `Rank · ${options.sortBy === "cost" ? "cost" : "tokens"}`,
+      label:
+        periodLabel === "lifetime"
+          ? `Rank · ${options.sortBy === "cost" ? "cost" : "tokens"}`
+          : "Rank · lifetime",
       color: getRankColor(data.stats.rank, palette),
     },
     {
       id: "submissions",
       value: data.stats.submissionCount.toLocaleString("en-US"),
-      label: "Submissions",
+      label:
+        periodLabel === "lifetime" ? "Submissions" : "Submissions · lifetime",
       color: palette.text,
     },
     {
       id: "active-days",
       value: activity.activeDays.toLocaleString("en-US"),
-      label: "Active days · 1y",
+      label: `Active days · ${activityPeriodLabel}`,
       color: palette.text,
     },
     {
       id: "peak-day",
       value: peakDate,
-      label: "Peak day · 1y",
+      label: `Peak day · ${activityPeriodLabel}`,
       color: palette.text,
     },
-    {
-      id: "year-tokens",
-      value: formatNumber(yearTokens, tokensCompact),
-      label: "Tokens · 1y",
-      color: palette.text,
-    },
-    {
-      id: "year-cost",
-      value: formatCurrency(yearCost, costCompact),
-      label: "Cost · 1y",
-      color: palette.cost,
-    },
+    ...(periodLabel === "lifetime"
+      ? [
+          {
+            id: "year-tokens",
+            value: formatNumber(yearTokens, tokensCompact),
+            label: "Tokens · 1y",
+            color: palette.text,
+          },
+          {
+            id: "year-cost",
+            value: formatCurrency(yearCost, costCompact),
+            label: "Cost · 1y",
+            color: palette.cost,
+          },
+        ]
+      : [
+          {
+            id: "range-start",
+            value: data.dateRange?.start ?? "N/A",
+            label: "Range start",
+            color: palette.text,
+          },
+          {
+            id: "range-end",
+            value: data.dateRange?.end ?? "N/A",
+            label: "Range end",
+            color: palette.text,
+          },
+        ]),
   ];
   const detailBottom = 190;
   const graphY = 208;
@@ -136,6 +169,7 @@ export function renderBlueprintEmbedSvg(
         width: innerWidth,
         palette,
         contributions,
+        referenceDate,
       })
     : null;
   const height = graph ? 367 : 232;
@@ -151,6 +185,7 @@ export function renderBlueprintEmbedSvg(
     x: PAD,
     y: 26,
     right,
+    period: data.period,
   })}
   ${divider(PAD, right, 64, palette)}
   ${details

--- a/packages/frontend/src/lib/embed/renderBlueprintEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderBlueprintEmbedSvg.ts
@@ -108,7 +108,7 @@ export function renderBlueprintEmbedSvg(
       label:
         periodLabel === "lifetime"
           ? `Rank · ${options.sortBy === "cost" ? "cost" : "tokens"}`
-          : "Rank · lifetime",
+          : `Rank · ${periodLabel}`,
       color: getRankColor(data.stats.rank, palette),
     },
     {

--- a/packages/frontend/src/lib/embed/renderGraphEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderGraphEmbedSvg.ts
@@ -88,7 +88,7 @@ export function renderGraphEmbedSvg(
       label:
         periodLabel === "lifetime"
           ? `Rank · ${sortBy}`
-          : "Lifetime rank",
+          : `Rank · ${periodLabel}`,
       color: getRankColor(data.stats.rank, palette),
     },
   ];

--- a/packages/frontend/src/lib/embed/renderGraphEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderGraphEmbedSvg.ts
@@ -14,6 +14,8 @@ import {
   escapeXml,
   fittedText,
   formatRank,
+  getEmbedPeriodLabel,
+  getEmbedPeriodReferenceDate,
   getRankColor,
   resolvePalette,
 } from "./embedShared";
@@ -38,6 +40,11 @@ export function renderGraphEmbedSvg(
   const theme: EmbedTheme = options.theme === "light" ? "light" : "dark";
   const palette = resolvePalette(theme, options.color ?? null);
   const sortBy = options.sortBy === "cost" ? "cost" : "tokens";
+  const periodLabel = getEmbedPeriodLabel(data.period);
+  const referenceDate = getEmbedPeriodReferenceDate(
+    data.period,
+    data.dateRange,
+  );
   const right = W - PAD;
   const tokens = formatNumber(
     data.stats.totalTokens,
@@ -62,14 +69,26 @@ export function renderGraphEmbedSvg(
     contributions: options.contributions ?? [],
     showDayLabels: true,
     showLegend: true,
+    referenceDate,
   });
   const H = Math.ceil(58 + graph.height + 32);
   const stats = [
-    { value: tokens, label: "Tokens", color: palette.brand },
-    { value: cost, label: "Cost", color: palette.cost },
+    {
+      value: tokens,
+      label: periodLabel === "lifetime" ? "Tokens" : `Tokens · ${periodLabel}`,
+      color: palette.brand,
+    },
+    {
+      value: cost,
+      label: periodLabel === "lifetime" ? "Cost" : `Cost · ${periodLabel}`,
+      color: palette.cost,
+    },
     {
       value: rank,
-      label: `Rank · ${sortBy}`,
+      label:
+        periodLabel === "lifetime"
+          ? `Rank · ${sortBy}`
+          : "Lifetime rank",
       color: getRankColor(data.stats.rank, palette),
     },
   ];
@@ -85,6 +104,7 @@ export function renderGraphEmbedSvg(
     x: PAD,
     y: 34,
     right: 336,
+    period: data.period,
   })}
   ${stats
     .map((stat, index) => {

--- a/packages/frontend/src/lib/embed/renderIsometric3DSvg.ts
+++ b/packages/frontend/src/lib/embed/renderIsometric3DSvg.ts
@@ -6,6 +6,8 @@ import {
   formatDateLabel,
   getContributionIntensity,
   getContributionWindow,
+  getEmbedPeriodLabel,
+  getEmbedPeriodReferenceDate,
 } from "./embedShared";
 
 export type EmbedTheme = "dark" | "light";
@@ -130,8 +132,16 @@ export function renderIsometric3DEmbedSvg(
   const compactNumbers = options.compact ?? false;
   const palette = THEMES[theme];
   const cls = theme === "dark" ? "d" : "l";
+  const periodLabel = getEmbedPeriodLabel(data.period);
+  const referenceDate = getEmbedPeriodReferenceDate(
+    data.period,
+    data.dateRange,
+  );
 
-  const contributionWindow = getContributionWindow(contributions);
+  const contributionWindow = getContributionWindow(
+    contributions,
+    referenceDate,
+  );
   const visibleContributions = contributionWindow.days;
   const start = new Date(`${contributionWindow.calendarStart}T00:00:00Z`);
   const today = new Date(`${contributionWindow.rangeEnd}T00:00:00Z`);
@@ -206,16 +216,33 @@ export function renderIsometric3DEmbedSvg(
     .map((c) => c.date)
     .sort();
   const activeDays = activeDates.length;
-  const dateRange = formatActiveDateRange(activeDates);
+  const dateRange = data.dateRange
+    ? formatActiveDateRange([data.dateRange.start, data.dateRange.end])
+    : formatActiveDateRange(activeDates);
 
   const dataRailHeight = 72;
   const dataRailY = height - dataRailHeight;
   const metricWidth = (width - px * 2) / 4;
   const metrics = [
-    { label: "Tokens", value: tokens },
-    { label: "Cost", value: cost },
-    { label: "Rank", value: rank },
-    { label: "Active days", value: String(activeDays) },
+    {
+      label: periodLabel === "lifetime" ? "Tokens" : `Tokens · ${periodLabel}`,
+      value: tokens,
+    },
+    {
+      label: periodLabel === "lifetime" ? "Cost" : `Cost · ${periodLabel}`,
+      value: cost,
+    },
+    {
+      label: periodLabel === "lifetime" ? "Rank" : "Rank · lifetime",
+      value: rank,
+    },
+    {
+      label:
+        periodLabel === "lifetime"
+          ? "Active days"
+          : `Active days · ${periodLabel}`,
+      value: String(activeDays),
+    },
   ];
   const metricMarkup = metrics
     .map((metric, index) => {
@@ -245,7 +272,7 @@ export function renderIsometric3DEmbedSvg(
   <style>${faceCss}</style>
   <rect width="${width}" height="${height}" rx="${rx}" fill="${palette.surface}"/>
   ${fittedText({ text: username, x: px, y: 29, maxWidth: 300, fill: palette.text, fontSize: 16, minFontSize: 9, fontFamily: FONT_STACK, fontWeight: 600 })}
-  ${fittedText({ text: `tokscale.ai/u/${data.user.username}`, x: width - px, y: 29, maxWidth: 260, fill: palette.muted, fontSize: 11, minFontSize: 8, fontFamily: FONT_STACK, textAnchor: "end" })}
+  ${fittedText({ text: `tokscale.ai/u/${data.user.username}${periodLabel === "lifetime" ? "" : ` · ${periodLabel}`}`, x: width - px, y: 29, maxWidth: 260, fill: palette.muted, fontSize: 11, minFontSize: 8, fontFamily: FONT_STACK, textAnchor: "end" })}
   <text x="${px}" y="49" fill="${palette.muted}" font-size="10" font-family="${FONT_STACK}">${updated}</text>
   ${fittedText({ text: dateRange, x: width - px, y: 49, maxWidth: 260, fill: palette.muted, fontSize: 10, minFontSize: 8, fontFamily: FONT_STACK, textAnchor: "end" })}
   <line x1="${px}" y1="62.5" x2="${width - px}" y2="62.5" stroke="${palette.divider}" stroke-opacity="${palette.dividerOpacity}"/>

--- a/packages/frontend/src/lib/embed/renderIsometric3DSvg.ts
+++ b/packages/frontend/src/lib/embed/renderIsometric3DSvg.ts
@@ -233,7 +233,7 @@ export function renderIsometric3DEmbedSvg(
       value: cost,
     },
     {
-      label: periodLabel === "lifetime" ? "Rank" : "Rank · lifetime",
+      label: periodLabel === "lifetime" ? "Rank" : `Rank · ${periodLabel}`,
       value: rank,
     },
     {

--- a/packages/frontend/src/lib/embed/renderMinimalEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderMinimalEmbedSvg.ts
@@ -15,6 +15,8 @@ import {
   escapeXml,
   fittedText,
   formatRank,
+  getEmbedPeriodLabel,
+  getEmbedPeriodReferenceDate,
   getRankColor,
   resolvePalette,
 } from "./embedShared";
@@ -42,6 +44,11 @@ export function renderMinimalEmbedSvg(
   const tokensFormat = options.tokensFormat ?? "compact";
   const costFormat = options.costFormat ?? "compact";
   const contributions = options.graph ? (options.contributions ?? []) : null;
+  const periodLabel = getEmbedPeriodLabel(data.period);
+  const referenceDate = getEmbedPeriodReferenceDate(
+    data.period,
+    data.dateRange,
+  );
   const right = W - PAD;
 
   const tokens = formatNumber(
@@ -65,6 +72,7 @@ export function renderMinimalEmbedSvg(
         width: W - PAD * 2,
         palette,
         contributions,
+        referenceDate,
       })
     : null;
   const height = graph ? Math.ceil(graphY + graph.height + 32) : 162;
@@ -80,14 +88,15 @@ export function renderMinimalEmbedSvg(
     x: PAD,
     y: 28,
     right,
+    period: data.period,
   })}
   ${divider(PAD, right, 60, palette)}
-  <text x="${PAD}" y="82" fill="${palette.muted}" font-size="11" font-weight="600" font-family="${FIGTREE_FONT_STACK}">Total tokens</text>
+  <text x="${PAD}" y="82" fill="${palette.muted}" font-size="11" font-weight="600" font-family="${FIGTREE_FONT_STACK}">${periodLabel === "lifetime" ? "Total tokens" : `Tokens · ${periodLabel}`}</text>
   ${fittedText({ text: tokens, x: PAD, y: 118, maxWidth: 296, fill: palette.brand, fontSize: 34, minFontSize: 14, fontWeight: 600 })}
   <line x1="350" y1="74" x2="350" y2="132" stroke="${palette.divider}"/>
-  <text x="372" y="80" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">Cost</text>
+  <text x="372" y="80" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">${periodLabel === "lifetime" ? "Cost" : `Cost · ${periodLabel}`}</text>
   ${fittedText({ text: cost, x: 372, y: 99, maxWidth: 202, fill: palette.cost, fontSize: 17, minFontSize: 8, fontWeight: 600 })}
-  <text x="372" y="114" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">Rank</text>
+  <text x="372" y="114" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">${periodLabel === "lifetime" ? "Rank" : "Rank · lifetime"}</text>
   ${fittedText({ text: rank, x: 372, y: 132, maxWidth: 202, fill: rankColor, fontSize: 16, minFontSize: 8, fontWeight: 600 })}
   ${graph ? `${divider(PAD, right, 136, palette)}\n  ${graph.svg}` : ""}
   ${cardFooter({

--- a/packages/frontend/src/lib/embed/renderMinimalEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderMinimalEmbedSvg.ts
@@ -96,7 +96,7 @@ export function renderMinimalEmbedSvg(
   <line x1="350" y1="74" x2="350" y2="132" stroke="${palette.divider}"/>
   <text x="372" y="80" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">${periodLabel === "lifetime" ? "Cost" : `Cost · ${periodLabel}`}</text>
   ${fittedText({ text: cost, x: 372, y: 99, maxWidth: 202, fill: palette.cost, fontSize: 17, minFontSize: 8, fontWeight: 600 })}
-  <text x="372" y="114" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">${periodLabel === "lifetime" ? "Rank" : "Rank · lifetime"}</text>
+  <text x="372" y="114" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">${periodLabel === "lifetime" ? "Rank" : `Rank · ${periodLabel}`}</text>
   ${fittedText({ text: rank, x: 372, y: 132, maxWidth: 202, fill: rankColor, fontSize: 16, minFontSize: 8, fontWeight: 600 })}
   ${graph ? `${divider(PAD, right, 136, palette)}\n  ${graph.svg}` : ""}
   ${cardFooter({

--- a/packages/frontend/src/lib/embed/renderOrbitEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderOrbitEmbedSvg.ts
@@ -119,7 +119,7 @@ export function renderOrbitEmbedSvg(
     period: data.period,
   })}
   ${divider(PAD, right, 66, palette)}
-  <text x="${PAD}" y="92" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">${periodLabel === "lifetime" ? `Rank · ${sortBy === "cost" ? "cost" : "tokens"}` : "Rank · lifetime"}</text>
+  <text x="${PAD}" y="92" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">${periodLabel === "lifetime" ? `Rank · ${sortBy === "cost" ? "cost" : "tokens"}` : `Rank · ${periodLabel}`}</text>
   ${fittedText({
     text: rankText,
     x: PAD,

--- a/packages/frontend/src/lib/embed/renderOrbitEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderOrbitEmbedSvg.ts
@@ -15,6 +15,8 @@ import {
   escapeXml,
   fittedText,
   formatRank,
+  getEmbedPeriodLabel,
+  getEmbedPeriodReferenceDate,
   getRankColor,
   layoutContributions,
   resolvePalette,
@@ -41,6 +43,11 @@ export function renderOrbitEmbedSvg(
   const theme: EmbedTheme = options.theme === "light" ? "light" : "dark";
   const palette = resolvePalette(theme, options.color ?? null);
   const sortBy = options.sortBy === "cost" ? "cost" : "tokens";
+  const periodLabel = getEmbedPeriodLabel(data.period);
+  const referenceDate = getEmbedPeriodReferenceDate(
+    data.period,
+    data.dateRange,
+  );
   const rank = data.stats.rank;
   const rankTotal = data.stats.rankTotal ?? null;
   const rankText = rank
@@ -51,7 +58,7 @@ export function renderOrbitEmbedSvg(
       ? Math.max(0, Math.min(1, (rankTotal - rank) / rankTotal))
       : 0;
   const layout = options.contributions?.length
-    ? layoutContributions(options.contributions)
+    ? layoutContributions(options.contributions, referenceDate)
     : null;
   const contributions = options.graph ? (options.contributions ?? []) : null;
   const right = W - PAD;
@@ -63,12 +70,13 @@ export function renderOrbitEmbedSvg(
         width: W - PAD * 2,
         palette,
         contributions,
+        referenceDate,
       })
     : null;
   const height = graph ? 384 : 248;
   const statRows = [
     {
-      label: "Tokens",
+      label: periodLabel === "lifetime" ? "Tokens" : `Tokens · ${periodLabel}`,
       value: formatNumber(
         data.stats.totalTokens,
         (options.tokensFormat ?? "compact") === "compact",
@@ -76,7 +84,7 @@ export function renderOrbitEmbedSvg(
       color: palette.text,
     },
     {
-      label: "Cost",
+      label: periodLabel === "lifetime" ? "Cost" : `Cost · ${periodLabel}`,
       value: formatCurrency(
         data.stats.totalCost,
         (options.costFormat ?? "compact") === "compact",
@@ -86,7 +94,10 @@ export function renderOrbitEmbedSvg(
     ...(layout
       ? [
           {
-            label: "Active days",
+            label:
+              periodLabel === "lifetime"
+                ? "Active days"
+                : `Active days · ${periodLabel}`,
             value: String(layout.activeDays),
             color: palette.text,
           },
@@ -105,9 +116,10 @@ export function renderOrbitEmbedSvg(
     x: PAD,
     y: 28,
     right,
+    period: data.period,
   })}
   ${divider(PAD, right, 66, palette)}
-  <text x="${PAD}" y="92" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">Rank · ${sortBy === "cost" ? "cost" : "tokens"}</text>
+  <text x="${PAD}" y="92" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">${periodLabel === "lifetime" ? `Rank · ${sortBy === "cost" ? "cost" : "tokens"}` : "Rank · lifetime"}</text>
   ${fittedText({
     text: rankText,
     x: PAD,

--- a/packages/frontend/src/lib/embed/renderProfileEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderProfileEmbedSvg.ts
@@ -14,6 +14,8 @@ import {
   divider,
   escapeXml,
   fittedText,
+  getEmbedPeriodLabel,
+  getEmbedPeriodReferenceDate,
   formatRank,
   getRankColor,
   resolvePalette,
@@ -49,6 +51,11 @@ function renderProfileCardSvg(
     options.costFormat ?? (compactNumbers ? "compact" : "full");
   const sortBy: EmbedSortBy = options.sortBy === "cost" ? "cost" : "tokens";
   const contributions = !compact ? (options.contributions ?? null) : null;
+  const periodLabel = getEmbedPeriodLabel(data.period);
+  const referenceDate = getEmbedPeriodReferenceDate(
+    data.period,
+    data.dateRange,
+  );
 
   const width = compact ? 460 : 680;
   const x = compact ? 18 : 24;
@@ -64,6 +71,7 @@ function renderProfileCardSvg(
         contributions,
         showDayLabels: true,
         showLegend: true,
+        referenceDate,
       })
     : null;
   const height = compact
@@ -89,11 +97,22 @@ function renderProfileCardSvg(
         options.rankFormat,
       )
     : "N/A";
-  const rankLabel = `Rank (${sortBy === "cost" ? "Cost" : "Tokens"})`;
+  const rankLabel =
+    periodLabel === "lifetime"
+      ? `Rank (${sortBy === "cost" ? "Cost" : "Tokens"})`
+      : "Lifetime rank";
   const rankColor = getRankColor(data.stats.rank, palette);
   const metrics = [
-    { label: "Tokens", value: tokens, color: palette.brand },
-    { label: "Cost", value: cost, color: palette.cost },
+    {
+      label: periodLabel === "lifetime" ? "Tokens" : `Tokens · ${periodLabel}`,
+      value: tokens,
+      color: palette.brand,
+    },
+    {
+      label: periodLabel === "lifetime" ? "Cost" : `Cost · ${periodLabel}`,
+      value: cost,
+      color: palette.cost,
+    },
     { label: rankLabel, value: rank, color: rankColor },
   ];
 
@@ -133,6 +152,7 @@ function renderProfileCardSvg(
     x,
     y: headerY,
     right,
+    period: data.period,
   })}
   ${divider(x, right, compact ? 58 : 64, palette)}
   ${metricSvg}

--- a/packages/frontend/src/lib/embed/renderProfileEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderProfileEmbedSvg.ts
@@ -100,7 +100,7 @@ function renderProfileCardSvg(
   const rankLabel =
     periodLabel === "lifetime"
       ? `Rank (${sortBy === "cost" ? "Cost" : "Tokens"})`
-      : "Lifetime rank";
+      : `Rank · ${periodLabel}`;
   const rankColor = getRankColor(data.stats.rank, palette);
   const metrics = [
     {

--- a/packages/frontend/src/lib/embed/renderReceiptEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderReceiptEmbedSvg.ts
@@ -79,7 +79,7 @@ export function renderReceiptEmbedSvg(
     [
       periodLabel === "lifetime"
         ? `Rank · ${options.sortBy === "cost" ? "cost" : "tokens"}`
-        : "Rank · lifetime",
+        : `Rank · ${periodLabel}`,
       rank,
       getRankColor(data.stats.rank, palette),
     ],

--- a/packages/frontend/src/lib/embed/renderReceiptEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderReceiptEmbedSvg.ts
@@ -15,6 +15,8 @@ import {
   escapeXml,
   fittedText,
   formatRank,
+  getEmbedPeriodLabel,
+  getEmbedPeriodReferenceDate,
   getRankColor,
   layoutContributions,
   resolvePalette,
@@ -41,8 +43,13 @@ export function renderReceiptEmbedSvg(
   const theme: EmbedTheme = options.theme === "light" ? "light" : "dark";
   const palette = resolvePalette(theme, options.color ?? null);
   const contributions = options.graph ? (options.contributions ?? []) : null;
+  const periodLabel = getEmbedPeriodLabel(data.period);
+  const referenceDate = getEmbedPeriodReferenceDate(
+    data.period,
+    data.dateRange,
+  );
   const layout = options.contributions?.length
-    ? layoutContributions(options.contributions)
+    ? layoutContributions(options.contributions, referenceDate)
     : null;
   const right = W - PAD;
   const rank = data.stats.rank
@@ -54,7 +61,7 @@ export function renderReceiptEmbedSvg(
     : "Unranked";
   const rows = [
     [
-      "Tokens",
+      periodLabel === "lifetime" ? "Tokens" : `Tokens · ${periodLabel}`,
       formatNumber(
         data.stats.totalTokens,
         (options.tokensFormat ?? "full") === "compact",
@@ -62,7 +69,7 @@ export function renderReceiptEmbedSvg(
       palette.brand,
     ],
     [
-      "Cost",
+      periodLabel === "lifetime" ? "Cost" : `Cost · ${periodLabel}`,
       formatCurrency(
         data.stats.totalCost,
         (options.costFormat ?? "full") === "compact",
@@ -70,12 +77,22 @@ export function renderReceiptEmbedSvg(
       palette.cost,
     ],
     [
-      `Rank · ${options.sortBy === "cost" ? "cost" : "tokens"}`,
+      periodLabel === "lifetime"
+        ? `Rank · ${options.sortBy === "cost" ? "cost" : "tokens"}`
+        : "Rank · lifetime",
       rank,
       getRankColor(data.stats.rank, palette),
     ],
     ...(layout
-      ? [["Active days", String(layout.activeDays), palette.text]]
+      ? [
+          [
+            periodLabel === "lifetime"
+              ? "Active days"
+              : `Active days · ${periodLabel}`,
+            String(layout.activeDays),
+            palette.text,
+          ],
+        ]
       : []),
   ] as const;
   const graphY = 224;
@@ -86,6 +103,7 @@ export function renderReceiptEmbedSvg(
         width: W - PAD * 2,
         palette,
         contributions,
+        referenceDate,
       })
     : null;
   const height = graph ? 352 : 250;
@@ -101,6 +119,7 @@ export function renderReceiptEmbedSvg(
     x: PAD,
     y: 26,
     right,
+    period: data.period,
   })}
   ${divider(PAD, right, 64, palette)}
   ${rows

--- a/packages/frontend/src/lib/embed/renderTerminalEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderTerminalEmbedSvg.ts
@@ -15,6 +15,8 @@ import {
   escapeXml,
   fittedText,
   formatRank,
+  getEmbedPeriodLabel,
+  getEmbedPeriodReferenceDate,
   getRankColor,
   resolvePalette,
 } from "./embedShared";
@@ -41,6 +43,11 @@ export function renderTerminalEmbedSvg(
   const palette = resolvePalette(theme, options.color ?? null);
   const sortBy = options.sortBy === "cost" ? "cost" : "tokens";
   const contributions = options.graph ? (options.contributions ?? []) : null;
+  const periodLabel = getEmbedPeriodLabel(data.period);
+  const referenceDate = getEmbedPeriodReferenceDate(
+    data.period,
+    data.dateRange,
+  );
   const right = W - PAD;
   const rank = data.stats.rank
     ? formatRank(
@@ -51,7 +58,7 @@ export function renderTerminalEmbedSvg(
     : "unranked";
   const rows = [
     {
-      label: "tokens",
+      label: periodLabel === "lifetime" ? "tokens" : `tokens.${periodLabel}`,
       value: formatNumber(
         data.stats.totalTokens,
         (options.tokensFormat ?? "full") === "compact",
@@ -59,7 +66,7 @@ export function renderTerminalEmbedSvg(
       color: palette.brand,
     },
     {
-      label: "cost",
+      label: periodLabel === "lifetime" ? "cost" : `cost.${periodLabel}`,
       value: formatCurrency(
         data.stats.totalCost,
         (options.costFormat ?? "compact") === "compact",
@@ -67,7 +74,10 @@ export function renderTerminalEmbedSvg(
       color: palette.cost,
     },
     {
-      label: `rank.${sortBy}`,
+      label:
+        periodLabel === "lifetime"
+          ? `rank.${sortBy}`
+          : `rank.lifetime.${sortBy}`,
       value: rank,
       color: getRankColor(data.stats.rank, palette),
     },
@@ -81,6 +91,7 @@ export function renderTerminalEmbedSvg(
         palette,
         contributions,
         mono: true,
+        referenceDate,
       })
     : null;
   const height = graph ? Math.ceil(graphY + graph.height + 32) : 176;
@@ -96,6 +107,7 @@ export function renderTerminalEmbedSvg(
     x: PAD,
     y: 28,
     right,
+    period: data.period,
   })}
   ${divider(PAD, right, 60, palette)}
   <g data-readout="usage">

--- a/packages/frontend/src/lib/embed/renderTerminalEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderTerminalEmbedSvg.ts
@@ -77,7 +77,7 @@ export function renderTerminalEmbedSvg(
       label:
         periodLabel === "lifetime"
           ? `rank.${sortBy}`
-          : `rank.lifetime.${sortBy}`,
+          : `rank.${periodLabel}.${sortBy}`,
       value: rank,
       color: getRankColor(data.stats.rank, palette),
     },

--- a/packages/frontend/src/lib/embed/renderVitalsEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderVitalsEmbedSvg.ts
@@ -14,6 +14,9 @@ import {
   escapeXml,
   fittedText,
   formatRank,
+  getEmbedPeriodDayCount,
+  getEmbedPeriodLabel,
+  getEmbedPeriodReferenceDate,
   getRankColor,
   layoutContributions,
   resolvePalette,
@@ -40,8 +43,21 @@ export function renderVitalsEmbedSvg(
   const theme: EmbedTheme = options.theme === "light" ? "light" : "dark";
   const palette = resolvePalette(theme, options.color ?? null);
   const contributions = options.contributions ?? [];
-  const layout = layoutContributions(contributions);
-  const rangeCells = layout.cells.filter(({ inRange }) => inRange);
+  const periodLabel = getEmbedPeriodLabel(data.period);
+  const activityPeriodLabel =
+    periodLabel === "lifetime" ? "1y" : periodLabel;
+  const referenceDate = getEmbedPeriodReferenceDate(
+    data.period,
+    data.dateRange,
+  );
+  const layout = layoutContributions(contributions, referenceDate);
+  const dateRange = data.dateRange;
+  const rangeCells = dateRange
+    ? layout.cells.filter(
+        ({ date }) => date >= dateRange.start && date <= dateRange.end,
+      )
+    : layout.cells.filter(({ inRange }) => inRange);
+  const activeDays = rangeCells.filter(({ intensity }) => intensity > 0).length;
   const avgIntensity = rangeCells.length
     ? rangeCells.reduce((sum, day) => sum + day.intensity, 0) /
       rangeCells.length
@@ -53,7 +69,11 @@ export function renderVitalsEmbedSvg(
     : "Unranked";
   const activityCoverage = Math.min(
     1,
-    layout.activeDays / Math.max(1, layout.rangeDays),
+    activeDays /
+      Math.max(
+        1,
+        getEmbedPeriodDayCount(data.period) ?? layout.rangeDays,
+      ),
   );
   const right = W - PAD;
   const tokens = formatNumber(
@@ -76,11 +96,12 @@ export function renderVitalsEmbedSvg(
     x: PAD,
     y: 27,
     right,
+    period: data.period,
   })}
   ${divider(PAD, right, 62, palette)}
-  <text x="${PAD}" y="82" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">Active days · 1y</text>
+  <text x="${PAD}" y="82" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">Active days · ${activityPeriodLabel}</text>
   ${fittedText({
-    text: String(layout.activeDays),
+    text: String(activeDays),
     x: PAD,
     y: 111,
     maxWidth: 180,
@@ -91,9 +112,9 @@ export function renderVitalsEmbedSvg(
   })}
   <rect x="${PAD}" y="121" width="${right - PAD}" height="5" rx="2.5" fill="${palette.graphGrade0}"/>
   <rect x="${PAD}" y="121" width="${((right - PAD) * activityCoverage).toFixed(1)}" height="5" rx="2.5" fill="${palette.brand}"/>
-  <text x="${right}" y="141" fill="${palette.muted}" font-size="10" text-anchor="end" font-family="${FIGTREE_FONT_STACK}">${Math.round(activityCoverage * 100)}% of trailing year</text>
+  <text x="${right}" y="141" fill="${palette.muted}" font-size="10" text-anchor="end" font-family="${FIGTREE_FONT_STACK}">${Math.round(activityCoverage * 100)}% of ${periodLabel === "lifetime" ? "trailing year" : activityPeriodLabel}</text>
   ${divider(PAD, right, 150, palette)}
-  <text x="${PAD}" y="166" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">Tokens</text>
+  <text x="${PAD}" y="166" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">${periodLabel === "lifetime" ? "Tokens" : `Tokens · ${periodLabel}`}</text>
   ${fittedText({
     text: tokens,
     x: PAD,
@@ -104,7 +125,7 @@ export function renderVitalsEmbedSvg(
     minFontSize: 8,
     fontWeight: 600,
   })}
-  <text x="264" y="166" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">Cost</text>
+  <text x="264" y="166" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">${periodLabel === "lifetime" ? "Cost" : `Cost · ${periodLabel}`}</text>
   ${fittedText({
     text: cost,
     x: right,
@@ -116,7 +137,7 @@ export function renderVitalsEmbedSvg(
     fontWeight: 600,
     textAnchor: "end",
   })}
-  <text x="${PAD}" y="201" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">Average intensity · 1y</text>
+  <text x="${PAD}" y="201" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">Average intensity · ${activityPeriodLabel}</text>
   ${fittedText({
     text: `${avgIntensity.toFixed(1)} / 4`,
     x: PAD,
@@ -127,7 +148,7 @@ export function renderVitalsEmbedSvg(
     minFontSize: 8,
     fontWeight: 600,
   })}
-  <text x="264" y="201" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">Rank · ${options.sortBy === "cost" ? "cost" : "tokens"}</text>
+  <text x="264" y="201" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">${periodLabel === "lifetime" ? `Rank · ${options.sortBy === "cost" ? "cost" : "tokens"}` : "Rank · lifetime"}</text>
   ${fittedText({
     text: rankText,
     x: right,

--- a/packages/frontend/src/lib/embed/renderVitalsEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderVitalsEmbedSvg.ts
@@ -148,7 +148,7 @@ export function renderVitalsEmbedSvg(
     minFontSize: 8,
     fontWeight: 600,
   })}
-  <text x="264" y="201" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">${periodLabel === "lifetime" ? `Rank · ${options.sortBy === "cost" ? "cost" : "tokens"}` : "Rank · lifetime"}</text>
+  <text x="264" y="201" fill="${palette.muted}" font-size="10" font-weight="600" font-family="${FIGTREE_FONT_STACK}">${periodLabel === "lifetime" ? `Rank · ${options.sortBy === "cost" ? "cost" : "tokens"}` : `Rank · ${periodLabel}`}</text>
   ${fittedText({
     text: rankText,
     x: right,


### PR DESCRIPTION
> [!NOTE]
> **Why weekly and monthly ranks matter:** [@0thernet](https://tokscale.ai/u/0thernet) is currently **#6 over the trailing 7 days** and **#8 over the trailing 30 days**, compared with **#41 all-time** by tokens (checked August 22, 2026). All-time rank mostly measures accumulated history. It is a poor benchmark for people who only recently started logging or who are rapidly ramping up their usage and tokenmaxxing. Shorter windows show current pace and momentum.

## Summary

- add `period=all|month|week` to public SVG embeds, with `month` and `week` matching the profile's trailing 30-day and 7-day windows
- scope token totals, cost totals, leaderboard rank, contribution queries, intensity, and activity labels to the selected period; submission count remains explicitly lifetime
- label the selected window in every card style so finite-period stats and ranks cannot be mistaken for all-time values
- add a Lifetime / 30d / 7d selector to the embed dialog and preserve the period in generated embed and profile links
- document the parameter and example in every maintained README translation

Existing embeds remain unchanged because `period=all` is the default.

## Related

- Profile-page counterpart: [#1179](https://github.com/junhoyeo/tokscale/pull/1179)

## Testing

- Vitest full frontend suite: 918 passed, 6 integration tests skipped
- `bun run --cwd packages/frontend typecheck`
- `bun run --cwd packages/frontend lint` (passes with 17 existing warnings)
- `bun run --cwd packages/frontend build`
