### PR TITLE
perf(opencode): scan only rows changed since the last cached parse

### DIFF
--- a/crates/tokscale-cli/src/tui/themes.rs
+++ b/crates/tokscale-cli/src/tui/themes.rs
@@ -41,12 +41,11 @@ impl TerminalColorMode {
             return Self::Compatible;
         }
 
-        if term_program == "tmux" {
-            if matches!(colorterm.as_str(), "truecolor" | "24bit")
-                || term.contains("tmux-256color")
-            {
-                return Self::FullColor;
-            }
+        if term_program == "tmux"
+            && (matches!(colorterm.as_str(), "truecolor" | "24bit")
+                || term.contains("tmux-256color"))
+        {
+            return Self::FullColor;
         }
 
         if matches!(colorterm.as_str(), "truecolor" | "24bit")

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -9366,6 +9366,185 @@ mod tests {
         }
     }
 
+    /// Build a `message` table with the columns a modern OpenCode database has.
+    fn create_timed_opencode_db(db_path: &std::path::Path) -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE session (
+                 id TEXT PRIMARY KEY,
+                 directory TEXT NOT NULL,
+                 title TEXT
+             );
+             CREATE TABLE message (
+                 id TEXT PRIMARY KEY,
+                 session_id TEXT NOT NULL,
+                 time_created INTEGER NOT NULL,
+                 time_updated INTEGER NOT NULL,
+                 data TEXT NOT NULL
+             );
+             INSERT INTO session (id, directory, title)
+             VALUES ('session-1', '/tmp/project', 'A session');",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn timed_opencode_payload(id: &str, output: i64) -> String {
+        format!(
+            r#"{{
+                "id": "{id}",
+                "role": "assistant",
+                "modelID": "claude-sonnet-4",
+                "providerID": "anthropic",
+                "tokens": {{ "input": 100, "output": {output}, "reasoning": 0, "cache": {{ "read": 0, "write": 0 }} }},
+                "time": {{ "created": 1700000000000.0 }}
+            }}"#
+        )
+    }
+
+    fn insert_timed_opencode_row(conn: &rusqlite::Connection, id: &str, created: i64, output: i64) {
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data)
+             VALUES (?1, 'session-1', ?2, ?2, ?3)",
+            rusqlite::params![id, created, timed_opencode_payload(id, output)],
+        )
+        .unwrap();
+    }
+
+    fn total_output_tokens(messages: &[UnifiedMessage]) -> i64 {
+        messages.iter().map(|message| message.tokens.output).sum()
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_opencode_warm_scan_reads_only_changed_rows_and_agrees_with_a_cold_parse() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+
+        let db_dir = source_home.path().join(".local/share/opencode");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        let db_path = db_dir.join("opencode.db");
+        let conn = create_timed_opencode_db(&db_path);
+        insert_timed_opencode_row(&conn, "msg-aaa", 1_000, 50);
+        insert_timed_opencode_row(&conn, "msg-zzz", 2_000, 60);
+
+        let cold = parse_all_messages_with_pricing(
+            source_home.path().to_str().unwrap(),
+            &["opencode".to_string()],
+            None,
+        );
+        assert_eq!(cold.len(), 2);
+        assert_eq!(total_output_tokens(&cold), 110);
+
+        let entry = message_cache::SourceMessageCache::load()
+            .get(
+                message_cache::CacheIdentity::for_client(ClientId::OpenCode),
+                &db_path,
+            )
+            .expect("the cold parse caches the database");
+        assert!(
+            entry.opencode_incremental.is_some(),
+            "a cold parse has to leave the mark a warm scan resumes from"
+        );
+
+        // The oldest row, first by id, is rewritten long after it was
+        // inserted -- the case an id-keyed mark would skip -- and a newer row
+        // arrives alongside it.
+        conn.execute(
+            "UPDATE message SET data = ?2, time_updated = ?3 WHERE id = ?1",
+            rusqlite::params!["msg-aaa", timed_opencode_payload("msg-aaa", 500), 9_000],
+        )
+        .unwrap();
+        insert_timed_opencode_row(&conn, "msg-mmm", 9_500, 70);
+
+        let rescans_before = sessions::opencode_schema::INCREMENTAL_RESCANS
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let warm = parse_all_messages_with_pricing(
+            source_home.path().to_str().unwrap(),
+            &["opencode".to_string()],
+            None,
+        );
+        assert_eq!(
+            sessions::opencode_schema::INCREMENTAL_RESCANS
+                .load(std::sync::atomic::Ordering::Relaxed),
+            rescans_before + 1,
+            "the warm scan must take the incremental path, not re-parse everything"
+        );
+        assert_eq!(warm.len(), 3);
+        assert_eq!(
+            total_output_tokens(&warm),
+            630,
+            "the rewritten row must be counted at its new value, once"
+        );
+
+        // Same database state, empty cache: the two paths have to agree.
+        let fresh_cache_home = tempfile::TempDir::new().unwrap();
+        let _fresh_cache_env = redirect_cache_home(fresh_cache_home.path());
+        let recold = parse_all_messages_with_pricing(
+            source_home.path().to_str().unwrap(),
+            &["opencode".to_string()],
+            None,
+        );
+        let mut warm_keys: Vec<Option<String>> = warm
+            .iter()
+            .map(|message| message.dedup_key.clone())
+            .collect();
+        let mut cold_keys: Vec<Option<String>> = recold
+            .iter()
+            .map(|message| message.dedup_key.clone())
+            .collect();
+        warm_keys.sort();
+        cold_keys.sort();
+        assert_eq!(warm_keys, cold_keys);
+        assert_eq!(total_output_tokens(&warm), total_output_tokens(&recold));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_opencode_warm_scan_re_parses_after_a_row_is_deleted() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+
+        let db_dir = source_home.path().join(".local/share/opencode");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        let db_path = db_dir.join("opencode.db");
+        let conn = create_timed_opencode_db(&db_path);
+        insert_timed_opencode_row(&conn, "msg-aaa", 1_000, 50);
+        insert_timed_opencode_row(&conn, "msg-zzz", 2_000, 60);
+
+        let cold = parse_all_messages_with_pricing(
+            source_home.path().to_str().unwrap(),
+            &["opencode".to_string()],
+            None,
+        );
+        assert_eq!(cold.len(), 2);
+
+        // OpenCode cascades a session delete onto its messages. An incremental
+        // scan cannot see the row that went away, so the guard has to force a
+        // full re-parse rather than keep counting it.
+        conn.execute("DELETE FROM message WHERE id = 'msg-zzz'", [])
+            .unwrap();
+
+        let rescans_before = sessions::opencode_schema::INCREMENTAL_RESCANS
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let warm = parse_all_messages_with_pricing(
+            source_home.path().to_str().unwrap(),
+            &["opencode".to_string()],
+            None,
+        );
+        assert_eq!(
+            sessions::opencode_schema::INCREMENTAL_RESCANS
+                .load(std::sync::atomic::Ordering::Relaxed),
+            rescans_before,
+            "a deletion must not be served by an incremental scan"
+        );
+        assert_eq!(warm.len(), 1);
+        assert_eq!(warm[0].dedup_key.as_deref(), Some("msg-aaa"));
+        assert_eq!(total_output_tokens(&warm), 50);
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_sqlite_source_cache_invalidates_on_wal_change() {

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1491,6 +1491,120 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         )
     }
 
