### PR TITLE
fix(cursor): extend timeout to 120s for explicit sync of large CSV exports

### DIFF
--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -182,7 +182,7 @@ async fn load_wrapped_data(options: &WrappedOptions) -> Result<WrappedData> {
     let mut cursor_sync_result: Option<cursor::SyncCursorResult> = None;
 
     if include_cursor && cursor_logged_in {
-        cursor_sync_result = Some(cursor::sync_cursor_cache().await);
+        cursor_sync_result = Some(cursor::sync_cursor_cache(false).await);
     }
 
     if let Some(sync) = cursor_sync_result.as_ref() {

--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -11,7 +11,15 @@ use std::time::{Duration, SystemTime};
 /// auto-sync (which runs synchronously before local reports and the TUI) while
 /// still tolerating routine API latency. If the network is hung, the report
 /// proceeds against cached data after this timeout instead of stalling forever.
+/// Explicit `tokscale cursor sync` overrides this for the usage-CSV download
+/// with [`CURSOR_EXPLICIT_SYNC_TIMEOUT`].
 const CURSOR_HTTP_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Per-request timeout for the usage-CSV download during an explicit
+/// `tokscale cursor sync`. Large accounts export CSVs that take well over the
+/// default [`CURSOR_HTTP_TIMEOUT`] to generate and stream (issue #1175); the
+/// user asked for the sync, so waiting longer beats failing fast.
+const CURSOR_EXPLICIT_SYNC_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Skip implicit pre-report sync when every expected Cursor account cache file
 /// was modified within this window. Prevents `tokscale models` (and its
@@ -1187,18 +1195,19 @@ where
     }
 }
 
+/// Timeout override for the usage-CSV download: explicit syncs get the longer
+/// [`CURSOR_EXPLICIT_SYNC_TIMEOUT`]; implicit syncs keep the client default.
+fn csv_timeout_override(explicit: bool) -> Option<Duration> {
+    explicit.then_some(CURSOR_EXPLICIT_SYNC_TIMEOUT)
+}
+
 pub async fn sync_cursor_cache(explicit: bool) -> SyncCursorResult {
     // Prefer a fresh token from the local Cursor desktop login when available.
     // This avoids stale manually-pasted cookies after Cursor refreshes its JWT.
     let _ = ensure_credentials_from_local_cursor();
 
     sync_cursor_cache_with_fetcher(move |session_token| async move {
-        let timeout = if explicit {
-            Some(Duration::from_secs(120))
-        } else {
-            None
-        };
-        fetch_cursor_usage_csv(&session_token, timeout).await
+        fetch_cursor_usage_csv(&session_token, csv_timeout_override(explicit)).await
     })
     .await
 }
@@ -1679,6 +1688,12 @@ mod tests {
         assert_eq!(CURSOR_HTTP_TIMEOUT, std::time::Duration::from_secs(15));
         // Use the client briefly to ensure it's structurally valid.
         let _ = client.get("https://example.invalid").build();
+    }
+
+    #[test]
+    fn test_csv_timeout_override_only_for_explicit_sync() {
+        assert_eq!(csv_timeout_override(true), Some(Duration::from_secs(120)));
+        assert_eq!(csv_timeout_override(false), None);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -1008,13 +1008,20 @@ pub async fn validate_cursor_session(token: &str) -> ValidateSessionResult {
     }
 }
 
-pub async fn fetch_cursor_usage_csv(session_token: &str) -> Result<String> {
+pub async fn fetch_cursor_usage_csv(
+    session_token: &str,
+    timeout_override: Option<Duration>,
+) -> Result<String> {
     let client = build_cursor_http_client()?;
-    let response = client
+    let mut req = client
         .get(USAGE_CSV_ENDPOINT)
-        .headers(build_cursor_headers(session_token))
-        .send()
-        .await?;
+        .headers(build_cursor_headers(session_token));
+
+    if let Some(timeout) = timeout_override {
+        req = req.timeout(timeout);
+    }
+
+    let response = req.send().await?;
 
     if response.status() == reqwest::StatusCode::UNAUTHORIZED
         || response.status() == reqwest::StatusCode::FORBIDDEN
@@ -1180,13 +1187,18 @@ where
     }
 }
 
-pub async fn sync_cursor_cache() -> SyncCursorResult {
+pub async fn sync_cursor_cache(explicit: bool) -> SyncCursorResult {
     // Prefer a fresh token from the local Cursor desktop login when available.
     // This avoids stale manually-pasted cookies after Cursor refreshes its JWT.
     let _ = ensure_credentials_from_local_cursor();
 
-    sync_cursor_cache_with_fetcher(|session_token| async move {
-        fetch_cursor_usage_csv(&session_token).await
+    sync_cursor_cache_with_fetcher(move |session_token| async move {
+        let timeout = if explicit {
+            Some(Duration::from_secs(120))
+        } else {
+            None
+        };
+        fetch_cursor_usage_csv(&session_token, timeout).await
     })
     .await
 }
@@ -1448,7 +1460,7 @@ pub fn run_cursor_sync(json: bool) -> Result<()> {
     use tokio::runtime::Runtime;
 
     let rt = Runtime::new()?;
-    let result = rt.block_on(sync_cursor_cache());
+    let result = rt.block_on(sync_cursor_cache(true));
 
     if json {
         println!("{}", serde_json::to_string_pretty(&result)?);

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1612,7 +1612,7 @@ where
     F: FnOnce() -> std::io::Result<tokio::runtime::Runtime>,
 {
     match build_runtime() {
-        Ok(rt) => rt.block_on(async { cursor::sync_cursor_cache().await }),
+        Ok(rt) => rt.block_on(async { cursor::sync_cursor_cache(false).await }),
         Err(error) => cursor::SyncCursorResult {
             synced: false,
             rows: 0,
@@ -5831,7 +5831,7 @@ fn run_submit_command(
     if include_cursor && cursor::is_cursor_logged_in() {
         println!("{}", "  Syncing Cursor usage data...".bright_black());
         let rt_sync = Runtime::new()?;
-        let sync_result = rt_sync.block_on(async { cursor::sync_cursor_cache().await });
+        let sync_result = rt_sync.block_on(async { cursor::sync_cursor_cache(false).await });
         if sync_result.synced {
             println!(
                 "{}",


### PR DESCRIPTION
Resolves #1175.

## Background
Previously, `tokscale cursor sync` used a hardcoded 15-second timeout for the Cursor CSV export endpoint. While this tight timeout makes sense for pre-report auto-syncs (to prevent the TUI from stalling indefinitely on a hung network), it causes explicit `tokscale cursor sync` commands to fail prematurely with an `error decoding response body` when downloading large usage histories.

## Changes
This PR distinguishes between explicit manual syncs and implicit auto-syncs by passing an `explicit: bool` flag down to `sync_cursor_cache`. 
- Manual `tokscale cursor sync` commands now use a **120-second timeout**, allowing large CSV exports to download completely.
- Background auto-syncs retain the fast **15-second cap**.

> Hope this is helpful for users with larger Cursor histories! Let me know if there's anything else needed here. 😊
