### PR TITLE
feat(usage): add OpenCode Go subscription usage provider

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -838,6 +838,7 @@ TUI では **Usage** タブに移動するとサブスクリプションデー�
 | **Kimi** | OAuth（`~/.kimi/credentials/kimi-code.json`） | Session、Weekly クォータ | `kimi` を実行してログイン |
 | **MiniMax** | API キー（環境変数） | モデルごとのプロンプトクォータ | `MINIMAX_API_KEY` または `MINIMAX_API_TOKEN` を設定 |
 | **MiniMax Token Plan** | API キー（環境変数） | 期間 + 週間の残量パーセントクォータ（リージョン別: CN minimaxi.com + Global minimax.io） | `MINIMAX_TOKEN_PLAN_CN_KEY` および/または `MINIMAX_TOKEN_PLAN_GLOBAL_KEY` を設定 |
+| **OpenCode Go** | API キー（`~/.local/share/opencode/auth.json` または環境変数） | Rolling、Weekly、Monthly クォータ | OpenCode で `/connect` を実行、または `OPENCODE_API_KEY` を設定 |
 | **Sakana**（Fugu） | セッションクッキー（環境変数またはファイル） — 課金コンソールの HTML スクレイプ、公開 API なし | 5時間、Weekly クォータウィンドウ（プランティアと月額料金をメタデータとして） | `SAKANA_SESSION_COOKIE` を設定（[docs/providers/sakana.md](docs/providers/sakana.md) を参照） |
 
 プロバイダーは自動検出されます — 有効な資格情報を持つものだけが表示されます。プロバイダーが表示されない場合は、ログイン済みか、必要な環境変数が設定されているか確認してください。

--- a/README.ko.md
+++ b/README.ko.md
@@ -835,6 +835,7 @@ TUI에서는 **Usage** 탭으로 이동해 구독 데이터를 확인하세요. 
 | **Kimi** | OAuth (`~/.kimi/credentials/kimi-code.json`) | 세션, 주간 할당량 | `kimi`를 실행해 로그인 |
 | **MiniMax** | API 키 (환경 변수) | 모델별 프롬프트 할당량 | `MINIMAX_API_KEY` 또는 `MINIMAX_API_TOKEN` 설정 |
 | **MiniMax Token Plan** | API 키 (환경 변수) | 구간 + 주간 잔여 비율 할당량 (지역별: CN minimaxi.com + Global minimax.io) | `MINIMAX_TOKEN_PLAN_CN_KEY` 및/또는 `MINIMAX_TOKEN_PLAN_GLOBAL_KEY` 설정 |
+| **OpenCode Go** | API 키 (`~/.local/share/opencode/auth.json` 또는 환경 변수) | Rolling, Weekly, Monthly 할당량 | OpenCode에서 `/connect` 실행, 또는 `OPENCODE_API_KEY` 설정 |
 | **Sakana** (Fugu) | 세션 쿠키 (환경 변수 또는 파일) — 빌링 콘솔 HTML 스크레이프, 공개 API 없음 | 5시간, 주간 할당량 창 (플랜 티어 + 월 가격은 메타데이터) | `SAKANA_SESSION_COOKIE` 설정 ([docs/providers/sakana.md](docs/providers/sakana.md) 참조) |
 
 프로바이더는 자동 감지됩니다 — 유효한 자격 증명이 있는 프로바이더만 표시됩니다. 프로바이더가 보이지 않으면 로그인했는지 또는 필요한 환경 변수를 설정했는지 확인하세요.

