### PR TITLE
fix(dsh): attribute usage to the served model

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1244,7 +1244,12 @@ fn parser_version(client: ClientId) -> u32 {
         // session-scoped dedup key, so a fork without `seedLength` counted the
         // copied summary twice. The key now falls back to `seq`, so v2 entries
         // carry keys that no longer match and must be reparsed.
-        ClientId::Dsh => 3,
+        // v3->v4: usage now prefers the concrete model reported by the
+        // provider (`replayState.response.responseModel`) over the configured
+        // request model. Finished DSH transcripts are append-only and keep the
+        // same fingerprint, so only this bump replaces cached alias/substitute
+        // attribution and its derived pricing.
+        ClientId::Dsh => 4,
         // First version of the fx (vercel-labs) usage-v2.json parser. Entries
         // are versioned from the start so later parser changes have an
         // obvious local counter to bump, like every other client here.
@@ -3304,6 +3309,90 @@ mod tests {
         // its fingerprint keeps matching and only the version bump discards the
         // v1 lock-timestamp anchor.
         assert_eq!(parser_version(ClientId::Droid), 7);
+    }
+
+    #[test]
+    fn test_dsh_served_model_parser_version_invalidates_v3_entries() {
+        // A finished transcript is never rewritten when attribution starts
+        // preferring the provider-reported response model, so its fingerprint
+        // remains valid and only the parser version can retire the old row.
+        assert_eq!(parser_version(ClientId::Dsh), 4);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn dsh_v3_shards_are_reparsed_with_the_concrete_served_model() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let source = write_temp_file(
+            br#"{"type":"session","id":"session-served","createdAt":1,"cwd":"/work"}
+{"type":"assistant/message","seq":42,"time":1787122684043,"data":{"turn":1,"message":{"id":"m-served","source":{"kind":"model","provider":"zai-coding-cn","model":"glm-5.2","replayState":{"response":{"responseModel":"glm-5.3"}}}},"usage":{"inputTokens":8425,"outputTokens":207,"cacheReadTokens":576}}}
+"#,
+        );
+        let current_identity = CacheIdentity::for_client(ClientId::Dsh);
+        assert_eq!(current_identity.parser_version, 4);
+        let stale_identity = CacheIdentity {
+            namespace: current_identity.namespace,
+            parser_version: 3,
+        };
+        let fingerprint = SourceFingerprint::from_path(source.path()).unwrap();
+        let stale_entry = CachedSourceEntry::new(
+            stale_identity,
+            source.path(),
+            fingerprint.clone(),
+            vec![UnifiedMessage::new(
+                current_identity.namespace,
+                "glm-5.2",
+                "zai-coding-cn",
+                "session-served",
+                1787122684043,
+                crate::TokenBreakdown {
+                    input: 999,
+                    output: 0,
+                    cache_read: 0,
+                    cache_write: 0,
+                    reasoning: 0,
+                },
+                0.0,
+            )],
+            Vec::new(),
+            None,
+        );
+        let stale_path = cache_shard_path(current_identity, source.path());
+        ensure_cache_dir(stale_path.parent().unwrap()).unwrap();
+        write_shard_with_limit(
+            &stale_path,
+            stale_identity,
+            &[stale_entry],
+            MAX_CACHE_SHARD_BYTES,
+        )
+        .unwrap();
+
+        let mut cache = SourceMessageCache::load();
+        assert!(cache.get(current_identity, source.path()).is_none());
+        assert_eq!(
+            SourceFingerprint::from_path(source.path()).unwrap(),
+            fingerprint
+        );
+
+        let rebuilt = crate::sessions::dsh::parse_dsh_file(source.path());
+        assert_eq!(rebuilt.len(), 1);
+        assert_eq!(rebuilt[0].model_id, "glm-5.3");
+        assert_ne!(rebuilt[0].tokens.input, 999);
+        cache.insert(CachedSourceEntry::new(
+            current_identity,
+            source.path(),
+            fingerprint,
+            rebuilt.clone(),
+            Vec::new(),
+            None,
+        ));
+        cache.save_if_dirty();
+
+        let warm = SourceMessageCache::load();
+        let cached = warm.get(current_identity, source.path()).unwrap();
+        assert_eq!(cached.parser_version, 4);
+        assert_eq!(cached.messages, rebuilt);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/dsh.rs
+++ b/crates/tokscale-core/src/sessions/dsh.rs
@@ -15,7 +15,10 @@
 //!   for messages whose `source` is absent).
 //! - `assistant/message`: authoritative per-call usage on `data.usage`
 //!   (`inputTokens`, `outputTokens`, `cacheReadTokens`, ...) plus the serving
-//!   provider/model on `data.message.source`.
+//!   provider and model on `data.message.source`. `source.model` is the model
+//!   configured for the request; when the provider serves a different model,
+//!   the response records its concrete identity on
+//!   `source.replayState.response.responseModel`, which takes precedence.
 //! - `compaction/summary`: the same usage and routing shape for the summarize
 //!   call DSH makes when it compacts a range. Real spend on the same account,
 //!   and disjoint from the loop steps around it.
@@ -248,7 +251,7 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
                     .map(str::to_string);
                 fallback_model = config
                     .and_then(|c| c.get("model"))
-                    .and_then(Value::as_str)
+                    .and_then(non_empty_string)
                     .map(str::to_string);
             }
             "user/message" => {
@@ -293,9 +296,7 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
                 }
 
                 let source = value.pointer("/data/message/source");
-                let model_id = source
-                    .and_then(|s| s.get("model"))
-                    .and_then(Value::as_str)
+                let model_id = served_model(source)
                     .or(fallback_model.as_deref())
                     .unwrap_or("unknown")
                     .to_string();
@@ -403,6 +404,32 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
     }
 
     messages
