### PR TITLE
feat(profile): add weekly and monthly ranks

### DIFF
--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -1014,6 +1014,7 @@ describe("GET /api/users/[username]", () => {
       { params: Promise.resolve({ username: "alice" }) },
     );
     const body = await response.json();
+    const sqlTexts = serializeSqlCalls();
 
     expect(response.status).toBe(200);
     expect(mockState.gte).toHaveBeenCalledWith(
@@ -1026,6 +1027,16 @@ describe("GET /api/users/[username]", () => {
       end: "2026-07-24",
     });
     expect(body.dateRange).toEqual({ start: "2026-07-18", end: "2026-07-24" });
+    expect(body.user.rank).toBe(1);
+    expect(
+      sqlTexts.some(
+        (text) =>
+          text.includes("FROM daily_breakdown d") &&
+          text.includes("RANK() OVER") &&
+          text.includes("d.date >= 2026-07-18") &&
+          text.includes("d.date <= 2026-07-24"),
+      ),
+    ).toBe(true);
     expect(body.stats).toEqual(
       expect.objectContaining({
         totalTokens: 35,
@@ -1059,7 +1070,13 @@ describe("GET /api/users/[username]", () => {
     expect(calendar.activeDays).toBe(body.stats.activeDays);
   });
 
-  it("recalculates profile overview stats from daily rows for rolling periods", async () => {
+  async function assertRollingProfilePeriod({
+    period,
+    start,
+  }: {
+    period: "week" | "month";
+    start: string;
+  }) {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-28T12:00:00.000Z"));
 
@@ -1165,21 +1182,32 @@ describe("GET /api/users/[username]", () => {
     mockState.pushExecuteResult([{ rank: 4 }]);
 
     const response = await GET(
-      new Request("http://localhost:3000/api/users/alice?period=week"),
+      new Request(`http://localhost:3000/api/users/alice?period=${period}`),
       { params: Promise.resolve({ username: "alice" }) },
     );
     const body = await response.json();
+    const sqlTexts = serializeSqlCalls();
 
     expect(response.status).toBe(200);
     expect(mockState.gte).toHaveBeenCalledWith(
       mockState.tables.dailyBreakdown.date,
-      "2026-06-22",
+      start,
     );
     // No upper bound in SQL: the window's end is the anchor, which is not known
     // when the query is built, and no row can sit above it anyway.
     expect(mockState.lte).not.toHaveBeenCalled();
-    expect(body.period).toBe("week");
-    expect(body.dateRange).toEqual({ start: "2026-06-22", end: "2026-06-28" });
+    expect(body.period).toBe(period);
+    expect(body.dateRange).toEqual({ start, end: "2026-06-28" });
+    expect(body.user.rank).toBe(4);
+    expect(
+      sqlTexts.some(
+        (text) =>
+          text.includes("FROM daily_breakdown d") &&
+          text.includes("RANK() OVER") &&
+          text.includes(`d.date >= ${start}`) &&
+          text.includes("d.date <= 2026-06-28"),
+      ),
+    ).toBe(true);
     expect(body.stats).toEqual(
       expect.objectContaining({
         totalTokens: 500,
@@ -1195,7 +1223,15 @@ describe("GET /api/users/[username]", () => {
     );
     expect(body.clients).toEqual(["codex", "claude"]);
     expect(body.models).toEqual(["gpt-5.5", "claude-sonnet-4-5"]);
-  });
+  }
+
+  it.each([
+    { period: "week", start: "2026-06-22" },
+    { period: "month", start: "2026-05-30" },
+  ] as const)(
+    "recalculates profile overview stats and rank for the $period period",
+    assertRollingProfilePeriod,
+  );
 
   it("returns submission freshness metadata for the latest submission", async () => {
     vi.useFakeTimers();

--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -127,6 +127,10 @@ const mockState = vi.hoisted(() => {
   };
 });
 
+const unstableCacheMock = vi.hoisted(() => vi.fn((fn: () => unknown) => fn));
+
+vi.mock("next/cache", () => ({ unstable_cache: unstableCacheMock }));
+
 vi.mock("@/lib/db", () => ({
   db: mockState.db,
   users: mockState.tables.users,
@@ -191,6 +195,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   mockState.reset();
+  unstableCacheMock.mockClear();
 });
 
 afterEach(() => {
@@ -1037,6 +1042,16 @@ describe("GET /api/users/[username]", () => {
           text.includes("d.date <= 2026-07-24"),
       ),
     ).toBe(true);
+    // The cache key carries the anchored window, not the one measured back
+    // from UTC today, so a moved anchor is a different cache entry.
+    expect(unstableCacheMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      ["profile-period-rank", "user-ahead-of-utc", "2026-07-18", "2026-07-24"],
+      {
+        revalidate: 60,
+        tags: ["leaderboard", "user:alice"],
+      },
+    );
     expect(body.stats).toEqual(
       expect.objectContaining({
         totalTokens: 35,
@@ -1208,6 +1223,14 @@ describe("GET /api/users/[username]", () => {
           text.includes("d.date <= 2026-06-28"),
       ),
     ).toBe(true);
+    expect(unstableCacheMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      ["profile-period-rank", "user-1", start, "2026-06-28"],
+      {
+        revalidate: 60,
+        tags: ["leaderboard", "user:alice"],
+      },
+    );
     expect(body.stats).toEqual(
       expect.objectContaining({
         totalTokens: 500,
@@ -1232,6 +1255,61 @@ describe("GET /api/users/[username]", () => {
     "recalculates profile overview stats and rank for the $period period",
     assertRollingProfilePeriod,
   );
+
+  it("skips the period rank scan when the user has no daily rows in the window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-28T12:00:00.000Z"));
+
+    mockState.pushSelectResult([
+      {
+        id: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        totalTokens: 1000,
+        totalCost: 10,
+        inputTokens: 600,
+        outputTokens: 400,
+        cacheReadTokens: 100,
+        cacheCreationTokens: 50,
+        reasoningTokens: 25,
+        submissionCount: 3,
+        earliestDate: "2026-01-01",
+        latestDate: "2026-01-15",
+        sessionCount: 8,
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        sourcesUsed: ["codex"],
+        modelsUsed: ["gpt-5.5"],
+        updatedAt: new Date("2026-01-15T10:00:00.000Z"),
+        cliVersion: "2.0.0",
+        schemaVersion: 2,
+      },
+    ]);
+    // The daily query only reaches back seven days, and this user's rows all
+    // predate the window.
+    mockState.pushSelectResult([]);
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/users/alice?period=week"),
+      { params: Promise.resolve({ username: "alice" }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    // A user with no rows in the window has no row in the ranked CTE either,
+    // so the answer is known without scanning every user's daily rows.
+    expect(body.user.rank).toBeNull();
+    expect(mockState.db.execute).not.toHaveBeenCalled();
+    expect(unstableCacheMock).not.toHaveBeenCalled();
+  });
 
   it("returns submission freshness metadata for the latest submission", async () => {
     vi.useFakeTimers();

--- a/packages/frontend/__tests__/components/profileHeader.test.ts
+++ b/packages/frontend/__tests__/components/profileHeader.test.ts
@@ -4,7 +4,11 @@
 process.env.TZ = "America/New_York";
 
 import { describe, expect, it } from "vitest";
-import { formatJoined, formatLastUpdated } from "../../src/components/profile";
+import {
+  formatJoined,
+  formatLastUpdated,
+  getProfileRankLabel,
+} from "../../src/components/profile";
 
 // A fixed instant, 2026-07-10 15:30:00 UTC.
 const ISO_A = "2026-07-10T15:30:00.000Z";
@@ -98,5 +102,13 @@ describe("formatJoined", () => {
   it("falls back to the host zone when no zone is given", () => {
     // TZ is pinned to America/New_York at the top of this file.
     expect(formatJoined(JOINED_BOUNDARY)).toBe("Dec 2025");
+  });
+});
+
+describe("getProfileRankLabel", () => {
+  it("makes the rank window explicit", () => {
+    expect(getProfileRankLabel("all")).toBe("All-time rank");
+    expect(getProfileRankLabel("month")).toBe("30d rank");
+    expect(getProfileRankLabel("week")).toBe("7d rank");
   });
 });

--- a/packages/frontend/src/components/profile/ProfileOverview.tsx
+++ b/packages/frontend/src/components/profile/ProfileOverview.tsx
@@ -22,6 +22,14 @@ export interface ProfileOverviewProps {
   className?: string;
 }
 
+export function getProfileRankLabel(
+  period: NonNullable<ProfileOverviewProps["period"]>,
+): string {
+  if (period === "month") return "30d rank";
+  if (period === "week") return "7d rank";
+  return "All-time rank";
+}
+
 const OverviewPanel = styled.section`
   overflow: hidden;
   border: 1px solid var(--service-border);
@@ -442,7 +450,7 @@ export function ProfileOverview({
               <Metadata aria-label="Profile details">
                 {user.rank != null && (
                   <RankItem>
-                    <span>Rank</span>
+                    <span>{getProfileRankLabel(period)}</span>
                     <strong>#{user.rank.toLocaleString("en-US")}</strong>
                   </RankItem>
                 )}

--- a/packages/frontend/src/components/profile/index.tsx
+++ b/packages/frontend/src/components/profile/index.tsx
@@ -4,6 +4,7 @@ export {
   ProfileOverview,
   formatJoined,
   formatLastUpdated,
+  getProfileRankLabel,
 } from "./ProfileOverview";
 export type { ProfileOverviewProps } from "./ProfileOverview";
 

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -225,28 +225,29 @@ export async function getPublicProfileResponse(
           .orderBy(desc(submissions.updatedAt))
           .limit(1),
 
-        // Ranks over rankable users only. A hidden user is absent from the CTE
-        // entirely, so this returns no row and the profile reports rank null —
-        // which is the intent: hiding withdraws someone from the standings, so
-        // there is no position left to display.
-        db.execute<{ rank: number }>(sql`
-        WITH user_totals AS (
-          SELECT
-            s.user_id,
-            SUM(s.total_tokens) as total_tokens
-          FROM submissions s
-          JOIN users u ON u.id = s.user_id
-          WHERE u.leaderboard_hidden = false
-          GROUP BY s.user_id
-        ),
-        ranked AS (
-          SELECT
-            user_id,
-            RANK() OVER (ORDER BY total_tokens DESC) as rank
-          FROM user_totals
-        )
-        SELECT rank FROM ranked WHERE user_id = ${user.id}
-      `),
+        // A finite rank needs the anchored profile range, which is only known
+        // after the stats query returns the newest submitted date. Keep the
+        // lifetime rank concurrent and defer only finite-period ranking.
+        period === "all"
+          ? db.execute<{ rank: number }>(sql`
+              WITH user_totals AS (
+                SELECT
+                  s.user_id,
+                  SUM(s.total_tokens) as total_tokens
+                FROM submissions s
+                JOIN users u ON u.id = s.user_id
+                WHERE u.leaderboard_hidden = false
+                GROUP BY s.user_id
+              ),
+              ranked AS (
+                SELECT
+                  user_id,
+                  RANK() OVER (ORDER BY total_tokens DESC) as rank
+                FROM user_totals
+              )
+              SELECT rank FROM ranked WHERE user_id = ${user.id}
+            `)
+          : Promise.resolve([]),
 
         db
           .select({
@@ -269,12 +270,42 @@ export async function getPublicProfileResponse(
 
     const [stats] = statsResult;
     const [latestSubmission] = latestSubmissionResult;
-    const rank = (rankResult as unknown as { rank: number }[])[0]?.rank || null;
     // Resolved only once the newest submitted date is known, so every window —
     // lifetime and period alike — ends on the data instead of on UTC "today".
     const rangeAnchor = getProfileRangeAnchor(stats?.latestDate, now);
     const periodRange = getProfilePeriodDateRange(period, rangeAnchor);
     const chartRange = periodRange ?? getRollingProfileDateRange(rangeAnchor);
+    // Ranks over rankable users only. A hidden user is absent from the CTE
+    // entirely, so this returns no row and the profile reports rank null. The
+    // finite query uses the exact same anchored window as the visible profile
+    // totals and chart.
+    const scopedRankResult = periodRange
+      ? await db.execute<{ rank: number }>(sql`
+          WITH user_totals AS (
+            SELECT
+              s.user_id,
+              SUM(d.tokens) as total_tokens
+            FROM daily_breakdown d
+            INNER JOIN submissions s ON d.submission_id = s.id
+            INNER JOIN users u ON u.id = s.user_id
+            WHERE u.leaderboard_hidden = false
+              AND d.date >= ${periodRange.start}
+              AND d.date <= ${periodRange.end}
+            GROUP BY s.user_id
+          ),
+          ranked AS (
+            SELECT
+              user_id,
+              RANK() OVER (ORDER BY total_tokens DESC) as rank
+            FROM user_totals
+          )
+          SELECT rank FROM ranked WHERE user_id = ${user.id}
+        `)
+      : rankResult;
+    const rank =
+      Number(
+        (scopedRankResult as unknown as { rank: number }[])[0]?.rank,
+      ) || null;
 
     type ModelData = {
       tokens: number;
@@ -669,7 +700,7 @@ export async function getPublicProfileResponse(
         displayName: user.displayName,
         avatarUrl: user.avatarUrl,
         createdAt: user.createdAt,
-        rank: isPeriodFiltered ? null : rank ? Number(rank) : null,
+        rank,
       },
       stats: {
         totalTokens: isPeriodFiltered

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -279,28 +279,56 @@ export async function getPublicProfileResponse(
     // entirely, so this returns no row and the profile reports rank null. The
     // finite query uses the exact same anchored window as the visible profile
     // totals and chart.
+    //
+    // The scan ranks every rankable user's daily rows, so it is cached for a
+    // minute per user and window instead of running on every request. A user
+    // with no daily rows in the window has no row in the CTE either, so the
+    // scan is skipped outright and the rank reported null directly.
+    const hasPeriodRows =
+      periodRange !== null &&
+      dailyData.some(
+        (day) => day.date >= periodRange.start && day.date <= periodRange.end,
+      );
     const scopedRankResult = periodRange
-      ? await db.execute<{ rank: number }>(sql`
-          WITH user_totals AS (
-            SELECT
-              s.user_id,
-              SUM(d.tokens) as total_tokens
-            FROM daily_breakdown d
-            INNER JOIN submissions s ON d.submission_id = s.id
-            INNER JOIN users u ON u.id = s.user_id
-            WHERE u.leaderboard_hidden = false
-              AND d.date >= ${periodRange.start}
-              AND d.date <= ${periodRange.end}
-            GROUP BY s.user_id
-          ),
-          ranked AS (
-            SELECT
-              user_id,
-              RANK() OVER (ORDER BY total_tokens DESC) as rank
-            FROM user_totals
-          )
-          SELECT rank FROM ranked WHERE user_id = ${user.id}
-        `)
+      ? hasPeriodRows
+        ? await unstable_cache(
+            () =>
+              db.execute<{ rank: number }>(sql`
+                WITH user_totals AS (
+                  SELECT
+                    s.user_id,
+                    SUM(d.tokens) as total_tokens
+                  FROM daily_breakdown d
+                  INNER JOIN submissions s ON d.submission_id = s.id
+                  INNER JOIN users u ON u.id = s.user_id
+                  WHERE u.leaderboard_hidden = false
+                    AND d.date >= ${periodRange.start}
+                    AND d.date <= ${periodRange.end}
+                  GROUP BY s.user_id
+                ),
+                ranked AS (
+                  SELECT
+                    user_id,
+                    RANK() OVER (ORDER BY total_tokens DESC) as rank
+                  FROM user_totals
+                )
+                SELECT rank FROM ranked WHERE user_id = ${user.id}
+              `),
+            [
+              "profile-period-rank",
+              user.id,
+              periodRange.start,
+              periodRange.end,
+            ],
+            {
+              revalidate: 60,
+              tags: [
+                "leaderboard",
+                `user:${normalizeUsernameCacheKey(user.username)}`,
+              ],
+            },
+          )()
+        : []
       : rankResult;
     const rank =
       Number(


### PR DESCRIPTION
> [!NOTE]
> **Why weekly and monthly ranks matter:** [@0thernet](https://tokscale.ai/u/0thernet) is currently **#6 over the trailing 7 days** and **#8 over the trailing 30 days**, compared with **#41 all-time** by tokens (checked August 22, 2026). All-time rank mostly measures accumulated history. It is a poor benchmark for people who only recently started logging or who are rapidly ramping up their usage and tokenmaxxing. Shorter windows show current pace and momentum.

## Summary

- compute profile rank over the same trailing 7-day or 30-day window selected for tokens, cost, activity, models, and charts
- preserve the existing all-time rank path for lifetime profiles
- label the profile rank pill as `All-time rank`, `30d rank`, or `7d rank` so its scope is explicit
- anchor finite-period ranking to the exact same end date as the profile, including submitted calendar dates ahead of UTC today
- continue excluding leaderboard-hidden accounts from both rank positions and ranking inputs

## Related

- Embed counterpart: [#1178](https://github.com/junhoyeo/tokscale/pull/1178)

## Testing

- Vitest full frontend suite: 912 passed, 6 integration tests skipped
- `bun run --cwd packages/frontend typecheck`
- `bun run --cwd packages/frontend lint` (passes with 17 existing warnings)
- `bun run --cwd packages/frontend build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add weekly (7d) and monthly (30d) profile ranks and label the rank pill with the window. Previously rank was all-time only and null for period filters; now rank matches the selected window, with a cached scan and empty-window short-circuit to reduce load.

- Compute period ranks from `daily_breakdown` within the same anchored start/end used for profile stats and charts; the anchor can extend beyond UTC today.
- Keep the lifetime rank path for period=all; defer only finite-period ranking until the range anchor is known.
- Exclude leaderboard-hidden users from both ranking inputs and standings.
- Cache the period rank scan for 60s per user and anchored window using `next/cache` `unstable_cache`; the key includes user id and [start, end] and uses leaderboard/user tags; skip the scan and return rank null when the user has no daily rows in the window.
- API/UI: user.rank now returns for week/month; the label reads “All-time rank,” “30d rank,” or “7d rank” via `getProfileRankLabel`.
- Tests assert SQL date bounds, windowed RANK() usage, cache keying, and label text.

<sup>Written for commit 8ff6237c1e6cf804b7b77e6b2ab29d84e87498da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

