### PR TITLE
feat(usage): add Antigravity subscription quota via the local language server

### DIFF
--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -2260,8 +2260,16 @@ fn antigravity_https_client() -> &'static reqwest::Client {
     })
 }
 
-#[cfg(not(target_os = "windows"))]
-async fn read_reqwest_response_with_cap(
+/// Reads at most `max_body_bytes` of a loopback RPC response.
+///
+/// `Content-Length` is consulted first so an oversized body is refused before a
+/// byte of it is read, but it is never the only check: the header is optional
+/// and a server is free to understate it, so the loop enforces the same ceiling
+/// on what actually arrives.
+///
+/// Shared with the `/usage` quota provider, which reaches the same language
+/// server over plain HTTP and needs the same ceiling for the same reason.
+pub(crate) async fn read_reqwest_response_with_cap(
     mut response: reqwest::Response,
     max_body_bytes: usize,
 ) -> Result<String> {

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -1,0 +1,393 @@
+//! Antigravity subscription quota.
+//!
+//! Unlike every other provider here, this one never reaches a cloud API. The
+//! Antigravity CLI (`agy`) and IDE both run a language server that holds the
+//! OAuth token, calls Google Code Assist, caches the answer, and exposes it
+//! over a loopback Connect-RPC endpoint. `/usage` inside the CLI reads exactly
+//! that:
+//!
+//! ```text
+//! POST http://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary
+//! Connect-Protocol-Version: 1
+//! {}
+//! ```
+//!
+//! No CSRF token is required for this method, and tokscale never has to hold
+//! an Antigravity credential of its own — the token stays inside the language
+//! server and we only read the numbers it already computed.
+//!
+//! Calling Google's `cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota`
+//! directly was tried first and rejected: authentication succeeds, but a
+//! `GEMINI_CLI` client identity is answered with `UNSUPPORTED_CLIENT` /
+//! `SUBSCRIPTION_REQUIRED` now that individual users have been migrated to
+//! Antigravity.
+//!
+//! Antigravity meters quota **per model group** — Gemini models share one
+//! weekly and one five-hour limit, Claude and GPT models share another — so
+//! this provider emits one [`UsageOutput`] per group and names the group in
+//! the account label. That reuses the existing multi-output path (the same one
+//! Codex uses for multiple accounts) and renders as
+//! `Antigravity (Gemini Models)`, rather than flattening every bucket into one
+//! list where no row can be attributed to a group.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use super::{UsageAccount, UsageMetric, UsageOutput};
+
+const PROVIDER: &str = "Antigravity";
+const RPC_PATH: &str = "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary";
+
+/// The loopback call itself answers in a few milliseconds. This bound only
+/// matters when a candidate port belongs to some unrelated process that
+/// accepts the connection and then goes quiet.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(400);
+
+// ── Wire format ──
+
+#[derive(Debug, Deserialize)]
+struct QuotaSummaryEnvelope {
+    response: QuotaSummary,
+}
+
+#[derive(Debug, Deserialize)]
+struct QuotaSummary {
+    #[serde(default)]
+    groups: Vec<QuotaGroup>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QuotaGroup {
+    #[serde(rename = "displayName", default)]
+    display_name: String,
+    #[serde(default)]
+    buckets: Vec<QuotaBucket>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QuotaBucket {
+    #[serde(rename = "displayName", default)]
+    display_name: String,
+    /// `"weekly"` or `"5h"`.
+    #[serde(default)]
+    window: Option<String>,
+    /// Fraction **remaining**, 0.0 to 1.0 — not the fraction used.
+    #[serde(rename = "remainingFraction", default)]
+    remaining_fraction: Option<f64>,
+    #[serde(rename = "resetTime", default)]
+    reset_time: Option<String>,
+}
+
+// ── Provider interface ──
+
+/// Whether a reachable language server is serving quota right now.
+///
+/// This probes rather than checking for a credential file, because Antigravity
+/// keeps its token inside the running process: "is it installed" and "can we
+/// read quota" are different questions, and only the second one should put a
+/// card on screen. The probe is a loopback request against a port read out of
+/// the CLI log, so it costs a few milliseconds.
+pub fn has_credentials() -> bool {
+    let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    else {
+        return false;
+    };
+    rt.block_on(async { discover_port().await.is_some() })
+}
+
+pub fn fetch_all() -> Result<Vec<UsageOutput>> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+
+    rt.block_on(async {
+        let port = discover_port()
+            .await
+            .context("Antigravity language server is not running")?;
+        let summary = call_rpc(port).await?;
+
+        if summary.groups.is_empty() {
+            anyhow::bail!("Antigravity is running but not signed in");
+        }
+
+        Ok(summary.groups.into_iter().map(output_for_group).collect())
+    })
+}
+
+fn output_for_group(group: QuotaGroup) -> UsageOutput {
+    let name = group.display_name;
+    UsageOutput {
+        provider: PROVIDER.to_string(),
+        // The "account" slot carries the model group. Antigravity has a single
+        // account but several independently metered groups, and this is the
+        // field the renderer already appends in parentheses.
+        account: Some(UsageAccount {
+            id: slug(&name),
+            label: Some(name),
+            is_active: true,
+        }),
+        credential_source: None,
+        plan: None,
+        email: None,
+        metrics: group.buckets.into_iter().map(metric).collect(),
+        reset_credits: None,
+        credit_status: None,
+        spend_control: None,
+    }
+}
+
+/// Stable identifier for a group, derived from its display name.
+fn slug(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+fn metric(bucket: QuotaBucket) -> UsageMetric {
+    // The wire format reports what is **left**; `UsageMetric` leads with what
+    // has been used. Getting this backwards turns "7% left" into "7% used",
+    // which is the most dangerous way to be wrong about a quota.
+    let remaining = bucket.remaining_fraction.unwrap_or(0.0).clamp(0.0, 1.0) * 100.0;
+
+    UsageMetric {
+        // `displayName` reads "Weekly Limit Remaining", which is too long for a
+        // card once the group name is also shown; `window` is the short form.
+        label: bucket
+            .window
+            .filter(|w| !w.is_empty())
+            .unwrap_or(bucket.display_name),
+        used_percent: 100.0 - remaining,
+        remaining_percent: remaining,
+        remaining_label: None,
+        resets_at: bucket.reset_time,
+    }
+}
+
+async fn call_rpc(port: u16) -> Result<QuotaSummary> {
+    let client = reqwest::Client::builder().timeout(PROBE_TIMEOUT).build()?;
+    let envelope: QuotaSummaryEnvelope = client
+        .post(format!("http://127.0.0.1:{port}{RPC_PATH}"))
+        // Connect-RPC rejects the request without this header.
+        .header("Connect-Protocol-Version", "1")
+        .json(&serde_json::json!({}))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    Ok(envelope.response)
+}
+
+// ── Port discovery ──
+
+/// Find a language server port that answers `RetrieveUserQuotaSummary`.
+///
+/// Two sources, cheapest first:
+///
+/// 1. The CLI log, which records `listening on random port at NNNN for HTTP`
+///    on every start. Reading one file beats enumerating processes.
+/// 2. [`crate::antigravity::detect_antigravity_connections`], which finds the
+///    IDE's language server. That path needs a CSRF token on the process
+///    command line, which the `agy` CLI does not have — hence source 1.
+///
+/// Candidates are probed rather than trusted: the process listens on both an
+/// HTTPS (gRPC) port and an HTTP one, and only the latter speaks plain JSON.
+async fn discover_port() -> Option<u16> {
+    for port in ports_from_cli_log() {
+        if call_rpc(port).await.is_ok() {
+            return Some(port);
+        }
+    }
+
+    for connection in crate::antigravity::detect_antigravity_connections().ok()? {
+        if call_rpc(connection.port).await.is_ok() {
+            return Some(connection.port);
+        }
+    }
+
+    None
+}
+
+fn cli_log_path() -> Option<PathBuf> {
+    Some(
+        tokscale_core::paths::home_dir()?
+            .join(".gemini")
+            .join("antigravity-cli")
+            .join("cli.log"),
+    )
+}
+
+/// Ports the CLI logged, most recent first.
+fn ports_from_cli_log() -> Vec<u16> {
+    let Some(path) = cli_log_path() else {
+        return Vec::new();
+    };
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let mut ports = parse_logged_ports(&text);
+    // The log is appended across runs, so the last entry is the current one.
+    ports.reverse();
+    ports.truncate(4);
+    ports
+}
+
+fn parse_logged_ports(text: &str) -> Vec<u16> {
+    const MARKER: &str = "listening on random port at ";
+    text.lines()
+        .filter(|line| line.contains("for HTTP") && !line.contains("for HTTPS"))
+        .filter_map(|line| {
+            let rest = &line[line.find(MARKER)? + MARKER.len()..];
+            let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+            digits.parse::<u16>().ok().filter(|p| *p != 0)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remaining_fraction_becomes_used_percent() {
+        let m = metric(QuotaBucket {
+            display_name: "Weekly Limit Remaining".to_string(),
+            window: Some("weekly".to_string()),
+            remaining_fraction: Some(0.414_529_86),
+            reset_time: Some("2026-08-29T03:58:44Z".to_string()),
+        });
+
+        assert_eq!(m.label, "weekly");
+        assert!((m.remaining_percent - 41.452_986).abs() < 1e-6);
+        assert!((m.used_percent - 58.547_014).abs() < 1e-6);
+    }
+
+    #[test]
+    fn bucket_without_a_window_falls_back_to_its_display_name() {
+        let m = metric(QuotaBucket {
+            display_name: "Weekly Limit Remaining".to_string(),
+            window: None,
+            remaining_fraction: Some(1.0),
+            reset_time: None,
+        });
+        assert_eq!(m.label, "Weekly Limit Remaining");
+    }
+
+    #[test]
+    fn out_of_range_fractions_are_clamped() {
+        for fraction in [-1.0, 0.0, 1.0, 4.2] {
+            let m = metric(QuotaBucket {
+                display_name: "x".to_string(),
+                window: None,
+                remaining_fraction: Some(fraction),
+                reset_time: None,
+            });
+            assert!((0.0..=100.0).contains(&m.remaining_percent));
+            assert!((0.0..=100.0).contains(&m.used_percent));
+        }
+    }
+
+    #[test]
+    fn log_parsing_takes_the_http_port_and_skips_the_grpc_one() {
+        let log = concat!(
+            "I0827 15:07:44 server.go:599] Language server listening on random port at 2578 for HTTPS (gRPC)\n",
+            "I0827 15:07:44 server.go:607] Language server listening on random port at 2579 for HTTP\n",
+        );
+        assert_eq!(parse_logged_ports(log), vec![2579]);
+    }
+
+    #[test]
+    fn log_parsing_skips_malformed_lines() {
+        let log = "listening on random port at abc for HTTP\nunrelated line\n";
+        assert!(parse_logged_ports(log).is_empty());
+    }
+
+    #[test]
+    fn quota_summary_parses_a_recorded_response() {
+        let raw = r#"{
+          "response": {
+            "groups": [
+              {
+                "displayName": "Gemini Models",
+                "description": "Models within this group: Gemini Flash, Gemini Pro",
+                "buckets": [
+                  {
+                    "bucketId": "gemini-weekly",
+                    "displayName": "Weekly Limit Remaining",
+                    "window": "weekly",
+                    "remainingFraction": 0.41452986,
+                    "resetTime": "2026-08-29T03:58:44Z"
+                  },
+                  {
+                    "bucketId": "gemini-5h",
+                    "displayName": "Five Hour Limit Remaining",
+                    "window": "5h",
+                    "remainingFraction": 1
+                  }
+                ]
+              },
+              {
+                "displayName": "Claude and GPT models",
+                "buckets": [
+                  {
+                    "bucketId": "3p-weekly",
+                    "window": "weekly",
+                    "remainingFraction": 0.89853734
+                  }
+                ]
+              }
+            ]
+          }
+        }"#;
+
+        let envelope: QuotaSummaryEnvelope = serde_json::from_str(raw).expect("parses");
+        let outputs: Vec<UsageOutput> = envelope
+            .response
+            .groups
+            .into_iter()
+            .map(output_for_group)
+            .collect();
+
+        assert_eq!(outputs.len(), 2, "one output per model group");
+
+        let gemini = &outputs[0];
+        assert_eq!(gemini.provider, "Antigravity");
+        assert_eq!(
+            gemini.account.as_ref().unwrap().label.as_deref(),
+            Some("Gemini Models")
+        );
+        assert_eq!(gemini.metrics.len(), 2);
+        assert!((gemini.metrics[0].remaining_percent - 41.452_986).abs() < 1e-6);
+        assert!((gemini.metrics[1].remaining_percent - 100.0).abs() < 1e-9);
+
+        let third_party = &outputs[1];
+        assert_eq!(
+            third_party.account.as_ref().unwrap().label.as_deref(),
+            Some("Claude and GPT models")
+        );
+        assert_eq!(
+            third_party.account.as_ref().unwrap().id,
+            "claude-and-gpt-models"
+        );
+    }
+
+    #[test]
+    fn group_slugs_are_stable_and_url_safe() {
+        assert_eq!(slug("Gemini Models"), "gemini-models");
+        assert_eq!(slug("Claude and GPT models"), "claude-and-gpt-models");
+        assert_eq!(slug("  spaced  "), "spaced");
+    }
+}

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -30,7 +30,8 @@
 //! `Antigravity (Gemini Models)`, rather than flattening every bucket into one
 //! list where no row can be attributed to a group.
 
-use std::path::PathBuf;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -176,18 +177,33 @@ fn metric(bucket: QuotaBucket) -> UsageMetric {
     }
 }
 
+/// Byte ceiling for one quota response.
+///
+/// `PROBE_TIMEOUT` bounds how long the language server may take, not how much
+/// it may send inside that window, and `Response::json` buffers the whole body
+/// before anything looks at it. Port discovery probes candidate ports, so this
+/// also runs against whatever else happens to be listening on loopback -- a
+/// port that answers with an endless stream would otherwise allocate until the
+/// timeout, and usage providers share a fan-out, so that takes the whole
+/// `tokscale usage` report down rather than one provider.
+///
+/// A real summary is a handful of bucket objects well under a kilobyte; 1 MiB
+/// leaves room for new fields while keeping the worst case bounded.
+const MAX_QUOTA_BODY_BYTES: usize = 1024 * 1024;
+
 async fn call_rpc(port: u16) -> Result<QuotaSummary> {
     let client = reqwest::Client::builder().timeout(PROBE_TIMEOUT).build()?;
-    let envelope: QuotaSummaryEnvelope = client
+    let response = client
         .post(format!("http://127.0.0.1:{port}{RPC_PATH}"))
         // Connect-RPC rejects the request without this header.
         .header("Connect-Protocol-Version", "1")
         .json(&serde_json::json!({}))
         .send()
         .await?
-        .error_for_status()?
-        .json()
-        .await?;
+        .error_for_status()?;
+    let body =
+        crate::antigravity::read_reqwest_response_with_cap(response, MAX_QUOTA_BODY_BYTES).await?;
+    let envelope: QuotaSummaryEnvelope = serde_json::from_str(&body)?;
     Ok(envelope.response)
 }
 
@@ -230,12 +246,37 @@ fn cli_log_path() -> Option<PathBuf> {
     )
 }
 
+/// Bytes of `cli.log` read when looking for logged ports.
+///
+/// The log is appended across every CLI run and nothing rotates it, so reading
+/// it whole grows without bound on a long-lived install. Only the most recent
+/// entries matter here -- the tail is where the current port is -- so reading
+/// the end is both bounded and the answer this function actually wants.
+const CLI_LOG_TAIL_BYTES: u64 = 256 * 1024;
+
+/// Read the last `max_bytes` of a file, or the whole file when it is smaller.
+///
+/// The leading partial line the offset can land in is dropped by the caller's
+/// line parse, which requires a whole `listening on random port at NNNN` match.
+fn read_tail(path: &Path, max_bytes: u64) -> Option<String> {
+    let mut file = std::fs::File::open(path).ok()?;
+    let len = file.metadata().ok()?.len();
+    if len > max_bytes {
+        file.seek(SeekFrom::Start(len - max_bytes)).ok()?;
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes).ok()?;
+    // Lossy because the tail offset can split a multi-byte character, and a
+    // replacement char in a line this parse ignores costs nothing.
+    Some(String::from_utf8_lossy(&bytes).into_owned())
+}
+
 /// Ports the CLI logged, most recent first.
 fn ports_from_cli_log() -> Vec<u16> {
     let Some(path) = cli_log_path() else {
         return Vec::new();
     };
-    let Ok(text) = std::fs::read_to_string(path) else {
+    let Some(text) = read_tail(&path, CLI_LOG_TAIL_BYTES) else {
         return Vec::new();
     };
     let mut ports = parse_logged_ports(&text);
@@ -260,6 +301,45 @@ fn parse_logged_ports(text: &str) -> Vec<u16> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The log is appended across every run and never rotated, so the read has
+    /// to be bounded -- and the bound has to keep the *end*, because that is
+    /// where the port of the currently running server was written.
+    #[test]
+    fn reads_the_end_of_an_oversized_log() {
+        use std::io::Write;
+
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        let filler = "noise from an earlier run\n".repeat(4096);
+        write!(file, "{filler}").unwrap();
+        writeln!(file, "listening on random port at 41234 for HTTP").unwrap();
+        file.flush().unwrap();
+
+        let tail = read_tail(file.path(), 512).expect("the log is readable");
+        assert!(
+            tail.len() as u64 <= 512,
+            "read {} bytes past the 512 byte ceiling",
+            tail.len()
+        );
+        assert_eq!(
+            parse_logged_ports(&tail),
+            vec![41234],
+            "the most recent port must survive the truncation"
+        );
+    }
+
+    #[test]
+    fn reads_a_whole_log_smaller_than_the_ceiling() {
+        use std::io::Write;
+
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(file, "listening on random port at 5001 for HTTP").unwrap();
+        writeln!(file, "listening on random port at 5002 for HTTP").unwrap();
+        file.flush().unwrap();
+
+        let tail = read_tail(file.path(), CLI_LOG_TAIL_BYTES).expect("the log is readable");
+        assert_eq!(parse_logged_ports(&tail), vec![5001, 5002]);
+    }
 
     #[test]
     fn remaining_fraction_becomes_used_percent() {

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(test, allow(dead_code))]
 
 mod amp;
+mod antigravity;
 mod claude;
 pub mod codex;
 mod copilot;
@@ -381,6 +382,13 @@ fn usage_providers(codex_fetch: Fetch) -> Vec<UsageProvider> {
         ("Codex", codex::has_credentials, codex_fetch),
         ("Z.ai", zai::has_credentials, Fetch::Single(zai::fetch)),
         ("Amp", amp::has_credentials, Fetch::Single(amp::fetch)),
+        (
+            "Antigravity",
+            antigravity::has_credentials,
+            // One output per model group: Antigravity meters Gemini models and
+            // Claude/GPT models against separate limits.
+            Fetch::Multi(antigravity::fetch_all),
+        ),
         (
             "Copilot",
             copilot::has_credentials,


### PR DESCRIPTION
## What

Adds Antigravity to `tokscale usage` as a subscription-quota provider. It reports the weekly and five-hour limits for each model group, matching what the Antigravity CLI shows under `/usage`.

```
╭────────────────────────────────────────────────────────────────╮
│ Antigravity (Gemini Models)                                    │
│ weekly        41% left   [=====-------]resets Sat Aug 29 11:58 │
│ 5h            100% left  [============]resets in 4h 59m        │
╰────────────────────────────────────────────────────────────────╯
╭────────────────────────────────────────────────────────────────╮
│ Antigravity (Claude and GPT models)                            │
│ weekly        90% left   [===========-]resets Mon Aug 31 23:56 │
│ 5h            100% left  [============]resets in 4h 59m        │
╰────────────────────────────────────────────────────────────────╯
```

## Why

Antigravity is already a supported client for local session parsing, but only for token accounting — `tokscale usage` never showed it, so there was no way to see how much subscription quota was left. #303 asked for quota support and was closed after the trajectory-export work landed, which answers "how much did I use" rather than "how much is left".

## How

The Antigravity CLI (`agy`) and IDE both run a language server that holds the OAuth token, calls Google Code Assist, caches the answer, and exposes it over a loopback Connect-RPC endpoint. `/usage` inside the CLI reads exactly that:

```
POST http://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary
Connect-Protocol-Version: 1

{}
```

`RetrieveUserQuotaSummary` needs no CSRF token and no credential of tokscale's own, so the Antigravity token never leaves its process — we only read numbers the language server already computed.

Calling Google's `cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota` directly was tried first and rejected: authentication succeeds, but a `GEMINI_CLI` client identity is answered with `UNSUPPORTED_CLIENT` / `SUBSCRIPTION_REQUIRED` now that individual users have been migrated to Antigravity. Going through the local RPC also avoids handling the user's token at all.

Port discovery reads the port out of the CLI log (`listening on random port at NNNN for HTTP`) first, and falls back to the existing `detect_antigravity_connections()` for the IDE — whose language server is the only one carrying a CSRF token on its command line, which is why the log is needed for the CLI. Candidates are probed rather than trusted, because the process listens on both an HTTPS (gRPC) port and an HTTP one and only the latter speaks plain JSON.

`has_credentials()` probes instead of looking for a credential file, because Antigravity keeps its token inside the running process: "is it installed" and "can we read quota" are different questions, and only the second should put a card on screen. When Antigravity is not running the provider is filtered out silently, with no diagnostic noise.

## Note on model groups

Antigravity meters quota **per model group** — Gemini models share one weekly and one five-hour limit, Claude and GPT models share another — while `UsageOutput.metrics` is a flat, account-level list. Flattening produces four rows that cannot be attributed to a group.

This emits one `UsageOutput` per group and names the group in the account label, reusing the existing `Fetch::Multi` path (the same one Codex uses for several accounts). That keeps every existing type untouched.

The alternative would be an optional `group: Option<String>` on `UsageMetric`, which reads a little more naturally but requires touching every provider's metric constructor. Happy to switch if you prefer that shape.

## Testing

`cargo fmt --all -- --check` is clean, and `cargo clippy` reports nothing in the new file.

`cargo test --workspace --all-features` on Windows:

| | unit tests | integration tests |
|---|---|---|
| `main` at 62ca1eb | 1171 passed | 158 passed, 7 failed |
| with this change | 1178 passed | 158 passed, 7 failed |

The seven integration failures are identical before and after — they are the pre-existing timezone auto-pinning failures on Windows (see #997 / #1014), untouched by this change. The seven added unit tests cover the remaining-to-used percentage conversion, the log-port parsing (including skipping the gRPC port), group slugs, and parsing a recorded `RetrieveUserQuotaSummary` response. None of them require Antigravity to be running.

Verified manually against a live Antigravity CLI: the reported percentages match `/usage` exactly.

## Note for maintainers

While testing this from a GUI process I hit an unrelated issue worth flagging: `usage/grok.rs::fetch_agent_billing` spawns `grok agent --no-leader stdio` without `CREATE_NO_WINDOW`, so on Windows every refresh flashes a console window. That is invisible when tokscale runs in a terminal, but any GUI consumer sees it. Not touching it here to keep this change focused — happy to open a separate PR if that would be useful.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Antigravity subscription quota to `tokscale usage`. It now shows weekly and 5-hour remaining limits per model group (Gemini vs Claude/GPT) by reading from Antigravity's local language server, without ever handling the user's OAuth token.

**Behavior**
- Reports the same numbers the Antigravity CLI shows under `/usage`.
- Emits one usage output per model group, labeled with the group name.
- Silently skips Antigravity when the language server is not running or not signed in.

**Implementation**
- Reads quota from a loopback Connect-RPC endpoint on the language server; no own credentials needed.
- Discovers the port from the CLI log first, then falls back to IDE process detection, probing candidate ports since the process exposes both gRPC and HTTP ports.
- Bounds both reads: the CLI log is tailed to 256 KiB and the RPC response is capped at 1 MiB, reusing the existing response reader.
- Flattens model-group limits into separate outputs to keep existing types untouched.
- Includes unit tests for conversion, port parsing, log bounding, and recorded response parsing.

<sup>Written for commit b9ddfa9ad5107ef0f23f326aa6963c8e3cef8e22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

