### PR TITLE
fix(pricing): keep subscription-namespace exact matches out of submission

### DIFF
--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -184,6 +184,17 @@ pub struct ResolutionEvidence {
     pub alias_applied: bool,
     pub normalized: bool,
     pub stripped: bool,
+    /// Whether the matched key is rooted at a subscription namespace whose
+    /// rows publish a plan, not a tariff (see
+    /// `ZERO_PRICED_SUBSCRIPTION_NAMESPACES`).
+    ///
+    /// Independent of `kind`, because the namespace disqualifies the row no
+    /// matter how it was reached. `kind` records how strong the match was, and
+    /// a `kimi-for-coding/<model>` id is genuinely an exact hit on its own
+    /// dataset key — the key just is not a price sheet. Encoding this as a
+    /// weaker `kind` would misreport the match and would still leave every
+    /// future resolution path free to hand the row a strong kind again.
+    pub subscription_namespace: bool,
 }
 
 impl ResolutionEvidence {
@@ -196,6 +207,7 @@ impl ResolutionEvidence {
             alias_applied: false,
             normalized: false,
             stripped: false,
+            subscription_namespace: false,
         }
     }
 
@@ -207,6 +219,14 @@ impl ResolutionEvidence {
     /// that decides safety is what keeps a diagnostic from claiming candidates
     /// disagreed when the lookup only ever saw one.
     pub fn submission_safety_gap(&self) -> Option<SubmissionSafetyGap> {
+        // Checked ahead of `kind` because it disqualifies every kind. A
+        // subscription namespace prices the plan rather than the request, so
+        // the strongest possible match on one of its rows still proves only
+        // that the plan lists the model — never that the request was billed at
+        // the rate the row publishes.
+        if self.subscription_namespace {
+            return Some(SubmissionSafetyGap::UnverifiedProviderIdentity);
+        }
         match self.kind {
             // These fallbacks start from a bare id and add or borrow a
             // provider-qualified row. Matching the model spelling alone does
@@ -255,6 +275,11 @@ impl ResolutionEvidence {
             alias_applied: self.alias_applied || donor.alias_applied,
             normalized: self.normalized || donor.normalized,
             stripped: self.stripped || donor.stripped,
+            // Either side taints the composed row: the filled row is quoted
+            // under its own key, and it quotes the donor's rates. `kind` alone
+            // does not carry this, because a subscription-namespace donor can
+            // hold a perfectly strong kind.
+            subscription_namespace: self.subscription_namespace || donor.subscription_namespace,
         }
     }
 }
@@ -299,6 +324,23 @@ impl LookupResult {
 
     fn with_stripping(mut self) -> Self {
         self.evidence.stripped = true;
+        self
+    }
+
+    /// Record whether the selected key is rooted at a zero-priced subscription
+    /// namespace.
+    ///
+    /// Read off the key at the end of resolution rather than stamped at each
+    /// construction site: resolution has many terminal branches (full-key
+    /// exact, model-part, provider-scoped, stripped prefix or suffix, forced
+    /// source, generic-prefix retry), every one of them can land on such a
+    /// row, and only some of them ever consult a provider hint.
+    /// `key_root_matches_provider_hint` guards the hint-driven promotion; this
+    /// covers the rest, including the id that IS the qualified key and so
+    /// takes the full-key exact branch without a hint being involved at all.
+    fn with_subscription_namespace_check(mut self) -> Self {
+        self.evidence.subscription_namespace =
+            key_root_is_zero_priced_subscription_namespace(&self.matched_key);
         self
     }
 }
@@ -505,7 +547,31 @@ impl PricingLookup {
         self.lookup_with_source_and_provider(model_id, force_source, None)
     }
 
+    /// Resolve a model id, then judge the selected key's namespace.
+    ///
+    /// The namespace check runs here, on the way out, because this is the one
+    /// place every dataset resolution passes through. `resolve_with_source`
+    /// below has a dozen terminal `return`s across the alias, exact,
+    /// model-part, provider-scoped, prefix-strip and suffix-strip branches;
+    /// stamping the flag on each of them would leave the next branch anybody
+    /// adds unguarded, which is exactly how the full-key exact branch came to
+    /// hand a `kimi-for-coding/*` row submission-safe `Exact` evidence while
+    /// the promotion path was already refusing it.
+    ///
+    /// Custom pricing is resolved by `PricingService` and never reaches here,
+    /// which is deliberate: an entry in `custom-pricing.json` is the user
+    /// asserting a rate for their own id, not a dataset row being read as one.
     pub fn lookup_with_source_and_provider(
+        &self,
+        model_id: &str,
+        force_source: Option<&str>,
+        provider_id: Option<&str>,
+    ) -> Option<LookupResult> {
+        self.resolve_with_source_and_provider(model_id, force_source, provider_id)
+            .map(LookupResult::with_subscription_namespace_check)
+    }
+
+    fn resolve_with_source_and_provider(
         &self,
         model_id: &str,
         force_source: Option<&str>,
@@ -2642,6 +2708,14 @@ const ZERO_PRICED_SUBSCRIPTION_NAMESPACES: &[&str] = &["kimi_for_coding"];
 /// `pricing::aliases` redirects each known `kimi-for-coding` model id away from
 /// this namespace, but that table is a whitelist extended one id at a time;
 /// this covers the ids nobody has enumerated yet.
+///
+/// Two callers, because refusing the promotion is not the whole rule.
+/// `key_root_matches_provider_hint` keeps a hinted model-part hit from being
+/// upgraded, and `LookupResult::with_subscription_namespace_check` marks
+/// whichever resolution finally wins. Only the second covers a lookup whose id
+/// IS the qualified key: that takes the full-key exact branch, which asks
+/// nothing about a provider and so was handed submission-safe `Exact`
+/// evidence with the promotion guard already in place.
 fn key_root_is_zero_priced_subscription_namespace(key: &str) -> bool {
     ZERO_PRICED_SUBSCRIPTION_NAMESPACES.contains(&normalized_key_root(key).as_str())
 }
@@ -2836,6 +2910,7 @@ fn select_best_match(
                     alias_applied: false,
                     normalized: false,
                     stripped: false,
+                    subscription_namespace: false,
                 },
             })
         })

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -493,6 +493,9 @@ impl PricingService {
                     // to disclose: the matched key is not the requested id.
                     normalized: result.normalized,
                     stripped: false,
+                    // A custom entry is the user stating a rate for their own
+                    // id, not a dataset namespace being read as a price sheet.
+                    subscription_namespace: false,
                 },
             })
     }
