### PR TITLE
fix(leaderboard): match period rank tiebreakers across profile and embed surfaces

### DIFF
--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -188,6 +188,11 @@ function serializeSqlCalls(): string[] {
   });
 }
 
+/** Whitespace-insensitive view of a query, for asserting on a whole clause. */
+function collapseSql(text: string | undefined): string {
+  return (text ?? "").replace(/\s+/g, " ").trim();
+}
+
 beforeAll(async () => {
   const routeModule = await import("../../src/app/api/users/[username]/route");
   GET = routeModule.GET;
@@ -1037,7 +1042,7 @@ describe("GET /api/users/[username]", () => {
       sqlTexts.some(
         (text) =>
           text.includes("FROM daily_breakdown d") &&
-          text.includes("RANK() OVER") &&
+          text.includes("ROW_NUMBER() OVER") &&
           text.includes("d.date >= 2026-07-18") &&
           text.includes("d.date <= 2026-07-24"),
       ),
@@ -1218,7 +1223,7 @@ describe("GET /api/users/[username]", () => {
       sqlTexts.some(
         (text) =>
           text.includes("FROM daily_breakdown d") &&
-          text.includes("RANK() OVER") &&
+          text.includes("ROW_NUMBER() OVER") &&
           text.includes(`d.date >= ${start}`) &&
           text.includes("d.date <= 2026-06-28"),
       ),
@@ -1255,6 +1260,138 @@ describe("GET /api/users/[username]", () => {
     "recalculates profile overview stats and rank for the $period period",
     assertRollingProfilePeriod,
   );
+
+  it("ranks the profile period window the way the leaderboard's period tab does", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-28T12:00:00.000Z"));
+
+    mockState.pushSelectResult([
+      {
+        id: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        totalTokens: 300,
+        totalCost: 3,
+        inputTokens: 180,
+        outputTokens: 120,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        reasoningTokens: 0,
+        submissionCount: 1,
+        earliestDate: "2026-06-28",
+        latestDate: "2026-06-28",
+        sessionCount: 1,
+      },
+    ]);
+    mockState.pushSelectResult([]);
+    mockState.pushSelectResult([
+      {
+        date: "2026-06-28",
+        timestampMs: 100,
+        tokens: 300,
+        cost: "3.0000",
+        inputTokens: 180,
+        outputTokens: 120,
+        sourceBreakdown: null,
+      },
+    ]);
+    // postgres-js hands a bigint rank back as a string.
+    mockState.pushExecuteResult([{ rank: "2" }]);
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/users/alice?period=week"),
+      { params: Promise.resolve({ username: "alice" }) },
+    );
+    const body = await response.json();
+    const sqlTexts = serializeSqlCalls();
+    const periodRankSql = sqlTexts.find((text) =>
+      text.includes("ROW_NUMBER() OVER"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(body.user.rank).toBe(2);
+    // Two users on the same token total have to read the same two distinct
+    // positions here and on the leaderboard's period tab, so the window clause
+    // has to match it term for term.
+    expect(periodRankSql).toBeDefined();
+    expect(collapseSql(periodRankSql)).toContain(
+      "ROW_NUMBER() OVER (ORDER BY total_tokens DESC, total_cost DESC, LOWER(username) ASC, user_id ASC) as rank",
+    );
+    // Shared RANK is what this window used to emit, and it is what made a tie
+    // read one number on the profile and another on the leaderboard.
+    expect(sqlTexts.some((text) => text.includes("RANK() OVER"))).toBe(false);
+    // Only the ordering within a tie changed: the same rows are ranked.
+    expect(collapseSql(periodRankSql)).toContain(
+      "WHERE u.leaderboard_hidden = false AND d.date >= 2026-06-22 AND d.date <= 2026-06-28",
+    );
+    expect(collapseSql(periodRankSql)).toContain(
+      "GROUP BY s.user_id, u.username",
+    );
+    expect(unstableCacheMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      ["profile-period-rank", "user-1", "2026-06-22", "2026-06-28"],
+      {
+        revalidate: 60,
+        tags: ["leaderboard", "user:alice"],
+      },
+    );
+  });
+
+  it("keeps the lifetime profile rank on shared RANK", async () => {
+    mockState.pushSelectResult([
+      {
+        id: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        totalTokens: 1000,
+        totalCost: 10,
+        inputTokens: 600,
+        outputTokens: 400,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        reasoningTokens: 0,
+        submissionCount: 1,
+        earliestDate: "2026-01-01",
+        latestDate: "2026-06-28",
+        sessionCount: 1,
+      },
+    ]);
+    mockState.pushSelectResult([]);
+    mockState.pushSelectResult([]);
+    mockState.pushExecuteResult([{ rank: "3" }]);
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/users/alice"),
+      { params: Promise.resolve({ username: "alice" }) },
+    );
+    const body = await response.json();
+    const sqlTexts = serializeSqlCalls();
+
+    expect(response.status).toBe(200);
+    expect(body.user.rank).toBe(3);
+    // The leaderboard's all-time tab shares one position between tied users.
+    // Ranking this window sequentially would be the same divergence mirrored.
+    expect(
+      sqlTexts.some((text) =>
+        collapseSql(text).includes(
+          "RANK() OVER (ORDER BY total_tokens DESC) as rank",
+        ),
+      ),
+    ).toBe(true);
+    expect(sqlTexts.some((text) => text.includes("ROW_NUMBER"))).toBe(false);
+  });
 
   it("skips the period rank scan when the user has no daily rows in the window", async () => {
     vi.useFakeTimers();

--- a/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
+++ b/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
@@ -142,16 +142,39 @@ type ModuleExports = typeof import("../../src/lib/embed/getUserEmbedStats");
 let getUserEmbedStats: ModuleExports["getUserEmbedStats"];
 let getUserEmbedContributions: ModuleExports["getUserEmbedContributions"];
 
+/**
+ * A conditional `ORDER BY` is interpolated as a nested `sql` fragment, so a
+ * plain `String(...)` would flatten it to `[object Object]` and hide the very
+ * clause these tests are about. Recurse into fragments instead, so a single
+ * assertion can read a whole window clause.
+ */
+function serializeSqlValue(value: unknown): string {
+  const fragment = value as { strings?: unknown; values?: unknown[] };
+  if (!value || typeof value !== "object" || !Array.isArray(fragment.strings)) {
+    return String(value);
+  }
+
+  const parts = fragment.strings as string[];
+  const values = fragment.values ?? [];
+
+  return parts.reduce(
+    (text, part, index) =>
+      `${text}${part}${index < values.length ? serializeSqlValue(values[index]) : ""}`,
+    "",
+  );
+}
+
 function serializeSqlCalls(): string[] {
   return mockState.sql.mock.calls.map((call) => {
     const [strings, ...values] = call as [TemplateStringsArray, ...unknown[]];
-    const textParts = Array.from(strings);
 
-    return textParts.reduce((text, part, index) => {
-      const nextValue = index < values.length ? String(values[index]) : "";
-      return `${text}${part}${nextValue}`;
-    }, "");
+    return serializeSqlValue({ strings: Array.from(strings), values });
   });
+}
+
+/** Whitespace-insensitive view of a query, for asserting on a whole clause. */
+function collapseSql(text: string | undefined): string {
+  return (text ?? "").replace(/\s+/g, " ").trim();
 }
 
 beforeAll(async () => {
@@ -165,7 +188,10 @@ beforeEach(() => {
 });
 
 describe("user embed data", () => {
-  it("keeps embed tie-breakers out of the rank window", async () => {
+  // The lifetime card has to agree with the leaderboard's all-time tab, which
+  // shares one position between tied users. Only the finite windows below rank
+  // sequentially.
+  it("keeps the lifetime embed rank on shared RANK with no tie-breakers", async () => {
     mockState.pushAwaitedResult([
       {
         id: "user-alice",
@@ -185,6 +211,9 @@ describe("user embed data", () => {
 
     expect(tokenSqlTexts.some((text) => text.includes("RANK() OVER"))).toBe(
       true,
+    );
+    expect(tokenSqlTexts.some((text) => text.includes("ROW_NUMBER"))).toBe(
+      false,
     );
     expect(
       tokenSqlTexts.some((text) =>
@@ -215,6 +244,7 @@ describe("user embed data", () => {
     expect(costSqlTexts.some((text) => text.includes("RANK() OVER"))).toBe(
       true,
     );
+    expect(costSqlTexts.some((text) => text.includes("ROW_NUMBER"))).toBe(false);
     expect(
       costSqlTexts.some((text) =>
         /CAST\(total_cost AS DECIMAL\(\d+,4\)\) DESC, total_tokens DESC/.test(
@@ -223,6 +253,75 @@ describe("user embed data", () => {
       ),
     ).toBe(false);
   });
+
+  it.each([
+    {
+      sortBy: "tokens" as const,
+      metricOrder: "total_tokens DESC, total_cost DESC",
+    },
+    {
+      sortBy: "cost" as const,
+      metricOrder: "total_cost DESC, total_tokens DESC",
+    },
+  ])(
+    "ranks the finite embed window the way the leaderboard's period tab ranks $sortBy",
+    async ({ sortBy, metricOrder }) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-03-12T12:00:00.000Z"));
+
+      try {
+        mockState.pushAwaitedResult([
+          {
+            id: "user-alice",
+            username: "alice",
+            displayName: "Alice",
+            avatarUrl: null,
+            totalTokens: 3000,
+            totalCost: 40,
+            submissionCount: 3,
+            latestDate: "2026-03-14",
+            updatedAt: new Date("2026-03-14T09:00:00.000Z"),
+          },
+        ]);
+        mockState.pushExecuteResult([{ totalTokens: 700, totalCost: 7 }]);
+        // postgres-js hands a bigint rank back as a string.
+        mockState.pushExecuteResult([{ rank: "2", total: 10 }]);
+
+        const stats = await getUserEmbedStats("alice", sortBy, "week");
+        const sqlTexts = serializeSqlCalls();
+        const periodRankSql = sqlTexts.find((text) =>
+          text.includes("ROW_NUMBER() OVER"),
+        );
+
+        // Two users on the same total have to read the same two distinct
+        // positions here and on the leaderboard's period tab, so the window
+        // clause has to match it term for term.
+        expect(periodRankSql).toBeDefined();
+        expect(collapseSql(periodRankSql)).toContain(
+          `ROW_NUMBER() OVER ( ORDER BY ${metricOrder}, LOWER(username) ASC, user_id ASC ) AS rank`,
+        );
+        // Shared RANK is what the profile and embed period windows used to
+        // emit, and it is what made a tie read differently per surface.
+        expect(sqlTexts.some((text) => text.includes("RANK() OVER"))).toBe(
+          false,
+        );
+        // Only the ordering within a tie changed: the same rows are counted,
+        // and the "of N" denominator still counts them all.
+        expect(collapseSql(periodRankSql)).toContain(
+          "WHERE u.leaderboard_hidden = false AND d.date >= 2026-03-08 AND d.date <= 2026-03-14",
+        );
+        expect(collapseSql(periodRankSql)).toContain(
+          "GROUP BY s.user_id, u.username",
+        );
+        expect(collapseSql(periodRankSql)).toContain(
+          "SELECT COUNT(*)::int FROM rankable",
+        );
+        expect(stats?.stats).toMatchObject({ rank: 2, rankTotal: 10 });
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("casts total_cost at full column precision for cost-sorted embed stats", async () => {
     mockState.pushAwaitedResult([
@@ -330,7 +429,7 @@ describe("user embed data", () => {
           (text) =>
             text.includes("WITH rankable AS") &&
             text.includes("FROM daily_breakdown d") &&
-            text.includes("RANK() OVER") &&
+            text.includes("ROW_NUMBER() OVER") &&
             text.includes("d.date >= 2026-03-08") &&
             text.includes("d.date <= 2026-03-14"),
         ),

--- a/packages/frontend/src/lib/embed/getUserEmbedStats.ts
+++ b/packages/frontend/src/lib/embed/getUserEmbedStats.ts
@@ -106,11 +106,17 @@ async function fetchUserEmbedStats(
     // Both the rank and the "of N" denominator count rankable users only, so a
     // hidden account neither holds a position nor inflates the total. A hidden
     // user is absent from the CTE, so this returns no row and rank stays null.
+    //
+    // The finite window ranks the way the leaderboard's period tab does —
+    // sequential ROW_NUMBER with the same tie-breakers — so two users on the
+    // same total read the same distinct positions on both surfaces. The
+    // lifetime window keeps shared RANK to match the all-time tab.
     const rankResult = dateRange
       ? await db.execute<{ rank: number; total: number }>(sql`
           WITH rankable AS (
             SELECT
               s.user_id,
+              u.username,
               SUM(d.tokens) AS total_tokens,
               SUM(CAST(d.cost AS DECIMAL(18,4))) AS total_cost
             FROM daily_breakdown d
@@ -119,18 +125,18 @@ async function fetchUserEmbedStats(
             WHERE u.leaderboard_hidden = false
               AND d.date >= ${dateRange.start}
               AND d.date <= ${dateRange.end}
-            GROUP BY s.user_id
+            GROUP BY s.user_id, u.username
           ),
           ranked AS (
             SELECT
               user_id,
-              RANK() OVER (
+              ROW_NUMBER() OVER (
                 ORDER BY
                   ${
                     sortBy === "cost"
-                      ? sql`total_cost DESC`
-                      : sql`total_tokens DESC`
-                  }
+                      ? sql`total_cost DESC, total_tokens DESC`
+                      : sql`total_tokens DESC, total_cost DESC`
+                  }, LOWER(username) ASC, user_id ASC
               ) AS rank
             FROM rankable
           )
@@ -164,9 +170,9 @@ async function fetchUserEmbedStats(
     const rankRow = (
       rankResult as unknown as { rank: number; total: number }[]
     )[0];
-    // Coerced because RANK() is a Postgres bigint, which postgres-js hands
-    // back as a string. Number(undefined) is NaN and falls through to null, so
-    // a missing row behaves as before.
+    // Coerced because RANK()/ROW_NUMBER() are Postgres bigints, which
+    // postgres-js hands back as strings. Number(undefined) is NaN and falls
+    // through to null, so a missing row behaves as before.
     rank = Number(rankRow?.rank) || null;
     rankTotal = Number(rankRow?.total) || null;
   }

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -228,6 +228,9 @@ export async function getPublicProfileResponse(
         // A finite rank needs the anchored profile range, which is only known
         // after the stats query returns the newest submitted date. Keep the
         // lifetime rank concurrent and defer only finite-period ranking.
+        //
+        // Shared RANK here on purpose: the leaderboard's all-time tab ranks
+        // the same way, so tied users read the same number on both surfaces.
         period === "all"
           ? db.execute<{ rank: number }>(sql`
               WITH user_totals AS (
@@ -280,6 +283,12 @@ export async function getPublicProfileResponse(
     // finite query uses the exact same anchored window as the visible profile
     // totals and chart.
     //
+    // The two windows deliberately differ, because the two leaderboard tabs
+    // they have to agree with do: the finite query mirrors the leaderboard's
+    // period path (sequential ROW_NUMBER with the same tie-breakers, so tied
+    // users get distinct positions in the same order), and the lifetime query
+    // mirrors the all-time path (shared RANK, so tied users share a position).
+    //
     // The scan ranks every rankable user's daily rows, so it is cached for a
     // minute per user and window instead of running on every request. A user
     // with no daily rows in the window has no row in the CTE either, so the
@@ -297,19 +306,21 @@ export async function getPublicProfileResponse(
                 WITH user_totals AS (
                   SELECT
                     s.user_id,
-                    SUM(d.tokens) as total_tokens
+                    u.username,
+                    SUM(d.tokens) as total_tokens,
+                    SUM(CAST(d.cost AS DECIMAL(18,4))) as total_cost
                   FROM daily_breakdown d
                   INNER JOIN submissions s ON d.submission_id = s.id
                   INNER JOIN users u ON u.id = s.user_id
                   WHERE u.leaderboard_hidden = false
                     AND d.date >= ${periodRange.start}
                     AND d.date <= ${periodRange.end}
-                  GROUP BY s.user_id
+                  GROUP BY s.user_id, u.username
                 ),
                 ranked AS (
                   SELECT
                     user_id,
-                    RANK() OVER (ORDER BY total_tokens DESC) as rank
+                    ROW_NUMBER() OVER (ORDER BY total_tokens DESC, total_cost DESC, LOWER(username) ASC, user_id ASC) as rank
                   FROM user_totals
                 )
                 SELECT rank FROM ranked WHERE user_id = ${user.id}


### PR DESCRIPTION
## What

Three surfaces show a user's rank for a finite period — the leaderboard's week/month/custom tab, the public profile's 7d/30d view, and the embed card's week/month view — and until now they did not agree on what a tie means.

`getLeaderboard.ts` builds its rank expression from a `sequentialRanks` flag. The period path passes `true` and emits `ROW_NUMBER() OVER (ORDER BY total_tokens DESC, total_cost DESC, LOWER(username) ASC, user_id ASC)` (a cost sort swaps the two metrics), which gives every user a distinct position and gives pagination a stable order. The all-time path passes `false` and emits `RANK() OVER (ORDER BY total_tokens DESC)`, so tied users share a position.

`publicProfileData.ts` and `getUserEmbedStats.ts` each rolled their own period rank with a bare `RANK() OVER (ORDER BY total_tokens DESC)`. So two users on the same period total read **#1 and #2** on the leaderboard's week tab, but **#1 and #1** — followed by a gap — on their own profile pages and on their embed cards, from the same data over the same window at the same moment.

## Change

Both finite-period rank queries now use the leaderboard's period expression and its tiebreak columns, matched to each surface's own ranking metric (the embed's cost sort orders `total_cost DESC, total_tokens DESC`, the tokens sort the other way around, and the profile ranks by tokens only).

The tiebreak needs `username` and `user_id` in scope, so each period CTE now also selects `u.username` (and, on the profile side, `SUM(CAST(d.cost AS DECIMAL(18,4))) AS total_cost` for the secondary term) and groups by `s.user_id, u.username`. `users.id` is the primary key the join runs through, so the added grouping column produces the same groups and the embed's `SELECT COUNT(*)::int FROM rankable` denominator is unchanged. The `u.leaderboard_hidden = false` filter and the date-range bounds are untouched — the same rows are ranked, and only the order within a tie moves. The `Number(...)` coercion of the returned bigint, the `unstable_cache` keys and tags, and the profile's empty-window skip all stay as they were.

**The all-time paths deliberately stay on shared `RANK()`.** They already agree with the leaderboard's all-time tab, and moving them to `ROW_NUMBER` would introduce exactly the same divergence in the other direction. Both files now carry a comment saying so, and the tests below pin it.

## Tests

`__tests__/api/usersProfile.test.ts` and `__tests__/lib/getUserEmbedStats.test.ts` mock `next/cache` and `drizzle-orm`'s `sql` tag, so they can assert on the SQL each path emits. Added there:

- `ranks the profile period window the way the leaderboard's period tab does` — asserts the period rank emits the full `ROW_NUMBER() OVER (ORDER BY total_tokens DESC, total_cost DESC, LOWER(username) ASC, user_id ASC)` clause, that no `RANK() OVER` is emitted on that path, that the hidden-user filter and both date bounds are unchanged, and that the cache key still carries the anchored window.
- `ranks the finite embed window the way the leaderboard's period tab ranks $sortBy` — the same check for the embed card, once per sort, pinning the metric order for each and the `of N` denominator.
- `keeps the lifetime profile rank on shared RANK` and the renamed `keeps the lifetime embed rank on shared RANK with no tie-breakers` — assert the all-time paths still emit `RANK()` and emit no `ROW_NUMBER` at all, so the mirror-image bug fails the suite too.

Four existing assertions that matched the old period SQL shape were updated from `RANK() OVER` to `ROW_NUMBER() OVER`. The embed test's SQL serializer now recurses into nested `sql` fragments — a conditional `ORDER BY` is interpolated as a value, and the old serializer flattened it to `[object Object]`, which hid the clause these tests are about.

Verified by falsification in both directions: reverting the source change fails 7 tests (the 3 new period tests plus the 4 updated ones) and leaves the two all-time tests passing; flipping the all-time queries to `ROW_NUMBER` instead fails exactly those two and nothing else.

## Verification

From `packages/frontend`, on the branch head:

- `npx tsc --noEmit` — exit 0
- `bun run test` — exit 0, **925 passed | 6 skipped (931)** across 87 passing / 1 skipped test files
- `bun run lint` — exit 0, 17 pre-existing warnings, none in the changed files

No database integration test: the repo has no harness for one on this path, so these tests pin the emitted SQL rather than Postgres' ordering of a real tie.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns finite-period ranks on profile and embed with the leaderboard’s period tab. Previously, profile/embed used shared RANK on period totals (ties showed the same position); now they use sequential ROW_NUMBER with the same tie-breakers as the leaderboard, so tied users read distinct positions consistently. All-time ranks remain on shared RANK.

- Period queries now rank by ROW_NUMBER over tokens/cost plus tie-breakers (tokens sort: total_tokens DESC, total_cost DESC, LOWER(username) ASC, user_id ASC; cost sort swaps the first two). CTEs include `u.username` (and profile includes summed `total_cost`) and group by `s.user_id, u.username`. Filters, date bounds, cache keys/tags, and the embed “of N” denominator are unchanged; only tie ordering moves. Tests assert emitted SQL for each path and update the SQL serializer to recurse nested fragments.

<sup>Written for commit ddf66e6cd6aec6b204a50d31e60ec48d556848a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