+    /// OpenCode's SQLite lane, where a warm scan reads only the rows that
+    /// changed since the last one.
+    ///
+    /// Bespoke rather than routed through `load_or_parse_sqlite_source`: the
+    /// incremental scan needs the cached *messages* to merge into, which the
+    /// generic parse closure never sees, plus the mark the previous scan left
+    /// on the entry. Codex has its own loader for the same reason.
+    fn load_or_parse_opencode_sqlite_source(
+        path: &Path,
+        source_cache: &message_cache::SourceMessageCache,
+        pricing: Option<&pricing::PricingService>,
+    ) -> CachedParseOutcome {
+        let identity = message_cache::CacheIdentity::for_client(ClientId::OpenCode);
+
+        fn finish(
+            identity: message_cache::CacheIdentity,
+            path: &Path,
+            fingerprint: Option<message_cache::SourceFingerprint>,
+            scan: sessions::opencode_schema::OpenCodeSchemaScan,
+            pricing: Option<&pricing::PricingService>,
+        ) -> CachedParseOutcome {
+            let mut messages = scan.messages;
+            let cache_entry = match fingerprint {
+                Some(fingerprint) if !messages.is_empty() => Some(
+                    message_cache::CachedSourceEntry::new(
+                        identity,
+                        path,
+                        fingerprint,
+                        messages.clone(),
+                        Vec::new(),
+                        None,
+                    )
+                    .with_opencode_incremental(scan.incremental),
+                ),
+                _ => None,
+            };
+            apply_pricing_to_messages(&mut messages, pricing);
+            CachedParseOutcome {
+                messages,
+                retained_message_keys: HashSet::new(),
+                cache_entry,
+                invalidate_cache: false,
+            }
+        }
+
+        let mut cached = source_cache.take(identity, path);
+        let Some(fingerprint_status) = message_cache::SourceFingerprint::check_sqlite_path(
+            path,
+            cached.as_ref().map(|entry| &entry.fingerprint),
+        ) else {
+            return finish(
+                identity,
+                path,
+                None,
+                sessions::opencode::scan_opencode_sqlite(path),
+                pricing,
+            );
+        };
+
+        let fingerprint = match fingerprint_status {
+            message_cache::FingerprintStatus::Unchanged => {
+                let Some(entry) = cached.take() else {
+                    unreachable!("an uncached source always builds a complete fingerprint")
+                };
+                if !entry.messages.is_empty() {
+                    return CachedParseOutcome {
+                        messages: cached_messages(entry, pricing),
+                        retained_message_keys: HashSet::new(),
+                        cache_entry: None,
+                        invalidate_cache: false,
+                    };
+                }
+                let fingerprint = entry.fingerprint.clone();
+                cached = Some(entry);
+                fingerprint
+            }
+            message_cache::FingerprintStatus::Changed(fingerprint) => fingerprint,
+        };
+
+        if let Some(entry) = cached {
+            if entry.fingerprint == fingerprint && !entry.messages.is_empty() {
+                return CachedParseOutcome {
+                    messages: cached_messages(entry, pricing),
+                    retained_message_keys: HashSet::new(),
+                    cache_entry: None,
+                    invalidate_cache: false,
+                };
+            }
+
+            // The database changed under an entry that recorded how far the
+            // last scan got. Read just the delta; the rescan itself decides
+            // whether that is still sound and says so by returning `None`.
+            if let (Some(state), false) = (
+                entry.opencode_incremental.as_ref(),
+                entry.messages.is_empty(),
+            ) {
+                let state = state.clone();
+                if let Some(scan) =
+                    sessions::opencode::rescan_opencode_sqlite(path, &state, entry.messages)
+                {
+                    return finish(identity, path, Some(fingerprint), scan, pricing);
+                }
+            }
+        }
+
+        finish(
+            identity,
+            path,
+            Some(fingerprint),
+            sessions::opencode::scan_opencode_sqlite(path),
+            pricing,
+        )
+    }
+
     fn load_or_parse_codex_source(
         path: &Path,
         source_cache: &message_cache::SourceMessageCache,
@@ -1638,13 +1752,7 @@ fn parse_all_messages_with_pricing_with_cache_policy(
             messages,
             cache_entry,
             ..
-        } = load_or_parse_sqlite_source(
-            message_cache::CacheIdentity::for_client(ClientId::OpenCode),
-            db_path,
-            &source_cache,
-            pricing,
-            sessions::opencode::parse_opencode_sqlite,
-        );
+        } = load_or_parse_opencode_sqlite_source(db_path, &source_cache, pricing);
 
         // Dedup across channel-suffixed dbs: the same session can end up in
         // both `opencode.db` and `opencode-<channel>.db` if the user

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -4450,6 +4450,64 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn test_v5_shard_migrates_messages_without_an_incremental_mark() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let source = write_temp_file(b"{}\n");
+        let identity = CacheIdentity::for_client(ClientId::OpenCode);
+        let entry = test_entry(identity, source.path(), "legacy-opencode");
+        let key = CacheKey::from_entry(&entry);
+        let shard_key = key.shard();
+        let legacy_path = shard_path(&cache_shard_dir().unwrap(), &shard_key);
+        ensure_cache_dir(legacy_path.parent().unwrap()).unwrap();
+        let legacy_entry = LegacyCachedSourceEntryV5 {
+            parser_namespace: entry.parser_namespace,
+            parser_version: entry.parser_version,
+            path: entry.path,
+            fingerprint: entry.fingerprint,
+            messages: entry.messages,
+            fallback_timestamp_indices: entry.fallback_timestamp_indices,
+            codex_incremental: entry.codex_incremental,
+            prime_accounting: entry.prime_accounting,
+        };
+        let envelope = CachedShardEnvelope {
+            format_version: LEGACY_CACHE_FORMAT_VERSION_V5,
+            parser_namespace: identity.namespace.to_string(),
+            parser_version: identity.parser_version,
+            payload: bincode::options().serialize(&vec![legacy_entry]).unwrap(),
+        };
+        let mut writer = BufWriter::new(File::create(&legacy_path).unwrap());
+        bincode::options()
+            .serialize_into(&mut writer, &envelope)
+            .unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+
+        // An entry written before the mark existed keeps its messages and
+        // takes one full parse to acquire one, rather than being discarded.
+        assert!(matches!(
+            read_shard(&legacy_path, identity),
+            ShardReadStatus::Migrated(entries)
+                if entries.len() == 1
+                    && entries[0].messages[0].session_id == "legacy-opencode"
+                    && entries[0].opencode_incremental.is_none()
+        ));
+
+        let mut cache = SourceMessageCache::load();
+        assert_eq!(
+            cache.get(identity, source.path()).unwrap().messages[0].session_id,
+            "legacy-opencode"
+        );
+        assert!(cache.has_rewrite_shard(&shard_key));
+        cache.save_if_dirty();
+        assert!(matches!(
+            read_shard(&legacy_path, identity),
+            ShardReadStatus::Loaded(entries) if entries.len() == 1
+        ));
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn test_v4_shard_migrates_messages_and_rewrites_once() {
         let temp_home = TempDir::new().unwrap();
         let _cache_env = sandbox_cache_env(temp_home.path());

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -28,8 +28,13 @@ use std::time::UNIX_EPOCH;
 // 5: Prime Agent entries cache reconciliation accounting beside their messages.
 // Version-4 shards have an explicit wire migration below, so other clients stay
 // warm and Prime entries need only one rebuild/backfill.
-const CACHE_FORMAT_VERSION: u32 = 5;
-const LEGACY_CACHE_FORMAT_VERSION: u32 = 4;
+// 6: OpenCode SQLite entries cache the mark an incremental rescan resumes from.
+// Both older layouts have wire migrations below, so nothing is discarded --
+// which matters most for Claude, whose entries are the only copy of compacted
+// history.
+const CACHE_FORMAT_VERSION: u32 = 6;
+const LEGACY_CACHE_FORMAT_VERSION_V4: u32 = 4;
+const LEGACY_CACHE_FORMAT_VERSION_V5: u32 = 5;
 // V2 intentionally starts cold and leaves source-message-cache.bin untouched:
 // the monolith did not record a trustworthy parser owner for migration.
 const CACHE_SHARD_DIRNAME: &str = "source-message-cache-v2";
@@ -1349,6 +1354,12 @@ pub(crate) struct CachedSourceEntry {
     /// transcripts. It shares this entry's parser identity and fingerprint, so
     /// a message cache hit can never pair with accounting from different bytes.
     pub prime_accounting: Option<crate::sessions::prime_agent::PrimeFileAccounting>,
+    /// OpenCode-only mark saying how far a previous scan of this database got,
+    /// so the next one reads only the rows that changed. Like the fields above
+    /// it lives on the entry rather than beside it: a mark paired with anything
+    /// other than the message list it was taken with would skip rows and
+    /// under-report.
+    pub opencode_incremental: Option<crate::sessions::opencode_schema::OpenCodeIncrementalState>,
 }
 
 /// Exact version-4 entry layout. Keeping this wire type lets existing shards
@@ -1377,6 +1388,38 @@ impl From<LegacyCachedSourceEntryV4> for CachedSourceEntry {
             fallback_timestamp_indices: entry.fallback_timestamp_indices,
             codex_incremental: entry.codex_incremental,
             prime_accounting: None,
+            opencode_incremental: None,
+        }
+    }
+}
+
+/// Exact version-5 entry layout, migrated for the same reason version 4 is.
+/// An OpenCode entry arrives with no incremental mark and takes one full parse
+/// to acquire it, which is what it would have done anyway.
+#[derive(Debug, Serialize, Deserialize)]
+struct LegacyCachedSourceEntryV5 {
+    parser_namespace: String,
+    parser_version: u32,
+    path: CachedPath,
+    fingerprint: SourceFingerprint,
+    messages: Vec<UnifiedMessage>,
+    fallback_timestamp_indices: Vec<usize>,
+    codex_incremental: Option<CodexIncrementalCache>,
+    prime_accounting: Option<crate::sessions::prime_agent::PrimeFileAccounting>,
+}
+
+impl From<LegacyCachedSourceEntryV5> for CachedSourceEntry {
+    fn from(entry: LegacyCachedSourceEntryV5) -> Self {
+        Self {
+            parser_namespace: entry.parser_namespace,
+            parser_version: entry.parser_version,
+            path: entry.path,
+            fingerprint: entry.fingerprint,
+            messages: entry.messages,
+            fallback_timestamp_indices: entry.fallback_timestamp_indices,
+            codex_incremental: entry.codex_incremental,
+            prime_accounting: entry.prime_accounting,
+            opencode_incremental: None,
         }
     }
 }
@@ -1399,7 +1442,17 @@ impl CachedSourceEntry {
             fallback_timestamp_indices,
             codex_incremental,
             prime_accounting: None,
+            opencode_incremental: None,
         }
+    }
+
+    /// Attach the mark a later OpenCode scan resumes from.
+    pub(crate) fn with_opencode_incremental(
+        mut self,
+        incremental: Option<crate::sessions::opencode_schema::OpenCodeIncrementalState>,
+    ) -> Self {
+        self.opencode_incremental = incremental;
+        self
     }
 
     pub(crate) fn with_prime_accounting(
@@ -1438,6 +1491,7 @@ impl CachedSourceEntry {
             fallback_timestamp_indices: std::mem::take(&mut self.fallback_timestamp_indices),
             codex_incremental: self.codex_incremental.take(),
             prime_accounting: self.prime_accounting.take(),
+            opencode_incremental: self.opencode_incremental.take(),
         }
     }
 
@@ -2224,10 +2278,21 @@ fn read_shard_with_limit(
         return ShardReadStatus::Stale;
     }
 
