### PR TITLE
fix(cli): show per-1M prices below a cent instead of rounding them to $0.00

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -3784,18 +3784,24 @@ fn run_pricing_lookup(
                 println!();
                 let input = pricing.pricing.input_cost_per_token.unwrap_or(0.0);
                 let output = pricing.pricing.output_cost_per_token.unwrap_or(0.0);
-                println!("  Input:  ${:.2} / 1M tokens", input * 1_000_000.0);
-                println!("  Output: ${:.2} / 1M tokens", output * 1_000_000.0);
+                println!(
+                    "  Input:  ${} / 1M tokens",
+                    format_per_million(input * 1_000_000.0)
+                );
+                println!(
+                    "  Output: ${} / 1M tokens",
+                    format_per_million(output * 1_000_000.0)
+                );
                 if let Some(cache_read) = pricing.pricing.cache_read_input_token_cost {
                     println!(
-                        "  Cache Read:  ${:.2} / 1M tokens",
-                        cache_read * 1_000_000.0
+                        "  Cache Read:  ${} / 1M tokens",
+                        format_per_million(cache_read * 1_000_000.0)
                     );
                 }
                 if let Some(cache_write) = pricing.pricing.cache_creation_input_token_cost {
                     println!(
-                        "  Cache Write: ${:.2} / 1M tokens",
-                        cache_write * 1_000_000.0
+                        "  Cache Write: ${} / 1M tokens",
+                        format_per_million(cache_write * 1_000_000.0)
                     );
                 }
                 println!();
@@ -3892,21 +3898,80 @@ fn run_pricing_list_overrides(json: bool) -> Result<()> {
     for entry in entries {
         println!("  {}", entry.model_id.bold());
         if let Some(input) = entry.input_cost_per_million_tokens {
-            println!("    Input:  ${:.2} / 1M tokens", input);
+            println!("    Input:  ${} / 1M tokens", format_per_million(input));
         }
         if let Some(output) = entry.output_cost_per_million_tokens {
-            println!("    Output: ${:.2} / 1M tokens", output);
+            println!("    Output: ${} / 1M tokens", format_per_million(output));
         }
         if let Some(cache_read) = entry.cache_read_input_token_cost_per_million_tokens {
-            println!("    Cache Read:  ${:.2} / 1M tokens", cache_read);
+            println!(
+                "    Cache Read:  ${} / 1M tokens",
+                format_per_million(cache_read)
+            );
         }
         if let Some(cache_write) = entry.cache_creation_input_token_cost_per_million_tokens {
-            println!("    Cache Write: ${:.2} / 1M tokens", cache_write);
+            println!(
+                "    Cache Write: ${} / 1M tokens",
+                format_per_million(cache_write)
+            );
         }
     }
     println!();
 
     Ok(())
+}
+
+/// Decimal places `format_per_million` may add past the first significant
+/// digit while looking for a rendering that round-trips back to the value.
+const PER_MILLION_EXTRA_DECIMALS: usize = 8;
+
+/// Render a dollar amount that is already scaled to one million tokens.
+///
+/// Two decimals is $0.01 resolution, and a lot of the pricing sheets live
+/// below that: anything under half a cent per 1M tokens collapses to `$0.00`
+/// and reads as "this model is free" rather than "this price is too small to
+/// show". So precision starts at whatever it takes to keep the first
+/// significant digit — which is what makes a real price impossible to render
+/// as `$0.00` — and escalates from there until the text round-trips.
+///
+/// Two decimals stay the floor in both directions. A genuine zero still
+/// renders `0.00`, so free models keep reading as free, and ordinary prices
+/// keep their cent column instead of being trimmed down to `$0.2`.
+fn format_per_million(amount: f64) -> String {
+    if !amount.is_finite() || amount == 0.0 {
+        return format!("{:.2}", amount);
+    }
+
+    // Leading zeros between the point and the first significant digit, so
+    // `min_decimals` always renders at least one nonzero digit.
+    let leading_zeros = (-amount.abs().log10().floor()).max(0.0) as usize;
+    let min_decimals = leading_zeros.saturating_add(1).max(2);
+    let max_decimals = min_decimals.saturating_add(PER_MILLION_EXTRA_DECIMALS);
+
+    for decimals in min_decimals..=max_decimals {
+        let rendered = format!("{:.*}", decimals, amount);
+        let Ok(parsed) = rendered.parse::<f64>() else {
+            continue;
+        };
+        // Sheet values carry the noise of their own decimal-to-binary
+        // conversion (a $0.10 price arrives as 0.09999999999999999), so accept
+        // the shortest rendering that is within representation error of the
+        // value rather than demanding an exact round-trip.
+        if (parsed - amount).abs() > f64::EPSILON * amount.abs().max(1.0) {
+            continue;
+        }
+        // Escalation overshoots on values that stop early ($0.0028 is reached
+        // at five decimals and renders "0.00280"), so drop the zeros it added.
+        // The decimal point stops the trim, so this cannot eat the integer
+        // part of a round number like "100.00".
+        let trimmed_zeros = rendered.len() - rendered.trim_end_matches('0').len();
+        let kept = decimals.saturating_sub(trimmed_zeros).max(2);
+        return format!("{:.*}", kept, amount);
+    }
+
+    // Smaller than the ceiling can round-trip. `max_decimals` still clears
+    // `leading_zeros`, so the price is visible even here.
+    format!("{:.*}", max_decimals, amount)
 }
 
 fn format_currency(n: f64) -> String {
@@ -6718,6 +6783,72 @@ mod tests {
         calculate_summary, calculate_years, ClientContribution, DailyContribution, DailyTotals,
         GraphMeta, GraphResult, TokenBreakdown,
     };
+
+    /// The overwhelming majority of the pricing sheet is at or above a cent
+    /// per 1M tokens, and that output must not move.
+    #[test]
+    fn format_per_million_keeps_two_decimals_for_ordinary_prices() {
+        // claude-sonnet-4 input/output, as `tokscale pricing` scales them.
+        assert_eq!(format_per_million(0.000003 * 1_000_000.0), "3.00");
+        assert_eq!(format_per_million(0.000015 * 1_000_000.0), "15.00");
+        // Its cache read: $0.30, stored as a value that is not exactly 0.3 in
+        // binary. The cent column has to survive that.
+        assert_eq!(format_per_million(0.0000003 * 1_000_000.0), "0.30");
+        assert_eq!(format_per_million(0.00000375 * 1_000_000.0), "3.75");
+        assert_eq!(format_per_million(0.06), "0.06");
+        assert_eq!(format_per_million(100.0), "100.00");
+    }
+
+    /// A model with no price is a different fact than a model with a small
+    /// one, and `$0.00` belongs to the first.
+    #[test]
+    fn format_per_million_renders_absent_price_as_zero() {
+        assert_eq!(format_per_million(0.0), "0.00");
+    }
+
+    /// The bug: below half a cent per 1M tokens, `{:.2}` rendered a real price
+    /// as free. Values are the ones LiteLLM actually publishes.
+    #[test]
+    fn format_per_million_never_renders_a_real_price_as_free() {
+        // perplexity/pplx-embed-v1-0.6b input.
+        assert_eq!(format_per_million(0.000000004 * 1_000_000.0), "0.004");
+        // fireworks_ai SSD-1B input, the cheapest key on the sheet.
+        assert_eq!(format_per_million(0.00000000013 * 1_000_000.0), "0.00013");
+        // tencent/deepseek-v4-pro cache read, whose input and output stay
+        // visible — so a zero here reads as a real price, not a lost digit.
+        assert_eq!(format_per_million(0.000000003625 * 1_000_000.0), "0.003625");
+        // tencent/deepseek-v4-flash cache read.
+        assert_eq!(format_per_million(0.0000000028 * 1_000_000.0), "0.0028");
+        // meta/muse-spark-1.2-contributor cache read.
+        assert_eq!(format_per_million(0.000000002 * 1_000_000.0), "0.002");
+        // Its input and output are ordinary and must not change alongside.
+        assert_eq!(format_per_million(0.000000435 * 1_000_000.0), "0.435");
+    }
+
+    /// gpt-5-nano and its four siblings sit at exactly $0.005 cache read.
+    /// `5e-9 * 1e6` lands a hair above the rounding boundary in binary, so two
+    /// decimals reported double the real price rather than half of it.
+    #[test]
+    fn format_per_million_shows_exact_half_cent_rather_than_doubling_it() {
+        let rendered = format_per_million(0.000000005 * 1_000_000.0);
+        assert_eq!(rendered, "0.005");
+        assert_ne!(rendered, "0.01");
+    }
+
+    /// The property worth holding across the whole sheet, not just the keys
+    /// that happen to break today: a nonzero price never reads as free.
+    #[test]
+    fn format_per_million_keeps_every_nonzero_price_visible() {
+        let mut cost_per_token = 0.5;
+        for _ in 0..40 {
+            cost_per_token /= 10.0;
+            let rendered = format_per_million(cost_per_token * 1_000_000.0);
+            assert!(
+                rendered.chars().any(|c| ('1'..='9').contains(&c)),
+                "{cost_per_token:e} per token rendered as ${rendered}"
+            );
+        }
+    }
 
     #[test]
     fn mcode_headless_args_inject_stream_json_immediately_after_exec() {

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -4093,6 +4093,45 @@ fn test_pricing_command_renders_sub_cent_prices() {
 }
 
 #[test]
+fn test_pricing_list_overrides_renders_sub_cent_prices() {
+    // `pricing list-overrides` reads per-1M values straight out of
+    // custom-pricing.json without scaling, so it shares the lookup path's
+    // formatter but not its arithmetic. Exercise it end to end: a cache-read
+    // override below a cent used to print $0.00, which is indistinguishable
+    // from an override the user never set.
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let config_dir = sandbox_config_dir(tmp.path());
+    fs::create_dir_all(&config_dir).expect("failed to create config dir");
+    fs::write(
+        config_dir.join("custom-pricing.json"),
+        serde_json::to_string(&serde_json::json!({
+            "models": {
+                "acme/sub-cent": {
+                    "input_cost_per_million_tokens": 0.435,
+                    "output_cost_per_million_tokens": 0.87,
+                    "cache_read_input_token_cost_per_million_tokens": 0.003625,
+                    "cache_creation_input_token_cost_per_million_tokens": 0.005,
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .expect("failed to write custom-pricing.json");
+
+    cmd_with_home(tmp.path())
+        .args(["pricing", "list-overrides", "--no-spinner"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("acme/sub-cent"))
+        .stdout(predicate::str::contains("Input:  $0.435 / 1M tokens"))
+        .stdout(predicate::str::contains("Output: $0.87 / 1M tokens"))
+        .stdout(predicate::str::contains(
+            "Cache Read:  $0.003625 / 1M tokens",
+        ))
+        .stdout(predicate::str::contains("Cache Write: $0.005 / 1M tokens"));
+}
+
+#[test]
 fn test_pricing_command_json() {
     let tmp = TempDir::new().expect("failed to create temp dir");
     prime_canonical_sonnet_pricing_cache(tmp.path(), "claude-sonnet-4-20250514");

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -4041,6 +4041,57 @@ fn test_pricing_command_success() {
         .stdout(predicate::str::contains("Output: $15.00 / 1M tokens"));
 }
 
+/// Sub-cent prices have to survive all the way to the terminal, not just
+/// through the formatter. Both keys below are real LiteLLM rows.
+#[test]
+fn test_pricing_command_renders_sub_cent_prices() {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_secs();
+    let payload = serde_json::to_string(&serde_json::json!({
+        "timestamp": now,
+        "data": {
+            // Ordinary input and output, cache read at $0.003625 / 1M. Two
+            // decimals blanked only the cache line, so the zero read as a real
+            // price sitting next to two believable ones.
+            "tencent/deepseek-v4-pro": {
+                "input_cost_per_token": 0.000000435,
+                "output_cost_per_token": 0.00000087,
+                "cache_read_input_token_cost": 0.000000003625,
+            },
+            // Cache read is exactly $0.005 / 1M, which two decimals rounded up
+            // to twice the real price rather than down to zero.
+            "gpt-5-nano": {
+                "input_cost_per_token": 0.00000005,
+                "output_cost_per_token": 0.0000004,
+                "cache_read_input_token_cost": 0.000000005,
+            },
+        },
+    }))
+    .unwrap();
+    let empty = format!(r#"{{"timestamp":{now},"data":{{}}}}"#);
+    write_canonical_pricing_cache_files(tmp.path(), &payload, &payload, &empty);
+
+    cmd_with_home(tmp.path())
+        .args(["pricing", "tencent/deepseek-v4-pro", "--no-spinner"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Input:  $0.435 / 1M tokens"))
+        .stdout(predicate::str::contains("Output: $0.87 / 1M tokens"))
+        .stdout(predicate::str::contains(
+            "Cache Read:  $0.003625 / 1M tokens",
+        ));
+
+    cmd_with_home(tmp.path())
+        .args(["pricing", "gpt-5-nano", "--no-spinner"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Input:  $0.05 / 1M tokens"))
+        .stdout(predicate::str::contains("Cache Read:  $0.005 / 1M tokens"));
+}
+
 #[test]
 fn test_pricing_command_json() {
     let tmp = TempDir::new().expect("failed to create temp dir");


### PR DESCRIPTION
Refs #1185

## What was wrong

`tokscale pricing` scaled every cost to a million tokens and formatted it with `{:.2}`. That is $0.01 resolution, and a lot of the pricing sheet lives below it: any value under half a cent per 1M tokens rendered `$0.00`. Against the LiteLLM sheet the CLI actually fetches, 12 model keys render a price they do not have. Nine of them render entirely free — the eight Fireworks image models ($0.00013–$0.001 per 1M) and `perplexity/pplx-embed-v1-0.6b` at $0.004 per 1M input — so a priced model was indistinguishable from an unpriced one.

Three more lose only their cache-read line while input and output stay visible. That is the worse shape of the two: on `tencent/deepseek-v4-pro` the input and output read $0.435 and $0.87, so the `$0.00` next to them reads as a real price of zero rather than a dropped digit.

Separately, five `gpt-5-nano` keys priced at exactly $0.005 per 1M rendered `$0.01` — double, not zero — because `5e-9 * 1e6` is `0.00500000000000000010` in binary and lands a hair above the rounding boundary.

The stored values were already correct and `--json` already printed them at full precision, so this was display only.

## What changed

One `format_per_million` helper now owns the rendering, and all eight call sites go through it: the four in `run_pricing_lookup` (which pass per-token values scaled by `1_000_000.0`) and the four in `run_pricing_list_overrides` (which read `*_per_million_tokens` from the user's `custom-pricing.json` and are already scaled). Taking the amount rather than the per-token cost is what lets both callers share it.

The helper starts at enough decimal places to keep the first significant digit, which is the property that makes a nonzero price impossible to render as `$0.00` however small it is, then escalates until the text round-trips back to the value, then trims the zeros that escalation added. Two decimals stay the floor in both directions: a genuine zero still renders `$0.00` so free models keep reading as free, and ordinary prices keep their cent column rather than being trimmed to `$0.2`.

The round-trip test uses a representation-error tolerance rather than exact string equality on purpose. Sheet values carry the noise of their own decimal-to-binary conversion — a $0.10 price arrives as `0.09999999999999999`, and roughly a thousand entries are like it — and demanding an exact round-trip would escalate all of those to full precision for no reason.

No stored value, JSON output, or cost arithmetic is touched. `format_cost_per_million` (the blended per-1M rate in reports) is a different quantity and is deliberately left alone.

## Verification

`cargo test -p tokscale-cli` passes: 1172 unit and 172 integration tests, zero failures. `cargo clippy -p tokscale-cli --all-targets -- -D warnings` and `cargo fmt --all -- --check` are both clean. Note that `--all-targets` also lints test code, which the CI invocation does not.

Five unit tests cover the helper directly as a pure function, and one integration test drives the real binary. The reporter noted they had measured the formatter rather than the binary's stdout, so that gap is now closed: with a primed pricing cache, `tokscale pricing tencent/deepseek-v4-pro` printed `Input:  $0.43`, `Output: $0.87`, `Cache Read:  $0.00` before this change and prints `$0.435`, `$0.87`, `$0.003625` after. `gpt-5-nano` cache read goes from `$0.01` to `$0.005`.

Verified by falsification rather than by the tests merely passing. Reverting the helper body to `format!("{:.2}", amount)` fails three of the five unit tests (`0.004` renders `0.00`, and the half-cent case renders `0.01` against an expected `0.005`) and the integration test. The two stability tests — ordinary prices keeping two decimals, and zero rendering `$0.00` — still pass under the old behavior, which is the point: they are guards against churn, not tests that only pass with the change in place.

## Not covered

The TUI and any other surface were not surveyed for the same two-decimal pattern; this changes only the two `pricing` subcommand paths, which is why this says Refs rather than Closes. The `run_pricing_list_overrides` sites are fixed by the same helper but have no measured population behind them, since they render whatever a user put in their own `custom-pricing.json`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows per‑1M prices below a cent instead of $0.00 or rounding to $0.01. Previously sub‑cent values looked free or rounded up; now the CLI prints enough decimals to show a real price while true zeros remain $0.00.

- Adds a shared format_per_million helper and routes eight pricing outputs through it.
- Uses dynamic precision: keep the first significant digit, expand until the text round‑trips within tolerance, then trim, with a 2‑decimal floor.
- Keeps outputs ≥ $0.01 identical; zero stays $0.00; exact half‑cent ($0.005) renders correctly instead of $0.01.
- Display‑only: stored values, `--json` output, and cost arithmetic are unchanged; `format_cost_per_million` is untouched.
- Adds unit tests and CLI tests covering sub‑cent rendering in both `pricing <model>` and `pricing list-overrides`.

<sup>Written for commit 41dd9b9d729ef53e2e281d2203b1fa2f759e27ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

