### PR TITLE
fix(pricing): keep the Kimi subscription namespace out of provider-scoped evidence

### DIFF
--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2589,30 +2589,68 @@ fn key_root_matches_hint(key: &str, hint_tags: &[String]) -> bool {
         .any(|tag| hint_tags.iter().any(|hint| hint == tag))
 }
 
+fn normalized_key_root(value: &str) -> String {
+    value
+        .trim()
+        .trim_end_matches('/')
+        .split('/')
+        .next()
+        .unwrap_or_default()
+        .to_lowercase()
+        .replace('-', "_")
+}
+
 /// Whether provider-tag folding makes the key root and hint match despite
 /// naming different billing endpoints. The alias keeps fallback rows reachable,
 /// but neither endpoint's root is the other endpoint's own top-level row.
 fn key_root_is_cross_provider_alias(key: &str, provider_id: &str) -> bool {
-    let normalize_root = |value: &str| {
-        value
-            .trim()
-            .trim_end_matches('/')
-            .split('/')
-            .next()
-            .unwrap_or_default()
-            .to_lowercase()
-            .replace('-', "_")
-    };
-    let root = normalize_root(key);
-    let hint = normalize_root(provider_id);
+    let root = normalized_key_root(key);
+    let hint = normalized_key_root(provider_id);
 
     let is_claude_endpoint = |value: &str| matches!(value, "anthropic" | "vertex" | "vertex_ai");
     root != hint && is_claude_endpoint(&root) && is_claude_endpoint(&hint)
 }
 