-    if envelope.format_version == LEGACY_CACHE_FORMAT_VERSION {
+    if envelope.format_version == LEGACY_CACHE_FORMAT_VERSION_V4 {
         return match bincode::options()
             .with_limit(max_shard_bytes)
             .deserialize::<Vec<LegacyCachedSourceEntryV4>>(&envelope.payload)
+        {
+            Ok(entries) => ShardReadStatus::Migrated(
+                entries.into_iter().map(CachedSourceEntry::from).collect(),
+            ),
+            Err(error) => ShardReadStatus::Invalid(error.to_string()),
+        };
+    }
+    if envelope.format_version == LEGACY_CACHE_FORMAT_VERSION_V5 {
+        return match bincode::options()
+            .with_limit(max_shard_bytes)
+            .deserialize::<Vec<LegacyCachedSourceEntryV5>>(&envelope.payload)
         {
             Ok(entries) => ShardReadStatus::Migrated(
                 entries.into_iter().map(CachedSourceEntry::from).collect(),
@@ -4366,7 +4431,7 @@ mod tests {
         let stale_path = shard_path(&cache_shard_dir().unwrap(), &stale_key);
         ensure_cache_dir(stale_path.parent().unwrap()).unwrap();
         let stale_envelope = CachedShardEnvelope {
-            format_version: LEGACY_CACHE_FORMAT_VERSION - 1,
+            format_version: LEGACY_CACHE_FORMAT_VERSION_V4 - 1,
             parser_namespace: codex.namespace.to_string(),
             parser_version: codex.parser_version,
             payload: b"prior UnifiedMessage layout".to_vec(),
@@ -4405,7 +4470,7 @@ mod tests {
             codex_incremental: entry.codex_incremental,
         };
         let envelope = CachedShardEnvelope {
-            format_version: LEGACY_CACHE_FORMAT_VERSION,
+            format_version: LEGACY_CACHE_FORMAT_VERSION_V4,
             parser_namespace: identity.namespace.to_string(),
             parser_version: identity.parser_version,
             payload: bincode::options().serialize(&vec![legacy_entry]).unwrap(),

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -2010,6 +2010,88 @@ mod tests {
     }
 
     #[test]
+    fn test_incremental_rescan_refuses_a_row_that_took_part_in_a_merge() {
+        // Forked history puts one message id on two rows, and the fingerprint
+        // dedup collapses them into a single entry. That entry is the only
+        // trace the second row left, so re-reading either side cannot
+        // reconstruct what the other contributed -- the scan has to re-parse.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = create_timed_v1_db(&db_path);
+        for (row_id, created) in [("msg_fork_a", 1_000_i64), ("msg_fork_b", 1_500)] {
+            conn.execute(
+                "INSERT INTO message (id, session_id, time_created, time_updated, data)
+                 VALUES (?1, 'ses_1', ?2, ?2, ?3)",
+                rusqlite::params![row_id, created, timed_v1_payload("msg_shared", 11)],
+            )
+            .unwrap();
+        }
+        drop(conn);
+
+        let cold = scan_opencode_sqlite(&db_path);
+        assert_eq!(
+            cold.messages.len(),
+            1,
+            "forked copies collapse to one entry"
+        );
+        let state = cold.incremental.clone().unwrap();
+        assert!(
+            state.merged_dedup_keys.contains(&"msg_shared".to_string()),
+            "the collapse has to be recorded for the next scan to notice it"
+        );
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "UPDATE message SET data = ?2, time_updated = ?3 WHERE id = ?1",
+            rusqlite::params!["msg_fork_b", timed_v1_payload("msg_shared", 77), 9_000],
+        )
+        .unwrap();
+        drop(conn);
+
+        assert!(
+            rescan_opencode_sqlite(&db_path, &state, cold.messages).is_none(),
+            "a rewritten fork copy must re-parse rather than guess at the collapse"
+        );
+        assert_eq!(scan_opencode_sqlite(&db_path).messages.len(), 2);
+    }
+
+    #[test]
+    fn test_incremental_rescan_refuses_a_new_row_that_would_collapse() {
+        // A fork created after the mark copies completed turns verbatim. A full
+        // scan collapses each copy into the original; appending them would
+        // count every copied turn twice.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = create_timed_v1_db(&db_path);
+        insert_timed_v1_message(&conn, "msg_a", 1_000, 11);
+        drop(conn);
+
+        let cold = scan_opencode_sqlite(&db_path);
+        assert_eq!(cold.messages.len(), 1);
+        let state = cold.incremental.clone().unwrap();
+        assert!(state.merged_dedup_keys.is_empty());
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data)
+             VALUES ('msg_a_copy', 'ses_1', 9_500, 9_500, ?1)",
+            rusqlite::params![timed_v1_payload("msg_a", 11)],
+        )
+        .unwrap();
+        drop(conn);
+
+        assert!(
+            rescan_opencode_sqlite(&db_path, &state, cold.messages).is_none(),
+            "a copied turn must re-parse rather than be appended beside its original"
+        );
+        assert_eq!(
+            scan_opencode_sqlite(&db_path).messages.len(),
+            1,
+            "the full parse still collapses the copy"
+        );
+    }
+
+    #[test]
     fn test_incremental_rescan_refuses_a_mark_from_a_different_schema_variant() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("opencode.db");

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -12,7 +12,7 @@
 // The message payload type and the SQLite driver are shared with every other
 // client that adopted OpenCode's schema.
 use super::opencode_schema::{
-    parse_opencode_schema_sqlite, rescan_opencode_schema_sqlite, reported_cost,
+    parse_opencode_schema_sqlite, reported_cost, rescan_opencode_schema_sqlite,
     scan_opencode_schema_sqlite, set_workspace_from_root, OpenCodeIncrementalState,
     OpenCodeSchemaConfig, OpenCodeSchemaMessage as OpenCodeMessage, OpenCodeSchemaScan,
 };
@@ -1949,7 +1949,8 @@ mod tests {
         // OpenCode cascades a session delete onto its messages; the row is
         // simply gone, and no incremental query can report its absence.
         let conn = Connection::open(&db_path).unwrap();
-        conn.execute("DELETE FROM message WHERE id = 'msg_b'", []).unwrap();
+        conn.execute("DELETE FROM message WHERE id = 'msg_b'", [])
+            .unwrap();
         drop(conn);
 
         assert!(
@@ -1977,7 +1978,8 @@ mod tests {
         let state = cold.incremental.clone().unwrap();
 
         let conn = Connection::open(&db_path).unwrap();
-        conn.execute("DELETE FROM message WHERE id = 'msg_b'", []).unwrap();
+        conn.execute("DELETE FROM message WHERE id = 'msg_b'", [])
+            .unwrap();
         insert_timed_v1_message(&conn, "msg_c", 9_500, 33);
         drop(conn);
 
@@ -2086,5 +2088,4 @@ mod integration_tests {
             "Expected to parse some messages from SQLite"
         );
     }
-
 }

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -12,8 +12,9 @@
 // The message payload type and the SQLite driver are shared with every other
 // client that adopted OpenCode's schema.
 use super::opencode_schema::{
-    parse_opencode_schema_sqlite, reported_cost, set_workspace_from_root, OpenCodeSchemaConfig,
-    OpenCodeSchemaMessage as OpenCodeMessage,
+    parse_opencode_schema_sqlite, rescan_opencode_schema_sqlite, reported_cost,
+    scan_opencode_schema_sqlite, set_workspace_from_root, OpenCodeIncrementalState,
+    OpenCodeSchemaConfig, OpenCodeSchemaMessage as OpenCodeMessage, OpenCodeSchemaScan,
 };
 use super::utils::read_file_or_none;
 use super::{normalize_opencode_agent_name, UnifiedMessage};
@@ -25,6 +26,26 @@ use std::path::Path;
 
 pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
     parse_opencode_schema_sqlite(db_path, OpenCodeSchemaConfig::opencode())
+}
+
+/// Full scan that also records where a later scan can resume from.
+pub(crate) fn scan_opencode_sqlite(db_path: &Path) -> OpenCodeSchemaScan {
+    scan_opencode_schema_sqlite(db_path, OpenCodeSchemaConfig::opencode())
+}
+
+/// Resume from `cached_state`, reading only the rows that changed. `None`
+/// means the caller has to fall back to [`scan_opencode_sqlite`].
+pub(crate) fn rescan_opencode_sqlite(
+    db_path: &Path,
+    cached_state: &OpenCodeIncrementalState,
+    cached_messages: Vec<UnifiedMessage>,
+) -> Option<OpenCodeSchemaScan> {
+    rescan_opencode_schema_sqlite(
+        db_path,
+        OpenCodeSchemaConfig::opencode(),
+        cached_state,
+        cached_messages,
+    )
 }
 
 pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
@@ -1756,6 +1777,281 @@ mod tests {
         assert!(loaded.migration_complete);
         assert_eq!(loaded.json_file_count, 2);
     }
+
+    // =========================================================================
+    // Incremental SQLite scan
+    // =========================================================================
+
+    /// A `message` table with the columns a modern OpenCode database actually
+    /// has. The existing fixtures above deliberately keep the minimal column
+    /// set, which is itself a case the incremental lane has to refuse.
+    fn create_timed_v1_db(db_path: &Path) -> Connection {
+        let conn = Connection::open(db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                directory TEXT NOT NULL,
+                title TEXT
+            );
+            CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );
+            INSERT INTO session (id, directory, title)
+            VALUES ('ses_1', '/tmp/project', 'A session');",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn timed_v1_payload(id: &str, output: i64) -> String {
+        format!(
+            r#"{{
+                "id": "{id}",
+                "role": "assistant",
+                "sessionID": "ses_1",
+                "modelID": "claude-sonnet-4",
+                "providerID": "anthropic",
+                "cost": 0.5,
+                "tokens": {{
+                    "input": 10,
+                    "output": {output},
+                    "reasoning": 0,
+                    "cache": {{ "read": 0, "write": 0 }}
+                }},
+                "time": {{ "created": 1783882279705, "completed": 1783882279943 }}
+            }}"#
+        )
+    }
+
+    fn insert_timed_v1_message(conn: &Connection, id: &str, created: i64, output: i64) {
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data)
+             VALUES (?1, 'ses_1', ?2, ?2, ?3)",
+            rusqlite::params![id, created, timed_v1_payload(id, output)],
+        )
+        .unwrap();
+    }
+
+    /// Rewrite a row's payload and stamp it as updated at `updated`, which is
+    /// what OpenCode does to a message long after inserting it.
+    fn touch_timed_v1_message(conn: &Connection, id: &str, updated: i64, output: i64) {
+        let changed = conn
+            .execute(
+                "UPDATE message SET data = ?2, time_updated = ?3 WHERE id = ?1",
+                rusqlite::params![id, timed_v1_payload(id, output), updated],
+            )
+            .unwrap();
+        assert_eq!(changed, 1, "fixture row {id} should exist");
+    }
+
+    fn by_dedup_key(messages: &[UnifiedMessage]) -> Vec<UnifiedMessage> {
+        let mut sorted = messages.to_vec();
+        sorted.sort_by(|left, right| left.dedup_key.cmp(&right.dedup_key));
+        sorted
+    }
+
+    fn output_tokens(messages: &[UnifiedMessage], dedup_key: &str) -> i64 {
+        messages
+            .iter()
+            .find(|message| message.dedup_key.as_deref() == Some(dedup_key))
+            .unwrap_or_else(|| panic!("{dedup_key} should be present"))
+            .tokens
+            .output
+    }
+
+    #[test]
+    fn test_incremental_rescan_matches_a_full_parse_of_the_same_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = create_timed_v1_db(&db_path);
+        insert_timed_v1_message(&conn, "msg_a", 1_000, 11);
+        insert_timed_v1_message(&conn, "msg_b", 2_000, 22);
+        drop(conn);
+
+        let cold = scan_opencode_sqlite(&db_path);
+        assert_eq!(cold.messages.len(), 2);
+        let state = cold
+            .incremental
+            .clone()
+            .expect("a table with the time columns is resumable");
+
+        let conn = Connection::open(&db_path).unwrap();
+        touch_timed_v1_message(&conn, "msg_a", 9_000, 111);
+        insert_timed_v1_message(&conn, "msg_c", 9_500, 33);
+        drop(conn);
+
+        let warm = rescan_opencode_sqlite(&db_path, &state, cold.messages)
+            .expect("an insert-only delta stays incremental");
+        let full = scan_opencode_sqlite(&db_path);
+
+        assert_eq!(
+            by_dedup_key(&warm.messages),
+            by_dedup_key(&full.messages),
+            "a warm incremental scan and a cold full parse must agree"
+        );
+        assert_eq!(warm.messages.len(), 3);
+        assert_eq!(output_tokens(&warm.messages, "msg_a"), 111);
+        assert_eq!(output_tokens(&warm.messages, "msg_c"), 33);
+    }
+
+    #[test]
+    fn test_incremental_rescan_reads_a_row_rewritten_long_after_it_was_inserted() {
+        // The row that changes is the *oldest* one and sorts first by id, so a
+        // mark keyed on the row id -- the Codex `consumed_offset` analogue --
+        // would skip it. On a real database 99.98% of rows are rewritten after
+        // insert, so that mark would under-report nearly everything.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = create_timed_v1_db(&db_path);
+        insert_timed_v1_message(&conn, "msg_aaa", 1_000, 11);
+        insert_timed_v1_message(&conn, "msg_zzz", 2_000, 22);
+        drop(conn);
+
+        let cold = scan_opencode_sqlite(&db_path);
+        let state = cold.incremental.clone().unwrap();
+        assert_eq!(output_tokens(&cold.messages, "msg_aaa"), 11);
+
+        let conn = Connection::open(&db_path).unwrap();
+        touch_timed_v1_message(&conn, "msg_aaa", 9_000, 999);
+        drop(conn);
+
+        let warm = rescan_opencode_sqlite(&db_path, &state, cold.messages)
+            .expect("an in-place rewrite is not a deletion");
+
+        assert_eq!(
+            output_tokens(&warm.messages, "msg_aaa"),
+            999,
+            "a row rewritten after insert must reach the incremental scan"
+        );
+        assert_eq!(warm.messages.len(), 2, "a rewrite must not duplicate a row");
+        assert_eq!(
+            by_dedup_key(&warm.messages),
+            by_dedup_key(&scan_opencode_sqlite(&db_path).messages)
+        );
+    }
+
+    #[test]
+    fn test_incremental_rescan_refuses_a_database_that_lost_a_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = create_timed_v1_db(&db_path);
+        insert_timed_v1_message(&conn, "msg_a", 1_000, 11);
+        insert_timed_v1_message(&conn, "msg_b", 2_000, 22);
+        drop(conn);
+
+        let cold = scan_opencode_sqlite(&db_path);
+        let state = cold.incremental.clone().unwrap();
+
+        // OpenCode cascades a session delete onto its messages; the row is
+        // simply gone, and no incremental query can report its absence.
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute("DELETE FROM message WHERE id = 'msg_b'", []).unwrap();
+        drop(conn);
+
+        assert!(
+            rescan_opencode_sqlite(&db_path, &state, cold.messages).is_none(),
+            "a lost row must force a full re-parse instead of keeping a stale count"
+        );
+
+        let full = scan_opencode_sqlite(&db_path);
+        assert_eq!(full.messages.len(), 1);
+        assert_eq!(full.messages[0].dedup_key.as_deref(), Some("msg_a"));
+    }
+
+    #[test]
+    fn test_incremental_rescan_refuses_a_delete_masked_by_an_insert() {
+        // The row count alone cannot tell this apart from "nothing happened",
+        // which is why the mark also records the `time_created` high-water.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = create_timed_v1_db(&db_path);
+        insert_timed_v1_message(&conn, "msg_a", 1_000, 11);
+        insert_timed_v1_message(&conn, "msg_b", 2_000, 22);
+        drop(conn);
+
+        let cold = scan_opencode_sqlite(&db_path);
+        let state = cold.incremental.clone().unwrap();
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute("DELETE FROM message WHERE id = 'msg_b'", []).unwrap();
+        insert_timed_v1_message(&conn, "msg_c", 9_500, 33);
+        drop(conn);
+
+        assert!(
+            rescan_opencode_sqlite(&db_path, &state, cold.messages).is_none(),
+            "an equal row count is not evidence that nothing was deleted"
+        );
+    }
+
+    #[test]
+    fn test_a_table_without_the_time_columns_records_no_mark() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = create_opencode_sqlite_db(&db_path);
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, 'ses_1', ?2)",
+            rusqlite::params!["msg_a", timed_v1_payload("msg_a", 11)],
+        )
+        .unwrap();
+        drop(conn);
+
+        let cold = scan_opencode_sqlite(&db_path);
+        assert_eq!(cold.messages.len(), 1);
+        assert!(
+            cold.incremental.is_none(),
+            "rows that cannot be rescanned incrementally must not be marked as if they could"
+        );
+    }
+
+    #[test]
+    fn test_incremental_rescan_refuses_a_mark_from_a_different_schema_variant() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+        insert_timed_v1_message(&conn, "msg_a", 1_000, 11);
+        drop(conn);
+
+        let cold = scan_opencode_sqlite(&db_path);
+        let state = cold.incremental.clone().unwrap();
+        assert_eq!(cold.messages[0].workspace_key, None);
+
+        // The session metadata table appears, so a full scan would now pick the
+        // joining variant and resolve a workspace the cached rows never had.
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                directory TEXT NOT NULL,
+                title TEXT
+            );
+            INSERT INTO session (id, directory, title)
+            VALUES ('ses_1', '/tmp/project', 'A session');",
+        )
+        .unwrap();
+        drop(conn);
+
+        assert!(
+            rescan_opencode_sqlite(&db_path, &state, cold.messages).is_none(),
+            "a variant change must invalidate the mark"
+        );
+        assert!(scan_opencode_sqlite(&db_path).messages[0]
+            .workspace_key
+            .is_some());
+    }
 }
 
 #[cfg(test)]
