### PR TITLE
fix(pricing): align provider-scoped submission resolution

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -5463,10 +5463,11 @@ mod tests {
     use super::{
         aggregate_hourly_usage_entries, aggregate_model_usage_entries,
         aggregate_monthly_usage_v2_entries, apply_pricing_if_available, build_graph_from_messages,
-        dedupe_latest_trae_messages, filter_messages_for_report,
-        generate_graph_with_loaded_pricing, get_home_dir_string, is_generic_routing_label,
-        merge_claude_cross_file_duplicate, message_cache, normalize_model_for_grouping,
-        opencode_json_superseded_by_sqlite, parse_all_messages_with_pricing_with_cache_policy,
+        dedupe_latest_trae_messages, exclude_unpriced_submission_messages,
+        filter_messages_for_report, generate_graph_with_loaded_pricing, get_home_dir_string,
+        is_generic_routing_label, merge_claude_cross_file_duplicate, message_cache,
+        normalize_model_for_grouping, opencode_json_superseded_by_sqlite,
+        parse_all_messages_with_pricing_with_cache_policy,
         parse_all_messages_with_pricing_with_env_strategy, parse_local_clients, parsed_to_unified,
         paths, pricing, retain_for_requested_clients, scanner, select_local_parse_pricing,
         sessions, unified_to_parsed, validate_priced_messages, ClientId, GraphPricingRequirement,
@@ -11595,6 +11596,85 @@ mod tests {
             graph.unpriced_submission_exclusions[0].reason,
             AMBIGUOUS_MODEL_PRICING_REASON
         );
+    }
+
+    /// Regression (#1211): the reporting lookup and the stricter submission
+    /// filter must agree when a first-party provider row competes with nested
+    /// reseller prices, and when OpenAI fast mode decorates a base GPT id.
+    #[test]
+    fn submission_keeps_first_party_prices_and_openai_fast_mode() {
+        let pricing = pricing::PricingService::new_with_custom_and_models_dev(
+            pricing::custom::CustomPricing::default(),
+            HashMap::from([(
+                "openai/gpt-5.5".to_string(),
+                pricing::ModelPricing {
+                    input_cost_per_token: Some(5e-6),
+                    output_cost_per_token: Some(30e-6),
+                    ..Default::default()
+                },
+            )]),
+            HashMap::new(),
+            HashMap::from([
+                (
+                    "anthropic/claude-opus-4-8".to_string(),
+                    pricing::ModelPricing {
+                        input_cost_per_token: Some(5e-6),
+                        output_cost_per_token: Some(25e-6),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "gateway/anthropic/claude-opus-4-8".to_string(),
+                    pricing::ModelPricing {
+                        input_cost_per_token: Some(8e-6),
+                        output_cost_per_token: Some(40e-6),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "vercel/openai/gpt-5.5-fast".to_string(),
+                    pricing::ModelPricing {
+                        input_cost_per_token: Some(9e-6),
+                        output_cost_per_token: Some(54e-6),
+                        ..Default::default()
+                    },
+                ),
+            ]),
+        );
+        let messages = vec![
+            UnifiedMessage::new(
+                "synthetic",
+                "claude-opus-4-8",
+                "anthropic",
+                "first-party-provider-row",
+                1_736_510_400_000,
+                TokenBreakdown {
+                    input: 100,
+                    output: 50,
+                    ..Default::default()
+                },
+                0.0,
+            ),
+            UnifiedMessage::new(
+                "synthetic",
+                "gpt-5.5-fast",
+                "openai",
+                "openai-fast-mode",
+                1_736_510_400_001,
+                TokenBreakdown {
+                    input: 100,
+                    output: 50,
+                    ..Default::default()
+                },
+                0.0,
+            ),
+        ];
+
+        let (submitted, exclusions) =
+            exclude_unpriced_submission_messages(messages, Some(&pricing));
+
+        assert_eq!(submitted.len(), 2);
+        assert!(exclusions.is_empty());
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -600,12 +600,15 @@ impl PricingLookup {
         // so for pricing lookup we resolve to the base model regardless of tier.
         // Mirrors the dash-suffix path (e.g. `-xhigh`), which is handled by
         // `try_strip_unknown_suffix` below.
-        let normalized_owned = strip_parenthesized_reasoning_tier(&lower).map(str::to_owned);
+        let tier_normalized_owned = strip_parenthesized_reasoning_tier(&lower).map(str::to_owned);
 
         // A tier suffix does not turn a router into a model: `auto(high)`
         // normalizes to `auto` below and would otherwise reach the model-part
         // fallback and elect an unrelated vendor, exactly as the bare form did.
-        if normalized_owned.as_deref().is_some_and(is_routing_label) {
+        if tier_normalized_owned
+            .as_deref()
+            .is_some_and(is_routing_label)
+        {
             return None;
         }
 
@@ -615,7 +618,7 @@ impl PricingLookup {
         // `-` and could match a shorter, unrelated model id by peeling the
         // parenthesized fragment off (e.g. `gpt-5.2-codex(invalid)` would
         // strip `-codex(invalid)` and resolve to `gpt-5.2`).
-        if normalized_owned.is_none()
+        if tier_normalized_owned.is_none()
             && lower
                 .strip_suffix(')')
                 .and_then(|inner| inner.rsplit_once('('))
@@ -624,7 +627,12 @@ impl PricingLookup {
             return None;
         }
 
-        let lower_ref: &str = normalized_owned.as_deref().unwrap_or(&lower);
+        let tier_normalized_ref = tier_normalized_owned.as_deref().unwrap_or(&lower);
+        let fast_normalized_owned = normalize_openai_fast_mode(tier_normalized_ref, provider_id);
+        let lower_ref = fast_normalized_owned
+            .as_deref()
+            .unwrap_or(tier_normalized_ref);
+        let normalized = tier_normalized_owned.is_some() || fast_normalized_owned.is_some();
 
         if alias_applied && force_source.is_none() && aliases::uses_cursor_pricing(model_id) {
             if let Some(result) = self.exact_match_cursor(lower_ref) {
@@ -659,7 +667,7 @@ impl PricingLookup {
             if alias_applied {
                 result = result.with_alias();
             }
-            if normalized_owned.is_some() {
+            if normalized {
                 result = result.with_normalization();
             }
             if matches_inferred_model_provider(lower_ref, provider_id)
@@ -676,7 +684,7 @@ impl PricingLookup {
         };
 
         // 1. Try direct lookup
-        if let Some(result) = do_lookup(lower_ref).map(&annotate_direct) {
+        if let Some(result) = do_lookup(lower_ref).map(annotate_direct) {
             if unsafe_claude_resolution(&result) {
                 return None;
             }
@@ -689,7 +697,7 @@ impl PricingLookup {
 
         let guarded_lookup = |candidate: &str| {
             do_lookup(candidate)
-                .map(&annotate_direct)
+                .map(annotate_direct)
                 .map(LookupResult::with_stripping)
                 .filter(|result| !unsafe_claude_resolution(result))
         };
@@ -2780,14 +2788,6 @@ fn select_best_match(
         return None;
     }
 
-    let candidate_count = all_usable_matches.len();
-    let first_pricing = dataset.get(all_usable_matches[0].as_str())?;
-    let price_consensus = all_usable_matches.iter().skip(1).all(|key| {
-        dataset
-            .get(key.as_str())
-            .is_some_and(|pricing| pricing_rows_equal(first_pricing, pricing))
-    });
-
     let hint_tags: Vec<String> = provider_id
         .map(provider_identity::provider_tags)
         .unwrap_or_default();
@@ -2897,6 +2897,40 @@ fn select_best_match(
                 .or_else(|| candidates.first())
         };
         key.and_then(|k| {
+            // A provider's own top-level row is authoritative for that
+            // endpoint. Nested occurrences of the same provider name are
+            // gateway/reseller offers, not peer answers to the hinted billing
+            // identity. Keep the broader candidate set for every weaker
+            // selection so reseller-only and alias-only ambiguity remains
+            // submission-unsafe. Zero-priced subscription namespaces are also
+            // kept in evidence: their canonical provider alias is what makes
+            // the paid row reachable, but it does not prove that usage was
+            // billed outside the subscription.
+            let evidence_matches: Vec<&String> = if provider_id
+                .is_some_and(|hint| key_root_matches_provider_hint(k, hint))
+                && !all_usable_matches
+                    .iter()
+                    .any(|candidate| key_root_is_zero_priced_subscription_namespace(candidate))
+            {
+                all_usable_matches
+                    .iter()
+                    .copied()
+                    .filter(|candidate| {
+                        provider_id
+                            .is_some_and(|hint| key_root_matches_provider_hint(candidate, hint))
+                    })
+                    .collect()
+            } else {
+                all_usable_matches.clone()
+            };
+            let candidate_count = evidence_matches.len();
+            let first_pricing = dataset.get(evidence_matches.first()?.as_str())?;
+            let price_consensus = evidence_matches.iter().skip(1).all(|candidate| {
+                dataset
+                    .get(candidate.as_str())
+                    .is_some_and(|pricing| pricing_rows_equal(first_pricing, pricing))
+            });
+
             dataset.get(k.as_str()).map(|pricing| LookupResult {
                 pricing: pricing.clone(),
                 source: source.into(),
@@ -2995,6 +3029,39 @@ fn normalize_provider_hint(provider_id: Option<&str>) -> Option<&str> {
     provider_id
         .map(str::trim)
         .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("unknown"))
+}
+
+/// Strip OpenAI's request-speed mode from the model identity.
+///
+/// Codex records `-fast` on GPT ids when the request used OpenAI's fast mode,
+/// but the mode does not identify a separately priced model. Catalogs can
+/// still contain reseller rows whose literal id ends in `-fast`; applying this
+/// normalization only under an OpenAI provider hint prevents those rows from
+/// displacing OpenAI's base tariff while preserving literal lookups for every
+/// other provider.
+fn normalize_openai_fast_mode(model_id: &str, provider_id: Option<&str>) -> Option<String> {
+    if provider_id
+        .and_then(provider_identity::canonical_provider)
+        .as_deref()
+        != Some("openai")
+    {
+        return None;
+    }
+
+    let (prefix, terminal) = model_id
+        .rsplit_once('/')
+        .map_or((None, model_id), |(prefix, terminal)| {
+            (Some(prefix), terminal)
+        });
+    let base = terminal.strip_suffix("-fast")?;
+    if !base.starts_with("gpt-") || base.len() == "gpt-".len() {
+        return None;
+    }
+
+    Some(match prefix {
+        Some(prefix) => format!("{prefix}/{base}"),
+        None => base.to_string(),
+    })
 }
 
 fn matches_inferred_model_provider(model_id: &str, provider_id: Option<&str>) -> bool {
@@ -5649,6 +5716,144 @@ mod tests {
         let unhinted = lookup.lookup("claude-opus-4-6-fast").unwrap();
         assert_eq!(unhinted.matched_key, "anthropic/claude-opus-4.6-fast");
         assert_eq!(unhinted.pricing.input_cost_per_token, Some(30e-6));
+    }
+
+    /// Regression (#1211): a provider hint can match both the provider's own
+    /// row and gateway rows that merely contain the provider in a nested path.
+    /// Those gateways publish their own markups; they are not conflicting
+    /// answers for the provider's first-party endpoint.
+    #[test]
+    fn provider_root_price_is_not_tainted_by_nested_reseller_rows() {
+        let models_dev = HashMap::from([
+            (
+                "anthropic/claude-opus-4-8".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(5e-6),
+                    output_cost_per_token: Some(25e-6),
+                    ..Default::default()
+                },
+            ),
+            (
+                "gateway-a/anthropic/claude-opus-4-8".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(7e-6),
+                    output_cost_per_token: Some(35e-6),
+                    ..Default::default()
+                },
+            ),
+            (
+                "gateway-b/anthropic/claude-opus-4-8".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(8e-6),
+                    output_cost_per_token: Some(40e-6),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        let result = lookup
+            .lookup_with_provider("claude-opus-4-8", Some("anthropic"))
+            .expect("the first-party Anthropic row should resolve");
+
+        assert_eq!(result.matched_key, "anthropic/claude-opus-4-8");
+        assert_eq!(result.evidence.kind, ResolutionKind::ProviderScoped);
+        assert_eq!(result.evidence.candidate_count, 1);
+        assert!(result.evidence.price_consensus);
+        assert!(result.evidence.is_submission_safe());
+    }
+
+    /// When no first-party root row exists, a provider name embedded in
+    /// multiple reseller paths still cannot establish which tariff applied.
+    #[test]
+    fn nested_reseller_disagreement_remains_submission_unsafe() {
+        let models_dev = HashMap::from([
+            (
+                "gateway-a/anthropic/claude-opus-4-8".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(7e-6),
+                    output_cost_per_token: Some(35e-6),
+                    ..Default::default()
+                },
+            ),
+            (
+                "gateway-b/anthropic/claude-opus-4-8".to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(8e-6),
+                    output_cost_per_token: Some(40e-6),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        let result = lookup
+            .lookup_with_provider("claude-opus-4-8", Some("anthropic"))
+            .expect("reporting should retain the best available estimate");
+
+        assert_eq!(result.evidence.kind, ResolutionKind::ModelPart);
+        assert_eq!(result.evidence.candidate_count, 2);
+        assert!(!result.evidence.price_consensus);
+        assert!(!result.evidence.is_submission_safe());
+    }
+
+    /// Regression (#1211): Codex's OpenAI `-fast` suffix describes request
+    /// service mode, not a separate model. An OpenAI hint must therefore use
+    /// the base model tariff instead of a reseller's literal `-fast` row.
+    #[test]
+    fn openai_fast_mode_normalizes_to_the_base_model() {
+        let litellm = HashMap::from([(
+            "openai/gpt-5.5".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(5e-6),
+                output_cost_per_token: Some(30e-6),
+                ..Default::default()
+            },
+        )]);
+        let models_dev = HashMap::from([(
+            "vercel/openai/gpt-5.5-fast".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(9e-6),
+                output_cost_per_token: Some(54e-6),
+                ..Default::default()
+            },
+        )]);
+        let lookup = PricingLookup::new_with_models_dev(
+            litellm,
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        for model_id in ["gpt-5.5-fast", "openai/gpt-5.5-fast"] {
+            let result = lookup
+                .lookup_with_provider(model_id, Some("openai"))
+                .expect("OpenAI fast mode should resolve through the base id");
+            assert_eq!(result.matched_key, "openai/gpt-5.5");
+            assert_eq!(result.pricing.input_cost_per_token, Some(5e-6));
+            assert!(result.evidence.normalized);
+            assert!(result.evidence.is_submission_safe());
+        }
+
+        let reseller = lookup
+            .lookup_with_provider("gpt-5.5-fast", Some("vercel"))
+            .expect("non-OpenAI providers keep literal model identities");
+        assert_eq!(reseller.matched_key, "vercel/openai/gpt-5.5-fast");
+        assert_eq!(reseller.pricing.input_cost_per_token, Some(9e-6));
+        assert!(!reseller.evidence.normalized);
     }
 
     /// Regression (#1004 follow-up): a reseller provider hint must select the


### PR DESCRIPTION
## Summary

- Prefer a first-party provider-root pricing row over nested reseller rows when a provider hint identifies the endpoint.
- Normalize OpenAI GPT `-fast` request mode to the base OpenAI model tariff while preserving literal `-fast` identities for other providers.
- Keep reseller-only disagreements available as reporting estimates but unsafe for submission, so ambiguous prices are never uploaded as authoritative usage.

Closes #1211.

## Why

The reporting resolver and the stricter submission filter could disagree when a first-party model row competed with reseller paths containing the same provider name. The resolver also treated OpenAI's `-fast` service mode as a separate model identity, allowing a reseller's literal `-fast` row to displace the first-party base tariff. In both cases valid first-party usage could be excluded from submission or attributed to the wrong price.

## Diff scope

- `crates/tokscale-core/src/pricing/lookup.rs`: narrow provider-scoped candidate selection, preserve ambiguity for reseller-only matches, and add OpenAI-only `-fast` normalization.
- `crates/tokscale-core/src/lib.rs`: add an end-to-end submission regression covering first-party provider pricing and OpenAI fast mode.
- No schema, migration, dependency, CI, release, or public API changes.

## Branch integrity

- Base: `main`
- Validated base SHA: `62ca1eb1677556972ba963fdfa3a41ab23c1eb4b`
- Head SHA: `6ec07d3686df240529a3e576a580a7f7d13e36d5`
- Ahead/behind: `1/0`
- Merge base: `62ca1eb1677556972ba963fdfa3a41ab23c1eb4b`
- `origin/main` is an ancestor of the branch; diff proof was computed against the freshly fetched base.

## Commit integrity

- One atomic commit: `6ec07d3686df240529a3e576a580a7f7d13e36d5 fix(pricing): align provider-scoped submission resolution`
- The final diff contains only the two intended Rust files.
- Ledger: not applicable — this change family does not require a ledger record.
- Version: unchanged — the publish workflow owns synchronized release version bumps.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: two intended modified files.
- `git diff --check origin/main...HEAD`: PASS, no output.
- No secrets, environment files, caches, build output, generated artifacts, or unrelated changes.

## Validation mode and proof

Validation mode: Mode 3 — shared pricing and submission-safety behavior.

- `cargo fmt --all -- --check`: PASS
- `cargo test -p tokscale-core pricing::lookup::tests::`: PASS, 217 tests
- `cargo test -p tokscale-core submission_keeps_first_party_prices_and_openai_fast_mode`: PASS
- `cargo test -p tokscale-core --lib`: PASS, 1879 passed and 2 ignored
- `cargo clippy -p tokscale-core --all-targets -- -D warnings`: reaches only the pre-existing `needless_lifetimes` finding at `sessions/pi.rs:474`, identical on `origin/main`; no new Clippy finding is introduced by this diff.
- Full workspace test suite: not run — not required for this core-only diff; mandatory GitHub CI remains final-SHA proof.

## CI context confirmation

- CI context names are unchanged.
- Pending — required GitHub CI starts after this PR is created and must pass on the final SHA before merge.

## Runtime safety

- Resolution remains fail-closed for ambiguous provider identity or price disagreement.
- No new locks, queues, I/O, or unbounded work were introduced.
- No invariant regression introduced.

## Migration and documentation notes

- Database migration: not applicable — no schema or data model changed.
- Documentation: not applicable — no commands, configuration, or user-facing workflow changed.

## Rollback plan

- Rollback: `git revert <post_merge_commit_sha>` after merge.
- Database downgrade: not applicable.
- Data repair: not applicable.
- Operational caveats: none known.

## Known residual risks

- Provider catalogs can add new nested namespaces over time; unmatched or conflicting reseller-only evidence intentionally remains submission-unsafe.
- The PR is ready for review, not merge-ready, until required remote CI passes on the final SHA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pricing resolution so the reporting lookup and submission filter agree when a provider hint matches both a first-party row and nested reseller rows, and when OpenAI `-fast` mode decorates a base GPT id.

**Behavior changes**
- A provider's own top-level pricing row now wins over nested reseller rows with the same provider name; reseller-only disagreements remain reporting estimates but stay submission-unsafe.
- OpenAI `-fast` request mode now resolves to the base model tariff; literal `-fast` identities are preserved for non-OpenAI providers.
- No schema, migration, dependency, or public API changes; resolution stays fail-closed for ambiguous provider identity or price disagreement.

<sup>Written for commit adc3d141cb98de63ece0fba66c3d505eb5b611a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