@@ -609,6 +612,109 @@ mod tests {
         let cost =
             service.calculate_cost_with_provider("nemotron-free-fixture", Some("kenari"), &usage);
         assert_eq!(cost, 0.0, "an all-zero row must price at exactly zero");
+    }
+
+    // Regression: the provider-hint guard only covers the model-part promotion
+    // path. An unaliased `kimi-for-coding/<model>` id IS its own dataset key,
+    // so it resolves through the full-key exact branch and was handed
+    // `ResolutionKind::Exact`, which is submission-safe by construction. The
+    // row publishes explicit 0.0 rates, so `covers_usage` accepted every
+    // bucket and real usage submitted to the leaderboard at $0.00. Runs
+    // through `PricingService` because the lookup helper alone does not show
+    // what submission validation actually asks.
+    //
+    // The plan rate stays visible for reporting; only its publishability
+    // changes. A qualified `moonshotai/*` key in the same dataset must keep
+    // its submission-safe exact evidence, so the rule cannot be "the key is
+    // qualified" or "the rates are zero".
+    #[test]
+    fn an_unaliased_kimi_subscription_key_is_not_submission_safe() {
+        let models_dev = HashMap::from([
+            (
+                "kimi-for-coding/k3-unlisted-fixture".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(0.0),
+                    output_cost_per_token: Some(0.0),
+                    cache_read_input_token_cost: Some(0.0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "moonshotai/k3-metered-fixture".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(1e-6),
+                    output_cost_per_token: Some(2e-6),
+                    cache_read_input_token_cost: Some(1e-7),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let service = PricingService::new_with_custom_and_models_dev(
+            CustomPricing::default(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+        let usage = cache_read_usage();
+
+        for hint in [Some("kimi_for_coding"), Some("moonshot"), None] {
+            let subscription = service
+                .resolve_for_usage_with_provider(
+                    "kimi-for-coding/k3-unlisted-fixture",
+                    hint,
+                    &usage,
+                )
+                .expect("the plan rate stays visible for reporting");
+            assert_eq!(
+                subscription.matched_key, "kimi-for-coding/k3-unlisted-fixture",
+                "hint: {hint:?}"
+            );
+            assert_eq!(
+                subscription.evidence.submission_safety_gap(),
+                Some(lookup::SubmissionSafetyGap::UnverifiedProviderIdentity),
+                "hint: {hint:?}"
+            );
+            assert!(
+                !subscription.evidence.is_submission_safe(),
+                "hint: {hint:?}"
+            );
+            assert!(
+                !service.covers_usage_with_provider(
+                    "kimi-for-coding/k3-unlisted-fixture",
+                    hint,
+                    &usage
+                ),
+                "a subscription-plan row must not authorize a submission, hint: {hint:?}"
+            );
+            // Reporting keeps the plan rate. The row is excluded from the
+            // leaderboard, not dropped from the user's own cost view.
+            assert_eq!(
+                service.calculate_cost_with_provider(
+                    "kimi-for-coding/k3-unlisted-fixture",
+                    hint,
+                    &usage
+                ),
+                0.0,
+                "hint: {hint:?}"
+            );
+
+            let metered = service
+                .resolve_for_usage_with_provider("moonshotai/k3-metered-fixture", hint, &usage)
+                .expect("Moonshot's own metered row must still price");
+            assert_eq!(
+                metered.matched_key, "moonshotai/k3-metered-fixture",
+                "hint: {hint:?}"
+            );
+            assert_eq!(
+                metered.evidence.submission_safety_gap(),
+                None,
+                "hint: {hint:?}"
+            );
+            assert!(
+                service.covers_usage_with_provider("moonshotai/k3-metered-fixture", hint, &usage),
+                "hint: {hint:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

`ZERO_PRICED_SUBSCRIPTION_NAMESPACES` and `key_root_is_zero_priced_subscription_namespace` closed one way into submission: a hinted model-part hit on a `kimi-for-coding/*` row is no longer promoted to `ProviderScoped`. The other way stayed open. When the reported model id IS the qualified key, `exact_match_models_dev` takes its full-key branch, which never consults a provider hint and returns `ResolutionEvidence::deterministic(ResolutionKind::Exact)`. `Exact` is submission-safe by construction, so the row's explicit `0.0` rates satisfy `covers_usage` and real usage publishes to the leaderboard at $0.00 — exactly the invariant the promotion guard set out to establish.

## Approach

Record the namespace on `ResolutionEvidence` rather than encoding it in `ResolutionKind`. `submission_safety_gap` consults the new `subscription_namespace` flag ahead of `kind`, so the namespace disqualifies the row however strong the match was, and `borrowing_from` ORs it from both sides so a composed row cannot launder it back to safe through a strong-kinded donor.

The flag is stamped once, on the way out of `lookup_with_source_and_provider`, which is the single point every dataset resolution passes through. The resolver has a dozen terminal `return`s across the alias, exact, model-part, provider-scoped, forced-source, prefix-strip and suffix-strip branches, and any of them can land on such a row; stamping at each construction site would leave the next branch anybody adds unguarded, which is how the full-key branch stayed open while the promotion path was already refusing it.

Demoting the match to `ModelPart` was the obvious alternative and was rejected: a `kimi-for-coding/<model>` id genuinely is an exact hit on its own dataset key — the key just is not a price sheet — so a weaker kind would misreport the match while still leaving every future path free to hand the row a strong kind again.

## What does not change

The rule keys on the namespace, not on the rates, so a genuinely free model whose row is all zeros still covers usage and still prices at exactly $0.00. The subscription row also stays usable for reporting: `resolve_for_usage_with_provider` still returns it and `calculate_cost_with_provider` still returns the published $0.00, so the user keeps seeing their plan rate. It simply no longer counts as proof of billing. Custom pricing is resolved by `PricingService` and never reaches the check, which is deliberate — an entry in `custom-pricing.json` is the user asserting a rate for their own id, not a dataset row being read as one.

## Tests

`an_unaliased_kimi_subscription_key_is_not_submission_safe` runs end to end through `PricingService` for the hints `kimi_for_coding`, `moonshot`, and none, asserting on the evidence and gap rather than the price: the qualified `kimi-for-coding/*` key resolves, reports `UnverifiedProviderIdentity`, is refused by `covers_usage_with_provider`, and still prices at $0.00 for display. The same test pins a qualified `moonshotai/*` row in the same dataset as gap-free and submission-safe, so the rule cannot be read as "the key is qualified" or "the rates are zero".

`hinted_kimi_k3_selects_the_real_moonshotai_row_with_provider_scoped_evidence`, `real_moonshot_row_outranks_the_zero_priced_subscription_row`, `kimi_subscription_namespace_row_is_not_provider_scoped_evidence` and `a_hinted_all_zero_row_covers_cache_usage_through_the_service` all pass untouched.

## Verification

`cargo test -p tokscale-core pricing` 395 passed, 0 failed. `cargo test -p tokscale-core` 1857 passed, 0 failed, 2 ignored. `cargo clippy -p tokscale-core --all-targets -- -D warnings` and `cargo fmt --all -- --check` both clean, and `cargo check --workspace --all-targets` builds.

Falsified in two steps. Removing the `with_subscription_namespace_check` stamp makes the new test fail on the evidence assertion with `left: None, right: Some(UnverifiedProviderIdentity)`, confirming the pre-fix path really did produce submission-safe evidence. Removing the evidence assertions as well makes it fail one line later on `covers_usage_with_provider` returning `true`, confirming the bypass reached the actual submission decision and was not only a flag mismatch. Restoring both re-runs green.
