### PR TITLE
perf(cache): compress source-message shard payloads

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -41,6 +41,41 @@ const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const LEGACY_MONOLITH_CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_SHARD_COUNT: usize = 256;
 const MAX_CACHE_SHARD_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Ceiling on the *uncompressed* entry payload inside a shard.
+///
+/// [`MAX_CACHE_SHARD_BYTES`] bounds what lands on disk. Since the payload is
+/// zstd-compressed the two are no longer the same number: real shards compress
+/// about 5.6x, so holding the serialize limit at the on-disk cap would refuse
+/// payloads that fit on disk several times over and send a heavy source back to
+/// re-parsing every scan. This bounds the pre-compression side on its own.
+const MAX_CACHE_SHARD_PAYLOAD_BYTES: u64 = 4 * MAX_CACHE_SHARD_BYTES;
+
+/// zstd frame magic (little-endian `0xFD2FB528`).
+///
+/// Shards written before compression hold a bare bincode payload, so the reader
+/// sniffs this rather than relying on a format bump: an old cache stays readable
+/// and is rewritten compressed on the next save, instead of being invalidated
+/// and forcing exactly the full re-parse this is meant to avoid.
+const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
+
+/// Compression level for shard payloads. Level 3 is zstd's default: on a real
+/// 83 MB shard it takes ~0.08s to write and ~0.05s to read back, against the
+/// tens of seconds a re-parse of the same source costs.
+const SHARD_COMPRESSION_LEVEL: i32 = 3;
+
+fn compress_shard_payload(payload: &[u8]) -> std::io::Result<Vec<u8>> {
+    zstd::stream::encode_all(payload, SHARD_COMPRESSION_LEVEL)
+}
+
+/// Decompress a payload written by [`compress_shard_payload`], passing through
+/// an uncompressed payload from a pre-compression shard unchanged.
+fn decompress_shard_payload(payload: Vec<u8>) -> std::io::Result<Vec<u8>> {
+    if payload.len() < ZSTD_MAGIC.len() || payload[..ZSTD_MAGIC.len()] != ZSTD_MAGIC {
+        return Ok(payload);
+    }
+    zstd::stream::decode_all(payload.as_slice())
+}
 const FINGERPRINT_SAMPLE_BYTES: usize = 4096;
 const FINGERPRINT_SAMPLE_POINTS: usize = 5;
 const HASH_BUFFER_BYTES: usize = 64 * 1024;
@@ -2224,10 +2259,15 @@ fn read_shard_with_limit(
         return ShardReadStatus::Stale;
     }
 
