### PR TITLE
fix(core): parse kind-1 updates for VS Code Copilot Chat v3

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1038,7 +1038,10 @@ fn parser_version(client: ClientId) -> u32 {
         // shared identity, and a valid span_id alone (no trace_id) is now a
         // stable dedup key instead of falling through to the line-index key.
         // v7->v8: stabilize duplicate agent attribution and partial timing boundaries.
-        ClientId::Copilot => 8,
+        // v8->v9: chatSessions v3 kind-1 incremental updates are now applied
+        // when reconstructing VS Code Copilot Chat requests; v8 aggregates
+        // carry those sessions as zero-token.
+        ClientId::Copilot => 9,
         // Pi subagent sessions now derive agent attribution from session_info
         // names; version-1 caches carry those messages without agent metadata.
         ClientId::Pi => 2,
@@ -3089,8 +3092,8 @@ mod tests {
     }
 
     #[test]
-    fn test_copilot_duplicate_metadata_parser_version_invalidates_v7_entries() {
-        assert_eq!(parser_version(ClientId::Copilot), 8);
+    fn test_copilot_kind1_update_parser_version_invalidates_v8_entries() {
+        assert_eq!(parser_version(ClientId::Copilot), 9);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/copilot_vscode.rs
+++ b/crates/tokscale-core/src/sessions/copilot_vscode.rs
@@ -40,6 +40,19 @@ fn parse_file(path: &Path) -> Vec<UnifiedMessage> {
                     requests.extend(arr.iter().cloned());
                 }
             }
+            1 => {
+                if let Some(k) = obj.get("k").and_then(Value::as_array) {
+                    if k.first().and_then(Value::as_str) == Some("requests") {
+                        if let Some(index) = k.get(1).and_then(|v| v.as_u64()).map(|u| u as usize) {
+                            if let Some(req) = requests.get_mut(index) {
+                                if let Some(value) = obj.get("v") {
+                                    apply_update(req, &k[2..], value.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             2 => {
                 if let Some(k) = obj.get("k").and_then(Value::as_array) {
                     let is_requests = k
@@ -62,6 +75,62 @@ fn parse_file(path: &Path) -> Vec<UnifiedMessage> {
         .iter()
         .filter_map(|req| request_to_message(req, &session_id, &workspace))
         .collect()
+}
+
+fn apply_update(target: &mut Value, path: &[Value], value: Value) {
+    if path.is_empty() {
+        *target = value;
+        return;
+    }
+
+    let mut current = target;
+    for i in 0..path.len() {
+        let key = &path[i];
+        let is_last = i == path.len() - 1;
+
+        if let Some(k_str) = key.as_str() {
+            if !current.is_object() {
+                *current = serde_json::Value::Object(serde_json::Map::new());
+            }
+            if is_last {
+                current.as_object_mut().unwrap().insert(k_str.to_string(), value.clone());
+            } else {
+                let obj = current.as_object_mut().unwrap();
+                if !obj.contains_key(k_str) {
+                    obj.insert(k_str.to_string(), serde_json::Value::Object(serde_json::Map::new()));
+                }
+            }
+            if !is_last {
+                current = current.get_mut(k_str).unwrap();
+            }
+        } else if let Some(k_idx) = key.as_u64() {
+            let idx = k_idx as usize;
+            if !current.is_array() {
+                *current = serde_json::Value::Array(Vec::new());
+            }
+            if is_last {
+                let arr = current.as_array_mut().unwrap();
+                if idx < arr.len() {
+                    arr[idx] = value.clone();
+                } else {
+                    while arr.len() < idx {
+                        arr.push(serde_json::Value::Null);
+                    }
+                    arr.push(value.clone());
+                }
+            } else {
+                let arr = current.as_array_mut().unwrap();
+                while arr.len() <= idx {
+                    arr.push(serde_json::Value::Null);
+                }
+            }
+            if !is_last {
+                current = current.get_mut(idx).unwrap();
+            }
+        } else {
+            return;
+        }
+    }
 }
 
 fn request_to_message(
@@ -355,5 +424,30 @@ mod tests {
         );
 
         assert!(parse_copilot_vscode_sessions(&[path]).is_empty());
+    }
+    #[test]
+    fn parse_kind1_path_updates() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("chatSessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "750e8400-e29b-41d4-a716-446655440002";
+        let path = sessions_dir.join(format!("{}.jsonl", uuid));
+
+        write_jsonl(
+            &path,
+            &[
+                r#"{"kind":0,"v":{"requests":[{"requestId":"r3","timestamp":1783918320000,"agent":{"id":"github.copilot"}}]}}"#,
+                r#"{"kind":1,"k":["requests",0,"promptTokens"],"v":18561}"#,
+                r#"{"kind":1,"k":["requests",0,"completionTokens"],"v":143}"#,
+                r#"{"kind":1,"k":["requests",0,"result"],"v":{"metadata":{"promptTokens":18561,"outputTokens":143,"resolvedModel":"gpt-5.6-luna"}}}"#,
+            ],
+        );
+
+        let messages = parse_copilot_vscode_sessions(&[path]);
+        assert_eq!(messages.len(), 1);
+        let m = &messages[0];
+        assert_eq!(m.model_id, "gpt-5.6-luna");
+        assert_eq!(m.tokens.input, 18561);
+        assert_eq!(m.tokens.output, 143);
     }
 }

--- a/crates/tokscale-core/src/sessions/copilot_vscode.rs
+++ b/crates/tokscale-core/src/sessions/copilot_vscode.rs
@@ -93,11 +93,17 @@ fn apply_update(target: &mut Value, path: &[Value], value: Value) {
                 *current = serde_json::Value::Object(serde_json::Map::new());
             }
             if is_last {
-                current.as_object_mut().unwrap().insert(k_str.to_string(), value.clone());
+                current
+                    .as_object_mut()
+                    .unwrap()
+                    .insert(k_str.to_string(), value.clone());
             } else {
                 let obj = current.as_object_mut().unwrap();
                 if !obj.contains_key(k_str) {
-                    obj.insert(k_str.to_string(), serde_json::Value::Object(serde_json::Map::new()));
+                    obj.insert(
+                        k_str.to_string(),
+                        serde_json::Value::Object(serde_json::Map::new()),
+                    );
                 }
             }
             if !is_last {

--- a/crates/tokscale-core/src/sessions/copilot_vscode.rs
+++ b/crates/tokscale-core/src/sessions/copilot_vscode.rs
@@ -44,6 +44,7 @@ fn parse_file(path: &Path) -> Vec<UnifiedMessage> {
                 if let Some(k) = obj.get("k").and_then(Value::as_array) {
                     if k.first().and_then(Value::as_str) == Some("requests") {
                         if let Some(index) = k.get(1).and_then(|v| v.as_u64()).map(|u| u as usize) {
+                            // Dropping out-of-range updates is intentional: padding placeholders would mint timestamp-0 messages.
                             if let Some(req) = requests.get_mut(index) {
                                 if let Some(value) = obj.get("v") {
                                     apply_update(req, &k[2..], value.clone());
@@ -55,11 +56,12 @@ fn parse_file(path: &Path) -> Vec<UnifiedMessage> {
             }
             2 => {
                 if let Some(k) = obj.get("k").and_then(Value::as_array) {
-                    let is_requests = k
-                        .first()
-                        .and_then(Value::as_str)
-                        .map(|s| s == "requests")
-                        .unwrap_or(false);
+                    // Only top-level `["requests"]` appends grow the requests
+                    // vec. Nested appends like `["requests", 0, "response"]`
+                    // carry no token data, and letting them extend the vec
+                    // would shift the positions that kind-1 updates address.
+                    let is_requests =
+                        k.len() == 1 && k.first().and_then(Value::as_str) == Some("requests");
                     if is_requests {
                         if let Some(arr) = obj.get("v").and_then(Value::as_array) {
                             requests.extend(arr.iter().cloned());
@@ -76,6 +78,11 @@ fn parse_file(path: &Path) -> Vec<UnifiedMessage> {
         .filter_map(|req| request_to_message(req, &session_id, &workspace))
         .collect()
 }
+
+/// Upper bound for numeric indexes in an update path. A corrupted line with a
+/// huge index would otherwise drive the padding loops below into an unbounded
+/// allocation.
+const MAX_PATH_ARRAY_INDEX: usize = 4096;
 
 fn apply_update(target: &mut Value, path: &[Value], value: Value) {
     if path.is_empty() {
@@ -110,6 +117,9 @@ fn apply_update(target: &mut Value, path: &[Value], value: Value) {
                 current = current.get_mut(k_str).unwrap();
             }
         } else if let Some(k_idx) = key.as_u64() {
+            if k_idx > MAX_PATH_ARRAY_INDEX as u64 {
+                return;
+            }
             let idx = k_idx as usize;
             if !current.is_array() {
                 *current = serde_json::Value::Array(Vec::new());
@@ -455,5 +465,50 @@ mod tests {
         assert_eq!(m.model_id, "gpt-5.6-luna");
         assert_eq!(m.tokens.input, 18561);
         assert_eq!(m.tokens.output, 143);
+    }
+
+    #[test]
+    fn nested_kind2_appends_do_not_shift_kind1_request_indexes() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("chatSessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "850e8400-e29b-41d4-a716-446655440003";
+        let path = sessions_dir.join(format!("{}.jsonl", uuid));
+
+        // Mirrors a real multi-request session: placeholder requests arrive
+        // without token data, kind-1 updates fill them in by position, and
+        // response parts stream in as nested kind-2 appends in between. If
+        // the nested append leaked into the top-level requests vec, the
+        // kind-1 updates for index 1 would land on a response part instead
+        // of r1, minting a timestamp-0 message with r1's tokens.
+        write_jsonl(
+            &path,
+            &[
+                r#"{"kind":0,"v":{"requests":[{"requestId":"r0","timestamp":1783918330000,"agent":{"id":"github.copilot"}}]}}"#,
+                r#"{"kind":1,"k":["requests",0,"promptTokens"],"v":12000}"#,
+                r#"{"kind":1,"k":["requests",0,"completionTokens"],"v":120}"#,
+                r#"{"kind":1,"k":["requests",0,"result"],"v":{"metadata":{"promptTokens":12000,"outputTokens":120,"resolvedModel":"gpt-5.3-codex"}}}"#,
+                r#"{"kind":2,"k":["requests",0,"response"],"v":[{"kind":"markdownContent","value":"part1"},{"kind":"markdownContent","value":"part2"},{"kind":"toolInvocationSerialized"}]}"#,
+                r#"{"kind":2,"k":["requests"],"v":[{"requestId":"r1","timestamp":1783918340000,"agent":{"id":"github.copilot"}}]}"#,
+                r#"{"kind":1,"k":["requests",1,"promptTokens"],"v":15000}"#,
+                r#"{"kind":1,"k":["requests",1,"completionTokens"],"v":250}"#,
+                r#"{"kind":1,"k":["requests",1,"result"],"v":{"metadata":{"promptTokens":15000,"outputTokens":250,"resolvedModel":"gpt-5.6-luna"}}}"#,
+            ],
+        );
+
+        let messages = parse_copilot_vscode_sessions(&[path]);
+        assert_eq!(messages.len(), 2);
+
+        let m0 = &messages[0];
+        assert_eq!(m0.timestamp, 1783918330000);
+        assert_eq!(m0.model_id, "gpt-5.3-codex");
+        assert_eq!(m0.tokens.input, 12000);
+        assert_eq!(m0.tokens.output, 120);
+
+        let m1 = &messages[1];
+        assert_eq!(m1.timestamp, 1783918340000);
+        assert_eq!(m1.model_id, "gpt-5.6-luna");
+        assert_eq!(m1.tokens.input, 15000);
+        assert_eq!(m1.tokens.output, 250);
     }
 }


### PR DESCRIPTION
Resolves #1181.

## Background
VS Code 1.134 Copilot Chat extension recently updated its session log format to `chatSessions v3`. In previous versions, usage data was fully written in `kind: 0` (initial snapshots) and `kind: 2` (array appends). 

However, in the new `v3` format, the initial request is merely a placeholder with no token data. The actual token usage and completion metadata are written incrementally as **single-field path updates** using `kind: 1` lines.

For example, a `kind: 1` update looks like this:
```json
{"kind":1,"k":["requests",1,"promptTokens"],"v":18561}
{"kind":1,"k":["requests",1,"completionTokens"],"v":143}
{"kind":1,"k":["requests",1,"result"],"v":{"metadata":{"promptTokens":18561,"outputTokens":143,"resolvedModel":"gpt-5.6-luna"}}}
```

Because Tokscale's `copilot_vscode.rs` parser historically ignored `kind: 1` lines, the parsed usage fields remained empty. As a result, Tokscale dropped these sessions entirely for having zero tokens, leading to inaccurate usage metrics.

## Changes
This PR introduces support for parsing `kind: 1` incremental updates by:
- Catching `kind: 1` events in the JSONL parser loop.
- Introducing a robust JSON path-application helper (`apply_update`) that traverses the `k` array (e.g., `["requests", 1, "promptTokens"]`).
- Safely constructing any intermediate JSON arrays or objects if they don't yet exist.
- Applying the `v` value to the leaf node on top of the `kind: 0` / `kind: 2` snapshots.

This change ensures that Tokscale's existing `request_to_message` logic accurately extracts `promptTokens`, `completionTokens`, and `resolvedModel` from the fully reconstructed JSON, restoring tracking compatibility for all users on the latest VS Code Copilot versions.