--- a/README.md
+++ b/README.md
@@ -840,6 +840,7 @@ In the TUI, navigate to the **Usage** tab to see subscription data. Use `[Refres
 | **Kimi** | OAuth (`~/.kimi/credentials/kimi-code.json`) | Session, Weekly quotas | Run `kimi` to log in |
 | **MiniMax** | API key (env var) | Prompt quotas per model | Set `MINIMAX_API_KEY` or `MINIMAX_API_TOKEN` |
 | **MiniMax Token Plan** | API key (env var) | Interval + weekly remaining-percent quotas (per region: CN minimaxi.com + Global minimax.io) | Set `MINIMAX_TOKEN_PLAN_CN_KEY` and/or `MINIMAX_TOKEN_PLAN_GLOBAL_KEY` |
+| **OpenCode Go** | API key (`~/.local/share/opencode/auth.json` or env var) | Rolling, Weekly, Monthly quotas | Run `/connect` in OpenCode, or set `OPENCODE_API_KEY` |
 | **Sakana** (Fugu) | Session cookie (env var or file) — billing-console HTML scrape, no public API | 5-hour, Weekly quota windows (plan tier + monthly price as metadata) | Set `SAKANA_SESSION_COOKIE` (see [docs/providers/sakana.md](docs/providers/sakana.md)) |
 
 Providers are auto-detected — only those with valid credentials are shown. If a provider is missing, ensure you've logged in or set the required environment variable.

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -837,6 +837,7 @@ tokscale usage --light
 | **Kimi** | OAuth（`~/.kimi/credentials/kimi-code.json`） | Session、Weekly 配额 | 运行 `kimi` 登录 |
 | **MiniMax** | API key（环境变量） | 各模型的 Prompt 配额 | 设置 `MINIMAX_API_KEY` 或 `MINIMAX_API_TOKEN` |
 | **MiniMax Token Plan** | API key（环境变量） | 区间 + 每周剩余百分比配额（按区域：CN minimaxi.com + Global minimax.io） | 设置 `MINIMAX_TOKEN_PLAN_CN_KEY` 和/或 `MINIMAX_TOKEN_PLAN_GLOBAL_KEY` |
+| **OpenCode Go** | API 密钥（`~/.local/share/opencode/auth.json` 或环境变量） | Rolling、Weekly、Monthly 配额 | 在 OpenCode 中运行 `/connect`，或设置 `OPENCODE_API_KEY` |
 | **Sakana**（Fugu） | 会话 cookie（环境变量或文件）—— 计费控制台 HTML 抓取，无公开 API | 5 小时、Weekly 配额窗口（套餐等级 + 月度价格作为元数据） | 设置 `SAKANA_SESSION_COOKIE`（参见 [docs/providers/sakana.md](docs/providers/sakana.md)） |
 
 提供商会被自动检测——仅显示具有有效凭据的提供商。如果缺少某个提供商，请确认您已登录或设置了所需的环境变量。

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -9,6 +9,7 @@ pub mod helpers;
 mod kimi;
 mod minimax;
 mod minimax_tokenplan;
+mod opencode_go;
 mod sakana;
 #[cfg(test)]
 mod test_server;
@@ -406,6 +407,11 @@ fn usage_providers(codex_fetch: Fetch) -> Vec<UsageProvider> {
             "Sakana",
             sakana::has_credentials,
             Fetch::Single(sakana::fetch),
+        ),
+        (
+            "OpenCode Go",
+            opencode_go::has_credentials,
+            Fetch::Multi(opencode_go::fetch_all),
         ),
     ]
 }

--- a/crates/tokscale-cli/src/commands/usage/opencode_go.rs
+++ b/crates/tokscale-cli/src/commands/usage/opencode_go.rs
@@ -163,7 +163,9 @@ fn fetch_blocking(usage_url: &str, auth_path: &Path) -> Result<Vec<UsageOutput>>
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()?;
         let resp = client
             .get(usage_url)
             .header("Authorization", format!("Bearer {api_key}"))
@@ -192,7 +194,7 @@ fn fetch_blocking(usage_url: &str, auth_path: &Path) -> Result<Vec<UsageOutput>>
             }
             anyhow::bail!(
                 "usage request failed (HTTP {status}): {}",
-                server_msg.unwrap_or(body)
+                server_msg.unwrap_or_else(|| body.chars().take(200).collect::<String>())
             );
         }
 
@@ -482,6 +484,16 @@ mod tests {
         r#"{"type":"error","error":{"type":"AuthError","message":"Missing API key."}}"#;
     const ENTITLEMENT_ERROR_BODY: &str = r#"{"type":"error","error":{"type":"EntitlementError","message":"OpenCode Go subscription required."}}"#;
 
+    /// Non-JSON HTML error page longer than 200 chars; the marker sits past
+    /// the truncation point.
+    const CDN_ERROR_BODY: &str = concat!(
+        "<html><head><title>502 Bad Gateway</title></head><body>",
+        "........................................................",
+        "........................................................",
+        "........................................................",
+        "<p>TAIL-MARKER</p></body></html>"
+    );
+
     fn write_auth(dir: &Path, key: &str) -> PathBuf {
         let path = dir.join("auth.json");
         std::fs::write(
@@ -584,6 +596,25 @@ mod tests {
         assert!(
             err.to_string().contains("403"),
             "non-entitlement 403 must surface as error: {err}"
+        );
+    }
+
+    /// A CDN 502 returns a full HTML page, not the API's JSON error shape.
+    /// The one-line diagnostic must not dump the whole body.
+    #[test]
+    #[serial_test::serial]
+    fn generic_failure_truncates_non_json_body() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let auth = write_auth(tmp.path(), "sk-cdn");
+        let _guard = EnvVarGuard::remove("OPENCODE_API_KEY");
+        let (url, _log) = spawn_usage_server(502, CDN_ERROR_BODY);
+
+        let err = fetch_blocking(&url, &auth).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("502"), "should mention HTTP status: {msg}");
+        assert!(
+            !msg.contains("TAIL-MARKER"),
+            "body beyond 200 chars must not appear: {msg}"
         );
     }
 

--- a/crates/tokscale-cli/src/commands/usage/opencode_go.rs
+++ b/crates/tokscale-cli/src/commands/usage/opencode_go.rs
@@ -1,0 +1,682 @@
+use anyhow::Result;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+use super::{UsageMetric, UsageOutput};
+
+const USAGE_URL: &str = "https://opencode.ai/zen/go/v1/usage";
+
+#[derive(Debug, Deserialize)]
+struct ApiResponse {
+    usage: Option<UsageData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UsageData {
+    rolling: Option<WindowMetric>,
+    weekly: Option<WindowMetric>,
+    monthly: Option<WindowMetric>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WindowMetric {
+    status: Option<String>,
+    percent: Option<f64>,
+    #[serde(rename = "resetsAt")]
+    resets_at: Option<String>,
+}
+
+/// The server returns `{ type: "error", error: { type, message } }` on 401/403.
+#[derive(Debug, Deserialize)]
+struct ErrorResponse {
+    error: Option<ErrorDetail>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrorDetail {
+    #[serde(rename = "type")]
+    error_type: Option<String>,
+    message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuthDocument {
+    #[serde(rename = "opencode-go")]
+    opencode_go: Option<AuthEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum AuthEntry {
+    #[serde(rename = "api")]
+    Api { key: String },
+    #[serde(other)]
+    Other,
+}
+
+fn auth_path() -> PathBuf {
+    let data_dir = std::env::var_os("XDG_DATA_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            crate::paths::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(".local")
+                .join("share")
+        });
+    data_dir.join("opencode").join("auth.json")
+}
+
+fn read_key_from_auth_at(path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    parse_key_from_auth(&content)
+}
+
+fn read_key_from_auth() -> Option<String> {
+    read_key_from_auth_at(&auth_path())
+}
+
+fn parse_key_from_auth(content: &str) -> Option<String> {
+    let doc: AuthDocument = serde_json::from_str(content).ok()?;
+    match doc.opencode_go? {
+        AuthEntry::Api { key } if !key.trim().is_empty() => Some(key),
+        _ => None,
+    }
+}
+
+fn read_api_key_at(path: &Path) -> Result<String> {
+    if let Some(key) = read_key_from_auth_at(path) {
+        return Ok(key);
+    }
+    if let Ok(key) = std::env::var("OPENCODE_API_KEY") {
+        if !key.trim().is_empty() {
+            return Ok(key);
+        }
+    }
+    anyhow::bail!(
+        "No OpenCode Go credentials found. \
+         Run '/connect' in OpenCode to set up OpenCode Go, \
+         or set OPENCODE_API_KEY."
+    )
+}
+
+fn parse_error(body: &str) -> Option<ErrorDetail> {
+    serde_json::from_str::<ErrorResponse>(body).ok()?.error
+}
+
+fn extract_error_message(body: &str) -> Option<String> {
+    parse_error(body)?.message.filter(|m| !m.trim().is_empty())
+}
+
+fn is_entitlement_error(body: &str) -> bool {
+    parse_error(body)
+        .and_then(|d| d.error_type)
+        .map(|t| t == "EntitlementError")
+        .unwrap_or(false)
+}
+
+fn window_to_metric(label: &str, w: &WindowMetric) -> UsageMetric {
+    let used = w.percent.unwrap_or(0.0).clamp(0.0, 100.0);
+    UsageMetric {
+        label: label.into(),
+        used_percent: used,
+        remaining_percent: 100.0 - used,
+        remaining_label: w
+            .status
+            .as_deref()
+            .filter(|s| *s == "rate-limited")
+            .map(|_| "rate-limited".into()),
+        resets_at: w.resets_at.clone(),
+    }
+}
+
+fn usage_metrics(resp: &ApiResponse) -> Vec<UsageMetric> {
+    let Some(ref usage) = resp.usage else {
+        return Vec::new();
+    };
+    let mut metrics = Vec::new();
+    if let Some(ref w) = usage.rolling {
+        metrics.push(window_to_metric("Rolling", w));
+    }
+    if let Some(ref w) = usage.weekly {
+        metrics.push(window_to_metric("Weekly", w));
+    }
+    if let Some(ref w) = usage.monthly {
+        metrics.push(window_to_metric("Monthly", w));
+    }
+    metrics
+}
+
+pub fn has_credentials() -> bool {
+    read_key_from_auth().is_some()
+        || std::env::var("OPENCODE_API_KEY")
+            .map(|k| !k.trim().is_empty())
+            .unwrap_or(false)
+}
+
+/// Injected URL and auth path so tests can point at a local server and a
+/// temp credential file without touching the real filesystem or network.
+fn fetch_blocking(usage_url: &str, auth_path: &Path) -> Result<Vec<UsageOutput>> {
+    let api_key = read_api_key_at(auth_path)?;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async {
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(usage_url)
+            .header("Authorization", format!("Bearer {api_key}"))
+            .header("Accept", "application/json")
+            .send()
+            .await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let server_msg = extract_error_message(&body);
+
+            if status == reqwest::StatusCode::UNAUTHORIZED {
+                let detail = server_msg.unwrap_or_else(|| "API key rejected".into());
+                anyhow::bail!(
+                    "{detail} (HTTP 401). \
+                     Run '/connect' in OpenCode to refresh, or check OPENCODE_API_KEY."
+                );
+            }
+            if status == reqwest::StatusCode::FORBIDDEN && is_entitlement_error(&body) {
+                return Ok(Vec::new());
+            }
+            if status == reqwest::StatusCode::FORBIDDEN {
+                let detail = server_msg.unwrap_or_else(|| "Forbidden".into());
+                anyhow::bail!("{detail} (HTTP 403)");
+            }
+            anyhow::bail!(
+                "usage request failed (HTTP {status}): {}",
+                server_msg.unwrap_or(body)
+            );
+        }
+
+        let body: ApiResponse = resp.json().await?;
+        let metrics = usage_metrics(&body);
+
+        Ok(vec![UsageOutput {
+            provider: "OpenCode Go".into(),
+            account: None,
+            credential_source: None,
+            plan: Some("Go".into()),
+            email: None,
+            metrics,
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
+        }])
+    })
+}
+
+pub fn fetch_all() -> Result<Vec<UsageOutput>> {
+    fetch_blocking(USAGE_URL, &auth_path())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use crate::commands::usage::test_server::{spawn_server, Seen};
+
+    #[test]
+    fn parses_api_key_from_auth_document() {
+        let key = parse_key_from_auth(r#"{"opencode-go":{"type":"api","key":"sk-test-key-123"}}"#);
+        assert_eq!(key.as_deref(), Some("sk-test-key-123"));
+    }
+
+    #[test]
+    fn ignores_oauth_entry_in_auth_document() {
+        let key = parse_key_from_auth(
+            r#"{"opencode-go":{"type":"oauth","access":"tok","refresh":"ref","expires":9999}}"#,
+        );
+        assert!(key.is_none(), "oauth entries must not produce an API key");
+    }
+
+    #[test]
+    fn ignores_empty_api_key() {
+        assert!(parse_key_from_auth(r#"{"opencode-go":{"type":"api","key":""}}"#).is_none());
+        assert!(parse_key_from_auth(r#"{"opencode-go":{"type":"api","key":"   "}}"#).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_opencode_go_entry_missing() {
+        assert!(parse_key_from_auth(
+            r#"{"openai":{"type":"oauth","access":"tok","accountId":"acct"}}"#
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn returns_none_for_malformed_json() {
+        assert!(parse_key_from_auth("not json").is_none());
+        assert!(parse_key_from_auth("").is_none());
+    }
+
+    #[test]
+    fn reads_key_from_auth_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("auth.json");
+        std::fs::write(
+            &path,
+            r#"{"opencode-go":{"type":"api","key":"sk-file-key"}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(read_key_from_auth_at(&path).as_deref(), Some("sk-file-key"));
+    }
+
+    #[test]
+    fn returns_none_for_missing_auth_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("does-not-exist.json");
+        assert!(read_key_from_auth_at(&path).is_none());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn auth_path_honors_xdg_data_home() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("XDG_DATA_HOME", tmp.path().to_str().unwrap());
+
+        assert_eq!(auth_path(), tmp.path().join("opencode").join("auth.json"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn auth_path_ignores_blank_xdg_data_home() {
+        let _guard = EnvVarGuard::set("XDG_DATA_HOME", "");
+        let unset = {
+            let _g = EnvVarGuard::remove("XDG_DATA_HOME");
+            auth_path()
+        };
+
+        let blank = auth_path();
+        assert_eq!(blank, unset);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn prefers_auth_file_over_env_var() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("auth.json");
+        std::fs::write(
+            &path,
+            r#"{"opencode-go":{"type":"api","key":"sk-from-file"}}"#,
+        )
+        .unwrap();
+        let _guard = EnvVarGuard::set("OPENCODE_API_KEY", "sk-from-env");
+
+        let key = read_api_key_at(&path).unwrap();
+        assert_eq!(key, "sk-from-file");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn falls_back_to_env_var_when_auth_file_missing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("no-file.json");
+        let _guard = EnvVarGuard::set("OPENCODE_API_KEY", "sk-env-fallback");
+
+        let key = read_api_key_at(&path).unwrap();
+        assert_eq!(key, "sk-env-fallback");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn errors_when_no_credentials_available() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("no-file.json");
+        let _guard = EnvVarGuard::remove("OPENCODE_API_KEY");
+
+        let err = read_api_key_at(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("/connect"),
+            "error should guide the user: {err}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn blank_env_var_is_not_a_credential() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("no-file.json");
+        let _guard = EnvVarGuard::set("OPENCODE_API_KEY", "   ");
+
+        assert!(read_api_key_at(&path).is_err());
+    }
+
+    #[test]
+    fn window_to_metric_normal_usage() {
+        let w = WindowMetric {
+            status: Some("ok".into()),
+            percent: Some(42.5),
+            resets_at: Some("2026-09-01T00:00:00Z".into()),
+        };
+        let m = window_to_metric("Rolling", &w);
+        assert_eq!(m.label, "Rolling");
+        assert!((m.used_percent - 42.5).abs() < f64::EPSILON);
+        assert!((m.remaining_percent - 57.5).abs() < f64::EPSILON);
+        assert!(m.remaining_label.is_none());
+        assert_eq!(m.resets_at.as_deref(), Some("2026-09-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn window_to_metric_rate_limited() {
+        let w = WindowMetric {
+            status: Some("rate-limited".into()),
+            percent: Some(100.0),
+            resets_at: None,
+        };
+        let m = window_to_metric("Weekly", &w);
+        assert_eq!(m.remaining_label.as_deref(), Some("rate-limited"));
+    }
+
+    #[test]
+    fn window_to_metric_clamps_out_of_range_percent() {
+        let over = WindowMetric {
+            status: None,
+            percent: Some(150.0),
+            resets_at: None,
+        };
+        let m = window_to_metric("X", &over);
+        assert_eq!(m.used_percent, 100.0);
+        assert_eq!(m.remaining_percent, 0.0);
+
+        let under = WindowMetric {
+            status: None,
+            percent: Some(-10.0),
+            resets_at: None,
+        };
+        let m = window_to_metric("X", &under);
+        assert_eq!(m.used_percent, 0.0);
+        assert_eq!(m.remaining_percent, 100.0);
+    }
+
+    #[test]
+    fn window_to_metric_missing_percent_defaults_to_zero() {
+        let w = WindowMetric {
+            status: None,
+            percent: None,
+            resets_at: None,
+        };
+        let m = window_to_metric("Rolling", &w);
+        assert_eq!(m.used_percent, 0.0);
+        assert_eq!(m.remaining_percent, 100.0);
+    }
+
+    #[test]
+    fn usage_metrics_parses_all_three_windows() {
+        let resp: ApiResponse = serde_json::from_str(FULL_USAGE_BODY).unwrap();
+        let metrics = usage_metrics(&resp);
+
+        assert_eq!(metrics.len(), 3);
+        assert_eq!(metrics[0].label, "Rolling");
+        assert!((metrics[0].used_percent - 25.0).abs() < f64::EPSILON);
+        assert_eq!(metrics[1].label, "Weekly");
+        assert!((metrics[1].used_percent - 50.0).abs() < f64::EPSILON);
+        assert_eq!(metrics[2].label, "Monthly");
+        assert!((metrics[2].used_percent - 10.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn usage_metrics_handles_partial_response() {
+        let resp: ApiResponse = serde_json::from_str(
+            r#"{"usage":{"weekly":{"status":"ok","percent":33,"resetsAt":"2026-09-01T00:00:00Z"}}}"#,
+        )
+        .unwrap();
+        let metrics = usage_metrics(&resp);
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].label, "Weekly");
+    }
+
+    #[test]
+    fn usage_metrics_empty_when_no_usage() {
+        let resp: ApiResponse = serde_json::from_str(r#"{}"#).unwrap();
+        assert!(usage_metrics(&resp).is_empty());
+    }
+
+    #[test]
+    fn extract_error_message_parses_server_error() {
+        let msg = extract_error_message(
+            r#"{"type":"error","error":{"type":"AuthError","message":"Missing API key."}}"#,
+        );
+        assert_eq!(msg.as_deref(), Some("Missing API key."));
+    }
+
+    #[test]
+    fn extract_error_message_returns_none_for_non_error_body() {
+        assert!(extract_error_message(r#"{"usage":{}}"#).is_none());
+        assert!(extract_error_message("not json").is_none());
+        assert!(extract_error_message("").is_none());
+    }
+
+    const USAGE_PATH: &str = "/zen/go/v1/usage";
+
+    const FULL_USAGE_BODY: &str = r#"{
+  "usage": {
+    "rolling": {
+      "status": "ok",
+      "percent": 25.0,
+      "resetsAt": "2026-09-01T02:15:00Z"
+    },
+    "weekly": {
+      "status": "ok",
+      "percent": 50.0,
+      "resetsAt": "2026-09-05T00:00:00Z"
+    },
+    "monthly": {
+      "status": "ok",
+      "percent": 10.0,
+      "resetsAt": "2026-10-01T00:00:00Z"
+    }
+  }
+}"#;
+
+    const AUTH_ERROR_BODY: &str =
+        r#"{"type":"error","error":{"type":"AuthError","message":"Missing API key."}}"#;
+    const ENTITLEMENT_ERROR_BODY: &str = r#"{"type":"error","error":{"type":"EntitlementError","message":"OpenCode Go subscription required."}}"#;
+
+    fn write_auth(dir: &Path, key: &str) -> PathBuf {
+        let path = dir.join("auth.json");
+        std::fs::write(
+            &path,
+            format!(r#"{{"opencode-go":{{"type":"api","key":"{key}"}}}}"#),
+        )
+        .unwrap();
+        path
+    }
+
+    fn spawn_usage_server(status: u16, body: &'static str) -> (String, Arc<Mutex<Vec<Seen>>>) {
+        let (base, log) = spawn_server(move |path, _| {
+            if path == USAGE_PATH {
+                (status, body.to_string())
+            } else {
+                (404, "{}".to_string())
+            }
+        });
+        (format!("{base}{USAGE_PATH}"), log)
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn successful_fetch_returns_all_metrics() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let auth = write_auth(tmp.path(), "sk-test");
+        let _guard = EnvVarGuard::remove("OPENCODE_API_KEY");
+        let (url, log) = spawn_usage_server(200, FULL_USAGE_BODY);
+
+        let outputs = fetch_blocking(&url, &auth).expect("200 should parse");
+        assert_eq!(outputs.len(), 1);
+        let output = &outputs[0];
+
+        assert_eq!(output.provider, "OpenCode Go");
+        assert_eq!(output.plan.as_deref(), Some("Go"));
+        assert_eq!(output.metrics.len(), 3);
+        assert_eq!(output.metrics[0].label, "Rolling");
+        assert_eq!(output.metrics[1].label, "Weekly");
+        assert_eq!(output.metrics[2].label, "Monthly");
+
+        let seen = log.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].request, format!("GET {USAGE_PATH}"));
+        assert_eq!(seen[0].bearer.as_deref(), Some("sk-test"));
+    }
+
+    /// The server returns `AuthError` with "Missing API key." on 401. The
+    /// error must surface that server message alongside actionable guidance.
+    #[test]
+    #[serial_test::serial]
+    fn unauthorized_response_surfaces_server_message() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let auth = write_auth(tmp.path(), "sk-expired");
+        let _guard = EnvVarGuard::remove("OPENCODE_API_KEY");
+        let (url, _log) = spawn_usage_server(401, AUTH_ERROR_BODY);
+
+        let err = fetch_blocking(&url, &auth).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Missing API key."),
+            "should include server message: {msg}"
+        );
+        assert!(msg.contains("401"), "should mention HTTP status: {msg}");
+        assert!(
+            msg.contains("/connect"),
+            "should guide user to /connect: {msg}"
+        );
+        assert!(
+            !msg.starts_with("OpenCode Go:"),
+            "error must not duplicate the provider prefix: {msg}"
+        );
+    }
+
+    /// 403 means the user has an API key but no active Go subscription.
+    /// This is not an error — the provider is silently omitted.
+    #[test]
+    #[serial_test::serial]
+    fn forbidden_response_returns_empty_output() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let auth = write_auth(tmp.path(), "sk-no-sub");
+        let _guard = EnvVarGuard::remove("OPENCODE_API_KEY");
+        let (url, _log) = spawn_usage_server(403, ENTITLEMENT_ERROR_BODY);
+
+        let outputs = fetch_blocking(&url, &auth).expect("403 entitlement must not be an error");
+        assert!(outputs.is_empty(), "no-subscription must return empty vec");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn non_entitlement_forbidden_is_an_error() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let auth = write_auth(tmp.path(), "sk-other");
+        let _guard = EnvVarGuard::remove("OPENCODE_API_KEY");
+        let (url, _log) = spawn_usage_server(
+            403,
+            r#"{"type":"error","error":{"type":"OtherError","message":"Something else."}}"#,
+        );
+
+        let err = fetch_blocking(&url, &auth).unwrap_err();
+        assert!(
+            err.to_string().contains("403"),
+            "non-entitlement 403 must surface as error: {err}"
+        );
+    }
+
+    #[test]
+    fn is_entitlement_error_detects_entitlement_type() {
+        assert!(is_entitlement_error(ENTITLEMENT_ERROR_BODY));
+        assert!(!is_entitlement_error(AUTH_ERROR_BODY));
+        assert!(!is_entitlement_error(
+            r#"{"type":"error","error":{"type":"OtherError"}}"#
+        ));
+        assert!(!is_entitlement_error("not json"));
+        assert!(!is_entitlement_error(""));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn fetch_uses_env_var_when_auth_file_absent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let auth = tmp.path().join("no-file.json");
+        let _guard = EnvVarGuard::set("OPENCODE_API_KEY", "sk-env-key");
+        let (url, log) = spawn_usage_server(200, FULL_USAGE_BODY);
+
+        let outputs = fetch_blocking(&url, &auth).expect("env var fallback should work");
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].metrics.len(), 3);
+
+        let seen = log.lock().unwrap();
+        assert_eq!(seen[0].bearer.as_deref(), Some("sk-env-key"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn fetch_errors_with_no_credentials() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let auth = tmp.path().join("no-file.json");
+        let _guard = EnvVarGuard::remove("OPENCODE_API_KEY");
+
+        let err = fetch_blocking("http://127.0.0.1:1/unused", &auth).unwrap_err();
+        assert!(
+            err.to_string().contains("No OpenCode Go credentials"),
+            "should report missing credentials: {err}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn auth_file_not_touched_on_rejected_token() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let auth = write_auth(tmp.path(), "sk-readonly");
+        let _guard = EnvVarGuard::remove("OPENCODE_API_KEY");
+        let before = std::fs::read(&auth).unwrap();
+        let (url, _log) = spawn_usage_server(401, AUTH_ERROR_BODY);
+
+        let _ = fetch_blocking(&url, &auth);
+
+        let after = std::fs::read(&auth).unwrap();
+        assert_eq!(
+            before, after,
+            "tokscale must never rewrite OpenCode's auth.json"
+        );
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add OpenCode Go as a subscription usage provider in `tokscale usage`. Reads the API key from `~/.local/share/opencode/auth.json` (the `opencode-go` entry written by `/connect`) with `OPENCODE_API_KEY` env var fallback, and fetches rolling/weekly/monthly quota from `https://opencode.ai/zen/go/v1/usage`.

