### PR TITLE
fix(pricing): resolve provider-specific model aliases

### DIFF
--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -36,6 +36,10 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("kimi-for-coding", "kimi-k2.7-code");
     m.insert("kimi-for-coding-highspeed", "kimi-k2.7-code-highspeed");
     m.insert("k3", "kimi-k3");
+    // models.dev also publishes `kimi-for-coding/k3-256k` at $0.00, so the
+    // long-context spelling must resolve to the same real moonshotai row as
+    // bare `k3` instead of landing on the zero-priced subscription namespace.
+    m.insert("k3-256k", "kimi-k3");
     // Kimi Work (the Kimi desktop app's agent mode) embeds the same kimi-code
     // kernel and writes the same wire protocol, but reports its own ids.
     // Unaliased they fuzzy-match badly: `k2d6-agent` landed on
@@ -256,6 +260,10 @@ mod tests {
             Some("kimi-k2.7-code-highspeed")
         );
         assert_eq!(resolve_alias("k3"), Some("kimi-k3"));
+        // The long-context spelling has its own zero-priced
+        // `kimi-for-coding/k3-256k` row on models.dev, so it must resolve to
+        // the same real moonshotai row as bare `k3`.
+        assert_eq!(resolve_alias("k3-256k"), Some("kimi-k3"));
     }
 
     #[test]
@@ -294,6 +302,19 @@ mod tests {
         ] {
             assert_eq!(resolve_alias(tier), Some("grok-4.6"), "tier: {tier}");
             assert!(uses_cursor_pricing(tier), "tier: {tier}");
+        }
+    }
+
+    #[test]
+    fn cursor_pricing_alias_keys_stay_disjoint_from_model_aliases() {
+        // `resolve_alias` consults MODEL_ALIASES first, so a key present in
+        // both maps would resolve through MODEL_ALIASES while
+        // `uses_cursor_pricing` still forced the Cursor catalog for it.
+        for key in super::CURSOR_PRICING_ALIASES.keys() {
+            assert!(
+                !super::MODEL_ALIASES.contains_key(key),
+                "{key} is in both CURSOR_PRICING_ALIASES and MODEL_ALIASES"
+            );
         }
     }
 

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -1,6 +1,24 @@
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 
+static CURSOR_PRICING_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
+    let mut aliases = HashMap::new();
+    for tier in [
+        "cursor-grok-4.6-high",
+        "cursor-grok-4.6-high-fast",
+        "cursor-grok-4.6-low",
+        "cursor-grok-4.6-low-fast",
+        "cursor-grok-4.6-medium",
+        "cursor-grok-4.6-medium-fast",
+        "cursor-grok-4.6-xhigh",
+    ] {
+        aliases.insert(tier, "grok-4.6");
+    }
+    aliases.insert("grok-composer-2.5", "composer-2.5");
+    aliases.insert("grok-composer-2.5-fast", "composer-2.5-fast");
+    aliases
+});
+
 static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     let mut m = HashMap::new();
     m.insert("big-pickle", "glm-4.7");
@@ -141,8 +159,6 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("gemini-3-flash", "gemini-3-flash-preview");
     m.insert("gemini-3-flash-c", "gemini-3-flash-preview");
     m.insert("gemini-3-flash-a", "gemini-3.5-flash-high");
-    m.insert("grok-composer-2.5", "composer-2.5");
-    m.insert("grok-composer-2.5-fast", "composer-2.5-fast");
     // OpenAI documents the API spelling below as a moving alias for
     // `gpt-5.6-sol`; Codex records the same alias with its `gpt-` prefix.
     // Keep the API, Codex, and provider-qualified spellings pinned to the
@@ -168,6 +184,9 @@ pub fn resolve_alias(model_id: &str) -> Option<&'static str> {
     if let Some(target) = MODEL_ALIASES.get(lowered.as_str()) {
         return Some(target);
     }
+    if let Some(target) = CURSOR_PRICING_ALIASES.get(lowered.as_str()) {
+        return Some(target);
+    }
     // kimi-code reports some rows as `kimi-code/<id>`. The Kimi parser strips
     // that prefix before pricing, but any other path reaching pricing with the
     // qualified form would otherwise miss every alias above and fall through to
@@ -177,9 +196,13 @@ pub fn resolve_alias(model_id: &str) -> Option<&'static str> {
     MODEL_ALIASES.get(bare).copied()
 }
 