+    let payload = match decompress_shard_payload(envelope.payload) {
+        Ok(payload) => payload,
+        Err(error) => return ShardReadStatus::Invalid(error.to_string()),
+    };
+
     if envelope.format_version == LEGACY_CACHE_FORMAT_VERSION {
         return match bincode::options()
-            .with_limit(max_shard_bytes)
-            .deserialize::<Vec<LegacyCachedSourceEntryV4>>(&envelope.payload)
+            .with_limit(MAX_CACHE_SHARD_PAYLOAD_BYTES)
+            .deserialize::<Vec<LegacyCachedSourceEntryV4>>(&payload)
         {
             Ok(entries) => ShardReadStatus::Migrated(
                 entries.into_iter().map(CachedSourceEntry::from).collect(),
@@ -2240,8 +2280,8 @@ fn read_shard_with_limit(
     }
 
     match bincode::options()
-        .with_limit(max_shard_bytes)
-        .deserialize(&envelope.payload)
+        .with_limit(MAX_CACHE_SHARD_PAYLOAD_BYTES)
+        .deserialize(&payload)
     {
         Ok(entries) => ShardReadStatus::Loaded(entries),
         Err(error) => ShardReadStatus::Invalid(error.to_string()),
@@ -2255,9 +2295,10 @@ fn write_shard_with_limit(
     max_shard_bytes: u64,
 ) -> std::io::Result<()> {
     let payload = bincode::options()
-        .with_limit(max_shard_bytes)
+        .with_limit(MAX_CACHE_SHARD_PAYLOAD_BYTES)
         .serialize(entries)
         .map_err(std::io::Error::other)?;
+    let payload = compress_shard_payload(&payload)?;
     let envelope = CachedShardEnvelope {
         format_version: CACHE_FORMAT_VERSION,
         parser_namespace: identity.namespace.to_string(),
@@ -2534,6 +2575,49 @@ pub(crate) fn codex_cache_entry_matches_fingerprint(
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn shard_payload_round_trips_through_compression() {
+        let raw = b"opencode".repeat(4096).to_vec();
+        let compressed = compress_shard_payload(&raw).expect("compress");
+        assert!(
+            compressed.len() < raw.len(),
+            "a repetitive payload must get smaller, got {} from {}",
+            compressed.len(),
+            raw.len()
+        );
+        assert_eq!(compressed[..ZSTD_MAGIC.len()], ZSTD_MAGIC);
+        assert_eq!(
+            decompress_shard_payload(compressed).expect("decompress"),
+            raw
+        );
+    }
+
+    #[test]
+    fn an_uncompressed_payload_from_an_older_shard_is_passed_through() {
+        // Shards written before compression hold bare bincode. They must stay
+        // readable: invalidating them would force the full re-parse that
+        // compression exists to keep avoiding.
+        let bare = bincode::options()
+            .serialize(&vec![1_u32, 2, 3])
+            .expect("serialize");
+        assert_ne!(bare[..ZSTD_MAGIC.len().min(bare.len())], ZSTD_MAGIC);
+        assert_eq!(
+            decompress_shard_payload(bare.clone()).expect("passthrough"),
+            bare
+        );
+    }
+
+    #[test]
+    fn a_short_payload_is_not_mistaken_for_a_zstd_frame() {
+        for len in 0..ZSTD_MAGIC.len() {
+            let short = vec![0x28_u8; len];
+            assert_eq!(
+                decompress_shard_payload(short.clone()).expect("passthrough"),
+                short
+            );
+        }
+    }
     use super::*;
     use crate::paths::json_path_literal;
     use crate::TokenBreakdown;
@@ -4225,6 +4309,21 @@ mod tests {
         assert!(loaded.get(identity, &path_two).is_some());
     }
 
+    /// `len` bytes of printable ASCII with no exploitable structure, so zstd
+    /// cannot shrink it. A plain `char::repeat` compresses to near zero and
+    /// stops a size-sensitive test from measuring what it means to measure.
+    fn incompressible_text(len: usize, seed: u64) -> String {
+        let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+        (0..len)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                char::from(b'!' + (state % 90) as u8)
+            })
+            .collect()
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_aggregate_cache_can_exceed_individual_shard_limit() {
@@ -4236,10 +4335,14 @@ mod tests {
         let identity = CacheIdentity::for_client(ClientId::Claude);
         let (path_one, path_two) = write_sources_in_distinct_shards(&source_dir, identity);
 
+        // Payloads are compressed, so a run of one repeated byte would shrink to
+        // almost nothing and both shards would fit under the limit together --
+        // which is the opposite of what this test is about. Use high-entropy
+        // content so each shard stays a real fraction of the cap.
         let mut entry_one = test_entry(identity, &path_one, "session-1");
-        entry_one.messages[0].model_id = "a".repeat(20 * 1024);
+        entry_one.messages[0].model_id = incompressible_text(20 * 1024, 1);
         let mut entry_two = test_entry(identity, &path_two, "session-2");
-        entry_two.messages[0].model_id = "b".repeat(20 * 1024);
+        entry_two.messages[0].model_id = incompressible_text(20 * 1024, 2);
 
         let mut cache = SourceMessageCache::default();
         cache.insert(entry_one);


### PR DESCRIPTION
Shard payloads were stored as bare bincode. On a real 14 GB OpenCode database the shard holding 340,216 messages is 83 MB, and that same payload compresses to 15.6 MB with zstd at level 3 — 5.6x. zstd is already a dependency of this crate.

The reason this matters is not disk. `MAX_CACHE_SHARD_BYTES` gates both reading and writing a shard, so a source whose payload crosses 256 MiB stops being cacheable at all: `save_if_dirty` logs "future scans may remain cold" exactly once and the source is re-parsed on every subsequent scan, forever, with no further warning. Compression moves that cliff roughly 5.6x further out.

The two limits are now separate, because compression made them different quantities. `MAX_CACHE_SHARD_BYTES` continues to bound what lands on disk. `MAX_CACHE_SHARD_PAYLOAD_BYTES` bounds the uncompressed payload before it is compressed; holding the serialize limit at the on-disk cap would have refused payloads that fit on disk several times over, which is the failure this is meant to remove.

Old caches stay readable. The reader sniffs the zstd frame magic instead of relying on a format-version bump, so a pre-compression shard is passed through unchanged and rewritten compressed on its next save. Bumping the format version would have invalidated every existing shard and forced precisely the full re-parse this change exists to avoid — worst for the heavy users it is meant to help.

Measured on the real 83 MB shard: compression 0.08s, decompression 0.05s, against the tens of seconds a re-parse of the same source costs.

One existing test needed its fixture changed rather than its assertion. `test_aggregate_cache_can_exceed_individual_shard_limit` built its payload from `"a".repeat(20 * 1024)`, which compresses to almost nothing, so both shards fell under the cap and the test could no longer observe the property it exists to check. It now uses high-entropy content of the same length, so each shard stays a real fraction of the limit and the aggregate still exceeds it.

Scope note: this does not fix #1209. Peak RSS during a scan is dominated by live in-memory messages (measured at 1.37 GB live in 12.6 million blocks for a single OpenCode scan), not by cache size. This removes the cliff that makes a heavy source cold on every run, which is an amplifier of that cost rather than its cause.

Refs #1209


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compresses source-message shard payloads with zstd so heavy sources stay cacheable instead of falling off a hard size cliff and being re-parsed on every scan.

- Compression keeps old caches readable: the reader sniffs the zstd frame magic and passes pre-compression shards through unchanged.
- `MAX_CACHE_SHARD_PAYLOAD_BYTES` now bounds the uncompressed payload separately from `MAX_CACHE_SHARD_BYTES`, which still bounds the on-disk size.
- Does not fix #1209; peak RSS during scans is dominated by live in-memory messages, not cache size.

<sup>Written for commit 59a1d8d7c64170526f3266b79f05c2f4b42e0f39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