Closes junhoyeo/tokscale#1103

## What changed

- New `opencode_go.rs` usage provider module with `has_credentials()` / `fetch_all()`
- Registered as `Fetch::Multi` in `usage_providers()` so 403 EntitlementError (no active subscription) silently omits the provider instead of showing a "— skipped" diagnostic
- Auth precedence: `auth.json` `opencode-go` api key → `OPENCODE_API_KEY` env var
- Parses the server's structured `{ type: "error", error: { type, message } }` response on 401/403 and surfaces the server message with actionable guidance
- Added OpenCode Go to the Supported Providers table in README (en/ko/ja/zh-cn)

## Testing

- 30 unit tests covering: auth.json parsing (api key, oauth ignored, empty key, missing file, malformed JSON), XDG_DATA_HOME resolution, credential precedence (file > env > error), window metric edge cases (clamping, missing percent, rate-limited status), usage response parsing (full/partial/empty), HTTP error handling via test_server (200, 401, 403 entitlement, 403 other, no credentials), and auth file immutability on rejected tokens
- `cargo fmt --check`: clean
- `cargo clippy -D warnings`: clean

## Verification
`usage --light`:

<img width="438" height="99" alt="Screenshot 2026-08-24 at 22 19 21" src="https://github.com/user-attachments/assets/62c5e200-55aa-4791-bd20-de3d592d1248" />

