### PR TITLE
fix(cli): work around an Antigravity RPC sync hang on Windows via curl.exe fallback

### DIFF
--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -1938,6 +1938,40 @@ fn https_rpc_request(
     method: &str,
     body: &Value,
 ) -> Result<Value> {
+    // The idea is to bypass tokio-native-tls SChannel renegotiation deadlocks on Windows
+    // by giving the task to the native OS curl.exe
+    #[cfg(target_os = "windows")] {
+        let url = format!(
+            "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/{}",
+            connection.port, method
+        );
+        let body_str = serde_json::to_string(body)?;
+
+        let output = std::process::Command::new("curl.exe")
+            .args([
+                "-k", "-sS", "--http1.1", "--max-time", "10",
+                "-X", "POST", &url,
+                "-H", "Content-Type: application/json",
+                "-H", "Connect-Protocol-Version: 1",
+                "-H", &format!("X-Codeium-Csrf-Token: {}", connection.csrf_token),
+                "-d", &body_str,
+            ])
+            .output()
+            .with_context(|| "Failed to execute curl.exe for Windows RPC fallback")?;
+
+        if !output.status.success() {
+            anyhow::bail!(
+                "Windows curl.exe RPC fallback failed (exit code {}): {}",
+                output.status.code().unwrap_or(0),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let response_body = String::from_utf8_lossy(&output.stdout);
+        Ok(serde_json::from_str(&response_body)?)
+    }
+
+    #[cfg(not(target_os = "windows"))]
     antigravity_https_runtime().block_on(async {
         let url = format!(
             "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/{}",

--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -1948,17 +1948,43 @@ fn https_rpc_request(
     method: &str,
     body: &Value,
 ) -> Result<Value> {
-    // The idea is to bypass tokio-native-tls SChannel renegotiation deadlocks on Windows
-    // by giving the task to the native OS curl.exe
+    // On Windows, the reqwest (rustls) request to the local DesktopAgent
+    // stalls until the timeout, while the in-box curl.exe (SChannel) completes
+    // the same request instantly (#1129). The mechanism is unverified, so the
+    // request is handed to curl.exe instead of guessing at a rustls-side fix.
+    // `--http1.1` is a defensive pin: unlike this workspace's reqwest build
+    // (no `http2` feature), curl can negotiate h2 via ALPN.
     #[cfg(target_os = "windows")]
     {
+        // curl config-file values are enclosed in double quotes, inside which
+        // backslashes and double quotes must be backslash-escaped.
+        fn curl_config_quote(value: &str) -> String {
+            let mut quoted = String::with_capacity(value.len() + 2);
+            quoted.push('"');
+            for ch in value.chars() {
+                if matches!(ch, '\\' | '"') {
+                    quoted.push('\\');
+                }
+                quoted.push(ch);
+            }
+            quoted.push('"');
+            quoted
+        }
+
         let url = format!(
             "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/{}",
             connection.port, method
         );
         let body_str = serde_json::to_string(body)?;
 
-        let output = std::process::Command::new("curl.exe")
+        // Resolve curl.exe by absolute path: a PATH lookup can be shadowed by
+        // a user-writable directory, handing the CSRF token to an impostor.
+        let system32_curl = std::env::var_os("SystemRoot")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| std::path::PathBuf::from("C:\\Windows"))
+            .join("System32\\curl.exe");
+
+        let mut child = std::process::Command::new(&system32_curl)
             .args([
                 "-k",
                 "-sS",
@@ -1972,24 +1998,76 @@ fn https_rpc_request(
                 "Content-Type: application/json",
                 "-H",
                 "Connect-Protocol-Version: 1",
-                "-H",
-                &format!("X-Codeium-Csrf-Token: {}", connection.csrf_token),
-                "-d",
-                &body_str,
+                "-K",
+                "-",
+                "--write-out",
+                "\\n%{http_code}",
             ])
-            .output()
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .with_context(|| "Failed to execute curl.exe for Windows RPC fallback")?;
+
+        // The CSRF token and body ride stdin (`-K -`) rather than argv, which
+        // any same-user process can read.
+        let config = format!(
+            "header = {}\ndata = {}\n",
+            curl_config_quote(&format!("X-Codeium-Csrf-Token: {}", connection.csrf_token)),
+            curl_config_quote(&body_str),
+        );
+        child
+            .stdin
+            .take()
+            .context("curl.exe stdin unavailable for Windows RPC fallback")?
+            .write_all(config.as_bytes())
+            .context("Failed to write curl.exe config for Windows RPC fallback")?;
+
+        let output = child
+            .wait_with_output()
             .with_context(|| "Failed to execute curl.exe for Windows RPC fallback")?;
 
         if !output.status.success() {
             anyhow::bail!(
                 "Windows curl.exe RPC fallback failed (exit code {}): {}",
-                output.status.code().unwrap_or(0),
+                output
+                    .status
+                    .code()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "unknown".into()),
                 String::from_utf8_lossy(&output.stderr)
             );
         }
 
-        let response_body = String::from_utf8_lossy(&output.stdout);
-        Ok(serde_json::from_str(&response_body)?)
+        if output.stdout.len() > MAX_RPC_BODY_BYTES {
+            anyhow::bail!(
+                "Antigravity RPC body of {} bytes exceeds {MAX_RPC_BODY_BYTES} cap",
+                output.stdout.len()
+            );
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let (response_body, status_line) = stdout.rsplit_once('\n').with_context(|| {
+            format!("curl.exe returned no HTTP status for Antigravity RPC {method}")
+        })?;
+        let status: u16 = status_line.trim().parse().with_context(|| {
+            format!(
+                "curl.exe returned unparseable HTTP status {:?} for Antigravity RPC {method}",
+                status_line.trim()
+            )
+        })?;
+        if !(200..300).contains(&status) {
+            anyhow::bail!(
+                "Antigravity HTTPS RPC {} failed with status {}: {}",
+                method,
+                status,
+                response_body
+            );
+        }
+
+        serde_json::from_str(response_body).with_context(|| {
+            format!("Failed to parse Antigravity RPC {method} response from curl.exe")
+        })
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -1134,6 +1134,7 @@ fn is_antigravity_process(command: &str) -> bool {
         || lower.contains("\\antigravity\\")
 }
 
+#[cfg(not(target_os = "windows"))]
 fn process_executable_path(pid: u32) -> Option<PathBuf> {
     #[cfg(target_os = "linux")]
     {
@@ -1261,6 +1262,7 @@ fn parse_port_from_windows_address(address: &str) -> Option<u16> {
     port.parse::<u16>().ok()
 }
 
+#[cfg(not(target_os = "windows"))]
 fn run_port_query(program: &str, warning_label: &str, args: &[&str]) -> Result<Vec<u16>> {
     match run_command(program, args) {
         Ok(output) => Ok(parse_ports(&output)),
@@ -1283,6 +1285,7 @@ fn is_command_not_found(err: &anyhow::Error) -> bool {
     })
 }
 
+#[cfg(not(target_os = "windows"))]
 fn parse_ports(output: &str) -> Vec<u16> {
     let mut ports = Vec::new();
     for line in output.lines() {
@@ -1293,6 +1296,7 @@ fn parse_ports(output: &str) -> Vec<u16> {
     ports
 }
 
+#[cfg(not(target_os = "windows"))]
 fn parse_port_from_line(line: &str) -> Option<u16> {
     for token in line.split_whitespace() {
         if let Some(port) = token
@@ -1598,6 +1602,7 @@ fn contains_antigravity_marker(value: &Value) -> bool {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
 fn run_command(program: &str, args: &[&str]) -> Result<String> {
     let output = run_command_output(program, args)?;
 
@@ -1999,6 +2004,7 @@ fn https_rpc_request(
     })
 }
 
+#[cfg(not(target_os = "windows"))]
 fn antigravity_https_runtime() -> &'static tokio::runtime::Runtime {
     HTTPS_RPC_RUNTIME.get_or_init(|| {
         tokio::runtime::Builder::new_current_thread()
@@ -2008,6 +2014,7 @@ fn antigravity_https_runtime() -> &'static tokio::runtime::Runtime {
     })
 }
 
+#[cfg(not(target_os = "windows"))]
 fn antigravity_https_client() -> &'static reqwest::Client {
     HTTPS_RPC_CLIENT.get_or_init(|| {
         reqwest::Client::builder()
@@ -2028,6 +2035,7 @@ fn antigravity_https_client() -> &'static reqwest::Client {
     })
 }
 
+#[cfg(not(target_os = "windows"))]
 async fn read_reqwest_response_with_cap(
     mut response: reqwest::Response,
     max_body_bytes: usize,

--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -15,8 +15,13 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 const MAX_RPC_BODY_BYTES: usize = 16 * 1024 * 1024;
 const MAX_IDENTITY_PROBE_BYTES: usize = 4096;
 const ANTIGRAVITY_MANIFEST_VERSION: i32 = 1;
+
+#[cfg(not(target_os = "windows"))]
 static HTTPS_RPC_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+#[cfg(not(target_os = "windows"))]
 static HTTPS_RPC_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
 static RPC_TRANSPORT: OnceLock<Mutex<HashMap<u16, RpcTransport>>> = OnceLock::new();
 
 /// Which transport an Antigravity RPC port has already answered on.
@@ -1945,7 +1950,8 @@ fn https_rpc_request(
 ) -> Result<Value> {
     // The idea is to bypass tokio-native-tls SChannel renegotiation deadlocks on Windows
     // by giving the task to the native OS curl.exe
-    #[cfg(target_os = "windows")] {
+    #[cfg(target_os = "windows")]
+    {
         let url = format!(
             "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/{}",
             connection.port, method
@@ -1954,12 +1960,22 @@ fn https_rpc_request(
 
         let output = std::process::Command::new("curl.exe")
             .args([
-                "-k", "-sS", "--http1.1", "--max-time", "10",
-                "-X", "POST", &url,
-                "-H", "Content-Type: application/json",
-                "-H", "Connect-Protocol-Version: 1",
-                "-H", &format!("X-Codeium-Csrf-Token: {}", connection.csrf_token),
-                "-d", &body_str,
+                "-k",
+                "-sS",
+                "--http1.1",
+                "--max-time",
+                "10",
+                "-X",
+                "POST",
+                &url,
+                "-H",
+                "Content-Type: application/json",
+                "-H",
+                "Connect-Protocol-Version: 1",
+                "-H",
+                &format!("X-Codeium-Csrf-Token: {}", connection.csrf_token),
+                "-d",
+                &body_str,
             ])
             .output()
             .with_context(|| "Failed to execute curl.exe for Windows RPC fallback")?;
@@ -2637,6 +2653,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn parse_port_from_line_reads_lsof_output() {
         assert_eq!(
             parse_port_from_line("proc 123 user 12u IPv4 0x0 0t0 TCP 127.0.0.1:41234 (LISTEN)"),
@@ -2897,6 +2914,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn run_port_query_treats_missing_lsof_as_empty() {
         let ports = run_port_query(
             "__tokscale_missing_lsof__",


### PR DESCRIPTION
Closes #1129

## Problem

On Windows, querying local Antigravity language server RPC endpoints
over HTTPS hangs indefinitely. The Windows SChannel / tokio-native-tls
stack cannot complete the TLS handshake against the local server,
causing commands like `antigravity sync` to time out.

## Solution

On Windows targets, `https_rpc_request` now routes HTTPS requests through
`curl.exe` instead of using `reqwest` / native TLS.

The command uses:

- `-k` (`--insecure`): acceptable here because the endpoint is always
  `https://127.0.0.1:<port>/...` and the local Antigravity language server
  presents a self-signed certificate that Windows SChannel cannot validate.
  This path never targets remote hosts.
- `--http1.1`: avoids HTTP/2 negotiation issues with the local server.
- `--max-time 10`: prevents the previous indefinite hang.

If `curl.exe` is unavailable, the function returns a clear error instead
of falling back to the old hanging path.

Also adds `#[cfg(not(target_os = "windows"))]` guards to unused
`reqwest` / `tokio` helpers that are only referenced on non-Windows paths.

## Testing

Tested manually on Windows with active Antigravity language server
connections.

Before:
```
    HTTPS RPC failed... Operation timed out after 10008 milliseconds with 0 bytes received
```
After:
```
    Antigravity sync
    detected connections: 2
    cached sessions after sync: 158
```

`cargo build --target x86_64-pc-windows-msvc` produces no warnings.

No automated test exercises the live Antigravity RPC TLS handshake yet.
The curl argument construction is isolated and could be unit-tested later.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows hangs in Antigravity CLI HTTPS RPC by invoking the in-box `curl.exe` for local calls. Old behavior: TLS handshake stalled and could treat error JSON as success. New behavior: Windows shells out to `curl.exe` over HTTP/1.1 with a 10s cap, validates HTTP status, and keeps the CSRF token off argv; non-Windows is unchanged.

- Windows-only path uses `%SystemRoot%\System32\curl.exe`; returns a clear error if missing.
- Stays local to `127.0.0.1`, accepts the self-signed cert with `-k`, pins `--http1.1`, and sets `--max-time 10`.
- Sends the CSRF header and body via stdin using `-K -` (escaped) to avoid argv leaks; caps stdout at `MAX_RPC_BODY_BYTES`; fails on non-2xx with method-aware errors.
- Adds `#[cfg(not(target_os = "windows"))]` around unused `reqwest`/`tokio` helpers and tests to silence Windows build warnings.
- No migration required; ensure `curl.exe` is present on Windows at runtime.

<sup>Written for commit 06525a04813b6ad0bf90cd99710f47b093fc1278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

