### PR TITLE
feat(import): attribute ccusage --by-agent rows to the agent that reported them

### DIFF
--- a/crates/tokscale-cli/src/commands/import.rs
+++ b/crates/tokscale-cli/src/commands/import.rs
@@ -20,6 +20,11 @@
 //! - the unified/agent-aware report — `period`, `agent: "all"`, and
 //!   `metadata.agents` naming the participants. Reasoning, when present, is
 //!   nested under `metadata`, not beside the other token fields.
+//! - the same report run with `--by-agent` — every row additionally carries an
+//!   `agents` array, one entry per agent that ran that day, each with its own
+//!   `modelBreakdowns`. It is the only shape that records *who* made each
+//!   call, so it is attributed directly rather than guessed at by model
+//!   family; see [`resolve_client`].
 //! - `ccusage-codex` — spells cost `costUSD` and puts `reasoningOutputTokens`
 //!   beside the token fields (see ccusage#831).
 //!
@@ -83,6 +88,11 @@ pub struct ImportOutcome {
     /// but their summed tokens/cost diverge from the aggregate-level
     /// totals beyond a small tolerance — a sign of partial breakdown data.
     pub breakdown_reconciliation_warnings: Vec<String>,
+    /// Number of ccusage rows that carried `agents` (a `--by-agent` export)
+    /// and were therefore attributed to the client each breakdown was reported
+    /// under, rather than to whichever listed agent the model family matched.
+    /// Surfaced so the caller can say which of the two the numbers came from.
+    pub agent_attributed_rows: usize,
 }
 
 /// Parse an export of the given `format` into normalized tokscale data.
@@ -195,6 +205,8 @@ pub fn parse_clawdboard_export(json: &str) -> Result<ImportOutcome> {
     let mut non_finite_cost_rows = 0usize;
     let mut multi_model_fallback_rows = 0usize;
     let mut breakdown_reconciliation_warnings: Vec<String> = Vec::new();
+    // clawdboard rows are already per-client, so nothing here is agent-attributed.
+    let agent_attributed_rows = 0usize;
     let today = chrono::Utc::now().date_naive();
 
     for agg in &export.daily_aggregates {
@@ -335,6 +347,7 @@ pub fn parse_clawdboard_export(json: &str) -> Result<ImportOutcome> {
         non_finite_cost_rows,
         multi_model_fallback_rows,
         breakdown_reconciliation_warnings,
+        agent_attributed_rows,
     })
 }
 