+}
+
+/// Return the concrete model that served a DSH call.
+///
+/// `source.model` is the configured request model. Floating aliases and
+/// provider-side substitutions can resolve to another model, which pi-ai
+/// records as `replayState.response.responseModel` when it differs from the
+/// request. That response identity is authoritative for attribution, pricing,
+/// and the model slot in the dedup key. Rows without it keep the configured
+/// source model, then the caller falls back to the latest request header.
+fn served_model(source: Option<&Value>) -> Option<&str> {
+    source
+        .and_then(|value| value.pointer("/replayState/response/responseModel"))
+        .and_then(non_empty_string)
+        .or_else(|| {
+            source
+                .and_then(|value| value.get("model"))
+                .and_then(non_empty_string)
+        })
+}
+
+fn non_empty_string(value: &Value) -> Option<&str> {
+    value
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
 }
 
 /// Split DSH's usage row into Tokscale's five additive buckets.
@@ -643,6 +670,72 @@ mod tests {
     }
 
     #[test]
+    fn attributes_usage_to_the_model_reported_by_the_provider() {
+        // Real DSH/pi-ai response shape: the session requested glm-5.2, while
+        // the provider returned glm-5.3 and pi-ai preserved that substitution
+        // in replayState.response.responseModel.
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-served","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"assistant/message","seq":42,"time":1787122684043,"data":{"turn":1,"message":{"id":"m-served","source":{"kind":"model","provider":"zai-coding-cn","model":"glm-5.2","replayState":{"response":{"kind":"pi-ai","version":2,"api":"openai-completions","provider":"zai-coding-cn","model":"glm-5.2","responseModel":"glm-5.3","stopReason":"toolUse"}}}},"usage":{"inputTokens":8425,"outputTokens":207,"cacheReadTokens":576}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "glm-5.3");
+        assert_eq!(messages[0].provider_id, "zai-coding-cn");
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("dsh:msg:m-served:1787122684043:zai-coding-cn:glm-5.3:8425:207:576:0:0")
+        );
+    }
+
+    #[test]
+    fn resolves_a_floating_request_alias_to_its_concrete_served_model() {
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-alias","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"assistant/message","time":1787122684043,"data":{"turn":1,"message":{"id":"m-alias","source":{"kind":"model","provider":"openrouter","model":"~x-ai/grok-latest","replayState":{"response":{"kind":"pi-ai","version":2,"api":"openai-completions","provider":"openrouter","model":"~x-ai/grok-latest","responseModel":"x-ai/grok-4.6","stopReason":"stop"}}}},"usage":{"inputTokens":100,"outputTokens":20}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "x-ai/grok-4.6");
+        assert_eq!(messages[0].provider_id, "openrouter");
+    }
+
+    #[test]
+    fn served_model_uses_only_non_empty_string_response_values() {
+        for (source, expected) in [
+            (
+                serde_json::json!({
+                    "model": " configured ",
+                    "replayState": { "response": { "responseModel": " served " } }
+                }),
+                Some("served"),
+            ),
+            (
+                serde_json::json!({
+                    "model": " configured ",
+                    "replayState": { "response": { "responseModel": "   " } }
+                }),
+                Some("configured"),
+            ),
+            (
+                serde_json::json!({
+                    "model": " configured ",
+                    "replayState": { "response": { "responseModel": 123 } }
+                }),
+                Some("configured"),
+            ),
+            (serde_json::json!({ "model": "   " }), None),
+        ] {
+            assert_eq!(served_model(Some(&source)), expected);
+        }
+        assert_eq!(served_model(None), None);
+    }
+
+    #[test]
     fn counts_compaction_summary_usage() {
         // The summarize call DSH makes when it compacts a range. Real spend on
         // the same account, disjoint from the loop steps around it (#1152).
@@ -672,6 +765,23 @@ mod tests {
         // A summary is not a loop step, so it never claims the turn.
         assert!(messages[0].is_turn_start);
         assert!(!summary.is_turn_start);
+    }
+
+    #[test]
+    fn compaction_summary_uses_the_concrete_served_model() {
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"session-summary-model","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"compaction/summary","seq":8,"time":1786669450002,"data":{"message":{"source":{"provider":"openrouter","model":"~x-ai/grok-latest","replayState":{"response":{"responseModel":"x-ai/grok-4.6"}}}},"usage":{"inputTokens":10,"outputTokens":20}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "x-ai/grok-4.6");
+        assert!(messages[0]
+            .dedup_key
+            .as_deref()
+            .is_some_and(|key| key.contains(":openrouter:x-ai/grok-4.6:")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Attribute DSH assistant and compaction usage to the concrete model reported by the provider response.
- Preserve the configured request model and request-header routing as ordered fallbacks when no usable response model exists.
- Bump the DSH parser cache identity from 3 to 4 so unchanged append-only transcripts are reparsed with corrected model attribution and pricing.

## Why

DSH stores the configured request model on `data.message.source.model`, but floating aliases and provider-side substitutions can resolve to a different concrete model. Pi-ai records that actual identity at `source.replayState.response.responseModel`. Using only the configured model attributes tokens, cost resolution, and the model component of the dedup key to the wrong model whenever the provider serves a substitute.

Completed DSH transcripts are append-only and retain the same source fingerprint, so changing the parser alone would leave existing v3 cache shards warm indefinitely. The parser-version bump makes the correction effective for both cold and previously cached data; the existing aggregate parser-generation guard also forces derived TUI data to rebuild.

## Diff scope

- `crates/tokscale-core/src/sessions/dsh.rs`: prefer a trimmed, non-empty provider response model; fall back to the configured source model and then request-header model; apply the same rule to assistant messages and compaction summaries.
- `crates/tokscale-core/src/message_cache.rs`: bump the DSH parser version and verify a v3 shard is rejected, reparsed, and persisted with the served model under v4.
- No schema, dependency, CI, release workflow, CLI contract, or public API changes.

## Branch integrity

- Base: `main`
- Validated base SHA: `62ca1eb1677556972ba963fdfa3a41ab23c1eb4b`
- Head SHA: `1491538e8dfc9ef9a4a66dcecc4034d4c7e7b9d0`
- Ahead/behind: `1/0`
- Merge base: `62ca1eb1677556972ba963fdfa3a41ab23c1eb4b`
- `origin/main` is an ancestor of the branch; diff proof was computed against the freshly fetched base.

## Commit integrity

- One atomic commit: `1491538e8dfc9ef9a4a66dcecc4034d4c7e7b9d0 fix(dsh): attribute usage to the served model`
- The final diff contains only the DSH parser and its client-scoped source-cache identity/tests.
- Ledger: not applicable — this change family does not require a ledger record.
- Version: release manifests are unchanged — synchronized package version bumps are owned by the publish workflow; the internal DSH parser cache identity is intentionally bumped from 3 to 4.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: two intended modified Rust files.
- `git diff --check origin/main...HEAD`: PASS, no output.
- No secrets, environment files, caches, build output, generated artifacts, migrations, or unrelated changes.

## Validation mode and proof

Validation mode: Mode 2 — narrow DSH parser and client-scoped cache invalidation change.

- `cargo fmt --all -- --check`: PASS.
- `cargo test -p tokscale-core dsh --lib`: PASS, 32 tests.
- `cargo test -p tokscale-core --lib`: PASS, 1881 passed and 2 ignored.
- `cargo clippy -p tokscale-core --lib -- --cap-lints warn`: PASS; three pre-existing warnings remain outside this diff.
- CLI and full workspace suites: not run — no CLI path or non-core contract changed; the targeted parser/cache tests and complete core library suite cover the impact, while mandatory GitHub CI remains final-SHA proof.

## CI context confirmation

- CI context names are unchanged.
- Pending — required GitHub CI starts after this PR is created and must pass on the final SHA before merge.

## Runtime safety

- `responseModel` is accepted only when it is a non-empty string after trimming; malformed or blank values preserve the existing fallback chain.
- Provider identity is unchanged, while the concrete served model becomes the authoritative model for attribution, pricing, and dedup identity.
- DSH parser version 4 invalidates only DSH source shards; other client caches are unaffected.
- The existing parser-generation mechanism converts derived aggregate cache mismatches to a cache miss, preventing pre-fix totals from being displayed after the bump.
- No new locks, queues, I/O paths, or unbounded work were introduced.
- No invariant regression introduced.

## Migration and operational notes

- Database migration: not applicable — no database schema or stored server data changed.
- Existing local DSH source shards and derived aggregate cache entries rebuild once because their parser generation no longer matches.
- No manual migration or data repair is required.

## Documentation integrity

Not applicable — no command, configuration, data location, or user-facing workflow changed.

## Rollback plan

- Rollback: `git revert <post_merge_commit_sha>` after merge.
- Database downgrade: not applicable.
- Data repair: not applicable; local cache identities are disposable and will be rebuilt by the active parser generation.
- Operational caveat: reverting restores configured-model attribution for provider substitutions and triggers another one-time cache rebuild.

## Known residual risks

- A provider-reported concrete model that is not yet present in pricing data may become explicitly unpriced instead of inheriting a configured alias price; this is safer than pricing usage against a model the provider did not serve.
- When `responseModel` is absent or malformed, attribution intentionally falls back to the configured source model and then the latest request header.
- The PR is ready for review, not merge-ready, until required remote CI passes on the final SHA.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes DSH assistant and compaction usage to the concrete model reported by the provider instead of the configured request model. Previously, floating aliases or provider-side substitutions attributed tokens, cost, and dedup identity to the wrong model. Now `replayState.response.responseModel` is preferred, with the configured model and request-header model as fallbacks when that value is missing or malformed.

Bumps the DSH parser cache identity from 3 to 4 so unchanged append-only transcripts get reparsed with corrected attribution; derived aggregate caches rebuild automatically. No schema, dependency, CI, or public API changes.

<sup>Written for commit 1491538e8dfc9ef9a4a66dcecc4034d4c7e7b9d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