+pub fn uses_cursor_pricing(model_id: &str) -> bool {
+    CURSOR_PRICING_ALIASES.contains_key(model_id.to_lowercase().as_str())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::resolve_alias;
+    use super::{resolve_alias, uses_cursor_pricing};
     use std::collections::HashMap;
 
     #[test]
@@ -256,6 +279,22 @@ mod tests {
             resolve_alias("kimi-for-coding-highspeed"),
             Some("kimi-k2.7-code-highspeed")
         );
+    }
+
+    #[test]
+    fn cursor_grok_reasoning_tiers_resolve_to_the_base_model() {
+        for tier in [
+            "cursor-grok-4.6-high",
+            "cursor-grok-4.6-high-fast",
+            "cursor-grok-4.6-low",
+            "cursor-grok-4.6-low-fast",
+            "cursor-grok-4.6-medium",
+            "cursor-grok-4.6-medium-fast",
+            "cursor-grok-4.6-xhigh",
+        ] {
+            assert_eq!(resolve_alias(tier), Some("grok-4.6"), "tier: {tier}");
+            assert!(uses_cursor_pricing(tier), "tier: {tier}");
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -4352,6 +4352,56 @@ mod tests {
     }
 
     #[test]
+    fn hinted_kimi_k3_selects_the_real_moonshotai_row_with_provider_scoped_evidence() {
+        // models.dev carries the `kimi-for-coding/*` subscription namespace at
+        // $0.00 alongside the real `moonshotai/kimi-k3` row. A Kimi client
+        // reporting model `k3` with a kimi/moonshot provider hint must price
+        // at the real moonshotai rates with provider-scoped evidence instead
+        // of landing on the zero-priced subscription row.
+        let models_dev = HashMap::from([
+            (
+                "kimi-for-coding/k3".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(0.0),
+                    output_cost_per_token: Some(0.0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "moonshotai/kimi-k3".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(1e-6),
+                    output_cost_per_token: Some(2e-6),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        for hint in ["kimi_for_coding", "moonshot"] {
+            let result = lookup
+                .lookup_with_provider("k3", Some(hint))
+                .expect("the hinted Kimi alias must price");
+
+            assert_eq!(result.source, "Models.dev", "hint: {hint}");
+            assert_eq!(result.matched_key, "moonshotai/kimi-k3", "hint: {hint}");
+            assert_eq!(
+                result.evidence.kind,
+                ResolutionKind::ProviderScoped,
+                "hint: {hint}"
+            );
+            assert!(result.evidence.alias_applied, "hint: {hint}");
+            assert!(result.evidence.is_submission_safe(), "hint: {hint}");
+        }
+    }
+
+    #[test]
     fn cursor_specific_aliases_explicitly_select_cursor_pricing() {
         let cursor = HashMap::from([(
             "grok-4.6".to_string(),

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -1,4 +1,4 @@
-use super::{aliases, litellm::ModelPricing};
+use super::{aliases, litellm::ModelPricing, self_hosted};
 use crate::{provider_identity, strip_parenthesized_reasoning_tier, TokenBreakdown};
 use std::collections::HashMap;
 use std::sync::RwLock;
@@ -187,7 +187,7 @@ pub struct ResolutionEvidence {
 }
 
 impl ResolutionEvidence {
-    fn deterministic(kind: ResolutionKind) -> Self {
+    pub(super) fn deterministic(kind: ResolutionKind) -> Self {
         Self {
             kind,
             candidate_count: 1,
@@ -511,6 +511,12 @@ impl PricingLookup {
         force_source: Option<&str>,
         provider_id: Option<&str>,
     ) -> Option<LookupResult> {
+        if force_source.is_none() {
+            if let Some(result) = self_hosted::lookup(model_id, provider_id) {
+                return Some(result);
+            }
+        }
+
         // A router is not a model. Resolving one by model-part match elects
         // whatever unrelated vendor publishes the same word, and the result is
         // billed as if it were the real thing (#1062).
@@ -554,6 +560,12 @@ impl PricingLookup {
 
         let lower_ref: &str = normalized_owned.as_deref().unwrap_or(&lower);
 
+        if alias_applied && force_source.is_none() && aliases::uses_cursor_pricing(model_id) {
+            if let Some(result) = self.exact_match_cursor(lower_ref) {
+                return Some(result.with_alias());
+            }
+        }
+
         // Helper to perform lookup with the given source constraint
         let do_lookup = |id: &str| match force_source {
             Some("litellm") => self.lookup_litellm_only(id, provider_id),
@@ -583,6 +595,16 @@ impl PricingLookup {
             }
             if normalized_owned.is_some() {
                 result = result.with_normalization();
+            }
+            if matches_inferred_model_provider(lower_ref, provider_id)
+                && provider_id
+                    .is_some_and(|hint| key_root_matches_provider_hint(&result.matched_key, hint))
+                && matches!(
+                    result.evidence.kind,
+                    ResolutionKind::ModelPart | ResolutionKind::ProviderPrefix
+                )
+            {
+                result = result.with_kind(ResolutionKind::ProviderScoped);
             }
             result
         };
@@ -2861,6 +2883,18 @@ fn normalize_provider_hint(provider_id: Option<&str>) -> Option<&str> {
         .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("unknown"))
 }
 
+fn matches_inferred_model_provider(model_id: &str, provider_id: Option<&str>) -> bool {
+    let Some(provider_id) = provider_id else {
+        return false;
+    };
+    let terminal_model_id = model_id.rsplit('/').next().unwrap_or(model_id);
+    let Some(inferred) = provider_identity::inferred_provider_from_model(terminal_model_id) else {
+        return false;
+    };
+    provider_identity::canonical_provider(provider_id)
+        == provider_identity::canonical_provider(inferred)
+}
+
 fn build_lookup_cache_key(model_id: &str, provider_id: Option<&str>) -> String {
     match provider_id {
         Some(provider) if !provider.trim().is_empty() => {
@@ -4244,6 +4278,111 @@ mod tests {
             Some(SubmissionSafetyGap::UnverifiedProviderIdentity)
         );
         assert!(!result.evidence.is_submission_safe());
+    }
+
+    #[test]
+    fn inferred_model_vendor_does_not_verify_a_reseller_pricing_row() {
+        let models_dev = HashMap::from([(
+            "venice/gpt-5.4".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(1e-6),
+                output_cost_per_token: Some(2e-6),
+                ..Default::default()
+            },
+        )]);
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        let result = lookup
+            .lookup_with_provider("gpt-5.4", Some("openai"))
+            .expect("the reseller price remains available as an estimate");
+
+        assert_eq!(result.matched_key, "venice/gpt-5.4");
+        assert_eq!(result.evidence.kind, ResolutionKind::ModelPart);
+        assert_eq!(
+            result.evidence.submission_safety_gap(),
+            Some(SubmissionSafetyGap::UnverifiedProviderIdentity)
+        );
+    }
+
+    #[test]
+    fn forced_source_does_not_return_builtin_self_hosted_pricing() {
+        let lookup = PricingLookup::new(HashMap::new(), HashMap::new(), HashMap::new());
+
+        assert!(lookup
+            .lookup_with_source_and_provider("local-model", Some("litellm"), Some("llama.cpp"),)
+            .is_none());
+    }
+
+    #[test]
+    fn ordinary_aliases_preserve_upstream_precedence_over_cursor_overrides() {
+        let cursor = HashMap::from([(
+            "kimi-k3".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(9e-6),
+                output_cost_per_token: Some(18e-6),
+                ..Default::default()
+            },
+        )]);
+        let models_dev = HashMap::from([(
+            "moonshotai/kimi-k3".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(1e-6),
+                output_cost_per_token: Some(2e-6),
+                ..Default::default()
+            },
+        )]);
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            cursor,
+            HashMap::new(),
+            models_dev,
+        );
+
+        let result = lookup.lookup("k3").expect("the Kimi alias must price");
+
+        assert_eq!(result.source, "Models.dev");
+        assert_eq!(result.matched_key, "moonshotai/kimi-k3");
+    }
+
+    #[test]
+    fn cursor_specific_aliases_explicitly_select_cursor_pricing() {
+        let cursor = HashMap::from([(
+            "grok-4.6".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(2e-6),
+                output_cost_per_token: Some(6e-6),
+                ..Default::default()
+            },
+        )]);
+        let models_dev = HashMap::from([(
+            "xai/grok-4.6".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(1e-6),
+                output_cost_per_token: Some(3e-6),
+                ..Default::default()
+            },
+        )]);
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            cursor,
+            HashMap::new(),
+            models_dev,
+        );
+
+        let result = lookup
+            .lookup("cursor-grok-4.6-high")
+            .expect("the Cursor tier alias must price");
+
+        assert_eq!(result.source, "Cursor");
+        assert_eq!(result.matched_key, "grok-4.6");
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -169,6 +169,10 @@ impl PricingService {
                 },
             );
         }
+        // Grok 4.6: $2.00/$6.00 per 1M input/output, $0.50/M cache read;
+        // >200K-context tier $4.00/$12.00 per 1M, $1.00/M cache read
+        // Source: Cursor model docs (cursor.com/docs/models#model-pricing);
+        // rates mirror models.dev xai/grok-4.6 including the >200K context tier
         overrides.insert(
             "grok-4.6".to_string(),
             ModelPricing {

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -6,6 +6,7 @@ pub mod litellm;
 pub mod lookup;
 pub mod models_dev;
 pub mod openrouter;
+mod self_hosted;
 
 use custom::CustomPricing;
 use lookup::{compute_cost, LookupResult, PricingLookup, ResolutionEvidence, ResolutionKind};
@@ -168,6 +169,18 @@ impl PricingService {
                 },
             );
         }
+        overrides.insert(
+            "grok-4.6".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(2e-6),
+                output_cost_per_token: Some(6e-6),
+                cache_read_input_token_cost: Some(5e-7),
+                input_cost_per_token_above_200k_tokens: Some(4e-6),
+                output_cost_per_token_above_200k_tokens: Some(12e-6),
+                cache_read_input_token_cost_above_200k_tokens: Some(1e-6),
+                ..Default::default()
+            },
+        );
         overrides
     }
 
@@ -717,6 +730,34 @@ mod tests {
             Some("azure"),
             &cache_read_usage()
         ));
+    }
+
+    #[test]
+    fn self_hosted_llama_cpp_usage_is_covered_at_zero_cost() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let usage = TokenBreakdown {
+            input: 100,
+            output: 50,
+            cache_read: 25,
+            cache_write: 10,
+            reasoning: 5,
+        };
+
+        for provider in ["llama.cpp", "llama.cpp_modal"] {
+            assert!(service.covers_usage_with_provider(
+                "Qwen3.8-27B-ABLITERATED-Q4_K_M-MTP-Q4_0",
+                Some(provider),
+                &usage,
+            ));
+            assert_eq!(
+                service.calculate_cost_with_provider(
+                    "Qwen3.8-27B-ABLITERATED-Q4_K_M-MTP-Q4_0",
+                    Some(provider),
+                    &usage,
+                ),
+                0.0,
+            );
+        }
     }
 
     // Custom overrides are exact-only and provider-agnostic, so they must be

--- a/crates/tokscale-core/src/pricing/self_hosted.rs
+++ b/crates/tokscale-core/src/pricing/self_hosted.rs
@@ -1,0 +1,22 @@
+use super::{
+    lookup::{LookupResult, ResolutionEvidence, ResolutionKind},
+    ModelPricing,
+};
+use crate::provider_identity;
+
+pub fn lookup(model_id: &str, provider_id: Option<&str>) -> Option<LookupResult> {
+    provider_id
+        .filter(|provider| provider_identity::is_self_hosted_provider(provider))
+        .map(|_| LookupResult {
+            pricing: ModelPricing {
+                input_cost_per_token: Some(0.0),
+                output_cost_per_token: Some(0.0),
+                cache_read_input_token_cost: Some(0.0),
+                cache_creation_input_token_cost: Some(0.0),
+                ..Default::default()
+            },
+            source: "Self-hosted".to_string(),
+            matched_key: model_id.to_string(),
+            evidence: ResolutionEvidence::deterministic(ResolutionKind::BuiltIn),
+        })
+}

--- a/crates/tokscale-core/src/provider_identity.rs
+++ b/crates/tokscale-core/src/provider_identity.rs
@@ -13,6 +13,7 @@ fn canonicalize_provider_segment(segment: &str) -> Option<String> {
         "x_ai" | "xai" => "xai",
         "z_ai" | "zai" => "zai",
         "moonshot" | "moonshotai" => "moonshotai",
+        "kimi_for_coding" => "moonshotai",
         "meta" | "meta_llama" => "meta_llama",
         "azure" | "azure_ai" => "azure_ai",
         "anthropic" | "vertex" | "vertex_ai" => "anthropic",
@@ -60,6 +61,13 @@ fn canonicalize_provider_segment(segment: &str) -> Option<String> {
 
 pub fn canonical_provider(raw: &str) -> Option<String> {
     provider_tags(raw).into_iter().next()
+}
+
+pub fn is_self_hosted_provider(raw: &str) -> bool {
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "llama.cpp" | "llama.cpp_modal"
+    )
 }
 
 pub fn provider_tags(raw: &str) -> Vec<String> {
@@ -372,6 +380,7 @@ mod tests {
             ("MiniMax", vec!["minimax"]),
             ("openrouter/google", vec!["openrouter", "google"]),
             ("bedrock/anthropic", vec!["bedrock", "anthropic"]),
+            ("kimi_for_coding", vec!["moonshotai"]),
         ];
 
         for (raw, expected) in cases {
@@ -388,6 +397,14 @@ mod tests {
         );
         assert_eq!(canonical_provider("<synthetic>"), None);
         assert_eq!(canonical_provider("unknown"), None);
+    }
+
+    #[test]
+    fn self_hosted_runtime_classification_is_canonical_provider_policy() {
+        for provider in ["llama.cpp", "LLAMA.CPP_MODAL"] {
+            assert!(is_self_hosted_provider(provider));
+        }
+        assert!(!is_self_hosted_provider("openrouter"));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -418,8 +418,14 @@ mod tests {
             msg.workspace_key.as_deref(),
             Some("/Users/alice/current-opencode-repo")
         );
-        assert_eq!(msg.workspace_label.as_deref(), Some("current-opencode-repo"));
-        assert_eq!(msg.session_title.as_deref(), Some("Current OpenCode session"));
+        assert_eq!(
+            msg.workspace_label.as_deref(),
+            Some("current-opencode-repo")
+        );
+        assert_eq!(
+            msg.session_title.as_deref(),
+            Some("Current OpenCode session")
+        );
         assert_eq!(msg.dedup_key.as_deref(), Some("msg_current_v2"));
     }
 
@@ -450,7 +456,11 @@ mod tests {
         drop(conn);
 
         let messages = parse_opencode_sqlite(&db_path);
-        assert_eq!(messages.len(), 1, "usage should parse without session metadata");
+        assert_eq!(
+            messages.len(),
+            1,
+            "usage should parse without session metadata"
+        );
         assert_eq!(messages[0].workspace_key, None);
         assert_eq!(messages[0].session_title, None);
         assert_eq!(


### PR DESCRIPTION
## Problem

Tokscale detected and counted usage for these models, but excluded it from submission as unpriced. The pricing resolver could locate matching rates, while the submission-safety check could not prove that scanner-specific provider and model identifiers referred to the same authoritative pricing entries.

This affected Cursor Grok reasoning tiers, Kimi K3 usage reported through `kimi_for_coding`, and self-hosted llama.cpp models. Temporary model identifiers such as OpenRouter's `ox-alpha` remain catalog-driven and are intentionally not hardcoded.

## Summary

- resolve scanner-specific Cursor Grok model identifiers to authoritative pricing entries
- preserve upstream-first pricing precedence for ordinary aliases while explicitly marking aliases that require Cursor pricing
- canonicalize `kimi_for_coding` as Moonshot so Kimi K3 pricing is submission-safe
- centralize self-hosted runtime identity in the provider model and provide zero-cost pricing through a dedicated pricing source
- keep reseller fallbacks untrusted unless the matched pricing key also establishes the requested provider
- honor explicit pricing-source constraints for self-hosted providers

## Testing

All local checks passed:

- [x] `rustfmt --edition 2021 --check crates/tokscale-core/src/pricing/aliases.rs crates/tokscale-core/src/pricing/lookup.rs crates/tokscale-core/src/pricing/mod.rs crates/tokscale-core/src/pricing/self_hosted.rs crates/tokscale-core/src/provider_identity.rs`
- [x] `cargo clippy --locked -p tokscale-core --all-features -- -D warnings`
- [x] `cargo test -p tokscale-core --all-features` (1,823 passed, 2 intentionally ignored)
- [x] `cargo build -p tokscale-cli`
- [x] `target/debug/tokscale --no-spinner pricing cursor-grok-4.6-high`
- [x] `target/debug/tokscale --no-spinner pricing k3`
- [x] `target/debug/tokscale --no-spinner submit --dry-run`
