### PR TITLE
fix(tui): enable full color in tmux with 256color or truecolor support

### DIFF
--- a/crates/tokscale-cli/src/tui/themes.rs
+++ b/crates/tokscale-cli/src/tui/themes.rs
@@ -41,6 +41,14 @@ impl TerminalColorMode {
             return Self::Compatible;
         }
 
+        if term_program == "tmux" {
+            if matches!(colorterm.as_str(), "truecolor" | "24bit")
+                || term.contains("tmux-256color")
+            {
+                return Self::FullColor;
+            }
+        }
+
         if matches!(colorterm.as_str(), "truecolor" | "24bit")
             || term.contains("truecolor")
             || term.contains("24bit")
@@ -681,6 +689,23 @@ mod tests {
     #[test]
     fn xterm_256_without_truecolor_evidence_uses_compatible_colors() {
         let mode = TerminalColorMode::from_env(env(&[("TERM", "xterm-256color")]));
+
+        assert_eq!(mode, TerminalColorMode::Compatible);
+    }
+
+    #[test]
+    fn tmux_program_with_tmux_256_term_keeps_full_color() {
+        let mode = TerminalColorMode::from_env(env(&[
+            ("TERM_PROGRAM", "tmux"),
+            ("TERM", "tmux-256color"),
+        ]));
+
+        assert_eq!(mode, TerminalColorMode::FullColor);
+    }
+
+    #[test]
+    fn tmux_256_without_term_program_uses_compatible_colors() {
+        let mode = TerminalColorMode::from_env(env(&[("TERM", "tmux-256color")]));
 
         assert_eq!(mode, TerminalColorMode::Compatible);
     }


### PR DESCRIPTION
`tmux -2u` can support `FullColor`,  but since `v4.13`, tmux is falled back into `Compatible` mode, lead to broken theme palette.

This commit add `tmux-256color` to the `FullColor` list.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tmux color detection so sessions with 256color or truecolor support use FullColor instead of falling back to Compatible, which broke the theme palette since tmux v4.13.

- The new check only applies when `TERM_PROGRAM` is `tmux`; a bare `tmux-256color` TERM without that evidence still uses Compatible.

<sup>Written for commit 0eb2fe484fc214543c23452f5ddd9107d0174380. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