@@ -1790,4 +2086,5 @@ mod integration_tests {
             "Expected to parse some messages from SQLite"
         );
     }
+
 }

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -1989,6 +1989,121 @@ mod tests {
         );
     }
 
+    /// Rewrite a row so the usage queries stop selecting it, without changing
+    /// the row count. `payload` replaces the whole `data` object.
+    fn disqualify_timed_v1_message(conn: &Connection, id: &str, updated: i64, payload: &str) {
+        let changed = conn
+            .execute(
+                "UPDATE message SET data = ?2, time_updated = ?3 WHERE id = ?1",
+                rusqlite::params![id, payload, updated],
+            )
+            .unwrap();
+        assert_eq!(changed, 1, "fixture row {id} should exist");
+    }
+
+    #[test]
+    fn test_incremental_rescan_refuses_a_row_that_lost_its_tokens() {
+        // The row is still there, so the count guard sees nothing wrong, and
+        // the usage query no longer returns it, so the merge is never told to
+        // drop it. Only the disqualification probe can catch this.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = create_timed_v1_db(&db_path);
+        insert_timed_v1_message(&conn, "msg_a", 1_000, 11);
+        insert_timed_v1_message(&conn, "msg_b", 2_000, 22);
+        drop(conn);
+
+        let cold = scan_opencode_sqlite(&db_path);
+        let state = cold.incremental.clone().unwrap();
+        assert_eq!(cold.messages.len(), 2);
+
+        let conn = Connection::open(&db_path).unwrap();
+        disqualify_timed_v1_message(
+            &conn,
+            "msg_b",
+            9_000,
+            r#"{"id": "msg_b", "sessionID": "ses_1", "role": "assistant"}"#,
+        );
+        drop(conn);
+
+        assert!(
+            rescan_opencode_sqlite(&db_path, &state, cold.messages).is_none(),
+            "a row that stopped carrying tokens must force a full re-parse"
+        );
+
+        let full = scan_opencode_sqlite(&db_path);
+        assert_eq!(full.messages.len(), 1);
+        assert_eq!(full.messages[0].dedup_key.as_deref(), Some("msg_a"));
+    }
+
+    #[test]
+    fn test_incremental_rescan_refuses_a_row_that_stopped_being_an_assistant_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = create_timed_v1_db(&db_path);
+        insert_timed_v1_message(&conn, "msg_a", 1_000, 11);
+        insert_timed_v1_message(&conn, "msg_b", 2_000, 22);
+        drop(conn);
+
+        let cold = scan_opencode_sqlite(&db_path);
+        let state = cold.incremental.clone().unwrap();
+
+        let conn = Connection::open(&db_path).unwrap();
+        disqualify_timed_v1_message(
+            &conn,
+            "msg_b",
+            9_000,
+            r#"{"id": "msg_b", "sessionID": "ses_1", "role": "user",
+                "tokens": {"input": 1, "output": 2, "cache": {"read": 0, "write": 0}}}"#,
+        );
+        drop(conn);
+
+        assert!(
+            rescan_opencode_sqlite(&db_path, &state, cold.messages).is_none(),
+            "a row whose role moved off assistant must force a full re-parse"
+        );
+    }
+
+    #[test]
+    fn test_incremental_rescan_keeps_going_when_a_never_counted_row_changes() {
+        // The guard above must not fire on ordinary traffic. User turns are
+        // rewritten constantly -- 92,002 of the 92,028 non-assistant rows on a
+        // real 14 GB database carry `time_updated > time_created` -- and none
+        // of them ever backed a cached message, so none of them is evidence
+        // that the cache went stale.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = create_timed_v1_db(&db_path);
+        insert_timed_v1_message(&conn, "msg_a", 1_000, 11);
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data)
+             VALUES ('msg_user', 'ses_1', 2_000, 2_000, ?1)",
+            rusqlite::params![r#"{"id": "msg_user", "sessionID": "ses_1", "role": "user"}"#],
+        )
+        .unwrap();
+        drop(conn);
+
+        let cold = scan_opencode_sqlite(&db_path);
+        let state = cold.incremental.clone().unwrap();
+        assert_eq!(cold.messages.len(), 1, "only the assistant turn is usage");
+
+        let conn = Connection::open(&db_path).unwrap();
+        disqualify_timed_v1_message(
+            &conn,
+            "msg_user",
+            9_000,
+            r#"{"id": "msg_user", "sessionID": "ses_1", "role": "user", "text": "edited"}"#,
+        );
+        drop(conn);
+
+        let warm = rescan_opencode_sqlite(&db_path, &state, cold.messages)
+            .expect("a rewritten user turn must not cost a full re-parse");
+        assert_eq!(
+            by_dedup_key(&warm.messages),
+            by_dedup_key(&scan_opencode_sqlite(&db_path).messages)
+        );
+    }
+
     #[test]
     fn test_a_table_without_the_time_columns_records_no_mark() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/tokscale-core/src/sessions/opencode_schema.rs
+++ b/crates/tokscale-core/src/sessions/opencode_schema.rs
@@ -994,13 +994,8 @@ fn collect_rows_since(
     since: i64,
     on_row: &mut dyn FnMut(OpenCodeSchemaRow),
 ) -> bool {
-    let scan = sqlite_for_each_row_on_with_params(
-        conn,
-        db_path,
-        query,
-        &[&since],
-        None,
-        &mut |row| {
+    let scan =
+        sqlite_for_each_row_on_with_params(conn, db_path, query, &[&since], None, &mut |row| {
             let id: String = row.get(0)?;
             let session_id: String = row.get(1)?;
             let data_json: String = row.get(2)?;
@@ -1008,8 +1003,7 @@ fn collect_rows_since(
             let session_title: Option<String> = row.get(4)?;
             on_row((id, session_id, data_json, workspace_root, session_title));
             Ok(())
-        },
-    );
+        });
     scan.prepared()
 }
 
@@ -1057,6 +1051,12 @@ pub(crate) struct OpenCodeGroupMark {
 pub(crate) struct OpenCodeIncrementalState {
     pub groups: Vec<Option<OpenCodeGroupMark>>,
 }
+
+/// Counts the rescans that stayed incremental, so a test can tell an
+/// incremental scan apart from a full re-parse that happened to agree with it.
+#[cfg(test)]
+pub(crate) static INCREMENTAL_RESCANS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
 
 /// A scan's messages plus the state a later scan needs to resume from it.
 pub(crate) struct OpenCodeSchemaScan {
@@ -1275,13 +1275,9 @@ pub(crate) fn rescan_opencode_schema_sqlite(
         }
 
         let query = incremental.queries.get(chosen)?;
-        if !collect_rows_since(
-            db_path,
-            &conn,
-            query,
-            mark.updated_high_water,
-            &mut |row| acc.ingest(row, &cfg, &db_namespace),
-        ) {
+        if !collect_rows_since(db_path, &conn, query, mark.updated_high_water, &mut |row| {
+            acc.ingest(row, &cfg, &db_namespace)
+        }) {
             return None;
         }
 
@@ -1293,8 +1289,11 @@ pub(crate) fn rescan_opencode_schema_sqlite(
         }));
     }
 
+    let messages = merge_incremental_messages(cached_messages, acc.messages)?;
+    #[cfg(test)]
+    INCREMENTAL_RESCANS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     Some(OpenCodeSchemaScan {
-        messages: merge_incremental_messages(cached_messages, acc.messages)?,
+        messages,
         incremental: Some(OpenCodeIncrementalState { groups: marks }),
     })
 }

