### PR TITLE
fix(frontend): preserve parser growth after re-attribution

### DIFF
--- a/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
+++ b/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
@@ -534,6 +534,54 @@ describe("POST /api/submit antigravity-cli re-attribution high-water", () => {
     ).toBe(55_000);
   });
 
+  it("credits later growth even when the original stored cell is still larger", async () => {
+    const { store } = await submitOldThenNew("antigravity-cli");
+    const grown = submissionBody("antigravity-cli", [
+      { date: "2026-08-07", tokens: 60_000, messages: 3 },
+      { date: "2026-08-08", tokens: 120_000, messages: 6 },
+      { date: "2026-08-09", tokens: 80_000, messages: 4 },
+    ]);
+
+    installTx(store);
+    mockSubmit(grown);
+    const response = await post(grown);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+
+    expect(json.metrics.totalTokens).toBe(260_000);
+    expect(storedTokens(store)).toBe(260_000);
+    expect(
+      store.days.find((day) => day.date === "2026-08-07")?.sourceBreakdown[
+        "antigravity-cli"
+      ].tokens,
+    ).toBe(240_000);
+
+    const state = store.device.parserStates["antigravity-cli"] as {
+      aggregate: { tokens: number };
+      days: Record<string, { tokens: number }>;
+      observedDays: Record<string, { tokens: number }>;
+    };
+    expect(state.aggregate.tokens).toBe(260_000);
+    expect(
+      Object.values(state.days).reduce((sum, day) => sum + day.tokens, 0),
+    ).toBe(260_000);
+    expect(state.observedDays["2026-08-07"].tokens).toBe(60_000);
+
+    // The credited ledger, not the parser's cellwise envelope, is the next
+    // lifetime baseline. Replaying the same snapshot therefore adds nothing.
+    installTx(store);
+    mockSubmit(grown);
+    const replay = await post(grown);
+    expect(replay.status).toBe(200);
+    expect((await replay.json()).metrics.totalTokens).toBe(260_000);
+    expect(storedTokens(store)).toBe(260_000);
+    expect(
+      (store.device.parserStates["antigravity-cli"] as {
+        aggregate: { tokens: number };
+      }).aggregate.tokens,
+    ).toBe(260_000);
+  });
+
   it("still inflates for a client that is legitimately not registered", async () => {
     // Claude's parser does not re-attribute submitted history, so it is not in
     // SUPPORTED_VERSIONED_PARSERS and takes the plain day-by-day merge path.

--- a/packages/frontend/__tests__/lib/parserHighWater.test.ts
+++ b/packages/frontend/__tests__/lib/parserHighWater.test.ts
@@ -166,6 +166,30 @@ describe("non-destructive parser generation high-water", () => {
     expect(plan.increments).toEqual({});
   });
 
+  it("keeps a zero-token legacy message inside the lifetime high-water", () => {
+    const legacyMessage = snapshot(
+      bucketContribution(
+        "2026-07-01",
+        { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+        0,
+        1
+      )
+    );
+    const movedMessage = snapshot(
+      bucketContribution(
+        "2026-07-02",
+        { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+        0,
+        1
+      )
+    );
+    const plan = baseline(legacyMessage, movedMessage);
+
+    expect(plan.mode).toBe("baseline-legacy");
+    expect(plan.increments).toEqual({});
+    expect(plan.nextState?.aggregate).toMatchObject({ tokens: 0, messages: 1 });
+  });
+
   it.each([
     { legacyDate: "2026-07-02", newDate: "2026-07-01" },
     { legacyDate: "2026-07-01", newDate: "2026-07-02" },
@@ -205,7 +229,7 @@ describe("non-destructive parser generation high-water", () => {
     { legacyDate: "2026-07-02", newDate: "2026-07-01" },
     { legacyDate: "2026-07-01", newDate: "2026-07-02" },
   ])(
-    "keeps synthesized scalar high-water when the first full scan is truncated ($legacyDate -> $newDate)",
+    "credits deferred growth when a truncated first scan is restored ($legacyDate -> $newDate)",
     ({ legacyDate, newDate }) => {
       const scalarLegacy = {
         tokens: 100,
@@ -239,9 +263,82 @@ describe("non-destructive parser generation high-water", () => {
         first.nextState?.days[legacyDate].models["model-a"].input
       ).toBe(100);
       expect(restored.increments[legacyDate]).toBeUndefined();
-      expect(restored.increments).toEqual({});
+      expect(restored.increments[newDate].models["model-b"]).toMatchObject({
+        input: 20,
+        tokens: 20,
+        cost: 2,
+      });
+      expect(restored.nextState?.aggregate.tokens).toBe(150);
     }
   );
+
+  it("preserves scalar usage not represented by a partial nested-model map", () => {
+    const nested = snapshot(
+      contribution("2026-07-01", 10, "model-a", 1)
+    )["2026-07-01"];
+    const mixedLegacy = {
+      ...nested,
+      tokens: 15,
+      input: 15,
+      cost: 1.5,
+      messages: 2,
+      modelId: "model-b",
+    } satisfies ClientBreakdownData;
+    const incoming = snapshot(
+      contribution("2026-07-01", 10, "model-a", 1),
+      contribution("2026-07-01", 5, "model-b", 0.5)
+    );
+    const first = baseline({ "2026-07-01": mixedLegacy }, incoming);
+    const replay = next(first.nextState!, incoming);
+
+    expect(first.increments).toEqual({});
+    expect(first.nextState?.aggregate).toMatchObject({
+      tokens: 15,
+      input: 15,
+      messages: 2,
+    });
+    expect(first.nextState?.days["2026-07-01"].models["model-b"]).toMatchObject({
+      tokens: 5,
+      input: 5,
+      cost: 0.5,
+      messages: 1,
+    });
+    expect(replay.increments).toEqual({});
+  });
+
+  it("normalizes old nested models that predate the reasoning bucket", () => {
+    const oldModel = {
+      tokens: 10,
+      cost: 1,
+      input: 10,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      messages: 1,
+    } as ClientBreakdownData["models"][string];
+    const oldDay = {
+      tokens: 10,
+      cost: 1,
+      input: 10,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 1,
+      models: { "model-a": oldModel },
+    } satisfies ClientBreakdownData;
+    const incoming = snapshot(
+      contribution("2026-07-01", 10, "model-a", 1)
+    );
+    const first = baseline({ "2026-07-01": oldDay }, incoming);
+    const replay = next(first.nextState!, incoming);
+
+    expect(first.nextState?.aggregate.reasoning).toBe(0);
+    expect(
+      first.nextState?.days["2026-07-01"].models["model-a"].reasoning
+    ).toBe(0);
+    expect(replay.increments).toEqual({});
+  });
 
   it("is idempotent when the same v2 full snapshot is replayed", () => {
     const first = baseline({}, snapshot(contribution("2026-07-01", 100)));
@@ -496,11 +593,189 @@ describe("non-destructive parser generation high-water", () => {
       )
     );
 
-    const priorModel = shifted.nextState?.days["2026-07-01"].models["model-a"];
-    expect(priorModel?.input).toBe(100);
-    expect(priorModel?.cacheRead).toBe(100);
-    expect(priorModel?.inputIncludingCacheRead).toBe(100);
+    const creditedModel =
+      shifted.nextState?.days["2026-07-01"].models["model-a"];
+    const observedModel =
+      shifted.nextState?.observedDays?.["2026-07-01"].models["model-a"];
+    expect(creditedModel?.input).toBe(100);
+    expect(creditedModel?.cacheRead).toBe(0);
+    expect(creditedModel?.inputIncludingCacheRead).toBe(100);
+    expect(observedModel?.input).toBe(0);
+    expect(observedModel?.cacheRead).toBe(100);
+    expect(observedModel?.inputIncludingCacheRead).toBe(100);
     expect(grown.increments["2026-07-01"].models["model-a"].cacheRead).toBe(50);
+  });
+
+  it("credits same-day growth after re-attribution through a deterministic residual cell", () => {
+    const stored = snapshot(
+      bucketContribution(
+        "2026-07-01",
+        { input: 240, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+        24,
+        12
+      )
+    );
+    const reattributed = snapshot(
+      bucketContribution(
+        "2026-07-01",
+        { input: 40, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+        4,
+        2
+      ),
+      bucketContribution(
+        "2026-07-02",
+        { input: 100, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+        10,
+        5
+      ),
+      bucketContribution(
+        "2026-07-03",
+        { input: 100, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+        10,
+        5
+      )
+    );
+    const first = baseline(stored, reattributed);
+    const grownSnapshot = snapshot(
+      bucketContribution(
+        "2026-07-01",
+        { input: 60, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+        6,
+        3
+      ),
+      bucketContribution(
+        "2026-07-02",
+        { input: 100, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+        10,
+        5
+      ),
+      bucketContribution(
+        "2026-07-03",
+        { input: 100, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+        10,
+        5
+      )
+    );
+    const grown = next(first.nextState!, grownSnapshot);
+    const replay = next(grown.nextState!, grownSnapshot);
+
+    expect(first.increments).toEqual({});
+    expect(grown.increments["2026-07-01"]).toBeUndefined();
+    expect(grown.increments["2026-07-03"].models["model-a"]).toMatchObject({
+      input: 20,
+      tokens: 20,
+      cost: 2,
+    });
+    expect(
+      Object.values(grown.increments).reduce(
+        (sum, day) => sum + day.tokens,
+        0
+      )
+    ).toBe(20);
+    expect(grown.nextState?.aggregate.tokens).toBe(260);
+    expect(
+      Object.values(grown.nextState?.days ?? {}).reduce(
+        (sum, day) => sum + day.tokens,
+        0
+      )
+    ).toBe(260);
+    expect(replay.increments).toEqual({});
+  });
+
+  it("recovers suppressed growth while migrating a legacy envelope state", () => {
+    const stored = legacy(
+      contribution("2026-07-01", 240, "model-a", 24)
+    );
+    const incoming = snapshot(
+      contribution("2026-07-01", 60, "model-a", 6),
+      contribution("2026-07-02", 100, "model-a", 10),
+      contribution("2026-07-03", 100, "model-a", 10)
+    );
+    const legacyEnvelopeState: ParserClientHighWaterState = {
+      version: 2,
+      baselineEstablished: true,
+      aggregate: {
+        tokens: 260,
+        input: 260,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        messages: 3,
+        inputIncludingCacheRead: 260,
+      },
+      days: snapshot(
+        contribution("2026-07-01", 240, "model-a", 24),
+        contribution("2026-07-02", 100, "model-a", 10),
+        contribution("2026-07-03", 100, "model-a", 10)
+      ),
+    };
+    const migrated = planParserHighWaterSubmission({
+      client: "copilot",
+      incomingVersion: 2,
+      fullHistory: true,
+      existingLegacyDays: stored,
+      incomingDays: incoming,
+      state: legacyEnvelopeState,
+    });
+    const replay = next(migrated.nextState!, incoming);
+
+    expect(migrated.mode).toBe("incremental");
+    expect(migrated.nextState?.stateVersion).toBe(2);
+    expect(
+      Object.values(migrated.increments).reduce(
+        (sum, day) => sum + day.tokens,
+        0
+      )
+    ).toBe(20);
+    expect(migrated.nextState?.aggregate.tokens).toBe(260);
+    expect(migrated.nextState?.aggregate.messages).toBe(3);
+    expect(replay.increments).toEqual({});
+  });
+
+  it("spends provable lifetime growth when bucket budgets are jointly infeasible", () => {
+    const first = baseline(
+      {},
+      snapshot(contribution("2026-07-01", 5, "model-b", 0.5))
+    );
+    const incoming = snapshot(
+      contribution("2026-07-01", 10, "model-a", 1),
+      bucketContribution(
+        "2026-07-01",
+        { input: 0, output: 15, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+        1.5,
+        1,
+        "model-b"
+      )
+    );
+    const grown = next(first.nextState!, incoming);
+    const replay = next(grown.nextState!, incoming);
+
+    expect(grown.increments["2026-07-01"].tokens).toBe(20);
+    expect(grown.increments["2026-07-01"].models["model-a"].input).toBe(10);
+    expect(grown.increments["2026-07-01"].models["model-b"].output).toBe(10);
+    expect(grown.nextState?.aggregate.tokens).toBe(25);
+    expect(replay.increments).toEqual({});
+  });
+
+  it("prefers genuine observed growth before deterministic residual capacity", () => {
+    const first = baseline(
+      legacy(contribution("2026-07-01", 100, "old-model", 5)),
+      snapshot(contribution("2026-07-03", 100, "moved-model", 5))
+    );
+    const incoming = snapshot(
+      contribution("2026-07-03", 100, "moved-model", 5),
+      contribution("2026-07-02", 50, "actual-new", 25)
+    );
+    const grown = next(first.nextState!, incoming);
+
+    expect(grown.increments["2026-07-03"]).toBeUndefined();
+    expect(grown.increments["2026-07-02"].models["actual-new"]).toMatchObject({
+      input: 50,
+      tokens: 50,
+      cost: 25,
+      messages: 1,
+    });
   });
 
   it("derives exclusive-input growth from the inclusive delta after a cache shift", () => {
@@ -937,6 +1212,89 @@ describe("non-destructive parser generation high-water", () => {
     }
   });
 
+  it("conserves every provable token and message across cells and buckets", () => {
+    const first = baseline(
+      {},
+      snapshot(
+        bucketContribution(
+          "2026-07-01",
+          { input: 50, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+          5,
+          2,
+          "model-a"
+        ),
+        bucketContribution(
+          "2026-07-02",
+          { input: 0, output: 50, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+          5,
+          3,
+          "model-b"
+        )
+      )
+    );
+    let state = first.nextState!;
+    let seed = 0x1206;
+
+    for (let index = 0; index < 40; index += 1) {
+      const rows: ReturnType<typeof bucketContribution>[] = [];
+      for (let cell = 0; cell < 4; cell += 1) {
+        seed = (seed * 1664525 + 1013904223) >>> 0;
+        const input = seed % 80;
+        seed = (seed * 1664525 + 1013904223) >>> 0;
+        const output = seed % 80;
+        const tokens = input + output;
+        rows.push(
+          bucketContribution(
+            cell < 2 ? "2026-07-01" : "2026-07-02",
+            { input, output, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+            tokens / 10,
+            Math.floor(tokens / 20),
+            cell % 2 === 0 ? "model-a" : "model-b"
+          )
+        );
+      }
+      const incoming = snapshot(...rows);
+      const incomingTokens = Object.values(incoming).reduce(
+        (sum, day) => sum + day.tokens,
+        0
+      );
+      const incomingMessages = Object.values(incoming).reduce(
+        (sum, day) => sum + day.messages,
+        0
+      );
+      const previousTokens = state.aggregate.tokens;
+      const previousMessages = state.aggregate.messages;
+      const plan = next(state, incoming);
+      const addedTokens = Object.values(plan.increments).reduce(
+        (sum, day) => sum + day.tokens,
+        0
+      );
+      const addedMessages = Object.values(plan.increments).reduce(
+        (sum, day) => sum + day.messages,
+        0
+      );
+
+      expect(addedTokens).toBe(Math.max(0, incomingTokens - previousTokens));
+      expect(addedMessages).toBe(
+        Math.max(0, incomingMessages - previousMessages)
+      );
+      expect(plan.nextState?.aggregate.tokens).toBe(
+        previousTokens + addedTokens
+      );
+      expect(plan.nextState?.aggregate.messages).toBe(
+        previousMessages + addedMessages
+      );
+      expect(
+        Object.values(plan.nextState?.days ?? {}).reduce(
+          (sum, day) => sum + day.tokens,
+          0
+        )
+      ).toBe(plan.nextState?.aggregate.tokens);
+      expect(next(plan.nextState!, incoming).increments).toEqual({});
+      state = plan.nextState!;
+    }
+  });
+
   it("fails closed when an accepted generation marker has lost its high-water", () => {
     const plan = planParserHighWaterSubmission({
       client: "copilot",
@@ -948,6 +1306,67 @@ describe("non-destructive parser generation high-water", () => {
     });
 
     expect(plan.mode).toBe("freeze");
+    expect(plan.nextState).toBeUndefined();
+  });
+
+  it("fails closed for an unknown allocation-state schema", () => {
+    const first = baseline({}, snapshot(contribution("2026-07-01", 100)));
+    const futureState = {
+      ...first.nextState!,
+      stateVersion: 999,
+    };
+    const plan = next(
+      futureState,
+      snapshot(contribution("2026-07-01", 150))
+    );
+
+    expect(plan.mode).toBe("freeze");
+    expect(plan.increments).toEqual({});
+    expect(plan.nextState).toBeUndefined();
+  });
+
+  it.each([
+    { stateVersion: 999, version: 2 },
+    { stateVersion: 2, version: 1 },
+  ])(
+    "does not re-baseline an invalid pending state ($stateVersion/$version)",
+    ({ stateVersion, version }) => {
+      const pending = planParserHighWaterSubmission({
+        client: "copilot",
+        incomingVersion: 2,
+        fullHistory: false,
+        existingLegacyDays: {},
+        incomingDays: {},
+      }).nextState!;
+      const plan = next(
+        { ...pending, stateVersion, version },
+        snapshot(contribution("2026-07-01", 100))
+      );
+
+      expect(plan.mode).toBe("freeze");
+      expect(plan.increments).toEqual({});
+      expect(plan.nextState).toBeUndefined();
+    }
+  );
+
+  it("fails closed when a v2 aggregate diverges from its credited cells", () => {
+    const first = baseline({}, snapshot(contribution("2026-07-01", 100)));
+    const inconsistentState = {
+      ...first.nextState!,
+      aggregate: {
+        ...first.nextState!.aggregate,
+        tokens: 120,
+        input: 120,
+        inputIncludingCacheRead: 120,
+      },
+    };
+    const plan = next(
+      inconsistentState,
+      snapshot(contribution("2026-07-01", 150))
+    );
+
+    expect(plan.mode).toBe("freeze");
+    expect(plan.increments).toEqual({});
     expect(plan.nextState).toBeUndefined();
   });
 

--- a/packages/frontend/src/lib/db/parserHighWater.ts
+++ b/packages/frontend/src/lib/db/parserHighWater.ts
@@ -49,6 +49,12 @@ const TOKEN_FIELDS = [
   "reasoning",
 ] as const;
 type TokenField = (typeof TOKEN_FIELDS)[number];
+const AGGREGATE_FIELDS = [
+  "tokens",
+  ...TOKEN_FIELDS,
+  "messages",
+  "inputIncludingCacheRead",
+] as const;
 
 export interface ParserAggregateHighWater {
   tokens: number;
@@ -63,12 +69,16 @@ export interface ParserAggregateHighWater {
 }
 
 export interface ParserClientHighWaterState {
+  /** Server-side allocation-state schema; absent identifies the legacy envelope. */
+  stateVersion?: number;
   version: number;
   /** False when identity was accepted from a partial scan but no baseline exists. */
   baselineEstablished?: boolean;
   aggregate: ParserAggregateHighWater;
-  /** Cellwise maxima for attribution of bounded aggregate growth. */
+  /** Stored/credited cells available for attribution of bounded aggregate growth. */
   days: Record<string, ClientBreakdownData>;
+  /** Last complete parser snapshot, used only to locate the next positive delta. */
+  observedDays?: Record<string, ClientBreakdownData>;
 }
 
 export type DeviceParserStates = Record<string, ParserClientHighWaterState>;
@@ -103,16 +113,26 @@ export interface ParserHighWaterPlan {
   nextState?: ParserClientHighWaterState;
 }
 
-function copyDictionary<T>(source?: Record<string, T>): Record<string, T> {
-  return Object.assign(createSafeRecord<T>(), source);
-}
-
 function copyModels(
   source?: Record<string, ModelBreakdownData>
 ): Record<string, ModelBreakdownData> {
   const result = createSafeRecord<ModelBreakdownData>();
   for (const [modelId, model] of Object.entries(source ?? {})) {
-    result[modelId] = { ...model };
+    const normalized = emptyModel();
+    for (const field of TOKEN_FIELDS) {
+      normalized[field] = positive(model[field] ?? 0);
+    }
+    normalized.tokens = TOKEN_FIELDS.reduce(
+      (sum, field) => sum + normalized[field],
+      0
+    );
+    normalized.cost = quantizeCost(model.cost ?? 0);
+    normalized.messages = positive(model.messages ?? 0);
+    normalized.inputIncludingCacheRead = positive(
+      model.inputIncludingCacheRead ??
+        normalized.input + normalized.cacheRead
+    );
+    result[modelId] = normalized;
   }
   return result;
 }
@@ -121,22 +141,45 @@ function modelsForHighWater(
   breakdown?: ClientBreakdownData
 ): Record<string, ModelBreakdownData> {
   const models = copyModels(breakdown?.models);
-  if (
-    breakdown?.modelId &&
-    Object.keys(models).length === 0
-  ) {
-    models[breakdown.modelId] = {
-      tokens: positive(breakdown.tokens || 0),
-      cost: positive(breakdown.cost || 0),
-      input: positive(breakdown.input || 0),
-      output: positive(breakdown.output || 0),
-      cacheRead: positive(breakdown.cacheRead || 0),
-      cacheWrite: positive(breakdown.cacheWrite || 0),
-      reasoning: positive(breakdown.reasoning || 0),
-      messages: positive(breakdown.messages || 0),
-      inputIncludingCacheRead:
-        positive(breakdown.input || 0) + positive(breakdown.cacheRead || 0),
-    };
+  if (!breakdown) return models;
+
+  // Legacy rows can carry a scalar total alongside a partial nested model
+  // breakdown. Preserve the unrepresented remainder as a real model cell;
+  // otherwise normalizing the credited ledger would silently shrink it and a
+  // later replay could re-credit tokens or messages that are already stored.
+  const represented = emptyModel();
+  for (const model of Object.values(models)) {
+    for (const field of TOKEN_FIELDS) represented[field] += model[field] || 0;
+    represented.cost += model.cost || 0;
+    represented.messages += model.messages || 0;
+  }
+  const remainder = emptyModel();
+  for (const field of TOKEN_FIELDS) {
+    remainder[field] = positive((breakdown[field] || 0) - represented[field]);
+  }
+  remainder.tokens = TOKEN_FIELDS.reduce(
+    (sum, field) => sum + remainder[field],
+    0
+  );
+  remainder.cost = quantizeCost(
+    positive((breakdown.cost || 0) - represented.cost)
+  );
+  remainder.messages = positive(
+    (breakdown.messages || 0) - represented.messages
+  );
+  if (remainder.tokens > 0 || remainder.cost > 0 || remainder.messages > 0) {
+    const remainderModel = breakdown.modelId || "unknown";
+    const prior = { ...(ownValue(models, remainderModel) ?? emptyModel()) };
+    const priorInclusiveInput = positive(
+      prior.inputIncludingCacheRead ?? prior.input + prior.cacheRead
+    );
+    for (const field of TOKEN_FIELDS) prior[field] += remainder[field];
+    prior.inputIncludingCacheRead =
+      priorInclusiveInput + remainder.input + remainder.cacheRead;
+    prior.tokens = TOKEN_FIELDS.reduce((sum, field) => sum + prior[field], 0);
+    prior.cost = quantizeCost(prior.cost + remainder.cost);
+    prior.messages += remainder.messages;
+    models[remainderModel] = prior;
   }
   return models;
 }
@@ -255,77 +298,46 @@ function aggregateSnapshot(
   return aggregate;
 }
 
-function maxModel(
-  previous: ModelBreakdownData | undefined,
-  incoming: ModelBreakdownData
-): ModelBreakdownData {
-  const result = emptyModel();
-  let tokenHighWaterAdvanced = previous == null;
-  for (const field of TOKEN_FIELDS) {
-    const prior = previous?.[field] ?? 0;
-    const next = incoming[field] || 0;
-    result[field] = Math.max(prior, next);
-    tokenHighWaterAdvanced ||= next > prior;
+const PARSER_HIGH_WATER_STATE_VERSION = 2;
+
+function normalizeStateDays(
+  source: Record<string, ClientBreakdownData>
+): Record<string, ClientBreakdownData> {
+  const normalized = createSafeRecord<ClientBreakdownData>();
+  for (const [date, day] of Object.entries(source)) {
+    normalized[date] = breakdownFromModels(modelsForHighWater(day));
   }
-  const priorInclusiveInput = positive(
-    previous?.inputIncludingCacheRead ??
-      (previous?.input ?? 0) + (previous?.cacheRead ?? 0)
-  );
-  const incomingInclusiveInput = positive(
-    incoming.inputIncludingCacheRead ?? incoming.input + incoming.cacheRead
-  );
-  result.inputIncludingCacheRead = Math.max(
-    priorInclusiveInput,
-    incomingInclusiveInput
-  );
-  tokenHighWaterAdvanced ||= incomingInclusiveInput > priorInclusiveInput;
-  result.tokens = TOKEN_FIELDS.reduce((sum, field) => sum + result[field], 0);
-  // Cost is contextual data for the token high-water snapshot, never its own
-  // monotonic signal: repricing alone must not authorize spend.
-  result.cost = quantizeCost(
-    tokenHighWaterAdvanced
-      ? Math.max(positive(previous?.cost ?? 0), positive(incoming.cost))
-      : previous?.cost ?? 0
-  );
-  result.messages = Math.max(
-    positive(previous?.messages ?? 0),
-    positive(incoming.messages)
-  );
-  return result;
+  return normalized;
 }
 
-function advanceDays(
+function applyCreditedIncrements(
   previous: Record<string, ClientBreakdownData>,
-  incoming: Record<string, ClientBreakdownData>
+  increments: Record<string, ClientBreakdownData>
 ): Record<string, ClientBreakdownData> {
-  const next = copyDictionary(previous);
-  for (const [date, day] of Object.entries(incoming)) {
-    const prior = ownValue(previous, date);
-    const models = modelsForHighWater(prior);
-    for (const [modelId, model] of Object.entries(day.models)) {
-      models[modelId] = maxModel(ownValue(models, modelId), model);
-    }
-    next[date] = breakdownFromModels(models);
+  const next = normalizeStateDays(previous);
+  for (const [date, increment] of Object.entries(increments)) {
+    next[date] = addClientBreakdownIncrement(
+      ownValue(next, date),
+      increment
+    );
   }
   return next;
 }
 
-function advanceAggregate(
-  previous: ParserAggregateHighWater,
-  incoming: ParserAggregateHighWater
-): ParserAggregateHighWater {
+function stateAfterCreditedIncrements(
+  version: number,
+  previousDays: Record<string, ClientBreakdownData>,
+  increments: Record<string, ClientBreakdownData>,
+  observedDays: Record<string, ClientBreakdownData>
+): ParserClientHighWaterState {
+  const days = applyCreditedIncrements(previousDays, increments);
   return {
-    tokens: Math.max(previous.tokens, incoming.tokens),
-    input: Math.max(previous.input, incoming.input),
-    output: Math.max(previous.output, incoming.output),
-    cacheRead: Math.max(previous.cacheRead, incoming.cacheRead),
-    cacheWrite: Math.max(previous.cacheWrite, incoming.cacheWrite),
-    reasoning: Math.max(previous.reasoning, incoming.reasoning),
-    messages: Math.max(previous.messages, incoming.messages),
-    inputIncludingCacheRead: Math.max(
-      previous.inputIncludingCacheRead,
-      incoming.inputIncludingCacheRead
-    ),
+    stateVersion: PARSER_HIGH_WATER_STATE_VERSION,
+    version,
+    baselineEstablished: true,
+    aggregate: aggregateSnapshot(days),
+    days,
+    observedDays: normalizeStateDays(observedDays),
   };
 }
 
@@ -339,8 +351,40 @@ function positive(value: number): number {
   return Number.isFinite(value) ? Math.max(0, value) : 0;
 }
 
+function tokenCandidates(
+  previous: ModelBreakdownData | undefined,
+  incoming: ModelBreakdownData
+): Record<TokenField, number> {
+  const candidates = Object.fromEntries(
+    TOKEN_FIELDS.map((field) => [
+      field,
+      positive(incoming[field] - (previous?.[field] ?? 0)),
+    ])
+  ) as Record<TokenField, number>;
+  // Submitted `input` is already exclusive of cache reads. Reconstruct the
+  // producer's inclusive input counter so a cache-composition shift is not
+  // itself growth, while a genuinely fully-cached request can still advance.
+  const inclusiveInputCandidate = positive(
+    positive(
+      incoming.inputIncludingCacheRead ??
+        incoming.input + incoming.cacheRead
+    ) -
+      positive(
+        previous?.inputIncludingCacheRead ??
+          (previous?.input ?? 0) + (previous?.cacheRead ?? 0)
+      )
+  );
+  candidates.cacheRead = Math.min(
+    candidates.cacheRead,
+    inclusiveInputCandidate
+  );
+  candidates.input = inclusiveInputCandidate - candidates.cacheRead;
+  return candidates;
+}
+
 function allocateIncrements(
-  previousDays: Record<string, ClientBreakdownData>,
+  previousCreditedDays: Record<string, ClientBreakdownData>,
+  previousObservedDays: Record<string, ClientBreakdownData>,
   incomingDays: Record<string, ClientBreakdownData>,
   previousAggregate: ParserAggregateHighWater,
   incomingAggregate: ParserAggregateHighWater
@@ -349,33 +393,48 @@ function allocateIncrements(
   let messageBudget = positive(
     incomingAggregate.messages - previousAggregate.messages
   );
+  const previousObservedAggregate = aggregateSnapshot(previousObservedDays);
   const inclusiveInputBudget = positive(
     incomingAggregate.inputIncludingCacheRead -
-      previousAggregate.inputIncludingCacheRead
+      previousObservedAggregate.inputIncludingCacheRead
   );
-  let supportedCellCacheReadGrowth = 0;
-  for (const [date, incomingDay] of Object.entries(incomingDays)) {
-    const previousDay = ownValue(previousDays, date);
-    const previousModels = modelsForHighWater(previousDay);
-    for (const [modelId, model] of Object.entries(incomingDay.models)) {
-      const prior = ownValue(previousModels, modelId);
-      const inclusiveGrowth = positive(
-        positive(
-          model.inputIncludingCacheRead ?? model.input + model.cacheRead
-        ) -
-          positive(
-            prior?.inputIncludingCacheRead ??
-              (prior?.input ?? 0) + (prior?.cacheRead ?? 0)
-          )
-      );
-      supportedCellCacheReadGrowth += Math.min(
-        positive(model.cacheRead - (prior?.cacheRead ?? 0)),
-        inclusiveGrowth
-      );
-    }
-  }
+  const dates = Object.keys(incomingDays).sort((a, b) => b.localeCompare(a));
+  const cells = dates.flatMap((date) => {
+    const incoming = incomingDays[date];
+    const creditedModels = modelsForHighWater(
+      ownValue(previousCreditedDays, date)
+    );
+    const observedModels = modelsForHighWater(
+      ownValue(previousObservedDays, date)
+    );
+    return Object.keys(incoming.models)
+      .sort()
+      .map((modelId) => {
+        const model = incoming.models[modelId];
+        const credited = ownValue(creditedModels, modelId);
+        return {
+          date,
+          modelId,
+          model,
+          credited,
+          observed: ownValue(observedModels, modelId),
+          increment: emptyModel(),
+          tokenCapacity: positive(model.tokens - (credited?.tokens ?? 0)),
+          messageCapacity: positive(
+            model.messages - (credited?.messages ?? 0)
+          ),
+        };
+      });
+  });
+  const supportedCellCacheReadGrowth = cells.reduce(
+    (sum, cell) =>
+      sum + tokenCandidates(cell.observed, cell.model).cacheRead,
+    0
+  );
   const cacheReadBudget = Math.min(
-    positive(incomingAggregate.cacheRead - previousAggregate.cacheRead),
+    positive(
+      incomingAggregate.cacheRead - previousObservedAggregate.cacheRead
+    ),
     supportedCellCacheReadGrowth,
     inclusiveInputBudget
   );
@@ -384,94 +443,128 @@ function allocateIncrements(
     // high-water and at least one cell's observed inclusive growth support it.
     // Unsupported cache moves reserve nothing, so the remainder flows to input.
     input: inclusiveInputBudget - cacheReadBudget,
-    output: positive(incomingAggregate.output - previousAggregate.output),
+    output: positive(
+      incomingAggregate.output - previousObservedAggregate.output
+    ),
     cacheRead: cacheReadBudget,
-    cacheWrite: positive(incomingAggregate.cacheWrite - previousAggregate.cacheWrite),
-    reasoning: positive(incomingAggregate.reasoning - previousAggregate.reasoning),
+    cacheWrite: positive(
+      incomingAggregate.cacheWrite - previousObservedAggregate.cacheWrite
+    ),
+    reasoning: positive(
+      incomingAggregate.reasoning - previousObservedAggregate.reasoning
+    ),
   };
-  const increments = createSafeRecord<ClientBreakdownData>();
-  const dates = Object.keys(incomingDays).sort((a, b) => b.localeCompare(a));
-  for (const date of dates) {
-    const incrementModels = createSafeRecord<ModelBreakdownData>();
-    const incoming = incomingDays[date];
-    const previous = ownValue(previousDays, date);
-    const previousModels = modelsForHighWater(previous);
-    for (const modelId of Object.keys(incoming.models).sort()) {
-      const model = incoming.models[modelId];
-      const prior = ownValue(previousModels, modelId);
-      const increment = emptyModel();
-      const candidates = Object.fromEntries(
-        TOKEN_FIELDS.map((field) => [
-          field,
-          positive(model[field] - (prior?.[field] ?? 0)),
-        ])
-      ) as Record<TokenField, number>;
-      // Submitted `input` is already exclusive of cache reads. Reconstruct the
-      // producer's inclusive input counter before bounding cache growth, so a
-      // cache-only composition shift cannot mint tokens while a genuinely
-      // fully-cached request (exclusive input 0) can still advance.
-      const inclusiveInputCandidate = positive(
-        positive(
-          model.inputIncludingCacheRead ?? model.input + model.cacheRead
-        ) -
-          positive(
-            prior?.inputIncludingCacheRead ??
-              (prior?.input ?? 0) + (prior?.cacheRead ?? 0)
-          )
+
+  const allocateTokenPass = (
+    candidatesFor: (cell: (typeof cells)[number]) => Record<TokenField, number>,
+    respectBucketBudgets: boolean
+  ) => {
+    for (const cell of cells) {
+      const candidates = candidatesFor(cell);
+      let cellBudget = positive(
+        cell.tokenCapacity - cell.increment.tokens
       );
-      const cacheReadCandidate = Math.min(
-        candidates.cacheRead,
-        inclusiveInputCandidate
-      );
-      // Inclusive input is the conserved producer counter. Allocate its growth
-      // between cache and exclusive input from the current observed snapshot;
-      // comparing exclusive input against its independent maximum would lose
-      // real growth after a cache-composition shift.
-      candidates.cacheRead = cacheReadCandidate;
-      candidates.input = inclusiveInputCandidate - cacheReadCandidate;
-      let candidateTokens = 0;
       for (const field of TOKEN_FIELDS) {
-        const candidate = candidates[field];
-        candidateTokens += candidate;
-        const accepted = Math.min(candidate, bucketBudgets[field], tokenBudget);
-        increment[field] = accepted;
-        bucketBudgets[field] -= accepted;
+        const accepted = Math.min(
+          candidates[field],
+          tokenBudget,
+          cellBudget,
+          respectBucketBudgets ? bucketBudgets[field] : Number.POSITIVE_INFINITY
+        );
+        cell.increment[field] += accepted;
+        cell.increment.tokens += accepted;
         tokenBudget -= accepted;
-      }
-      increment.tokens = TOKEN_FIELDS.reduce(
-        (sum, field) => sum + increment[field],
-        0
-      );
-
-      // Metadata is cumulative in a date/model cell, so only its marginal
-      // growth can accompany new usage. If moves make cell growth exceed the
-      // device-wide token budget, the deterministic date/model ordering above
-      // receives the same fraction of marginal cost; the rest is deliberately
-      // not credited because no safe cell attribution exists. Repricing alone
-      // still cannot authorize spend.
-      if (increment.tokens > 0) {
-        const acceptedFraction =
-          candidateTokens > 0 ? increment.tokens / candidateTokens : 0;
-        const marginalCost = positive(model.cost - (prior?.cost ?? 0));
-        increment.cost = quantizeCost(marginalCost * acceptedFraction);
-      }
-
-      // Counts have their own device/client lifetime high-water. That lets a
-      // one-token new session add one whole message without using a lossy
-      // token fraction, while pure date/model moves have zero count budget.
-      const candidateMessages = positive(
-        model.messages - (prior?.messages ?? 0)
-      );
-      increment.messages = Math.min(candidateMessages, messageBudget);
-      messageBudget -= increment.messages;
-
-      if (increment.tokens > 0 || increment.messages > 0) {
-        incrementModels[modelId] = increment;
+        cellBudget -= accepted;
+        if (respectBucketBudgets) bucketBudgets[field] -= accepted;
       }
     }
-    if (Object.keys(incrementModels).length > 0) {
-      increments[date] = breakdownFromModels(incrementModels);
+  };
+
+  // Observed deltas are the most faithful attribution signal. Run this as a
+  // global pass so a newer cell's residual capacity cannot pre-empt genuine
+  // growth observed in another date/model cell.
+  allocateTokenPass(
+    (cell) => tokenCandidates(cell.observed, cell.model),
+    true
+  );
+
+  const currentDeficits = (cell: (typeof cells)[number]) =>
+    Object.fromEntries(
+      TOKEN_FIELDS.map((field) => [
+        field,
+        positive(
+          cell.model[field] -
+            (cell.credited?.[field] ?? 0) -
+            cell.increment[field]
+        ),
+      ])
+    ) as Record<TokenField, number>;
+
+  // First keep residual attribution inside the aggregate bucket deltas. Then,
+  // if independent bucket moves made those caps jointly infeasible, spend the
+  // remaining provable lifetime growth on current per-field deficits. The
+  // second pass still cannot mint usage: total and per-cell capacity remain
+  // hard caps, and only successfully allocated increments advance the ledger.
+  allocateTokenPass(currentDeficits, true);
+  allocateTokenPass(currentDeficits, false);
+
+  const allocateMessagePass = (
+    candidateFor: (cell: (typeof cells)[number]) => number
+  ) => {
+    for (const cell of cells) {
+      const cellBudget = positive(
+        cell.messageCapacity - cell.increment.messages
+      );
+      const accepted = Math.min(
+        positive(candidateFor(cell)),
+        messageBudget,
+        cellBudget
+      );
+      cell.increment.messages += accepted;
+      messageBudget -= accepted;
     }
+  };
+
+  // Message counts use the same observed-first rule, with their own lifetime
+  // budget so a tiny-token new request can still add one complete message.
+  allocateMessagePass(
+    (cell) => cell.model.messages - (cell.observed?.messages ?? 0)
+  );
+  allocateMessagePass(
+    (cell) =>
+      cell.model.messages -
+      (cell.credited?.messages ?? 0) -
+      cell.increment.messages
+  );
+
+  const modelsByDate = createSafeRecord<
+    Record<string, ModelBreakdownData>
+  >();
+  for (const cell of cells) {
+    if (cell.increment.tokens > 0) {
+      const acceptedFraction =
+        cell.tokenCapacity > 0
+          ? cell.increment.tokens / cell.tokenCapacity
+          : 0;
+      const marginalCost = positive(
+        cell.model.cost - (cell.credited?.cost ?? 0)
+      );
+      cell.increment.cost = quantizeCost(
+        marginalCost * acceptedFraction
+      );
+    }
+    if (cell.increment.tokens > 0 || cell.increment.messages > 0) {
+      const models =
+        ownValue(modelsByDate, cell.date) ??
+        createSafeRecord<ModelBreakdownData>();
+      models[cell.modelId] = cell.increment;
+      modelsByDate[cell.date] = models;
+    }
+  }
+
+  const increments = createSafeRecord<ClientBreakdownData>();
+  for (const [date, models] of Object.entries(modelsByDate)) {
+    increments[date] = breakdownFromModels(models);
   }
   return increments;
 }
@@ -480,23 +573,35 @@ function validState(
   state: ParserClientHighWaterState | undefined,
   version: number
 ): state is ParserClientHighWaterState {
-  return Boolean(
-    state &&
-      state.version === version &&
-      state.aggregate &&
-      state.days &&
-      Number.isFinite(state.aggregate.tokens) &&
-      state.aggregate.tokens >= 0 &&
-      TOKEN_FIELDS.every(
-        (field) =>
-          Number.isFinite(state.aggregate[field]) &&
-          state.aggregate[field] >= 0
-      ) &&
-      Number.isFinite(state.aggregate.messages) &&
-      state.aggregate.messages >= 0 &&
-      Number.isFinite(state.aggregate.inputIncludingCacheRead) &&
-      state.aggregate.inputIncludingCacheRead >= 0
-  );
+  if (
+    state == null ||
+    state.version !== version ||
+    (state.stateVersion != null &&
+      state.stateVersion !== PARSER_HIGH_WATER_STATE_VERSION) ||
+    state.aggregate == null ||
+    state.days == null ||
+    (state.stateVersion === PARSER_HIGH_WATER_STATE_VERSION &&
+      state.observedDays == null) ||
+    !AGGREGATE_FIELDS.every(
+      (field) =>
+        Number.isFinite(state.aggregate[field]) &&
+        state.aggregate[field] >= 0
+    )
+  ) {
+    return false;
+  }
+
+  // Allocation state v2 is an accounting ledger: its aggregate must describe
+  // exactly the credited cells. A mismatch would recreate the lost-growth bug
+  // by authorizing from one representation and persisting another, so freeze
+  // instead of trying to repair an ambiguous v2 state.
+  if (state.stateVersion === PARSER_HIGH_WATER_STATE_VERSION) {
+    const creditedAggregate = aggregateSnapshot(state.days);
+    return AGGREGATE_FIELDS.every(
+      (field) => creditedAggregate[field] === state.aggregate[field]
+    );
+  }
+  return true;
 }
 
 /**
@@ -506,8 +611,11 @@ function validState(
  * preserved; only positive lifetime growth beyond their aggregate may be added
  * at transition. Later full snapshots may add only growth bounded BOTH by
  * positive per-cell deltas and by device/client-wide cumulative high-water
- * growth. Date/model reshuffles and deleted local history therefore add
- * nothing and can never erase or duplicate stored rows.
+ * growth. The latest observed parser layout locates real growth; when its cell
+ * is already covered by a preserved legacy row, a deterministic current cell
+ * with uncredited capacity receives the bounded remainder. Only increments
+ * actually written advance the credited ledger, so growth cannot be lost.
+ * Date/model reshuffles and deleted local history never erase stored rows.
  */
 export function planParserHighWaterSubmission(args: {
   client: string;
@@ -540,18 +648,24 @@ export function planParserHighWaterSubmission(args: {
       mode: "freeze",
       increments: {},
       nextState: {
+        stateVersion: PARSER_HIGH_WATER_STATE_VERSION,
         version: supportedVersion,
         baselineEstablished: false,
         aggregate: emptyAggregate(),
         days: createSafeRecord<ClientBreakdownData>(),
+        observedDays: createSafeRecord<ClientBreakdownData>(),
       },
     };
   }
 
   const incomingAggregate = aggregateSnapshot(args.incomingDays);
+  if (args.state && !validState(args.state, supportedVersion)) {
+    return { mode: "freeze", increments: {} };
+  }
   if (args.state == null || args.state.baselineEstablished === false) {
     const legacyAggregate = aggregateSnapshot(args.existingLegacyDays);
-    const hasLegacy = legacyAggregate.tokens > 0;
+    const hasLegacy =
+      legacyAggregate.tokens > 0 || legacyAggregate.messages > 0;
     // At transition, preserving all legacy rows and crediting at most positive
     // lifetime aggregate growth is non-destructive. With deleted old usage D
     // and genuinely new usage N, incoming - legacy = N - D <= N; the existing
@@ -560,41 +674,66 @@ export function planParserHighWaterSubmission(args: {
     const increments = hasLegacy
       ? allocateIncrements(
           args.existingLegacyDays,
+          args.existingLegacyDays,
           args.incomingDays,
           legacyAggregate,
           incomingAggregate
         )
       : createSafeRecord<ClientBreakdownData>();
-    const nextState: ParserClientHighWaterState = {
-      version: supportedVersion,
-      baselineEstablished: true,
-      aggregate: advanceAggregate(legacyAggregate, incomingAggregate),
-      days: advanceDays(args.existingLegacyDays, args.incomingDays),
-    };
+    const nextState = hasLegacy
+      ? stateAfterCreditedIncrements(
+          supportedVersion,
+          args.existingLegacyDays,
+          increments,
+          args.incomingDays
+        )
+      : {
+          stateVersion: PARSER_HIGH_WATER_STATE_VERSION,
+          version: supportedVersion,
+          baselineEstablished: true,
+          aggregate: incomingAggregate,
+          days: normalizeStateDays(args.incomingDays),
+          observedDays: normalizeStateDays(args.incomingDays),
+        };
     return {
       mode: hasLegacy ? "baseline-legacy" : "baseline-new",
       increments,
       nextState,
     };
   }
-  if (!validState(args.state, supportedVersion)) {
-    return { mode: "freeze", increments: {} };
-  }
+  // State written before allocation schema v2 stored every observed cell
+  // maximum and advanced its aggregate even when no cell could accept that
+  // growth. Rebuild that one-time migration baseline from the rows that were
+  // actually credited, otherwise already-suppressed usage remains lost.
+  const previousCreditedDays =
+    args.state.stateVersion === PARSER_HIGH_WATER_STATE_VERSION
+      ? args.state.days
+      : args.existingLegacyDays;
+  const previousAggregate =
+    args.state.stateVersion === PARSER_HIGH_WATER_STATE_VERSION
+      ? args.state.aggregate
+      : aggregateSnapshot(previousCreditedDays);
+  const previousObservedDays =
+    args.state.stateVersion === PARSER_HIGH_WATER_STATE_VERSION
+      ? args.state.observedDays!
+      : previousCreditedDays;
+  const increments = allocateIncrements(
+    previousCreditedDays,
+    previousObservedDays,
+    args.incomingDays,
+    previousAggregate,
+    incomingAggregate
+  );
 
   return {
     mode: "incremental",
-    increments: allocateIncrements(
-      args.state.days,
-      args.incomingDays,
-      args.state.aggregate,
-      incomingAggregate
+    increments,
+    nextState: stateAfterCreditedIncrements(
+      supportedVersion,
+      previousCreditedDays,
+      increments,
+      args.incomingDays
     ),
-    nextState: {
-      version: supportedVersion,
-      baselineEstablished: true,
-      aggregate: advanceAggregate(args.state.aggregate, incomingAggregate),
-      days: advanceDays(args.state.days, args.incomingDays),
-    },
   };
 }
 
@@ -603,32 +742,15 @@ export function addClientBreakdownIncrement(
   increment: ClientBreakdownData
 ): ClientBreakdownData {
   if (!existing) return increment;
-  const models = copyModels(existing.models);
-  const represented = breakdownFromModels(models);
-  const remainder = emptyModel();
-  for (const field of TOKEN_FIELDS) {
-    remainder[field] = positive((existing[field] || 0) - represented[field]);
-  }
-  remainder.tokens = TOKEN_FIELDS.reduce(
-    (sum, field) => sum + remainder[field],
-    0
-  );
-  remainder.cost = quantizeCost(
-    positive((existing.cost || 0) - represented.cost)
-  );
-  remainder.messages = positive((existing.messages || 0) - represented.messages);
-  if (remainder.tokens > 0 || remainder.cost > 0 || remainder.messages > 0) {
-    const remainderModel = existing.modelId || "unknown";
-    const prior = { ...(ownValue(models, remainderModel) ?? emptyModel()) };
-    for (const field of TOKEN_FIELDS) prior[field] += remainder[field];
-    prior.tokens = TOKEN_FIELDS.reduce((sum, field) => sum + prior[field], 0);
-    prior.cost = quantizeCost(prior.cost + remainder.cost);
-    prior.messages += remainder.messages;
-    models[remainderModel] = prior;
-  }
+  const models = modelsForHighWater(existing);
   for (const [modelId, delta] of Object.entries(increment.models)) {
     const model = { ...(ownValue(models, modelId) ?? emptyModel()) };
+    const priorInclusiveInput = positive(
+      model.inputIncludingCacheRead ?? model.input + model.cacheRead
+    );
     for (const field of TOKEN_FIELDS) model[field] = (model[field] || 0) + delta[field];
+    model.inputIncludingCacheRead =
+      priorInclusiveInput + delta.input + delta.cacheRead;
     model.tokens = TOKEN_FIELDS.reduce((sum, field) => sum + model[field], 0);
     model.cost = quantizeCost((model.cost || 0) + delta.cost);
     model.messages = (model.messages || 0) + delta.messages;


### PR DESCRIPTION
## Summary

- Separate the parser state that has actually been credited from the latest complete parser snapshot used to locate future growth.
- Allocate provable lifetime growth through deterministic observed-first and residual passes without exceeding aggregate or per-cell capacity.
- Migrate legacy high-water envelopes from stored credited rows, preserving previously suppressed growth while keeping replays and pure re-attributions idempotent.

Closes #1206.

## Why

The existing high-water allocator compared incoming date/model cells with cellwise maxima and advanced the aggregate even when no cell could accept the lifetime growth. After history was re-attributed, genuine same-day work could remain below a preserved legacy cell maximum, produce no increment, and still advance the aggregate high-water. That usage was then permanently suppressed on every replay.

This change treats the persisted high-water as an accounting ledger. Credited cells determine the authoritative aggregate, while a separate observed snapshot identifies genuine movement between submissions. Only increments that are actually allocated advance the credited ledger.

## Diff scope

- `packages/frontend/src/lib/db/parserHighWater.ts`: introduce allocation-state schema v2, normalize credited state, track observed snapshots separately, migrate legacy envelopes, and enforce deterministic conservation-aware allocation.
- `packages/frontend/__tests__/lib/parserHighWater.test.ts`: cover same-day recovery, legacy migration, conservation, replay idempotency, cache/input composition changes, malformed-state fail-closed behavior, and property-style move/deletion sequences.
- `packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts`: verify the submit path credits later Antigravity growth even when the original stored cell remains larger.
- No database schema, SQL migration, dependency, CI, release workflow, or public API changes.

## Branch integrity

- Base: `main`
- Validated base SHA: `62ca1eb1677556972ba963fdfa3a41ab23c1eb4b`
- Head SHA: `33ebfd771c8ce0867e79b276bda5036bc5c298e6`
- Ahead/behind: `1/0`
- Merge base: `62ca1eb1677556972ba963fdfa3a41ab23c1eb4b`
- `origin/main` is an ancestor of the branch; diff proof was computed against the freshly fetched base.

## Commit integrity

- One atomic commit: `33ebfd771c8ce0867e79b276bda5036bc5c298e6 fix(frontend): preserve parser growth after re-attribution`
- The final diff contains only the parser high-water implementation and its two directly related test files.
- Ledger: not applicable — this change family does not require a ledger record.
- Version: unchanged — synchronized release version bumps are owned by the publish workflow.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: three intended modified files.
- `git diff --check origin/main...HEAD`: PASS, no output.
- No secrets, environment files, caches, build output, generated artifacts, migration files, or unrelated changes.

## Validation mode and proof

Validation mode: Mode 3 — persisted usage accounting and submission data integrity.

- `bun run --cwd packages/frontend test -- __tests__/lib/parserHighWater.test.ts __tests__/api/submitAntigravityCliHighWater.test.ts`: PASS, 68 tests.
- `bun run --cwd packages/frontend test`: PASS, 88 files and 945 tests; one database integration file with 6 tests is excluded by the repository's default suite.
- `bun run --cwd packages/frontend lint -- src/lib/db/parserHighWater.ts __tests__/lib/parserHighWater.test.ts __tests__/api/submitAntigravityCliHighWater.test.ts`: PASS.
- `bun run --cwd packages/frontend typecheck`: PASS.
- `RATCHET_CENSUS_DB_INTEGRATION=1` database suite: not run — no migration, census logic, or database query changed; mandatory GitHub CI remains final-SHA proof.

## CI context confirmation

- CI context names are unchanged.
- Pending — required GitHub CI starts after this PR is created and must pass on the final SHA before merge.

## Runtime and data safety

- Credited aggregate state must exactly equal the sum of credited cells; inconsistent or unknown state schemas freeze instead of guessing.
- Token and message increments remain bounded by lifetime aggregate growth and current per-cell capacity.
- Observed deltas are allocated before deterministic residual capacity, and stable date/model ordering makes replays deterministic.
- Only successfully allocated increments advance the credited ledger; identical snapshots and pure date/model moves add nothing.
- No new locks, queues, network I/O, or unbounded state were introduced.
- No invariant regression introduced.

## Migration notes

- Database migration: not applicable — no schema or SQL changed.
- Existing legacy parser envelopes are migrated lazily to allocation-state v2 using the rows that were actually credited, rather than legacy observed maxima.
- Unknown or internally inconsistent v2 state fails closed with no increment and no state advancement.

## Documentation integrity

Not applicable — no commands, configuration, release procedure, or user-facing workflow changed.

## Rollback plan

- Rollback: `git revert <post_merge_commit_sha>` after merge.
- Database downgrade: not applicable.
- Data repair: not expected; reverting restores the prior allocator but does not reverse increments already accepted under the bounded lifetime high-water.
- Operational caveat: rollback would reintroduce the same-day growth suppression described in #1206.

## Known residual risks

- When re-attribution makes the exact historical destination unknowable, bounded residual growth is assigned to a deterministic current cell with available capacity; lifetime totals remain correct, but that cell may be an attribution fallback rather than the original source date/model.
- The PR is ready for review, not merge-ready, until required remote CI passes on the final SHA.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parser growth being silently lost after history re-attribution by treating stored high-water as a credited ledger instead of a cellwise envelope maximum.

- Separates credited cells from the latest observed snapshot so only increments that are actually allocated advance the aggregate.
- Migrates legacy envelopes from credited rows, preserving previously suppressed same-day growth.
- Freezes on unknown or internally inconsistent state schemas instead of guessing.
- Bounds token and message increments by lifetime aggregate growth and per-cell capacity, with deterministic residual allocation.
- Replays and pure re-attributions remain idempotent.

Closes #1206. No database schema, SQL, dependency, CI, or public API changes.

<sup>Written for commit 33ebfd771c8ce0867e79b276bda5036bc5c298e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

