### PR TITLE
fix(copilot): support GH_TOKEN env and legacy Windows hosts path for credential detection

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/copilot.rs
+++ b/crates/tokscale-cli/src/commands/usage/copilot.rs
@@ -117,7 +117,9 @@ fn parse_token_from_hosts() -> Result<String> {
         if !path.exists() {
             continue;
         }
-        let content = std::fs::read_to_string(&path)?;
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
         // Parse YAML-like: look for "oauth_token: <token>" under "github.com:"
         let mut in_github = false;
         for line in content.lines() {
@@ -259,7 +261,16 @@ pub fn fetch() -> Result<UsageOutput> {
         .build()?;
     rt.block_on(async {
         let client = reqwest::Client::new();
-        let resp = fetch_api(&client, &token).await?;
+        let resp = fetch_api(&client, &token).await.map_err(|e| {
+            if e.to_string().contains("NEEDS_AUTH") {
+                anyhow::anyhow!(
+                    "GitHub token found but not authorized for Copilot. \
+                     Run 'gh auth login' or check your GH_TOKEN/GITHUB_TOKEN."
+                )
+            } else {
+                e
+            }
+        })?;
 
         let plan = resp
             .get("copilot_plan")

--- a/crates/tokscale-cli/src/commands/usage/copilot.rs
+++ b/crates/tokscale-cli/src/commands/usage/copilot.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use serde::Deserialize;
 
@@ -42,6 +44,55 @@ fn read_token_from_keychain() -> Result<String> {
     }
 }
 
+fn token_from_env() -> Option<String> {
+    for var in ["GH_TOKEN", "GITHUB_TOKEN"] {
+        if let Some(value) = std::env::var_os(var) {
+            let value = value.to_string_lossy().trim().to_string();
+            if !value.is_empty() {
+                return Some(value);
+            }
+        }
+    }
+    None
+}
+
+fn hosts_candidates() -> Vec<PathBuf> {
+    let mut candidates = vec![gh_config_dir().join("hosts.yml")];
+    if cfg!(windows) {
+        if let Some(home) = crate::paths::home_dir() {
+            let legacy = home.join(".config/gh/hosts.yml");
+            if legacy != candidates[0] {
+                candidates.push(legacy);
+            }
+        }
+    }
+    candidates
+}
+
+/// Paths and env vars probed by credential detection, for observability.
+/// Never includes the token value itself; only presence/absence is reported.
+pub(super) fn credential_probe() -> Vec<String> {
+    let mut probes = Vec::new();
+    for var in ["GH_TOKEN", "GITHUB_TOKEN"] {
+        probes.push(format!(
+            "{var}={}",
+            if std::env::var_os(var).is_some() {
+                "set"
+            } else {
+                "unset"
+            }
+        ));
+    }
+    for path in hosts_candidates() {
+        probes.push(format!(
+            "hosts={} ({})",
+            path.display(),
+            if path.exists() { "exists" } else { "missing" }
+        ));
+    }
+    probes
+}
+
 fn gh_config_dir() -> std::path::PathBuf {
     if let Ok(dir) = std::env::var("GH_CONFIG_DIR") {
         return std::path::PathBuf::from(dir);
@@ -62,32 +113,33 @@ fn gh_config_dir() -> std::path::PathBuf {
 }
 
 fn parse_token_from_hosts() -> Result<String> {
-    let path = gh_config_dir().join("hosts.yml");
-    if !path.exists() {
-        anyhow::bail!("No gh hosts file");
-    }
-    let content = std::fs::read_to_string(&path)?;
-    // Parse YAML-like: look for "oauth_token: <token>" under "github.com:"
-    let mut in_github = false;
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed == "github.com:" {
-            in_github = true;
+    for path in hosts_candidates() {
+        if !path.exists() {
             continue;
         }
-        // A non-indented, non-empty, non-comment line starts a new section
-        if in_github
-            && !line.starts_with(' ')
-            && !line.starts_with('\t')
-            && !trimmed.is_empty()
-            && !trimmed.starts_with('#')
-        {
-            in_github = false;
-        }
-        if in_github && trimmed.starts_with("oauth_token:") {
-            let token = trimmed.trim_start_matches("oauth_token:").trim();
-            if !token.is_empty() {
-                return Ok(token.to_string());
+        let content = std::fs::read_to_string(&path)?;
+        // Parse YAML-like: look for "oauth_token: <token>" under "github.com:"
+        let mut in_github = false;
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed == "github.com:" {
+                in_github = true;
+                continue;
+            }
+            // A non-indented, non-empty, non-comment line starts a new section
+            if in_github
+                && !line.starts_with(' ')
+                && !line.starts_with('\t')
+                && !trimmed.is_empty()
+                && !trimmed.starts_with('#')
+            {
+                in_github = false;
+            }
+            if in_github && trimmed.starts_with("oauth_token:") {
+                let token = trimmed.trim_start_matches("oauth_token:").trim();
+                if !token.is_empty() {
+                    return Ok(token.to_string());
+                }
             }
         }
     }
@@ -99,6 +151,9 @@ fn read_token_from_hosts() -> Result<String> {
 }
 
 fn read_credentials() -> Result<String> {
+    if let Some(token) = token_from_env() {
+        return Ok(token);
+    }
     read_token_from_keychain()
         .or_else(|_| read_token_from_hosts())
         .map_err(|_| {
@@ -187,6 +242,9 @@ async fn fetch_api(client: &reqwest::Client, token: &str) -> Result<serde_json::
 }
 
 pub fn has_credentials() -> bool {
+    if token_from_env().is_some() {
+        return true;
+    }
     if super::helpers::read_keychain("gh:github.com").is_ok() {
         return true;
     }

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -559,7 +559,15 @@ fn render_light(output: &UsageOutput) {
     println!("╰{}╯", "─".repeat(CARD_WIDTH));
 }
 
-pub fn run(json: bool, _light: bool) -> Result<()> {
+pub fn run(json: bool, _light: bool, debug: bool) -> Result<()> {
+    if debug {
+        // Log to stderr so `--json` stdout stays pure JSON for downstream
+        // consumers (see the note in the json branch below).
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("debug")
+            .with_writer(std::io::stderr)
+            .try_init();
+    }
     let report = fetch_all_report_with_intent(UsageFetchIntent::CliReadOnly);
     if json {
         // Keep stdout pure JSON: do NOT emit provider warnings here, since they

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -429,10 +429,25 @@ pub fn fetch_all_report_with_intent(intent: UsageFetchIntent) -> UsageFetchRepor
 }
 
 fn fetch_all_report_with_codex(codex_fetch: fn() -> UsageFetchReport) -> UsageFetchReport {
-    let active: Vec<_> = usage_providers(Fetch::Multi(codex::fetch_all))
-        .into_iter()
-        .filter(|(_, has, _)| has())
-        .collect();
+    let mut active: Vec<UsageProvider> = Vec::new();
+    // Observability (#947): when a provider is filtered out for lack of
+    // credentials, log what was probed so a missing quota card can be traced
+    // to credential detection rather than the fetch path.
+    for (provider, has, fetch) in usage_providers(Fetch::Multi(codex::fetch_all)) {
+        if has() {
+            active.push((provider, has, fetch));
+        } else {
+            tracing::debug!(
+                provider,
+                probes = ?if provider == "Copilot" {
+                    copilot::credential_probe()
+                } else {
+                    Vec::<String>::new()
+                },
+                "usage provider filtered out: no credentials detected"
+            );
+        }
+    }
 
     if active.is_empty() {
         return UsageFetchReport::default();

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -887,7 +887,7 @@ fn main() -> Result<()> {
         }
         Some(Commands::Usage { json, light }) => {
             reject_unsupported_home_override(&cli.home, "usage")?;
-            commands::usage::run(json, light)
+            commands::usage::run(json, light, cli.debug)
         }
         Some(Commands::Codex { subcommand }) => {
             reject_unsupported_home_override(&cli.home, "codex")?;


### PR DESCRIPTION
Refs #947 (covers the GH_TOKEN/GITHUB_TOKEN and legacy hosts.yml cases; Windows Credential Manager detection remains open)

Copilot Business quota card was hidden when credentials were only available via GH_TOKEN/GITHUB_TOKEN or a Windows legacy ~/.config/gh/hosts.yml, because has_credentials/read_credentials only probed GH_CONFIG_DIR/hosts.yml and keychain. The quota parsing itself (quota_snapshots / premium_interactions) was already correct, but the provider was filtered out before fetch, making the failure look like a Business parsing bug.

This PR makes credential detection match real gh auth flows: check GH_TOKEN/GITHUB_TOKEN first, probe both GH_CONFIG_DIR/hosts.yml and the Windows legacy path, and emit credential_probe diagnostics when a provider is filtered for lack of credentials so missing quota can be traced to detection rather than fetch.

Changes:
- `crates/tokscale-cli/src/commands/usage/copilot.rs`: add `token_from_env`, `hosts_candidates`, `credential_probe`; `read_credentials`/`has_credentials` prefer env then iterate hosts candidates; make `parse_token_from_hosts` iterate candidates
- `crates/tokscale-cli/src/commands/usage/mod.rs`: log `credential_probe` when Copilot is filtered out (`tracing::debug`)

Verification (on 688e52f3):
- `cargo fmt --all -- --check` PASS (FMT_EXIT:0)
- `cargo clippy --locked --workspace --all-features -- -D warnings` PASS (CLIPPY_EXIT:0)
- `cargo test --workspace --all-features` PASS (3152 passed, 5 ignored, 12 suites)