--- a/crates/tokscale-core/src/sessions/opencode_schema.rs
+++ b/crates/tokscale-core/src/sessions/opencode_schema.rs
@@ -730,6 +730,14 @@ struct SchemaAccumulator {
     messages: Vec<UnifiedMessage>,
     fingerprint_indices: HashMap<OpenCodeSchemaFingerprint, Vec<usize>>,
     dedup_states: Vec<SchemaDedupState>,
+    /// Dedup keys of every row that took part in a fingerprint merge, on both
+    /// sides of it.
+    ///
+    /// A merged entry is the only trace two rows left, so a later scan that
+    /// re-reads one of them cannot tell what the other contributed and cannot
+    /// reproduce the collapse. Only collected for a client with an incremental
+    /// lane, which is the only thing that reads it.
+    merged_dedup_keys: std::collections::HashSet<String>,
 }
 
 impl SchemaAccumulator {
@@ -922,6 +930,11 @@ impl SchemaAccumulator {
         };
 
         if let Some(index) = candidate {
+            let absorbed_dedup_key = if cfg.incremental_groups.is_some() {
+                unified.dedup_key.clone()
+            } else {
+                None
+            };
             // A duplicate carrying an authoritative cost upgrades the retained
             // entry's provenance. This is inert for clients that derive
             // provenance from the cost value alone: `cost_bits` is part of the
@@ -938,6 +951,14 @@ impl SchemaAccumulator {
                 self.messages[index].dedup_key = unified.dedup_key;
             }
             merge_duplicate_workspace(&mut self.messages[index], dedup_state, workspace_root);
+            if cfg.incremental_groups.is_some() {
+                if let Some(key) = self.messages[index].dedup_key.clone() {
+                    self.merged_dedup_keys.insert(key);
+                }
+                if let Some(key) = absorbed_dedup_key {
+                    self.merged_dedup_keys.insert(key);
+                }
+            }
             return;
         }
 
@@ -1050,7 +1071,20 @@ pub(crate) struct OpenCodeGroupMark {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct OpenCodeIncrementalState {
     pub groups: Vec<Option<OpenCodeGroupMark>>,
+    /// Dedup keys of the rows that took part in a fingerprint merge. A rescan
+    /// that re-reads one of them cannot reproduce the collapse -- the merged
+    /// entry is the only trace the other row left -- so it re-parses instead.
+    pub merged_dedup_keys: Vec<String>,
 }
+
+/// Ceiling on the merged-key set a mark will carry.
+///
+/// Forked history is a small fraction of a real database -- 2,711 of 342,927
+/// rows on the 14 GB profile this was measured against -- so a set anywhere
+/// near this size means the assumption does not hold for that database, and
+/// full scans are the honest answer rather than a mark whose bookkeeping is
+/// larger than the delta it saves.
+const MAX_MERGED_DEDUP_KEYS: usize = 250_000;
 
 /// Counts the rescans that stayed incremental, so a test can tell an
 /// incremental scan apart from a full re-parse that happened to agree with it.
@@ -1193,12 +1227,17 @@ pub(crate) fn scan_opencode_schema_sqlite(
         });
     }
 
+    resumable &= acc.merged_dedup_keys.len() <= MAX_MERGED_DEDUP_KEYS;
+    let merged_dedup_keys = acc.merged_dedup_keys.into_iter().collect();
+
     OpenCodeSchemaScan {
         messages: acc.messages,
-        incremental: cfg
-            .incremental_groups
-            .filter(|_| resumable)
-            .map(|_| OpenCodeIncrementalState { groups: marks }),
+        incremental: cfg.incremental_groups.filter(|_| resumable).map(|_| {
+            OpenCodeIncrementalState {
+                groups: marks,
+                merged_dedup_keys,
+            }
+        }),
     }
 }
 
@@ -1289,43 +1328,119 @@ pub(crate) fn rescan_opencode_schema_sqlite(
         }));
     }
 
-    let messages = merge_incremental_messages(cached_messages, acc.messages)?;
+    // A merge among the changed rows themselves is reproducible -- a full scan
+    // sees the same rows and collapses them the same way -- but it still leaves
+    // an entry a later rescan must not re-read piecemeal, so it joins the set.
+    let mut merged_dedup_keys = acc.merged_dedup_keys.clone();
+    merged_dedup_keys.extend(cached_state.merged_dedup_keys.iter().cloned());
+    if merged_dedup_keys.len() > MAX_MERGED_DEDUP_KEYS {
+        return None;
+    }
+
+    let messages = merge_incremental_messages(cached_messages, acc.messages, &merged_dedup_keys)?;
     #[cfg(test)]
     INCREMENTAL_RESCANS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     Some(OpenCodeSchemaScan {
         messages,
-        incremental: Some(OpenCodeIncrementalState { groups: marks }),
+        incremental: Some(OpenCodeIncrementalState {
+            groups: marks,
+            merged_dedup_keys: merged_dedup_keys.into_iter().collect(),
+        }),
     })
+}
+
+/// A digest of everything [`OpenCodeSchemaFingerprint`] compares, taken from
+/// the parsed message instead of the row.
+///
+/// Only ever used to ask "could a full scan have collapsed these two?", and it
+/// is deliberately the coarser of the two: `timestamp` and `duration_ms` are
+/// whole milliseconds where the row fingerprint keeps the raw float bits. A
+/// coarser digest can only claim a collapse that would not have happened,
+/// which costs a full re-parse -- the safe direction. It can never miss one.
+fn content_digest(message: &UnifiedMessage) -> u64 {
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    message.timestamp.hash(&mut hasher);
+    message.duration_ms.hash(&mut hasher);
+    message.model_id.hash(&mut hasher);
+    message.provider_id.hash(&mut hasher);
+    message.tokens.input.hash(&mut hasher);
+    message.tokens.output.hash(&mut hasher);
+    message.tokens.reasoning.hash(&mut hasher);
+    message.tokens.cache_read.hash(&mut hasher);
+    message.tokens.cache_write.hash(&mut hasher);
+    message.cost.to_bits().hash(&mut hasher);
+    message.agent.hash(&mut hasher);
+    hasher.finish()
 }
 
 /// Fold the rows a rescan re-read back into the cached message list.
 ///
-/// A changed row replaces the cached message carrying its id and a new row is
-/// appended, so the cached relative order survives and the result holds one
-/// entry per message id -- the same set a full scan of the same database state
-/// produces. The lane keys on `dedup_key` everywhere downstream (cross-database
-/// and legacy-JSON suppression both), so position carries no meaning beyond
-/// that.
+/// A changed row replaces the cached message carrying its dedup key and a new
+/// row is appended, so the cached relative order survives and the result holds
+/// one entry per key -- the same set a full scan of the same database state
+/// produces.
 ///