+// @keep: these roots look like providers and are not, which is the whole point.
+/// Dataset key roots that name a SUBSCRIPTION PLAN, not a billing endpoint.
+///
+/// Models.dev publishes every row under `kimi-for-coding/` with explicit
+/// 0.0/0.0 rates because a Kimi coding subscription is billed by the plan, not
+/// by the token. Rows like these are not a price sheet for anything.
+///
+/// Underscore-normalized to compare with `normalized_key_root`.
+const ZERO_PRICED_SUBSCRIPTION_NAMESPACES: &[&str] = &["kimi_for_coding"];
+
+/// Whether the key is rooted at a subscription namespace whose rows are
+/// published at $0.00, and so cannot prove a billing identity.
+///
+/// Same shape and same reason as `key_root_is_cross_provider_alias`: provider
+/// tag folding makes the root and the hint compare equal even though the root
+/// does not name the hinted billing endpoint. `kimi_for_coding` canonicalizes
+/// to `moonshotai` so a Kimi client's provider hint reaches the real
+/// `moonshotai/*` rates, and that direction of the fold is correct. The
+/// reverse is not: an exact model-part hit on a `kimi-for-coding/*` row says
+/// only that the plan lists the model, so promoting it to `ProviderScoped`
+/// would make `covers_usage` accept the explicit zero buckets and publish real
+/// usage to the leaderboard at $0.00. The row stays reachable as the weaker
+/// estimate it was, carrying `UnverifiedProviderIdentity`.
+///
+/// Unlike the claude-endpoint exception this ignores the hint spelling. A
+/// subscription namespace does not become a billing endpoint because the
+/// client happens to report its provider with the same word.
+///
+/// `pricing::aliases` redirects each known `kimi-for-coding` model id away from
+/// this namespace, but that table is a whitelist extended one id at a time;
+/// this covers the ids nobody has enumerated yet.
+fn key_root_is_zero_priced_subscription_namespace(key: &str) -> bool {
+    ZERO_PRICED_SUBSCRIPTION_NAMESPACES.contains(&normalized_key_root(key).as_str())
+}
+
 fn key_root_matches_provider_hint(key: &str, provider_id: &str) -> bool {
     let hint_tags = provider_identity::provider_tags(provider_id);
-    key_root_matches_hint(key, &hint_tags) && !key_root_is_cross_provider_alias(key, provider_id)
+    key_root_matches_hint(key, &hint_tags)
+        && !key_root_is_cross_provider_alias(key, provider_id)
+        && !key_root_is_zero_priced_subscription_namespace(key)
 }
 
 fn is_reseller_provider(key: &str) -> bool {
@@ -2765,6 +2803,7 @@ fn select_best_match(
             let by_root = candidates.iter().find(|k| {
                 key_root_matches_hint(k, &hint_tags)
                     && !provider_id.is_some_and(|hint| key_root_is_cross_provider_alias(k, hint))
+                    && !key_root_is_zero_priced_subscription_namespace(k)
             });
             let by_spelling = provider_id.and_then(|hint| {
                 let spelled: Vec<&&String> = candidates
@@ -4398,6 +4437,126 @@ mod tests {
             );
             assert!(result.evidence.alias_applied, "hint: {hint}");
             assert!(result.evidence.is_submission_safe(), "hint: {hint}");
+        }
+    }
+
+    /// `pricing::aliases` redirects every `kimi-for-coding` model id anybody has
+    /// noticed so far onto a real `moonshotai/*` row, so the zero-priced
+    /// subscription namespace is normally never reached. That whitelist is the
+    /// only thing standing between an id nobody has enumerated yet and a
+    /// leaderboard submission at $0.00: an exact model-part hit on a
+    /// `kimi-for-coding/*` row must stay the estimate it is, while the same
+    /// hint against Moonshot's own row still verifies.
+    #[test]
+    fn kimi_subscription_namespace_row_is_not_provider_scoped_evidence() {
+        let models_dev = HashMap::from([
+            (
+                "kimi-for-coding/k3-flash".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(0.0),
+                    output_cost_per_token: Some(0.0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "moonshotai/k3-pro".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(1e-6),
+                    output_cost_per_token: Some(2e-6),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        for hint in ["kimi_for_coding", "kimi-for-coding", "moonshot"] {
+            let subscription = lookup
+                .lookup_with_provider("k3-flash", Some(hint))
+                .expect("the subscription row stays reachable as an estimate");
+            assert_eq!(
+                subscription.matched_key, "kimi-for-coding/k3-flash",
+                "hint: {hint}"
+            );
+            assert_eq!(
+                subscription.evidence.kind,
+                ResolutionKind::ModelPart,
+                "hint: {hint}"
+            );
+            assert_eq!(
+                subscription.evidence.submission_safety_gap(),
+                Some(SubmissionSafetyGap::UnverifiedProviderIdentity),
+                "hint: {hint}"
+            );
+            assert!(!subscription.evidence.is_submission_safe(), "hint: {hint}");
+
+            let moonshot = lookup
+                .lookup_with_provider("k3-pro", Some(hint))
+                .expect("Moonshot's own row must still price");
+            assert_eq!(moonshot.matched_key, "moonshotai/k3-pro", "hint: {hint}");
+            assert_eq!(
+                moonshot.evidence.kind,
+                ResolutionKind::ProviderScoped,
+                "hint: {hint}"
+            );
+            assert!(moonshot.evidence.is_submission_safe(), "hint: {hint}");
+        }
+    }
+
+    /// When a model part exists in both places, the zero-priced subscription
+    /// row must also lose the candidate ranking, not merely the evidence
+    /// upgrade. Otherwise the reported cost for real usage is still $0.00; the
+    /// row is only kept out of the leaderboard.
+    #[test]
+    fn real_moonshot_row_outranks_the_zero_priced_subscription_row() {
+        let models_dev = HashMap::from([
+            (
+                "kimi-for-coding/k3-flash".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(0.0),
+                    output_cost_per_token: Some(0.0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "moonshotai/k3-flash".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(1e-6),
+                    output_cost_per_token: Some(2e-6),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        for hint in ["kimi_for_coding", "kimi-for-coding", "moonshot"] {
+            let result = lookup
+                .lookup_with_provider("k3-flash", Some(hint))
+                .expect("the hinted lookup must price");
+            assert_eq!(result.matched_key, "moonshotai/k3-flash", "hint: {hint}");
+            assert_eq!(
+                result.pricing.input_cost_per_token,
+                Some(1e-6),
+                "hint: {hint}"
+            );
+            // The two rows publish different rates, so the selected row is a
+            // reported estimate rather than a publishable price.
+            assert_eq!(
+                result.evidence.submission_safety_gap(),
+                Some(SubmissionSafetyGap::PriceDisagreement),
+                "hint: {hint}"
+            );
         }
     }
 


### PR DESCRIPTION
## The regression

`canonicalize` in `crates/tokscale-core/src/provider_identity.rs` gained a `"kimi_for_coding" => "moonshotai"` arm in the unreleased range (v4.13.0..main). Its purpose is sound: a client that reports provider `kimi_for_coding` should verify against the real `moonshotai/*` pricing row instead of falling through to an unpriced estimate.

`key_root_matches_provider_hint` in `crates/tokscale-core/src/pricing/lookup.rs` canonicalizes both the key root and the hint, so the fold also runs in the other direction. A models.dev key rooted at `kimi-for-coding/` now reads as the Moonshot billing provider. `kimi-for-coding/*` is a subscription namespace: its rows are published with explicit 0.0 input and output rates because the plan, not the token, is what was paid for. The consequence is that an exact model-part match against such a row was promoted to `ProviderScoped` evidence, `covers_usage` accepted the explicit zero buckets, and the row became submission-safe — so real usage would submit to the leaderboard at $0.00.

Nothing shows this today only because `pricing/aliases.rs` redirects every known id away from the namespace (`kimi-for-coding`, `kimi-for-coding-highspeed`, `k3`, `k3-256k`, `k3-agent`, `k3-agent-swarm`). That table is a whitelist that has been extended reactively each time somebody noticed a new id, so any current-but-unaliased or future `kimi-for-coding/<model>` row falls straight through it. Before the canonicalization arm, those rows resolved to a non-submittable estimate.

## The fix

Make the identity fold asymmetric, following the exception already in `key_root_is_cross_provider_alias` rather than inventing a new mechanism. A new `key_root_is_zero_priced_subscription_namespace` names the key roots that are subscription plans rather than billing endpoints (currently just `kimi_for_coding`), and `key_root_matches_provider_hint` refuses to treat such a root as the hinted provider. The two helpers now share an extracted `normalized_key_root`.

The same exclusion is applied to the `by_root` tier of `select_best_match`, mirroring where the claude-endpoint exception is already applied. Without it the subscription row still wins the candidate ranking when a real `moonshotai/*` row lists the same model part, so the leaderboard is protected but the user's reported cost is still $0.00. With it the real row is selected and the real rate is reported.

The exclusion deliberately ignores the hint spelling, which is where it differs from the claude-endpoint precedent. A subscription namespace does not become a billing endpoint because the client happens to report its provider with that same word, and Kimi clients do report the hint literally as `kimi-for-coding`.

Hint-side canonicalization is unchanged. A `kimi_for_coding` hint that resolves to a genuine `moonshotai/*` row still verifies as `ProviderScoped` and still submits, and every existing alias redirect resolves exactly as before.

## Tests

`kimi_subscription_namespace_row_is_not_provider_scoped_evidence` looks up an unaliased model against a `kimi-for-coding/*` row published at explicit 0.0/0.0, for hints `kimi_for_coding`, `kimi-for-coding` and `moonshot`. It asserts the resolution kind stays `ModelPart` and the gap is `UnverifiedProviderIdentity`, and that the same hints against a real `moonshotai/*` row in the same fixture still come back `ProviderScoped` and submission-safe.

`real_moonshot_row_outranks_the_zero_priced_subscription_row` covers the ranking half: with both rows listing the same model part, the real row is selected and the reported input rate is the real one.

Reverting the guard makes both new tests fail — `ProviderScoped` instead of `ModelPart` on the first, `kimi-for-coding/k3-flash` instead of `moonshotai/k3-flash` on the second — while `hinted_kimi_k3_selects_the_real_moonshotai_row_with_provider_scoped_evidence` still passes, confirming the two directions of the fold are independent.

## Verification

`cargo test -p tokscale-core pricing` (394 passed), `cargo test -p tokscale-core` (1847 passed, 2 ignored), `cargo clippy -p tokscale-core --all-targets -- -D warnings` and `cargo fmt --all -- --check` all exit 0.