@@ -394,6 +407,12 @@ struct CcusageDaily {
     model_breakdowns: Vec<CcusageModelBreakdown>,
     #[serde(default)]
     metadata: Option<CcusageMetadata>,
+    /// Present only under `--by-agent`: one entry per agent that ran that day,
+    /// each carrying its own `modelBreakdowns`. The row-level breakdowns are a
+    /// merge of these keyed by model name, so a model two agents both used
+    /// survives only here.
+    #[serde(default)]
+    agents: Vec<CcusageAgentBreakdown>,
 }
 
 impl CcusageDaily {
@@ -419,7 +438,8 @@ impl CcusageDaily {
     /// Whether the row carries no usage at all. ccusage emits a row for every
     /// day in the range, including days with nothing on them.
     fn is_empty_day(&self) -> bool {
-        self.model_breakdowns.is_empty()
+        self.agents.is_empty()
+            && self.model_breakdowns.is_empty()
             && self.models_used.is_empty()
             && self.input_tokens <= 0
             && self.output_tokens <= 0
@@ -441,6 +461,54 @@ struct CcusageMetadata {
     /// Where the unified report actually records reasoning output.
     #[serde(default)]
     reasoning_output_tokens: i64,
+}
+
+/// One agent's slice of a `--by-agent` row.
+///
+/// Same shape as the row itself minus `period`/`metadata`: ccusage serializes
+/// both from the same record (`agent_json` in its `adapter-all` crate), which
+/// is why the field names line up.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CcusageAgentBreakdown {
+    /// ccusage's own id for the agent (`claude`, `codex`, `opencode`, ...),
+    /// taken from its `BUILT_IN_AGENT_NAMES`. Every one of those ids is a
+    /// registered tokscale client, so this needs no inference — only the same
+    /// spelling normalization the rest of the importer applies.
+    agent: String,
+    #[serde(default)]
+    input_tokens: i64,
+    #[serde(default)]
+    output_tokens: i64,
+    #[serde(default)]
+    cache_creation_tokens: i64,
+    #[serde(default)]
+    cache_read_tokens: i64,
+    /// The unified report does not currently emit reasoning per agent (it is
+    /// dropped when rows are merged into `agent: "all"`), but `ccusage-codex`
+    /// spells it flat like this, so accept it if it ever appears here.
+    #[serde(default)]
+    reasoning_output_tokens: i64,
+    /// The agent's own `input + output + cacheCreation + cacheRead`. Used as a
+    /// per-agent cross-check, the same way the row's `totalTokens` is used for
+    /// the row.
+    #[serde(default)]
+    total_tokens: Option<i64>,
+    #[serde(default)]
+    total_cost: Option<CostValue>,
+    #[serde(default, rename = "costUSD", alias = "costUsd")]
+    cost_usd: Option<CostValue>,
+    #[serde(default)]
+    models_used: Vec<String>,
+    #[serde(default)]
+    model_breakdowns: Vec<CcusageModelBreakdown>,
+}
+
+impl CcusageAgentBreakdown {
+    /// `totalCost`, or `ccusage-codex`'s `costUSD` spelling of it.
+    fn declared_cost(&self) -> Option<&CostValue> {
+        self.total_cost.as_ref().or(self.cost_usd.as_ref())
+    }
 }
 
 #[derive(serde::Deserialize)]
@@ -525,13 +593,16 @@ fn ccusage_token_breakdown(
 /// than silently folded into the first one — misattributed usage is worse than
 /// usage the caller is told about.
 ///
-/// Known limit: this splits by *family*, not by which client actually made the
-/// call, and a family can belong to more than one listed agent. On a day with
-/// `["claude", "opencode"]`, Claude models all land on `claude` even though
-/// OpenCode routinely drives them — the unified row does not record enough to
-/// tell them apart. Splitting exactly needs ccusage's `--by-agent` output,
-/// where each agent carries its own `modelBreakdowns`; supporting that shape
-/// would remove the guess entirely and is the right follow-up here.
+/// This is a guess, and only a fallback. It splits by model *family*, not by
+/// which client actually made the call, and a family can belong to more than
+/// one listed agent: on a day with `["claude", "opencode"]`, Claude models all
+/// land on `claude` even though OpenCode routinely drives them. It also only
+/// knows three families, so on a multi-agent day the other thirteen agent ids
+/// ccusage can emit resolve to nothing and fall through to `unknown`.
+///
+/// A row carrying `agents` needs none of this — see [`attribute_agent`]. This
+/// path is what remains for the exports that predate `--by-agent` or were
+/// produced without it.
 fn resolve_client(model: &str, agents: &[String]) -> Option<String> {
     if agents.len() == 1 {
         return Some(normalize_client_id(&agents[0]));
@@ -595,6 +666,7 @@ pub fn parse_ccusage_export(json: &str) -> Result<ImportOutcome> {
     let mut non_finite_cost_rows = 0usize;
     let mut multi_model_fallback_rows = 0usize;
     let mut breakdown_reconciliation_warnings: Vec<String> = Vec::new();
+    let mut agent_attributed_rows = 0usize;
     let today = chrono::Utc::now().date_naive();
 
     for row in &export.daily {
@@ -628,7 +700,7 @@ pub fn parse_ccusage_export(json: &str) -> Result<ImportOutcome> {
             .unwrap_or_default();
         let day = days.entry(date.clone()).or_default();
 
-        if row.model_breakdowns.is_empty() {
+        if row.agents.is_empty() && row.model_breakdowns.is_empty() {
             // No per-model split: attribute the aggregate to the first listed
             // model, mirroring the clawdboard fallback.
             let model = row
@@ -664,32 +736,93 @@ pub fn parse_ccusage_export(json: &str) -> Result<ImportOutcome> {
         let mut mb_total = 0i64;
         let mut mb_cost = 0.0f64;
 
-        for mb in &row.model_breakdowns {
-            let client = attribute(&mb.model_name, &agents, &mut unknown);
-            let tokens = ccusage_token_breakdown(
-                mb.input_tokens,
-                mb.output_tokens,
-                mb.cache_read_tokens,
-                mb.cache_creation_tokens,
-                mb.reasoning_output_tokens,
-                &mut negative_values_clamped,
-            );
-            let raw_cost = sanitize_cost(mb.cost, &mut non_finite_cost_rows);
-            let cost = clamp_f64(raw_cost, &mut negative_values_clamped);
-            if cost > 0.0
-                && tokens.total() == 0
-                && !is_cursor_legacy_tokenless(&client, &mb.model_name)
-            {
-                suspect_cost_rows += 1;
+        if row.agents.is_empty() {
+            for mb in &row.model_breakdowns {
+                let client = attribute(&mb.model_name, &agents, &mut unknown);
+                let (tokens, cost) = add_model_breakdown(
+                    day,
+                    &client,
+                    mb,
+                    &mut negative_values_clamped,
+                    &mut non_finite_cost_rows,
+                    &mut suspect_cost_rows,
+                );
+                mb_total = mb_total.saturating_add(tokens);
+                mb_cost += cost;
             }
+        } else {
+            // `--by-agent`: the row names the agent behind every breakdown, so
+            // each one is attributed to the client that reported it and the
+            // family guess never runs. Two agents sharing a model stay apart
+            // here; the row-level `modelBreakdowns` has already merged them.
+            agent_attributed_rows += 1;
+            for agent in &row.agents {
+                let client = attribute_agent(&agent.agent, &mut unknown);
+                let mut agent_total = 0i64;
 
-            // `total()` re-adds the reasoning that `ccusage_token_breakdown`
-            // moved out of `output`, so this sum is back in ccusage's own
-            // vocabulary and is directly comparable to the row's scalars.
-            mb_total = mb_total.saturating_add(tokens.total());
-            mb_cost += cost;
+                if agent.model_breakdowns.is_empty() {
+                    // Same fallback as the row-level one, scoped to this agent.
+                    let model = agent
+                        .models_used
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| "unknown".to_string());
+                    if agent.models_used.len() > 1 {
+                        multi_model_fallback_rows += 1;
+                    }
+                    let raw_cost = agent
+                        .declared_cost()
+                        .map(|c| c.resolve(&mut unparseable_cost_rows))
+                        .unwrap_or(0.0);
+                    let raw_cost = sanitize_cost(raw_cost, &mut non_finite_cost_rows);
+                    let cost = clamp_f64(raw_cost, &mut negative_values_clamped);
+                    let tokens = ccusage_token_breakdown(
+                        agent.input_tokens,
+                        agent.output_tokens,
+                        agent.cache_read_tokens,
+                        agent.cache_creation_tokens,
+                        agent.reasoning_output_tokens,
+                        &mut negative_values_clamped,
+                    );
+                    if cost > 0.0
+                        && tokens.total() == 0
+                        && !is_cursor_legacy_tokenless(&client, &model)
+                    {
+                        suspect_cost_rows += 1;
+                    }
+                    agent_total = agent_total.saturating_add(tokens.total());
+                    mb_cost += cost;
+                    add_row(day, &client, &model, tokens, cost);
+                } else {
+                    for mb in &agent.model_breakdowns {
+                        let (tokens, cost) = add_model_breakdown(
+                            day,
+                            &client,
+                            mb,
+                            &mut negative_values_clamped,
+                            &mut non_finite_cost_rows,
+                            &mut suspect_cost_rows,
+                        );
+                        agent_total = agent_total.saturating_add(tokens);
+                        mb_cost += cost;
+                    }
+                }
 
-            add_row(day, &client, &mb.model_name, tokens, cost);
+                // Each agent entry declares its own `totalTokens`, so the
+                // row-level cross-check has a per-agent counterpart: it is what
+                // catches one agent's buckets being mapped through twice on a
+                // day whose row total still happens to add up.
+                if let Some(declared) = agent.total_tokens.filter(|t| *t > 0) {
+                    if tokens_diverge(agent_total, declared) {
+                        breakdown_reconciliation_warnings.push(format!(
+                            "{date}: agent '{}' imported {agent_total} token(s) but its own totalTokens reports {declared}",
+                            agent.agent
+                        ));
+                    }
+                }
+
+                mb_total = mb_total.saturating_add(agent_total);
+            }
         }
 
         // ccusage always populates the aggregate scalars alongside the
@@ -748,7 +881,54 @@ pub fn parse_ccusage_export(json: &str) -> Result<ImportOutcome> {
         non_finite_cost_rows,
         multi_model_fallback_rows,
         breakdown_reconciliation_warnings,
+        agent_attributed_rows,
     })
+}
+
+/// Convert one ccusage model breakdown into a tokscale row.
+///
+/// Returns the row's tokens in ccusage's *own* vocabulary (`total()` re-adds
+/// the reasoning that [`ccusage_token_breakdown`] moved out of `output`) plus
+/// its cost, so callers can reconcile against the scalars the export declares.
+fn add_model_breakdown(
+    day: &mut DayBuilder,
+    client: &str,
+    mb: &CcusageModelBreakdown,
+    negative_values_clamped: &mut usize,
+    non_finite_cost_rows: &mut usize,
+    suspect_cost_rows: &mut usize,
+) -> (i64, f64) {
+    let tokens = ccusage_token_breakdown(
+        mb.input_tokens,
+        mb.output_tokens,
+        mb.cache_read_tokens,
+        mb.cache_creation_tokens,
+        mb.reasoning_output_tokens,
+        negative_values_clamped,
+    );
+    let raw_cost = sanitize_cost(mb.cost, non_finite_cost_rows);
+    let cost = clamp_f64(raw_cost, negative_values_clamped);
+    if cost > 0.0 && tokens.total() == 0 && !is_cursor_legacy_tokenless(client, &mb.model_name) {
+        *suspect_cost_rows += 1;
+    }
+    let total = tokens.total();
+    add_row(day, client, &mb.model_name, tokens, cost);
+    (total, cost)
+}
+
+/// Take the client from a `--by-agent` entry, which states it outright.
+///
+/// Nothing is inferred here: the row already says which agent produced the
+/// usage, so the only work left is mapping ccusage's spelling onto tokscale's
+/// client id and flagging an id tokscale does not register. Every id in
+/// ccusage's `BUILT_IN_AGENT_NAMES` is registered today, so the warning path
+/// exists for ids added upstream before they are added here.
+fn attribute_agent(agent: &str, unknown: &mut BTreeSet<String>) -> String {
+    let client = normalize_client_id(agent);
+    if ClientId::from_str(&client).is_none() {
+        unknown.insert(client.clone());
+    }
+    client
 }
 
 /// Resolve a model to its client, recording anything unattributable so the
@@ -1346,6 +1526,59 @@ mod tests {
       ]
     }"#;
 
+    /// The same day as [`CCUSAGE_MIXED`] captured with `--by-agent`: the row
+    /// keeps its merged `modelBreakdowns` and gains an `agents` array whose
+    /// entries carry the per-agent split. Field names and nesting are copied
+    /// from a real `ccusage daily --by-agent --json` capture (ccusage 20.0.20).
+    const CCUSAGE_BY_AGENT: &str = r#"{
+      "daily": [
+        {
+          "agent": "all",
+          "period": "2026-08-14",
+          "inputTokens": 1100,
+          "outputTokens": 2200,
+          "cacheCreationTokens": 300,
+          "cacheReadTokens": 4400,
+          "totalCost": 30.0,
+          "totalTokens": 8000,
+          "metadata": { "agents": ["claude", "codex"] },
+          "modelsUsed": ["claude-opus-5", "gpt-5.6-sol"],
+          "modelBreakdowns": [
+            { "modelName": "claude-opus-5", "cost": 20.0, "inputTokens": 100,
+              "outputTokens": 200, "cacheReadTokens": 400, "cacheCreationTokens": 300 },
+            { "modelName": "gpt-5.6-sol", "cost": 10.0, "inputTokens": 1000,
+              "outputTokens": 2000, "cacheReadTokens": 4000, "cacheCreationTokens": 0,
+              "reasoningOutputTokens": 700 }
+          ],
+          "agents": [
+            {
+              "agent": "claude",
+              "inputTokens": 100, "outputTokens": 200,
+              "cacheCreationTokens": 300, "cacheReadTokens": 400,
+              "totalTokens": 1000, "totalCost": 20.0,
+              "modelsUsed": ["claude-opus-5"],
+              "modelBreakdowns": [
+                { "modelName": "claude-opus-5", "cost": 20.0, "inputTokens": 100,
+                  "outputTokens": 200, "cacheReadTokens": 400, "cacheCreationTokens": 300 }
+              ]
+            },
+            {
+              "agent": "codex",
+              "inputTokens": 1000, "outputTokens": 2000,
+              "cacheCreationTokens": 0, "cacheReadTokens": 4000,
+              "totalTokens": 7000, "totalCost": 10.0,
+              "modelsUsed": ["gpt-5.6-sol"],
+              "modelBreakdowns": [
+                { "modelName": "gpt-5.6-sol", "cost": 10.0, "inputTokens": 1000,
+                  "outputTokens": 2000, "cacheReadTokens": 4000, "cacheCreationTokens": 0,
+                  "reasoningOutputTokens": 700 }
+              ]
+            }
+          ]
+        }
+      ]
+    }"#;
+
     fn client_rows(out: &ImportOutcome, day: usize) -> Vec<(String, String)> {
         out.graph.contributions[day]
             .clients
@@ -1372,6 +1605,149 @@ mod tests {
         assert!((claude.cost - 20.0).abs() < 1e-9);
         assert!((codex.cost - 10.0).abs() < 1e-9);
         assert!(out.unknown_clients.is_empty());
+    }
+
+    #[test]
+    fn ccusage_by_agent_matches_the_family_guess_when_families_are_disjoint() {
+        // Same day, same numbers, both shapes. Claude and Codex models belong
+        // to different families here, so the guess was already right and the
+        // per-agent path must not move a single token.
+        let guessed = parse_ccusage_export(CCUSAGE_MIXED).unwrap();
+        let declared = parse_ccusage_export(CCUSAGE_BY_AGENT).unwrap();
+        assert_eq!(client_rows(&declared, 0), client_rows(&guessed, 0));
+        assert_eq!(
+            declared.graph.contributions[0].token_breakdown,
+            guessed.graph.contributions[0].token_breakdown
+        );
+        assert_eq!(declared.agent_attributed_rows, 1);
+        assert_eq!(guessed.agent_attributed_rows, 0);
+    }
+
+    #[test]
+    fn ccusage_by_agent_reconciles_against_each_agent_declared_total() {
+        // Every `agents` entry states its own totalTokens. That is the
+        // per-agent counterpart of the row-level cross-check, and it is what
+        // would catch one agent's buckets being mapped through twice.
+        let out = parse_ccusage_export(CCUSAGE_BY_AGENT).unwrap();
+        let claude = &out.graph.contributions[0].clients[0];
+        let codex = &out.graph.contributions[0].clients[1];
+        assert_eq!(claude.tokens.total(), 1000, "claude's declared totalTokens");
+        assert_eq!(codex.tokens.total(), 7000, "codex's declared totalTokens");
+        assert_eq!(out.graph.contributions[0].totals.tokens, 8000);
+        assert!(out.breakdown_reconciliation_warnings.is_empty());
+    }
+
+    #[test]
+    fn ccusage_by_agent_separates_two_agents_sharing_one_model() {
+        // The case the family guess cannot answer: OpenCode drives Claude
+        // models, so both agents report `claude-opus-5` and ccusage merges the
+        // two into one row-level breakdown. Reading `agents` keeps them apart;
+        // reading the merged row would hand OpenCode's whole day to Claude.
+        let json = r#"{"daily":[{"period":"2026-08-14","agent":"all",
+            "inputTokens":300,"outputTokens":600,"cacheCreationTokens":0,"cacheReadTokens":0,
+            "totalTokens":900,"totalCost":9.0,
+            "metadata":{"agents":["claude","opencode"]},
+            "modelsUsed":["claude-opus-5"],
+            "modelBreakdowns":[{"modelName":"claude-opus-5","cost":9.0,"inputTokens":300,
+              "outputTokens":600,"cacheReadTokens":0,"cacheCreationTokens":0}],
+            "agents":[
+              {"agent":"claude","inputTokens":100,"outputTokens":200,"cacheCreationTokens":0,
+               "cacheReadTokens":0,"totalTokens":300,"totalCost":3.0,
+               "modelsUsed":["claude-opus-5"],
+               "modelBreakdowns":[{"modelName":"claude-opus-5","cost":3.0,"inputTokens":100,
+                 "outputTokens":200,"cacheReadTokens":0,"cacheCreationTokens":0}]},
+              {"agent":"opencode","inputTokens":200,"outputTokens":400,"cacheCreationTokens":0,
+               "cacheReadTokens":0,"totalTokens":600,"totalCost":6.0,
+               "modelsUsed":["claude-opus-5"],
+               "modelBreakdowns":[{"modelName":"claude-opus-5","cost":6.0,"inputTokens":200,
+                 "outputTokens":400,"cacheReadTokens":0,"cacheCreationTokens":0}]}]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        assert_eq!(
+            client_rows(&out, 0),
+            vec![
+                ("claude".to_string(), "claude-opus-5".to_string()),
+                ("opencode".to_string(), "claude-opus-5".to_string()),
+            ]
+        );
+        assert_eq!(out.graph.contributions[0].clients[0].tokens.total(), 300);
+        assert_eq!(out.graph.contributions[0].clients[1].tokens.total(), 600);
+        assert!(out.unknown_clients.is_empty());
+        assert_eq!(out.graph.contributions[0].totals.tokens, 900);
+    }
+
+    #[test]
+    fn ccusage_by_agent_attributes_agents_the_family_guess_cannot() {
+        // `model_family` knows three families; ccusage names sixteen agents.
+        // On a shared day the other thirteen fall through to `unknown` and the
+        // export is reported as unsubmittable. Their own entries name them.
+        let json = r#"{"daily":[{"period":"2026-08-14","agent":"all",
+            "totalTokens":30,"totalCost":2.0,
+            "metadata":{"agents":["amp","droid"]},
+            "modelsUsed":["amp-fast","droid-core"],
+            "modelBreakdowns":[
+              {"modelName":"amp-fast","cost":1.0,"inputTokens":10,"outputTokens":5,
+               "cacheReadTokens":0,"cacheCreationTokens":0},
+              {"modelName":"droid-core","cost":1.0,"inputTokens":10,"outputTokens":5,
+               "cacheReadTokens":0,"cacheCreationTokens":0}],
+            "agents":[
+              {"agent":"amp","totalTokens":15,"totalCost":1.0,"modelsUsed":["amp-fast"],
+               "modelBreakdowns":[{"modelName":"amp-fast","cost":1.0,"inputTokens":10,
+                 "outputTokens":5,"cacheReadTokens":0,"cacheCreationTokens":0}]},
+              {"agent":"droid","totalTokens":15,"totalCost":1.0,"modelsUsed":["droid-core"],
+               "modelBreakdowns":[{"modelName":"droid-core","cost":1.0,"inputTokens":10,
+                 "outputTokens":5,"cacheReadTokens":0,"cacheCreationTokens":0}]}]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        assert_eq!(
+            client_rows(&out, 0),
+            vec![
+                ("amp".to_string(), "amp-fast".to_string()),
+                ("droid".to_string(), "droid-core".to_string()),
+            ]
+        );
+        assert!(
+            out.unknown_clients.is_empty(),
+            "the row names both agents, so nothing is unattributable"
+        );
+    }
+
+    #[test]
+    fn ccusage_by_agent_entry_without_breakdowns_uses_its_own_aggregate() {
+        // Mirrors the row-level fallback: an entry with no per-model split
+        // still belongs to its named agent, not to a guessed one.
+        let json = r#"{"daily":[{"period":"2026-08-14","agent":"all",
+            "totalTokens":15,"totalCost":1.0,
+            "metadata":{"agents":["goose"]},
+            "modelsUsed":["mystery-1"],
+            "agents":[{"agent":"goose","inputTokens":10,"outputTokens":5,
+              "totalTokens":15,"totalCost":1.0,"modelsUsed":["mystery-1"]}]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        assert_eq!(
+            client_rows(&out, 0),
+            vec![("goose".to_string(), "mystery-1".to_string())]
+        );
+        assert_eq!(out.multi_model_fallback_rows, 0);
+        assert!(out.unknown_clients.is_empty());
+    }
+
+    #[test]
+    fn ccusage_by_agent_warns_when_an_agent_total_disagrees() {
+        // A row total that still adds up can hide one agent's buckets being
+        // counted twice; the per-agent cross-check is what sees it.
+        let json = r#"{"daily":[{"period":"2026-08-14","agent":"all",
+            "totalTokens":30,"totalCost":2.0,
+            "metadata":{"agents":["claude"]},
+            "modelsUsed":["claude-opus-5"],
+            "agents":[{"agent":"claude","inputTokens":10,"outputTokens":5,
+              "totalTokens":900,"totalCost":1.0,"modelsUsed":["claude-opus-5"],
+              "modelBreakdowns":[{"modelName":"claude-opus-5","cost":1.0,"inputTokens":10,
+                "outputTokens":5,"cacheReadTokens":0,"cacheCreationTokens":0}]}]}]}"#;
+        let out = parse_ccusage_export(json).unwrap();
+        let warning = out
+            .breakdown_reconciliation_warnings
+            .iter()
+            .find(|w| w.contains("agent 'claude'"))
+            .expect("the agent's own totalTokens must be cross-checked");
+        assert!(warning.contains("900"), "{warning}");
     }
 
     #[test]

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5354,6 +5354,17 @@ fn run_import_command(
         "{}",
         format!("    Models: {}", graph.summary.models.len()).bright_black()
     );
+    if outcome.agent_attributed_rows > 0 {
+        eprintln!(
+            "{}",
+            format!(
+                "    Client attribution: exact, from the export's per-agent breakdowns \
+                 ({} row(s))",
+                outcome.agent_attributed_rows
+            )
+            .bright_black()
+        );
+    }
 
     if !outcome.unknown_clients.is_empty() {
         eprintln!(


### PR DESCRIPTION
Follow-up to #1128, which you invited in the merge comment: "`resolve_client` splits by model *family*, not by the client that made the call... ccusage's `--by-agent` output does, since each agent gets its own `modelBreakdowns`. That's the natural follow-up if you're interested; I didn't want to build it against a shape I couldn't capture a real sample of."

I captured one. This adds `agents` support to the ccusage importer, so a `--by-agent` export is attributed to the client that actually reported each breakdown instead of to whichever listed agent the model family matched.

## The real sample

`npx ccusage@20.0.20 daily --by-agent --json`, run against this machine's own Claude Code (~7.5 GB) and Codex (~8.9 GB) local session logs: **34 days, 2026-07-22 to 2026-08-24, 39 agent-day cells, 30,152,041,119 tokens / $29,733.75**, five of them multi-agent days.

The shape it actually emits, per row:

```json
{ "agent": "all", "period": "2026-08-20",
  "metadata": { "agents": ["claude", "codex"] },
  "modelBreakdowns": [ ... merged across agents ... ],
  "agents": [
    { "agent": "claude", "inputTokens": 210877, "outputTokens": 6845166,
      "cacheCreationTokens": 42883113, "cacheReadTokens": 1243450521,
      "totalTokens": 1293389677, "totalCost": 1162.413754899997,
      "modelsUsed": [...], "modelBreakdowns": [ ... ] },
    { "agent": "codex", "...": "..." }
  ] }
```

What the file proves, checked on all 34 rows:

- `input + output + cacheCreation + cacheRead == totalTokens` holds **per agent**, not just per row (39/39). So the anchor you added at row level has a per-agent counterpart, and this PR wires it in as a cross-check.
- Per-agent buckets sum exactly to the row buckets, and per-agent `modelBreakdowns` sum exactly to per-agent totals. No tolerance needed on real data.
- `metadata` still carries only the agent name list. Reasoning is not in there (see limitations).

## Why the row-level breakdown cannot recover the split

This is not inference from the file; it is ccusage's own code. `AllAccumulator::into_row` builds the row-level `modelBreakdowns` with `aggregate_model_breakdowns`, which merges entries **keyed by model name across agents** (`rust/crates/ccusage-adapter-all/src/types.rs`). Once two agents have used the same model on the same day, the row-level entry is their sum and nothing in it says so. `agents` is the only place the split survives.

There is a second, quieter loss. `model_family` knows three families; ccusage's `BUILT_IN_AGENT_NAMES` lists sixteen agent ids (`claude, codex, opencode, amp, droid, codebuff, hermes, pi, goose, openclaw, kilo, copilot, gemini, kimi, qwen, grok`). On a multi-agent day the other thirteen match no family, resolve to `unknown`, and the import warns that the leaderboard would reject it. All sixteen are already registered tokscale `ClientId`s, so a `--by-agent` row needs no inference at all — just the same spelling normalization the importer already applies.

## Before / after

Real day pair recomposed as a same-family collision (the token values are real — two real Claude-only days, 2026-08-17 and 2026-08-18 — with the second agent relabelled `opencode`, since I have no real OpenCode usage on this machine):

```
before:  Clients: claude              claude 3,316,732,440   opencode absent
after:   Clients: claude, opencode    claude 1,599,032,021   opencode 1,717,700,419
```

Both after-values are what the file declares for each agent.

On the real 34-day export, where `claude` and `codex` have disjoint families and the guess was already right, output is **byte-identical** to before, and every one of the 39 agent-day cells matches the declared `totalTokens` exactly and the declared `totalCost` to within $0.01. The import now also says which of the two paths produced the numbers:

```
    Clients: claude, codex
    Models: 7
    Client attribution: exact, from the export's per-agent breakdowns (34 row(s))
```

## What changed

- `CcusageDaily` gains `agents: Vec<CcusageAgentBreakdown>` (absent without `--by-agent`, so old exports are untouched).
- When present, each entry's breakdowns are attributed via `attribute_agent`, which only normalizes the spelling and flags an id tokscale does not register. `resolve_client` keeps its doc comment but is now explicitly the fallback for exports that predate `--by-agent`.
- Each entry's own `totalTokens` becomes a per-agent cross-check, appended to `breakdown_reconciliation_warnings` on divergence — a row total that still adds up can hide one agent's buckets being counted twice.
- `is_empty_day` now also looks at `agents`, so a row carrying only per-agent data is not dropped.
- The per-model mapping was extracted into `add_model_breakdown` and is shared by both paths, so they cannot drift.
- `ImportOutcome.agent_attributed_rows` counts rows attributed this way, and the CLI prints the line above.

Six tests, all in the existing `mod tests`: parity with the family guess when families are disjoint, the per-agent declared-total cross-check, two agents sharing one model, agents the family guess cannot name (`amp`/`droid`), an entry with no breakdowns, and the divergence warning.

I checked they can actually fail. Reverting the per-agent loop to the family guess turns two of them red:

```
left:  [("claude", "claude-opus-5")]
right: [("claude", "claude-opus-5"), ("opencode", "claude-opus-5")]
left:  [("unknown", "amp-fast"), ("unknown", "droid-core")]
right: [("amp", "amp-fast"), ("droid", "droid-core")]
```

and disabling the cross-check turns the sixth red on its own.

`cargo test --workspace --all-features`: 3158 passed / 0 failed. `cargo clippy --locked --workspace --all-features -- -D warnings` and `cargo fmt --all -- --check`: clean.

## Limitations, stated up front

- **My real capture only has `claude` and `codex`, and their families are disjoint** — so the real file cannot itself exhibit the collision. That case rests on ccusage's merge code plus the tests and the recomposed fixture above. I have no real OpenCode usage and did not invent one.
- **Reasoning is still zero for Codex on a `--by-agent` import, unchanged by this PR.** ccusage drops it when merging into `agent: "all"`: `row_json` writes `metadata` as `{ "agents": [...] }` whenever `row.metadata` is `None`, which is always true for unified rows. Confirmed on the real file — all 34 rows carry `metadata` with only `agents`, including the five days Codex ran with real reasoning tokens. The agent entries carry no metadata either, so there is nothing to read. `CcusageAgentBreakdown` accepts a flat `reasoningOutputTokens` if ccusage ever adds one. `ccusage codex daily --json` does carry it, and the importer already handles that shape (the `costUSD` + flat-reasoning path from #1128) — I confirmed that on a real capture too.
- **`--by-agent` also adds `agents` to weekly and monthly rows.** The importer only consumes `daily`; unchanged and out of scope.
- **`ImportOutcome` gains a public field.** Crate-internal in practice, but it is a struct-literal-breaking change for any out-of-tree construction.
- **Frontend checks not run** — bun is not installed here. The change is Rust-only and touches no frontend code.

## AI assistance

This patch was authored with Claude Code by INTFRAME, reviewed before submission, and I will respond to review here myself. Same disclosure as #1128.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes `ccusage` `--by-agent` exports to the agent that reported each breakdown, removing the model-family guess when the export provides per-agent data. Old behavior: attribute per-model usage by inferred family across listed agents. New behavior: attribute by the row’s `agents` entries; fall back to family inference only when `agents` is absent.

- Parses `daily[].agents[]` and maps each entry via exact agent id normalization; unknown ids are still flagged.
- Adds a per-agent totalTokens cross-check and surfaces any divergence in `breakdown_reconciliation_warnings`.
- Keeps the prior path for exports without `--by-agent`; per-model mapping is shared to prevent drift.
- Treats rows with only per-agent data as non-empty; aggregates and suspect-cost checks unchanged.
- Adds ImportOutcome.agent_attributed_rows and prints “Client attribution: exact…” in the CLI.

Migration
- If constructing ImportOutcome via struct literals out of tree, add the new field `agent_attributed_rows`.

<sup>Written for commit 2d74df51b5a62497bbc076b78e74d462780b10d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