-/// `None` when any message lacks a dedup key. The OpenCode driver always sets
-/// one, so this cannot happen; if it ever did, appending an unkeyed message
-/// would double count it on the next scan, and a full re-parse is the safe
-/// answer.
+/// The fingerprint dedup is what makes that non-trivial, because it lets one
+/// cached entry stand for more than one row (2,711 of 342,927 rows on the
+/// database this was measured against). Two rules keep the merge faithful to
+/// what a full scan would have produced:
+///
+/// * A row that already took part in a merge forces a full re-parse. The
+///   collapsed entry is the only trace the other row left, so re-reading one
+///   side cannot reconstruct what the other contributed.
+/// * A row whose content matches a cached message it is not itself replacing
+///   forces one too. That is a collapse a full scan would perform and this
+///   merge cannot see -- a forked copy arriving after the mark, or a rewrite
+///   that happens to land on another row's content.
+///
+/// `None` also when any message lacks a dedup key. The OpenCode driver always
+/// sets one, so that cannot happen; if it ever did, appending an unkeyed
+/// message would double count it on the next scan.
 fn merge_incremental_messages(
     cached: Vec<UnifiedMessage>,
     changed: Vec<UnifiedMessage>,
+    merged_dedup_keys: &std::collections::HashSet<String>,
 ) -> Option<Vec<UnifiedMessage>> {
     let mut merged = cached;
     let mut index_by_key: HashMap<String, usize> = HashMap::with_capacity(merged.len());
+    let mut index_by_digest: HashMap<u64, usize> = HashMap::with_capacity(merged.len());
     for (index, message) in merged.iter().enumerate() {
-        index_by_key.insert(message.dedup_key.clone()?, index);
+        // First index wins, matching the cross-database suppression the caller
+        // applies to this list: it keeps the first message carrying a key and
+        // drops the rest, so refreshing a later one would refresh a message
+        // nothing downstream reads.
+        index_by_key
+            .entry(message.dedup_key.clone()?)
+            .or_insert(index);
+        index_by_digest
+            .entry(content_digest(message))
+            .or_insert(index);
     }
 
     for message in changed {
         let key = message.dedup_key.clone()?;
-        match index_by_key.get(&key) {
-            Some(&index) => merged[index] = message,
+        if merged_dedup_keys.contains(&key) {
+            return None;
+        }
+        let digest = content_digest(&message);
+        match index_by_key.get(&key).copied() {
+            Some(index) => {
+                if index_by_digest
+                    .get(&digest)
+                    .is_some_and(|&other| other != index)
+                {
+                    return None;
+                }
+                index_by_digest.insert(digest, index);
+                merged[index] = message;
+            }
             None => {
+                if index_by_digest.contains_key(&digest) {
+                    return None;
+                }
+                index_by_digest.insert(digest, merged.len());
                 index_by_key.insert(key, merged.len());
                 merged.push(message);
             }

--- a/crates/tokscale-core/src/sessions/opencode_schema.rs
+++ b/crates/tokscale-core/src/sessions/opencode_schema.rs
@@ -16,13 +16,15 @@
 //! generics would monomorphize per client and *grow* the binary, which is the
 //! opposite of the point.
 
-use super::utils::{open_readonly_sqlite_opt, sqlite_for_each_row_on};
+use super::utils::{
+    open_readonly_sqlite_opt, sqlite_for_each_row_on, sqlite_for_each_row_on_with_params,
+};
 use super::{
     normalize_opencode_agent_name, normalize_workspace_key, workspace_label_from_key,
     UnifiedMessage,
 };
 use crate::{provider_identity, TokenBreakdown};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -242,6 +244,10 @@ pub(crate) struct OpenCodeSchemaConfig {
     pub namespace_rowid_dedup_key: bool,
     /// How duplicate rows collapse.
     pub dedup: DedupMode,
+    /// Incremental-scan support, one entry per `query_groups` entry and in the
+    /// same order. `None` leaves the client on full scans only, which is what
+    /// every client whose tables carry no `time_updated` column must do.
+    pub incremental_groups: Option<&'static [OpenCodeIncrementalGroup]>,
 }
 
 impl OpenCodeSchemaConfig {
@@ -265,6 +271,7 @@ impl OpenCodeSchemaConfig {
             capture_workspace: true,
             namespace_rowid_dedup_key: false,
             dedup: DedupMode::MergeUnlessIdConflict,
+            incremental_groups: None,
         }
     }
 
@@ -272,6 +279,7 @@ impl OpenCodeSchemaConfig {
         Self {
             query_groups: OPENCODE_QUERY_GROUPS,
             dual_schema: true,
+            incremental_groups: Some(OPENCODE_INCREMENTAL_GROUPS),
             ..Self::base("opencode")
         }
     }
@@ -401,6 +409,142 @@ const OPENCODE_V1_QUERIES: &[&str] = &[
 /// tables exist contribute rows, and the fingerprint dedup collapses any
 /// overlap between them.
 const OPENCODE_QUERY_GROUPS: &[&[&str]] = &[OPENCODE_V2_QUERIES, OPENCODE_V1_QUERIES];
+
+/// Incremental spelling of [`OPENCODE_V2_QUERIES`], one variant per full
+/// variant and in the same order.
+///
+/// The only difference is the leading `time_updated` bound. SQLite evaluates
+/// the conjuncts left to right, so an unchanged row is rejected on an integer
+/// comparison and its `data` payload is never parsed -- and parsing every
+/// payload is what the full scan spends its time on. `>=` and not `>`: a row
+/// written in the same millisecond the mark was taken must not be skipped,
+/// and re-reading the boundary rows costs nothing because the merge replaces
+/// by message id.
+const OPENCODE_V2_INCREMENTAL_QUERIES: &[&str] = &[
+    r#"
+        SELECT sm.id, sm.session_id, sm.data, NULLIF(s.directory, '') AS workspace_root, s.title AS session_title
+        FROM session_message sm
+        LEFT JOIN session_v2 s ON s.id = sm.session_id
+        WHERE sm.time_updated >= ?1
+          AND sm.type = 'assistant'
+          AND json_extract(sm.data, '$.tokens') IS NOT NULL
+        ORDER BY sm.id, sm.session_id
+    "#,
+    r#"
+        SELECT sm.id, sm.session_id, sm.data, NULLIF(s.directory, '') AS workspace_root, NULL AS session_title
+        FROM session_message sm
+        LEFT JOIN session_v2 s ON s.id = sm.session_id
+        WHERE sm.time_updated >= ?1
+          AND sm.type = 'assistant'
+          AND json_extract(sm.data, '$.tokens') IS NOT NULL
+        ORDER BY sm.id, sm.session_id
+    "#,
+    r#"
+        SELECT sm.id, sm.session_id, sm.data, NULLIF(s.directory, '') AS workspace_root, s.title AS session_title
+        FROM session_message sm
+        LEFT JOIN session s ON s.id = sm.session_id
+        WHERE sm.time_updated >= ?1
+          AND sm.type = 'assistant'
+          AND json_extract(sm.data, '$.tokens') IS NOT NULL
+        ORDER BY sm.id, sm.session_id
+    "#,
+    r#"
+        SELECT sm.id, sm.session_id, sm.data, NULLIF(s.directory, '') AS workspace_root, NULL AS session_title
+        FROM session_message sm
+        LEFT JOIN session s ON s.id = sm.session_id
+        WHERE sm.time_updated >= ?1
+          AND sm.type = 'assistant'
+          AND json_extract(sm.data, '$.tokens') IS NOT NULL
+        ORDER BY sm.id, sm.session_id
+    "#,
+    r#"
+        SELECT sm.id, sm.session_id, sm.data, NULL AS workspace_root, NULL AS session_title
+        FROM session_message sm
+        WHERE sm.time_updated >= ?1
+          AND sm.type = 'assistant'
+          AND json_extract(sm.data, '$.tokens') IS NOT NULL
+        ORDER BY sm.id, sm.session_id
+    "#,
+];
+
+/// Incremental spelling of [`OPENCODE_V1_QUERIES`]; see
+/// [`OPENCODE_V2_INCREMENTAL_QUERIES`] for why the bound leads and why it is
+/// inclusive.
+const OPENCODE_V1_INCREMENTAL_QUERIES: &[&str] = &[
+    r#"
+        SELECT m.id, m.session_id, m.data, NULLIF(s.directory, '') AS workspace_root, s.title AS session_title
+        FROM message m
+        LEFT JOIN session s ON s.id = m.session_id
+        WHERE m.time_updated >= ?1
+          AND json_extract(m.data, '$.role') = 'assistant'
+          AND json_extract(m.data, '$.tokens') IS NOT NULL
+        ORDER BY m.id, m.session_id
+    "#,
+    r#"
+        SELECT m.id, m.session_id, m.data, NULLIF(s.directory, '') AS workspace_root, NULL AS session_title
+        FROM message m
+        LEFT JOIN session s ON s.id = m.session_id
+        WHERE m.time_updated >= ?1
+          AND json_extract(m.data, '$.role') = 'assistant'
+          AND json_extract(m.data, '$.tokens') IS NOT NULL
+        ORDER BY m.id, m.session_id
+    "#,
+    r#"
+        SELECT m.id, m.session_id, m.data, NULL AS workspace_root, NULL AS session_title
+        FROM message m
+        WHERE m.time_updated >= ?1
+          AND json_extract(m.data, '$.role') = 'assistant'
+          AND json_extract(m.data, '$.tokens') IS NOT NULL
+        ORDER BY m.id, m.session_id
+    "#,
+];
+
+/// The cheap invariants one query group's table exposes, read in a single
+/// pass that never touches the `data` column.
+///
+/// `?1` is the `time_created` high-water the cached scan recorded, so the last
+/// aggregate counts exactly the rows inserted since. That is what lets the row
+/// count tell an insert apart from a delete: an incremental scan sees new rows
+/// but cannot see removed ones, and OpenCode drops a session's messages with
+/// `ON DELETE CASCADE`.
+const OPENCODE_V2_STATS_QUERY: &str = r#"
+    SELECT COUNT(*),
+           MAX(time_created),
+           MAX(time_updated),
+           COUNT(CASE WHEN time_created > ?1 THEN 1 END)
+    FROM session_message
+"#;
+
+const OPENCODE_V1_STATS_QUERY: &str = r#"
+    SELECT COUNT(*),
+           MAX(time_created),
+           MAX(time_updated),
+           COUNT(CASE WHEN time_created > ?1 THEN 1 END)
+    FROM message
+"#;
+
+/// Incremental support for one entry of [`OpenCodeSchemaConfig::query_groups`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct OpenCodeIncrementalGroup {
+    /// One incremental query per full variant in the matching group, in the
+    /// same order, so a variant index resolved against the full list also
+    /// selects the incremental spelling of that same variant.
+    queries: &'static [&'static str],
+    /// Row-population invariants for the group's base table.
+    stats: &'static str,
+}
+
+/// Incremental support for [`OPENCODE_QUERY_GROUPS`], in the same order.
+const OPENCODE_INCREMENTAL_GROUPS: &[OpenCodeIncrementalGroup] = &[
+    OpenCodeIncrementalGroup {
+        queries: OPENCODE_V2_INCREMENTAL_QUERIES,
+        stats: OPENCODE_V2_STATS_QUERY,
+    },
+    OpenCodeIncrementalGroup {
+        queries: OPENCODE_V1_INCREMENTAL_QUERIES,
+        stats: OPENCODE_V1_STATS_QUERY,
+    },
+];
 
 /// MiMo Code: `message` table, with the `session` join dropped on databases
 /// that predate it.
@@ -841,6 +985,34 @@ fn collect_rows(
     scan.prepared()
 }
 
+/// Run `query` with `since` bound to `?1`, handing every row to `on_row`.
+/// Returns whether the statement prepared, matching [`collect_rows`].
+fn collect_rows_since(
+    db_path: &Path,
+    conn: &rusqlite::Connection,
+    query: &str,
+    since: i64,
+    on_row: &mut dyn FnMut(OpenCodeSchemaRow),
+) -> bool {
+    let scan = sqlite_for_each_row_on_with_params(
+        conn,
+        db_path,
+        query,
+        &[&since],
+        None,
+        &mut |row| {
+            let id: String = row.get(0)?;
+            let session_id: String = row.get(1)?;
+            let data_json: String = row.get(2)?;
+            let workspace_root: Option<String> = row.get(3)?;
+            let session_title: Option<String> = row.get(4)?;
+            on_row((id, session_id, data_json, workspace_root, session_title));
+            Ok(())
+        },
+    );
+    scan.prepared()
+}
+
 /// Parse assistant turns out of a SQLite database that uses the OpenCode
 /// message schema, applying `cfg`'s per-client policy.
 ///
@@ -850,8 +1022,127 @@ pub(crate) fn parse_opencode_schema_sqlite(
     db_path: &Path,
     cfg: OpenCodeSchemaConfig,
 ) -> Vec<UnifiedMessage> {
+    scan_opencode_schema_sqlite(db_path, cfg).messages
+}
+
+// =============================================================================
+// Incremental scan
+// =============================================================================
+
+/// What one query group looked like on the scan that filled the cache.
+///
+/// Deliberately keyed on `time_updated` and not on the row id. OpenCode
+/// rewrites a message row long after inserting it -- on a real 14 GB database
+/// 434,851 of 434,955 rows carry `time_updated > time_created`, with lags of up
+/// to 79 days -- so an id high-water would skip the later rewrite of almost
+/// every row and permanently under-report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct OpenCodeGroupMark {
+    /// Digest of the full query variant the cached rows came from. Any edit to
+    /// the SQL changes it, which discards the mark rather than pairing new SQL
+    /// with rows the old SQL produced.
+    pub query_digest: u64,
+    /// Rows the group's table held.
+    pub row_count: i64,
+    /// Highest `time_created`. Rows above it on a later scan are exactly the
+    /// inserts, which is what makes the row count a deletion test.
+    pub created_high_water: i64,
+    /// Highest `time_updated`. The incremental scan reads from here.
+    pub updated_high_water: i64,
+}
+
+/// One mark per query group, in [`OpenCodeSchemaConfig::query_groups`] order.
+/// A group whose table this database does not have contributes `None`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct OpenCodeIncrementalState {
+    pub groups: Vec<Option<OpenCodeGroupMark>>,
+}
+
+/// A scan's messages plus the state a later scan needs to resume from it.
+pub(crate) struct OpenCodeSchemaScan {
+    pub messages: Vec<UnifiedMessage>,
+    /// `None` for a client with no incremental support, and for a database
+    /// that could not be opened.
+    pub incremental: Option<OpenCodeIncrementalState>,
+}
+
+impl OpenCodeSchemaScan {
+    fn empty() -> Self {
+        Self {
+            messages: Vec::new(),
+            incremental: None,
+        }
+    }
+}
+
+/// FNV-1a over a query variant's text.
+///
+/// Only ever compared against itself, so the algorithm matters less than that
+/// it is stable across runs and covers every byte of the SQL.
+fn query_digest(query: &str) -> u64 {
+    let mut digest: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in query.as_bytes() {
+        digest ^= u64::from(*byte);
+        digest = digest.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    digest
+}
+
+struct TableStats {
+    row_count: i64,
+    created_high_water: i64,
+    updated_high_water: i64,
+    /// Rows whose `time_created` is above the value bound to `?1`.
+    created_after_mark: i64,
+}
+
+/// Read a group's invariants, or `None` when the group's table is absent.
+///
+/// `MAX` over an empty table is NULL; both high-waters then collapse to
+/// `i64::MIN`, which makes the next incremental scan read everything rather
+/// than nothing.
+fn read_table_stats(
+    db_path: &Path,
+    conn: &rusqlite::Connection,
+    query: &str,
+    created_mark: i64,
+) -> Option<TableStats> {
+    let mut stats = None;
+    let scan = sqlite_for_each_row_on_with_params(
+        conn,
+        db_path,
+        query,
+        &[&created_mark],
+        None,
+        &mut |row| {
+            stats = Some(TableStats {
+                row_count: row.get(0)?,
+                created_high_water: row.get::<_, Option<i64>>(1)?.unwrap_or(i64::MIN),
+                updated_high_water: row.get::<_, Option<i64>>(2)?.unwrap_or(i64::MIN),
+                created_after_mark: row.get(3)?,
+            });
+            Ok(())
+        },
+    );
+    if scan.ran() {
+        stats
+    } else {
+        None
+    }
+}
+
+/// Full scan, also recording the state an incremental rescan resumes from.
+///
+/// The invariants are read *before* the rows on purpose. A mark taken after
+/// the rows could name a row the scan never saw, and the next incremental scan
+/// would then skip that row forever. Taken first, the worst case is a row that
+/// lands between the two reads and gets read twice, which the merge collapses.
+pub(crate) fn scan_opencode_schema_sqlite(
+    db_path: &Path,
+    cfg: OpenCodeSchemaConfig,
+) -> OpenCodeSchemaScan {
     let Some(conn) = open_readonly_sqlite_opt(db_path) else {
-        return Vec::new();
+        return OpenCodeSchemaScan::empty();
     };
 
     let db_namespace = if cfg.namespace_rowid_dedup_key {
@@ -861,15 +1152,186 @@ pub(crate) fn parse_opencode_schema_sqlite(
     };
 
     let mut acc = SchemaAccumulator::default();
-    for group in cfg.query_groups {
-        for query in *group {
+    let mut marks: Vec<Option<OpenCodeGroupMark>> = Vec::with_capacity(cfg.query_groups.len());
+    // A group that produced rows but no invariants -- an older database whose
+    // table predates the `time_updated` column -- has no way to be rescanned
+    // incrementally, and a mark that silently skipped it would serve those rows
+    // stale forever. One such group disqualifies the whole database.
+    let mut resumable = true;
+
+    for (group_index, group) in cfg.query_groups.iter().enumerate() {
+        let incremental = cfg
+            .incremental_groups
+            .and_then(|groups| groups.get(group_index));
+        // `i64::MAX` leaves the insert count at zero: nothing resumes from a
+        // full scan's own reading of it.
+        let stats = incremental
+            .and_then(|incremental| read_table_stats(db_path, &conn, incremental.stats, i64::MAX));
+
+        let mut chosen = None;
+        for (index, query) in group.iter().enumerate() {
             if collect_rows(db_path, &conn, query, &mut |row| {
                 acc.ingest(row, &cfg, &db_namespace)
             }) {
+                chosen = Some(index);
                 break;
+            }
+        }
+
+        marks.push(match (chosen, stats) {
+            (Some(index), Some(stats)) => Some(OpenCodeGroupMark {
+                query_digest: query_digest(group[index]),
+                row_count: stats.row_count,
+                created_high_water: stats.created_high_water,
+                updated_high_water: stats.updated_high_water,
+            }),
+            (Some(_), None) => {
+                resumable = false;
+                None
+            }
+            _ => None,
+        });
+    }
+
+    OpenCodeSchemaScan {
+        messages: acc.messages,
+        incremental: cfg
+            .incremental_groups
+            .filter(|_| resumable)
+            .map(|_| OpenCodeIncrementalState { groups: marks }),
+    }
+}
+
+/// Re-scan only the rows that changed since `cached_state`, merged into
+/// `cached_messages`.
+///
+/// Returns `None` whenever the cached state cannot be trusted, and the caller
+/// then runs [`scan_opencode_schema_sqlite`] instead. That covers a database
+/// that will not open, a schema variant that no longer matches the one the
+/// mark came from, a query variant whose SQL has since been edited, and -- the
+/// case that matters for correctness -- a table that lost rows. Deletions are
+/// invisible to an incremental scan, so anything short of a clean insert-only
+/// delta re-reads everything.
+pub(crate) fn rescan_opencode_schema_sqlite(
+    db_path: &Path,
+    cfg: OpenCodeSchemaConfig,
+    cached_state: &OpenCodeIncrementalState,
+    cached_messages: Vec<UnifiedMessage>,
+) -> Option<OpenCodeSchemaScan> {
+    let incremental_groups = cfg.incremental_groups?;
+    if cached_state.groups.len() != cfg.query_groups.len() {
+        return None;
+    }
+
+    let conn = open_readonly_sqlite_opt(db_path)?;
+    let db_namespace = if cfg.namespace_rowid_dedup_key {
+        db_path.to_string_lossy().into_owned()
+    } else {
+        String::new()
+    };
+
+    let mut acc = SchemaAccumulator::default();
+    let mut marks: Vec<Option<OpenCodeGroupMark>> = Vec::with_capacity(cached_state.groups.len());
+
+    for (group_index, group) in cfg.query_groups.iter().enumerate() {
+        let incremental = incremental_groups.get(group_index)?;
+        let cached_mark = cached_state.groups[group_index].as_ref();
+        let stats = read_table_stats(
+            db_path,
+            &conn,
+            incremental.stats,
+            cached_mark.map_or(i64::MAX, |mark| mark.created_high_water),
+        );
+
+        let (mark, stats) = match (cached_mark, stats) {
+            (Some(mark), Some(stats)) => (mark, stats),
+            // The group's table was absent when the cache was written and
+            // still is, so it contributed nothing then and contributes
+            // nothing now.
+            (None, None) => {
+                marks.push(None);
+                continue;
+            }
+            // The table appeared or vanished, or no variant prepared when the
+            // cache was written. Either way the cached rows no longer describe
+            // this database.
+            _ => return None,
+        };
+
+        // Deletion guard. Every row added since the mark carries a
+        // `time_created` above it, so a table that is insert-only holds
+        // exactly `row_count + created_after_mark` rows. Anything less is a row
+        // that went away, and an incremental scan has no way to notice it.
+        if Some(stats.row_count) != mark.row_count.checked_add(stats.created_after_mark) {
+            return None;
+        }
+
+        // A full scan takes the first variant that prepares; the cached rows
+        // carry that variant's workspace and title columns, so the mark is
+        // only reusable while the same variant still wins.
+        let chosen = group.iter().position(|query| conn.prepare(query).is_ok())?;
+        if query_digest(group[chosen]) != mark.query_digest {
+            return None;
+        }
+
+        let query = incremental.queries.get(chosen)?;
+        if !collect_rows_since(
+            db_path,
+            &conn,
+            query,
+            mark.updated_high_water,
+            &mut |row| acc.ingest(row, &cfg, &db_namespace),
+        ) {
+            return None;
+        }
+
+        marks.push(Some(OpenCodeGroupMark {
+            query_digest: mark.query_digest,
+            row_count: stats.row_count,
+            created_high_water: stats.created_high_water,
+            updated_high_water: stats.updated_high_water,
+        }));
+    }
+
+    Some(OpenCodeSchemaScan {
+        messages: merge_incremental_messages(cached_messages, acc.messages)?,
+        incremental: Some(OpenCodeIncrementalState { groups: marks }),
+    })
+}
+
+/// Fold the rows a rescan re-read back into the cached message list.
+///
+/// A changed row replaces the cached message carrying its id and a new row is
+/// appended, so the cached relative order survives and the result holds one
+/// entry per message id -- the same set a full scan of the same database state
+/// produces. The lane keys on `dedup_key` everywhere downstream (cross-database
+/// and legacy-JSON suppression both), so position carries no meaning beyond
+/// that.
+///
+/// `None` when any message lacks a dedup key. The OpenCode driver always sets
+/// one, so this cannot happen; if it ever did, appending an unkeyed message
+/// would double count it on the next scan, and a full re-parse is the safe
+/// answer.
+fn merge_incremental_messages(
+    cached: Vec<UnifiedMessage>,
+    changed: Vec<UnifiedMessage>,
+) -> Option<Vec<UnifiedMessage>> {
+    let mut merged = cached;
+    let mut index_by_key: HashMap<String, usize> = HashMap::with_capacity(merged.len());
+    for (index, message) in merged.iter().enumerate() {
+        index_by_key.insert(message.dedup_key.clone()?, index);
+    }
+
+    for message in changed {
+        let key = message.dedup_key.clone()?;
+        match index_by_key.get(&key) {
+            Some(&index) => merged[index] = message,
+            None => {
+                index_by_key.insert(key, merged.len());
+                merged.push(message);
             }
         }
     }
 
-    acc.messages
+    Some(merged)
 }

--- a/crates/tokscale-core/src/sessions/opencode_schema.rs
+++ b/crates/tokscale-core/src/sessions/opencode_schema.rs
@@ -523,6 +523,42 @@ const OPENCODE_V1_STATS_QUERY: &str = r#"
     FROM message
 "#;
 
+/// Changed rows the usage queries no longer select.
+///
+/// The row count is a deletion test, but a row that is rewritten until it stops
+/// being priceable usage -- its role moves off `assistant`, or its `tokens`
+/// object goes away -- leaves the count untouched while dropping out of the
+/// incremental result. The merge only replaces keys it is handed, so without
+/// this probe that row's cached message would stay counted for as long as the
+/// mark survives, and a cold scan would disagree with the cache indefinitely.
+///
+/// Only the ids are read: the caller needs to know whether a *cached* message
+/// came from the row, not what the row says now. Bounded by the same
+/// `time_updated` mark as the usage queries, so it reads the delta rather than
+/// the table -- unlike folding the predicate into the stats query, which costs
+/// a `json_extract` per row on every rescan (measured at +14.6s on a 14 GB
+/// database, against 5.1s for the whole stats pass).
+///
+/// The `COALESCE` matters: `json_extract` returns SQL NULL for an absent
+/// `$.role`, and an unguarded `NOT (NULL = 'assistant' AND ...)` evaluates to
+/// NULL, which `WHERE` drops -- silently exempting exactly the malformed rows
+/// this is meant to catch.
+const OPENCODE_V2_DISQUALIFIED_QUERY: &str = r#"
+    SELECT sm.id, json_extract(sm.data, '$.id')
+    FROM session_message sm
+    WHERE sm.time_updated >= ?1
+      AND NOT (sm.type = 'assistant'
+               AND json_extract(sm.data, '$.tokens') IS NOT NULL)
+"#;
+
+const OPENCODE_V1_DISQUALIFIED_QUERY: &str = r#"
+    SELECT m.id, json_extract(m.data, '$.id')
+    FROM message m
+    WHERE m.time_updated >= ?1
+      AND NOT (COALESCE(json_extract(m.data, '$.role'), '') = 'assistant'
+               AND json_extract(m.data, '$.tokens') IS NOT NULL)
+"#;
+
 /// Incremental support for one entry of [`OpenCodeSchemaConfig::query_groups`].
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct OpenCodeIncrementalGroup {
@@ -532,6 +568,10 @@ pub(crate) struct OpenCodeIncrementalGroup {
     queries: &'static [&'static str],
     /// Row-population invariants for the group's base table.
     stats: &'static str,
+    /// Changed rows the group's usage queries no longer select. One query for
+    /// the whole group rather than one per variant: the variants differ only
+    /// in the metadata join, which this does not read.
+    disqualified: &'static str,
 }
 
 /// Incremental support for [`OPENCODE_QUERY_GROUPS`], in the same order.
@@ -539,10 +579,12 @@ const OPENCODE_INCREMENTAL_GROUPS: &[OpenCodeIncrementalGroup] = &[
     OpenCodeIncrementalGroup {
         queries: OPENCODE_V2_INCREMENTAL_QUERIES,
         stats: OPENCODE_V2_STATS_QUERY,
+        disqualified: OPENCODE_V2_DISQUALIFIED_QUERY,
     },
     OpenCodeIncrementalGroup {
         queries: OPENCODE_V1_INCREMENTAL_QUERIES,
         stats: OPENCODE_V1_STATS_QUERY,
+        disqualified: OPENCODE_V1_DISQUALIFIED_QUERY,
     },
 ];
 
@@ -1028,6 +1070,44 @@ fn collect_rows_since(
     scan.prepared()
 }
 
+/// Whether any row that stopped qualifying as usage backs a cached message.
+///
+/// Returns `None` if the probe could not run, which the caller treats the same
+/// as a hit: an unverifiable delta is not a safe one.
+///
+/// Both candidate dedup keys are tested for every row -- the embedded id and
+/// the row id -- rather than reproducing [`SchemaAccumulator::ingest`]'s choice
+/// between them. The two spellings cannot collide across different rows in
+/// practice, and the failure directions are not symmetric: an extra key costs
+/// one unnecessary full scan, while a missed one leaves a stale message counted
+/// for the life of the mark.
+fn disqualified_row_backs_cached_message(
+    db_path: &Path,
+    conn: &rusqlite::Connection,
+    query: &str,
+    since: i64,
+    db_namespace: &str,
+    cached_keys: &std::collections::HashSet<&str>,
+) -> Option<bool> {
+    let mut hit = false;
+    let scan =
+        sqlite_for_each_row_on_with_params(conn, db_path, query, &[&since], None, &mut |row| {
+            if hit {
+                return Ok(());
+            }
+            let row_id: String = row.get(0)?;
+            let embedded_id: Option<String> = row.get(1)?;
+            let namespaced = format!("{db_namespace}:{row_id}");
+            hit = cached_keys.contains(row_id.as_str())
+                || cached_keys.contains(namespaced.as_str())
+                || embedded_id
+                    .as_deref()
+                    .is_some_and(|id| cached_keys.contains(id));
+            Ok(())
+        });
+    scan.prepared().then_some(hit)
+}
+
 /// Parse assistant turns out of a SQLite database that uses the OpenCode
 /// message schema, applying `cfg`'s per-client policy.
 ///
@@ -1271,6 +1351,12 @@ pub(crate) fn rescan_opencode_schema_sqlite(
 
     let mut acc = SchemaAccumulator::default();
     let mut marks: Vec<Option<OpenCodeGroupMark>> = Vec::with_capacity(cached_state.groups.len());
+    // Borrowed for the disqualification probe below; `cached_messages` is not
+    // consumed until the merge at the end of this function.
+    let cached_keys: std::collections::HashSet<&str> = cached_messages
+        .iter()
+        .filter_map(|message| message.dedup_key.as_deref())
+        .collect();
 
     for (group_index, group) in cfg.query_groups.iter().enumerate() {
         let incremental = incremental_groups.get(group_index)?;
@@ -1310,6 +1396,21 @@ pub(crate) fn rescan_opencode_schema_sqlite(
         // only reusable while the same variant still wins.
         let chosen = group.iter().position(|query| conn.prepare(query).is_ok())?;
         if query_digest(group[chosen]) != mark.query_digest {
+            return None;
+        }
+
+        // Rows that stopped being usage are invisible to the query above, so
+        // they are probed for separately. A hit means the cache holds a message
+        // whose row no longer backs it, and only a full scan can drop it.
+        if disqualified_row_backs_cached_message(
+            db_path,
+            &conn,
+            incremental.disqualified,
+            mark.updated_high_water,
+            &db_namespace,
+            &cached_keys,
+        ) != Some(false)
+        {
             return None;
         }
 

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -354,6 +354,22 @@ pub(crate) fn sqlite_for_each_row_on(
     what: Option<&str>,
     sink: &mut dyn FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<()>,
 ) -> SqliteScan {
+    sqlite_for_each_row_on_with_params(conn, db_path, sql, &[], what, sink)
+}
+
+/// [`sqlite_for_each_row_on`] with bound parameters.
+///
+/// Split out rather than folded into the caller so a query whose bounds come
+/// from cached state binds them instead of formatting them into the SQL text,
+/// which would also defeat SQLite's statement cache.
+pub(crate) fn sqlite_for_each_row_on_with_params(
+    conn: &Connection,
+    db_path: &Path,
+    sql: &str,
+    params: &[&dyn rusqlite::ToSql],
+    what: Option<&str>,
+    sink: &mut dyn FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<()>,
+) -> SqliteScan {
     let mut stmt = match conn.prepare(sql) {
         Ok(stmt) => stmt,
         Err(err) => {
@@ -369,7 +385,7 @@ pub(crate) fn sqlite_for_each_row_on(
         }
     };
 
-    let mut rows = match stmt.query([]) {
+    let mut rows = match stmt.query(params) {
         Ok(rows) => rows,
         Err(err) => {
             if let Some(what) = what {


### PR DESCRIPTION
## Problem

`tokscale submit` peaks at 3.88 GB RSS on a 14 GB `~/.local/share/opencode/opencode.db` (#1209). OpenCode alone accounts for 1.83 GB and 52 s of that, for 18.8B tokens; Codex reads 46.7B tokens in 0.51 GB and 1.4 s by comparison.

The cost is structural. `OPENCODE_V1_QUERIES` filters on `json_extract(m.data,'$.role')='assistant' AND json_extract(m.data,'$.tokens') IS NOT NULL`, so SQLite parses the payload of all 434,955 rows before it can return the 342,927 that match — 2.687 s of SQL — and the remaining ~50 s is the Rust-side materialisation of those messages. Nothing about a warm scan avoids any of it: the cache re-parses the whole database from scratch whenever the file changed, which for a database an editor is actively writing is every run. Above roughly 1.05M messages the shard also crosses `MAX_CACHE_SHARD_BYTES` (256 MiB), stops saving entirely, and the database is re-parsed cold forever.

## What this does

A cached OpenCode entry now records where the last scan got to, and a warm scan reads only the rows at or above that mark, merging them into the cached messages by message id. Same query otherwise, same projection, same ordering, same dedup.

The mark is `time_updated`, not the row id. OpenCode rewrites a message row long after inserting it: on that database 434,851 of 434,955 rows (99.98%) carry `time_updated > time_created`, with lags of up to 79 days. An id high-water — the analogue of Codex's `consumed_offset` — would therefore skip the later rewrite of essentially every row, and because the server's high-water is monotonic, one under-reported submission pins the total permanently. The bound also leads the two `json_extract` calls, because SQLite evaluates the conjuncts left to right and an unchanged row rejected on an integer comparison never has its payload parsed.

## Measured

End to end on the real 14 GB database, `tokscale --light --json -c opencode` against a copy-on-write clone of it, with `/usr/bin/time -l`:

| scan | wall | peak RSS |
|---|---|---|
| cold, empty cache | 15.87 s | 1.03 GiB |
| cold again, page cache hot | 7.96 s | 1.04 GiB |
| warm, database untouched | 2.60 s | 941 MiB |
| **warm, 50 rows changed** | **2.61 s** | **940 MiB** |

The last row is the one this PR adds. Before it, a database that changed at all took the full-parse path — the second row — because the fingerprint only says "the file moved". A live database moves on every run, so that was the normal case, not the exception. Now a changed database costs what an unchanged one costs.

The two scans agree. Sorting the 58 model entries the two runs emit (report entry order is not stable between runs), every field matches; the only difference in the whole document is `processingTimeMs`.

At the SQL level, comparing the query the scan actually runs:

| | rows returned | time |
|---|---|---|
| full scan (`WHERE json_extract(...)`) | 342,927 | 2.687 s |
| incremental scan (`WHERE time_updated >= mark AND json_extract(...)`) | 63 | 0.088 s |

The guard queries are the same shape and cost, because reading `time_created` / `time_updated` never touches the `data` column — it lives in overflow pages. `SELECT COUNT(*) FROM message` is 0.015 s and `SELECT COUNT(*) FROM message WHERE time_updated < mark` is 0.096 s.

## Forked history

The fingerprint dedup lets one cached entry stand for more than one row — 342,927 matching rows collapse to 340,216 messages on that database, so 2,711 rows are absorbed — and the merged entry is the only trace the absorbed row left. Merging a delta back by dedup key alone would therefore drop the absorbed side's contribution when the surviving side is re-read, and would append a forked copy created after the mark beside the original a full scan collapses it into.

The mark records the dedup keys of every row that took part in a merge, and a rescan re-parses when a changed row is one of them. A changed row whose content matches a cached message it is not itself replacing re-parses too, which covers the collapses that had not happened yet when the mark was taken. That content digest is deliberately coarser than the row fingerprint — whole milliseconds where the fingerprint keeps raw float bits — so it can only claim a collapse that would not have happened. One wasted full parse, never a missed one. Above 250,000 merged keys the mark is not written at all, so a database where the assumption does not hold stays on full scans instead of carrying bookkeeping larger than the delta it saves.

## Cache format

`CACHE_FORMAT_VERSION` goes 5 → 6 to make room for the mark on the cache entry, where it has to live: a mark paired with anything other than the message list it was taken with would skip rows and under-report. Both older layouts get explicit wire migrations, so version-4 and version-5 shards keep their messages instead of being discarded — which matters most for Claude, whose entries are the only copy of compacted history.

`parser_version` for OpenCode stays at 2, deliberately. An entry written by the old code migrates in with no mark, which the loader already treats as "full parse this once", so the fallback is safe without a bump. Bumping it would do the opposite of what this PR is for: it would discard every warm OpenCode entry — the 83 MB shard holding 340,216 messages on that profile — and force exactly the cold re-parse being removed here. The parse output is unchanged either way, which is what a `parser_version` actually guards.

## Scope

OpenCode's V1 (`message`) and V2 (`session_message`) variants only. MiMo Code and Kilo share the schema driver but declare no incremental support, so they take the full-scan path they took before, byte for byte. The database is still opened `SQLITE_OPEN_READ_ONLY` — no index is created and nothing is written to the user's database, which is why the bound has to lead the predicate rather than be supported by an index.

## Tests

- A warm incremental scan and a cold full parse of the same database state produce identical messages, at both the driver level and end to end through the source cache.
- A row rewritten long after it was inserted — the 99.98% case — reaches the incremental scan. Re-keying the mark on insert order makes this test fail with the row stuck at its stale value and the end-to-end total under-reporting at 180 instead of 630.
- A deleted row forces a full re-parse and leaves nothing stale counted, including when an insert masks the deletion in the row count.
- A table with no `time_updated` column records no mark, so it can only ever full-parse.
- A schema variant change invalidates the mark.
- A row that took part in a fingerprint merge, and a new row that would collapse into an existing one, both force a full re-parse.
- A version-5 shard migrates with its messages intact and no mark.