`usage --json`:
```json
{
  "provider": "OpenCode Go",
  "plan": "Go",
  "email": null,
  "metrics": [
    {
      "label": "Rolling",
      "used_percent": 0.0,
      "remaining_percent": 100.0,
      "remaining_label": null,
      "resets_at": "2026-08-24T18:22:00.952Z"
    },
    {
      "label": "Weekly",
      "used_percent": 0.0,
      "remaining_percent": 100.0,
      "remaining_label": null,
      "resets_at": "2026-08-31T00:00:00.952Z"
    },
    {
      "label": "Monthly",
      "used_percent": 0.0,
      "remaining_percent": 100.0,
      "remaining_label": null,
      "resets_at": "2026-09-24T12:11:13.952Z"
    }
  ]
}
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenCode Go as a subscription usage provider in `tokscale usage` and hardens failure modes. Previously unsupported and requests had no timeout; now quotas are shown, non-subscribed users see no noise, and hung requests stop after 30s with bounded error output.

- Registers `OpenCode Go` in `usage_providers()` as `Fetch::Multi`; a 403 `EntitlementError` returns no output instead of a "skipped" diagnostic.
- Reads the API key from `~/.local/share/opencode/auth.json` (`opencode-go`) with `OPENCODE_API_KEY` fallback; file takes precedence.
- Parses structured `{ type: "error" }` responses: 401 surfaces the server message with guidance; non-entitlement 403s error.
- Adds a 30s request timeout (matches `Sakana`) to prevent the TUI/CLI from hanging; truncates non-JSON error bodies to 200 chars.
- Updates the Supported Providers table in `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-cn.md`.

- No migration required. To enable, run `/connect` in OpenCode or set `OPENCODE_API_KEY`.

<sup>Written for commit d964e004659f446cb5fda53750daeda8f110ddad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



