### PR TITLE
perf(leaderboard): keep the default leaderboard cache warm

### DIFF
--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextResponse, after } from "next/server";
 import { revalidateTag } from "next/cache";
 import { db, apiTokens, submissions, submittedDevices, dailyBreakdown } from "@/lib/db";
 import { and, eq, sql } from "drizzle-orm";
@@ -41,6 +41,7 @@ import {
 } from "@/lib/db/parserHighWater";
 import { SOURCE_DISPLAY_NAMES } from "@/lib/constants";
 import { normalizeUsernameCacheKey, revalidateUsernamePaths } from "@/lib/db/usernameLookup";
+import { getLeaderboardData } from "@/lib/leaderboard/getLeaderboard";
 import { revalidateUserGroupLeaderboards } from "@/lib/groups/cache";
 import { LEGACY_DEVICE_KEY } from "@/lib/devices/shared";
 import { createSafeRecord, ownValue } from "@/lib/safeRecord";
@@ -1271,6 +1272,20 @@ export async function POST(request: Request) {
       revalidateTag(`user-rank:${usernameCacheKey}`, "max");
     } catch (e) {
       console.error("Public cache invalidation failed:", e);
+    }
+
+    // Re-warm the default leaderboard view in the background so the first
+    // visitor after the invalidation gets a cache hit instead of paying the
+    // multi-second cold aggregation query.
+    try {
+      after(() =>
+        getLeaderboardData().catch((e) => {
+          console.error("Leaderboard cache warmup failed:", e);
+        }),
+      );
+    } catch {
+      // `after` throws outside a request scope (e.g. direct handler calls in
+      // tests) — the warmup is best-effort, so skip it there.
     }
 
     try {

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -382,7 +382,7 @@ export function getLeaderboardData(
         customTo,
       ),
     [cacheKey],
-    { tags: ["leaderboard", `leaderboard:${period}`], revalidate: 60 },
+    { tags: ["leaderboard", `leaderboard:${period}`], revalidate: 300 },
   )();
 }
 
@@ -452,7 +452,7 @@ export function getUserRank(
     [`user-rank:${usernameCacheKey}:${periodKey}:${sortBy}`],
     {
       tags: ["leaderboard", "user-rank", `user-rank:${usernameCacheKey}`],
-      revalidate: 60,
+      revalidate: 300,
     },
   )();
 }


### PR DESCRIPTION
## Problem

The leaderboard is slow on first visit: `/api/leaderboard` TTFB measured at ~4.3s cold vs ~80ms warm. The all-time query aggregates the full `submissions` table per user with a `RANK()` window, and since **every submit invalidates the cache** via `revalidateTag("leaderboard")`, the first visitor after each submit paid that cold query.

## Fix

1. **Re-warm the default leaderboard view after each submit** — after the submit response is sent (`next/server` `after()`), recompute `getLeaderboardData()` with default params in the background, so visitors land on a warm cache instead of triggering the cold aggregation themselves. Wrapped in try/catch since `after()` throws outside a request scope (direct handler calls in tests).
2. **Raise `revalidate` from 60s to 300s** in `getLeaderboardData` / `getUserRank` — writes already invalidate explicitly via tags, so the TTL only bounds recomputation of an *unchanged* leaderboard.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run test` — 932 passed, 6 skipped

A follow-up with larger impact would be maintaining per-user aggregate totals (updated incrementally on submit) so the cold query drops from O(all submissions) to O(users) — happy to look into that separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)