### PR TITLE
fix(groups): align all-time filters and member search

### DIFF
--- a/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
@@ -5,6 +5,7 @@ import { expectNoNarrowedCostCast } from "../support/costCastWidths";
 const mockState = vi.hoisted(() => {
   const periodRows: Array<Record<string, unknown>> = [];
   const allTimeRows: Array<Record<string, unknown>> = [];
+  const scopedAllTimeRows: Array<Record<string, unknown>> = [];
   const statsRows: Array<Record<string, unknown>> = [];
   const countRows: Array<Record<string, unknown>> = [];
   const fromCalls: unknown[] = [];
@@ -16,6 +17,7 @@ const mockState = vi.hoisted(() => {
       username: "users.username",
       displayName: "users.displayName",
       avatarUrl: "users.avatarUrl",
+      leaderboardHidden: "users.leaderboardHidden",
     },
     submissions: {
       id: "submissions.id",
@@ -28,6 +30,7 @@ const mockState = vi.hoisted(() => {
       date: "dailyBreakdown.date",
       tokens: "dailyBreakdown.tokens",
       cost: "dailyBreakdown.cost",
+      sourceBreakdown: "dailyBreakdown.sourceBreakdown",
     },
     groupMembers: {
       groupId: "groupMembers.groupId",
@@ -40,7 +43,6 @@ const mockState = vi.hoisted(() => {
   const desc = vi.fn(() => "desc");
   const asc = vi.fn(() => "asc");
   const and = vi.fn(() => "and");
-  const or = vi.fn((...conditions: unknown[]) => ({ kind: "or", conditions }));
   const gte = vi.fn(() => "gte");
   const lte = vi.fn(() => "lte");
   const sql = Object.assign(
@@ -50,6 +52,11 @@ const mockState = vi.hoisted(() => {
       as: () => ({}),
     })),
     {
+      join: vi.fn((items: unknown[], separator: unknown) => ({
+        kind: "join",
+        items,
+        separator,
+      })),
       raw: vi.fn(),
     }
   );
@@ -68,6 +75,7 @@ const mockState = vi.hoisted(() => {
   }
 
   const db = {
+    execute: vi.fn(() => Promise.resolve([...scopedAllTimeRows])),
     select: vi.fn(() => {
       let selectedTable: unknown;
       const builder = {
@@ -102,26 +110,27 @@ const mockState = vi.hoisted(() => {
     desc,
     asc,
     and,
-    or,
     gte,
     lte,
     sql,
     reset() {
       periodRows.length = 0;
       allTimeRows.length = 0;
+      scopedAllTimeRows.length = 0;
       statsRows.length = 0;
       countRows.length = 0;
       fromCalls.length = 0;
       orderByCalls.length = 0;
       db.select.mockClear();
+      db.execute.mockClear();
       eq.mockClear();
       desc.mockClear();
       asc.mockClear();
       and.mockClear();
-      or.mockClear();
       gte.mockClear();
       lte.mockClear();
       sql.mockClear();
+      sql.join.mockClear();
       sql.raw.mockClear();
     },
     setPeriodRows(rows: Array<Record<string, unknown>>) {
@@ -131,6 +140,10 @@ const mockState = vi.hoisted(() => {
     setAllTimeRows(rows: Array<Record<string, unknown>>) {
       allTimeRows.length = 0;
       allTimeRows.push(...rows);
+    },
+    setScopedAllTimeRows(rows: Array<Record<string, unknown>>) {
+      scopedAllTimeRows.length = 0;
+      scopedAllTimeRows.push(...rows);
     },
   };
 });
@@ -152,7 +165,6 @@ vi.mock("drizzle-orm", () => ({
   desc: mockState.desc,
   asc: mockState.asc,
   and: mockState.and,
-  or: mockState.or,
   gte: mockState.gte,
   lte: mockState.lte,
   sql: mockState.sql,
@@ -167,6 +179,35 @@ function selectedKeys(callIndex: number): string[] {
     [Record<string, unknown> | undefined]
   >;
   return Object.keys(calls[callIndex]?.[0] ?? {});
+}
+
+function renderSql(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map(renderSql).join("");
+  }
+  if (!value || typeof value !== "object") {
+    return String(value ?? "");
+  }
+
+  const join = value as { kind?: string; items?: unknown[]; separator?: unknown };
+  if (join.kind === "join") {
+    return (join.items ?? []).map(renderSql).join(renderSql(join.separator));
+  }
+
+  const query = value as { strings?: string[]; values?: unknown[] };
+  if (!query.strings) {
+    return String(value);
+  }
+  return query.strings.reduce(
+    (text, part, index) =>
+      `${text}${part}${index < (query.values?.length ?? 0) ? renderSql(query.values?.[index]) : ""}`,
+    ""
+  );
+}
+
+function scopedAllTimeQuery(): string {
+  const calls = mockState.db.execute.mock.calls as unknown as Array<[unknown]>;
+  return renderSql(calls.at(-1)?.[0]);
 }
 
 beforeAll(async () => {
@@ -273,6 +314,33 @@ describe("group leaderboard data", () => {
     expect(leaderboard.pagination.totalUsers).toBe(1);
   });
 
+  it("finds a period member by display name without changing their rank", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
+    mockState.setPeriodRows([
+      { ...rows[0], displayName: "Platform Engineer" },
+      rows[1],
+    ]);
+
+    const leaderboard = await getGroupLeaderboardData(
+      "group-1",
+      "week",
+      1,
+      50,
+      "tokens",
+      "ENGINEER"
+    );
+
+    expect(leaderboard.users).toHaveLength(1);
+    expect(leaderboard.users[0]).toMatchObject({
+      rank: 2,
+      username: "alice",
+      displayName: "Platform Engineer",
+    });
+    expect(leaderboard.pagination.totalUsers).toBe(1);
+    expect(leaderboard.stats).toMatchObject({ totalTokens: 800, activeUsers: 2 });
+  });
+
   it("adds deterministic SQL tie-breakers before assigning all-time ranks", async () => {
     mockState.setAllTimeRows([
       {
@@ -313,6 +381,47 @@ describe("group leaderboard data", () => {
     ]);
   });
 
+  it("finds an all-time member by display name and handles null display names", async () => {
+    mockState.setAllTimeRows([
+      {
+        userId: "user-bob",
+        username: "bob",
+        displayName: null,
+        avatarUrl: null,
+        role: "member",
+        totalTokens: 600,
+        totalCost: "6.0000",
+      },
+      {
+        userId: "user-alice",
+        username: "alice",
+        displayName: "Platform Engineer",
+        avatarUrl: null,
+        role: "owner",
+        totalTokens: 200,
+        totalCost: "2.0000",
+      },
+    ]);
+
+    const leaderboard = await getGroupLeaderboardData(
+      "group-1",
+      "all",
+      1,
+      50,
+      "tokens",
+      "platform ENGINEER"
+    );
+
+    expect(leaderboard.users).toEqual([
+      expect.objectContaining({
+        rank: 2,
+        username: "alice",
+        displayName: "Platform Engineer",
+      }),
+    ]);
+    expect(leaderboard.stats).toMatchObject({ totalTokens: 800, activeUsers: 2 });
+  });
+
   // submissions.total_cost is decimal(18,4); narrowing the cast to DECIMAL(12,4)
   // (max 99,999,999.9999) overflows for any row >= $100,000,000 and crashes the
   // all-time group leaderboard exactly like the global leaderboard.
@@ -332,8 +441,77 @@ describe("group leaderboard data", () => {
     expectNoNarrowedCostCast(sqlTexts);
   });
 
-  it("ORs repeated directives in all-time group leaderboards", async () => {
-    mockState.setAllTimeRows([]);
+  it("scopes all-time directives through per-client and per-model daily usage", async () => {
+    mockState.setScopedAllTimeRows([
+      {
+        userId: "user-dana",
+        username: "dana",
+        displayName: "Dana",
+        avatarUrl: null,
+        role: "member",
+        totalTokens: "300",
+        totalCost: "3.0000",
+      },
+    ]);
+
+    const leaderboard = await getGroupLeaderboardData(
+      "group-1",
+      "all",
+      1,
+      50,
+      "tokens",
+      "client:codex model:gpt-5"
+    );
+    const query = scopedAllTimeQuery();
+
+    expect(mockState.db.execute).toHaveBeenCalledTimes(1);
+    expect(query).toContain("FROM group_members gm");
+    expect(query).toContain("INNER JOIN daily_breakdown d");
+    expect(query).toContain("jsonb_each(COALESCE(d.source_breakdown");
+    expect(query).toContain("jsonb_each(COALESCE(client.value->'models'");
+    expect(query).toContain("LOWER(client.key) LIKE %codex% ESCAPE '!'");
+    expect(query).toContain("LOWER(model.key) LIKE %gpt-5% ESCAPE '!'");
+    expect(query).toContain("(model.value->>'tokens')::numeric");
+    expect(query).toContain("(model.value->>'cost')::numeric");
+    expect(query).toContain("gm.group_id = group-1");
+    expect(query).toContain("u.leaderboard_hidden = false");
+    expect(query).not.toContain("sources_used");
+    expect(query).not.toContain("models_used");
+    expect(query).not.toContain("SUM(s.total_tokens)");
+    expect(leaderboard.users[0]).toMatchObject({
+      rank: 1,
+      username: "dana",
+      totalTokens: 300,
+      totalCost: 3,
+    });
+    expect(leaderboard.stats).toMatchObject({
+      totalTokens: 300,
+      totalCost: 3,
+      activeUsers: 1,
+    });
+  });
+
+  it("avoids model expansion for a client-only all-time directive", async () => {
+    mockState.setScopedAllTimeRows([]);
+
+    await getGroupLeaderboardData(
+      "group-1",
+      "all",
+      1,
+      50,
+      "cost",
+      "client:codex"
+    );
+    const query = scopedAllTimeQuery();
+
+    expect(query).toContain("(client.value->>'tokens')::numeric");
+    expect(query).toContain("(client.value->>'cost')::numeric");
+    expect(query).not.toContain("client.value->'models'");
+    expect(query).toContain('ORDER BY "totalCost" DESC, "totalTokens" DESC');
+  });
+
+  it("ORs repeated all-time directives and treats LIKE metacharacters literally", async () => {
+    mockState.setScopedAllTimeRows([]);
 
     await getGroupLeaderboardData(
       "group-1",
@@ -341,18 +519,23 @@ describe("group leaderboard data", () => {
       1,
       50,
       "tokens",
-      "client:opencode client:claude model:gpt-5"
+      "client:open_code client:claude model:gpt_5 model:opus"
     );
+    const query = scopedAllTimeQuery();
 
-    expect(mockState.or).toHaveBeenCalledTimes(2);
-    expect(mockState.or.mock.calls.map((call) => call.length)).toEqual([2, 1]);
-    // The rankable-user predicate is ANDed ahead of the directive groups: a
-    // site-wide hide applies to group boards too.
-    expect(mockState.and).toHaveBeenLastCalledWith(
-      expect.anything(),
-      mockState.or.mock.results[0]?.value,
-      mockState.or.mock.results[1]?.value
-    );
+    expect(query).toContain("LOWER(client.key) LIKE %open!_code% ESCAPE '!'");
+    expect(query).toContain(" OR LOWER(client.key) LIKE %claude% ESCAPE '!'");
+    expect(query).toContain("LOWER(model.key) LIKE %gpt!_5% ESCAPE '!'");
+    expect(query).toContain(" OR LOWER(model.key) LIKE %opus% ESCAPE '!'");
+  });
+
+  it("keeps the unfiltered all-time path on aggregate submissions", async () => {
+    mockState.setAllTimeRows([]);
+
+    await getGroupLeaderboardData("group-1", "all", 1, 50, "tokens");
+
+    expect(mockState.fromCalls).toContain(mockState.tables.submissions);
+    expect(mockState.db.execute).not.toHaveBeenCalled();
   });
 });
 
@@ -417,6 +600,29 @@ describe("group period leaderboard directive scoping", () => {
       totalCost: 3,
       activeUsers: 1,
     });
+  });
+
+  it("combines directive scoping with a case-insensitive display-name search", async () => {
+    useWeekOf([{ ...mixedClientDay, displayName: "Staff Engineer" }]);
+
+    const leaderboard = await getGroupLeaderboardData(
+      "group-1",
+      "week",
+      1,
+      50,
+      "tokens",
+      "client:codex ENGINEER"
+    );
+
+    expect(leaderboard.users).toEqual([
+      expect.objectContaining({
+        rank: 1,
+        username: "dana",
+        displayName: "Staff Engineer",
+        totalTokens: 300,
+        totalCost: 3,
+      }),
+    ]);
   });
 
   it("counts only the filtered model's share, not every client in the row", async () => {

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -1,12 +1,8 @@
 import { unstable_cache } from "next/cache";
-import { and, asc, desc, eq, gte, lte, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { db, dailyBreakdown, groupMembers, submissions, users } from "@/lib/db";
 import type { LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
-import {
-  escapeLikePattern,
-  hasDirectives,
-  parseSearchDirectives,
-} from "@/lib/leaderboard/searchDirectives";
+import { hasDirectives, parseSearchDirectives } from "@/lib/leaderboard/searchDirectives";
 import {
   scopeBreakdownToDirectives,
   type PeriodSourceBreakdown,
@@ -23,7 +19,7 @@ interface GroupLeaderboardPeriodRow {
   sourceBreakdown: PeriodSourceBreakdown | null;
 }
 
-interface GroupLeaderboardDbRow {
+interface GroupLeaderboardDbRow extends Record<string, unknown> {
   userId: string;
   username: string;
   displayName: string | null;
@@ -97,9 +93,13 @@ function compareGroupUsers(
   return left.username.localeCompare(right.username);
 }
 
-function matchesSearch(user: Pick<GroupLeaderboardUser, "username">, search: string): boolean {
-  const parsed = parseSearchDirectives(search);
-  return !parsed.text || user.username.toLowerCase().includes(parsed.text.toLowerCase());
+function matchesSearch(
+  user: Pick<GroupLeaderboardUser, "username" | "displayName">,
+  normalizedText: string
+): boolean {
+  return normalizedText.length === 0 ||
+    user.username.toLowerCase().includes(normalizedText) ||
+    (user.displayName?.toLowerCase().includes(normalizedText) ?? false);
 }
 
 function paginateRankedUsers(
@@ -112,7 +112,8 @@ function paginateRankedUsers(
   totalMembers: number
 ): GroupLeaderboardData {
   const offset = (page - 1) * limit;
-  const filteredUsers = usersWithRanks.filter((user) => matchesSearch(user, search));
+  const normalizedText = parseSearchDirectives(search).text.toLowerCase();
+  const filteredUsers = usersWithRanks.filter((user) => matchesSearch(user, normalizedText));
   const pagedUsers = filteredUsers.slice(offset, offset + limit);
 
   return {
@@ -250,8 +251,91 @@ async function fetchPeriodRows(
   }));
 }
 
+function escapeLeaderboardLike(value: string): string {
+  return value.replace(/[!%_]/g, "!$&");
+}
+
+function likeAny(
+  column: ReturnType<typeof sql>,
+  values: string[]
+): ReturnType<typeof sql> {
+  if (values.length === 0) return sql`TRUE`;
+  const patterns = values.map((value) => `%${escapeLeaderboardLike(value)}%`);
+  return sql`(${sql.join(
+    patterns.map((pattern) => sql`LOWER(${column}) LIKE ${pattern} ESCAPE '!'`),
+    sql` OR `
+  )})`;
+}
+
+function toRankedAllTimeRows(rows: GroupLeaderboardDbRow[]): GroupLeaderboardUser[] {
+  return rows.map((row, index) => ({
+    rank: index + 1,
+    userId: row.userId,
+    username: row.username,
+    displayName: row.displayName,
+    avatarUrl: row.avatarUrl,
+    role: row.role,
+    totalTokens: Number(row.totalTokens) || 0,
+    totalCost: Number(row.totalCost) || 0,
+  }));
+}
+
+// The submission-level source/model arrays only prove that a client or model
+// occurred somewhere in a user's history. They cannot say how much it used or
+// whether a requested client and model occurred together. Filtered all-time
+// boards therefore aggregate the same per-client/per-model daily JSON used by
+// period boards; rows from before that JSON existed deliberately contribute
+// nothing rather than re-crediting the user's entire lifetime total.
+async function fetchScopedAllTimeRows(
+  groupId: string,
+  sortBy: SortBy,
+  clients: string[],
+  models: string[]
+): Promise<GroupLeaderboardUser[]> {
+  const usesModels = models.length > 0;
+  const selectedBreakdown = usesModels ? sql`model.value` : sql`client.value`;
+  const clientCondition = likeAny(sql`client.key`, clients);
+  const modelRows = usesModels
+    ? sql`CROSS JOIN LATERAL jsonb_each(COALESCE(client.value->'models', '{}'::jsonb)) AS model(key, value)`
+    : sql``;
+  const modelCondition = usesModels
+    ? sql`AND ${likeAny(sql`model.key`, models)}`
+    : sql``;
+  const primaryOrderBy = sortBy === "cost" ? sql`"totalCost"` : sql`"totalTokens"`;
+  const secondaryOrderBy = sortBy === "cost" ? sql`"totalTokens"` : sql`"totalCost"`;
+
+  const rows = await db.execute<GroupLeaderboardDbRow>(sql`
+    SELECT
+      u.id AS "userId",
+      u.username,
+      u.display_name AS "displayName",
+      u.avatar_url AS "avatarUrl",
+      gm.role,
+      SUM(COALESCE((${selectedBreakdown}->>'tokens')::numeric, 0)) AS "totalTokens",
+      SUM(COALESCE((${selectedBreakdown}->>'cost')::numeric, 0)) AS "totalCost"
+    FROM group_members gm
+    INNER JOIN users u ON gm.user_id = u.id
+    INNER JOIN submissions s ON s.user_id = u.id
+    INNER JOIN daily_breakdown d ON d.submission_id = s.id
+    CROSS JOIN LATERAL jsonb_each(COALESCE(d.source_breakdown, '{}'::jsonb)) AS client(key, value)
+    ${modelRows}
+    WHERE gm.group_id = ${groupId}
+      AND u.leaderboard_hidden = false
+      AND ${clientCondition}
+      ${modelCondition}
+    GROUP BY u.id, u.username, u.display_name, u.avatar_url, gm.role
+    ORDER BY ${primaryOrderBy} DESC, ${secondaryOrderBy} DESC, LOWER(u.username) ASC, u.id ASC
+  `);
+
+  return toRankedAllTimeRows(rows);
+}
+
 async function fetchAllTimeRows(groupId: string, sortBy: SortBy, search: string = ""): Promise<GroupLeaderboardUser[]> {
   const parsed = parseSearchDirectives(search);
+
+  if (hasDirectives(parsed)) {
+    return fetchScopedAllTimeRows(groupId, sortBy, parsed.clients, parsed.models);
+  }
 
   const primaryOrderByColumn = sortBy === "cost"
     ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`
@@ -259,17 +343,6 @@ async function fetchAllTimeRows(groupId: string, sortBy: SortBy, search: string 
   const secondaryOrderByColumn = sortBy === "cost"
     ? sql`SUM(${submissions.totalTokens})`
     : sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`;
-
-  const clientConditions = parsed.clients.map((client) =>
-    sql`EXISTS (SELECT 1 FROM unnest(${submissions.sourcesUsed}) AS s WHERE LOWER(s) LIKE ${`%${escapeLikePattern(client)}%`})`
-  );
-  const modelConditions = parsed.models.map((model) =>
-    sql`EXISTS (SELECT 1 FROM unnest(${submissions.modelsUsed}) AS m WHERE LOWER(m) LIKE ${`%${escapeLikePattern(model)}%`})`
-  );
-  const conditions = [
-    clientConditions.length > 0 ? or(...clientConditions) : undefined,
-    modelConditions.length > 0 ? or(...modelConditions) : undefined,
-  ].filter((condition): condition is ReturnType<typeof sql> => condition !== undefined);
 
   const rows = await db
     .select({
@@ -290,7 +363,7 @@ async function fetchAllTimeRows(groupId: string, sortBy: SortBy, search: string 
         eq(groupMembers.groupId, groupId)
       )
     )
-    .where(and(eq(users.leaderboardHidden, false), ...conditions))
+    .where(eq(users.leaderboardHidden, false))
     .groupBy(users.id, users.username, users.displayName, users.avatarUrl, groupMembers.role)
     .orderBy(
       desc(primaryOrderByColumn),
@@ -299,16 +372,7 @@ async function fetchAllTimeRows(groupId: string, sortBy: SortBy, search: string 
       asc(users.id)
     );
 
-  return (rows as GroupLeaderboardDbRow[]).map((row, index) => ({
-    rank: index + 1,
-    userId: row.userId,
-    username: row.username,
-    displayName: row.displayName,
-    avatarUrl: row.avatarUrl,
-    role: row.role,
-    totalTokens: Number(row.totalTokens) || 0,
-    totalCost: Number(row.totalCost) || 0,
-  }));
+  return toRankedAllTimeRows(rows as GroupLeaderboardDbRow[]);
 }
 
 async function fetchGroupLeaderboardData(


### PR DESCRIPTION
## Summary

- Make all-time group leaderboard directives aggregate only the matching client/model share from `daily_breakdown.source_breakdown` instead of crediting each matching user with their entire lifetime total.
- Preserve directive semantics: repeated values OR within a category, client and model filters intersect inside the same client contribution, and literal SQL wildcard characters remain escaped.
- Add case-insensitive member search across both username and display name without changing the member's already-computed rank.
- Keep unfiltered and plain-text-only all-time requests on the existing aggregate submissions path.

Follow-up to #876 and #884.

## Why

The existing all-time group query uses `submissions.sources_used` and `submissions.models_used` only as presence checks. Those arrays can prove that a client or model occurred somewhere in a user's history, but they cannot say how much usage belongs to the match or whether a requested client and model occurred together. After the presence check passed, the query summed the user's complete lifetime tokens and cost, allowing unrelated usage to determine filtered ranks and totals.

Period group boards already scope usage through per-client and per-model daily JSON. This change uses the same source of truth for directive-filtered all-time boards. Rows from before `source_breakdown` existed contribute nothing while a directive is active rather than re-crediting an unverifiable lifetime total.

## Diff scope

- `packages/frontend/src/lib/groups/getGroupLeaderboard.ts`: add the directive-scoped all-time aggregation over `daily_breakdown.source_breakdown`, retain the aggregate fast path when no directives are present, and include display names in post-rank text search.
- `packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts`: cover filtered-share ranking and totals, client/model intersection, repeated directives, wildcard escaping, client-only query shape, multi-day aggregation, missing-breakdown fail-closed behavior, deterministic ordering, and username/display-name search.
- No schema, migration, write path, authentication, authorization, cache contract, route payload, dependency, CI, or release workflow changes.

## Branch integrity

- Base: `main`
- Validated base SHA: `62ca1eb1677556972ba963fdfa3a41ab23c1eb4b`
- Head SHA: `372f2b6f2c2c8b227ec5c35e17656dae78c21b4a`
- Ahead/behind: `1/0`
- Merge base: `62ca1eb1677556972ba963fdfa3a41ab23c1eb4b`
- `origin/main` is an ancestor of the branch; diff proof was computed against the freshly fetched base.

## Commit integrity

- One atomic commit: `372f2b6f2c2c8b227ec5c35e17656dae78c21b4a fix(groups): align all-time filters and member search`
- The final diff contains only the group leaderboard read path and its directly related tests.
- Ledger: not applicable — this change family does not require a ledger record.
- Version: release manifests are unchanged — synchronized package version bumps are owned by the publish workflow.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: two intended modified frontend files.
- `git diff --check origin/main...HEAD`: PASS, no output.
- No secrets, environment files, caches, build output, generated artifacts, migrations, or unrelated changes.

## Validation mode and proof

Validation mode: Mode 2 — localized group leaderboard read-path correction with no schema, auth, or write-path impact.

- `bun run --cwd packages/frontend test -- __tests__/lib/getGroupLeaderboard.test.ts __tests__/api/groupLeaderboardRoute.test.ts`: PASS, 23 tests.
- `bun run --cwd packages/frontend test -- --maxWorkers=4`: PASS, 88 files and 938 tests; one PostgreSQL integration file with 6 tests is excluded by the default suite.
- `bun run --cwd packages/frontend typecheck`: PASS.
- `bun run --cwd packages/frontend lint -- src/lib/groups/getGroupLeaderboard.ts __tests__/lib/getGroupLeaderboard.test.ts`: PASS.
- Live PostgreSQL `EXPLAIN`: not run — `DATABASE_URL` is not configured; no schema or migration changed, and tests cover the parameterized query shape and returned ranking semantics.

## CI context confirmation

- CI context names are unchanged.
- Pending — required GitHub CI starts after this PR is created and must pass on the final SHA before merge.

## Runtime and data safety

- The scoped query remains restricted to the requested group, excludes hidden users, and groups by stable user/member identity.
- Client-only directives avoid expanding nested model JSON; model directives expand only models inside matching client contributions.
- Same-type directive values are ORed, while client and model predicates are combined so `client:x model:y` counts model `y` only under client `x`.
- `%`, `_`, and the escape character are treated literally in bound `LIKE` patterns.
- Ranking order remains deterministic across primary metric, secondary metric, lowercase username, and user ID.
- Text search runs after rank calculation and matches username or display name case-insensitively, preserving rank and board-stat semantics.
- No new writes, locks, queues, external I/O, or unbounded in-memory collections were introduced.
- No invariant regression introduced.

## Migration and compatibility notes

- Database migration: not applicable — no schema or stored data changed.
- Directive-filtered all-time boards intentionally omit legacy daily rows with no `source_breakdown`; attributing their full lifetime totals would recreate the bug.
- Unfiltered and plain-text-only requests retain the aggregate submissions query, so legacy totals remain visible when no client/model attribution is requested.
- API response shape and pagination contract are unchanged.

## Documentation integrity

Not applicable — no command, configuration, route contract, or user-facing directive syntax changed.

## Rollback plan

- Rollback: `git revert <post_merge_commit_sha>` after merge.
- Database downgrade: not applicable.
- Data repair: not applicable — this is a read-only aggregation change.
- Operational caveat: reverting restores presence-only directive filters that rank matching users by their full lifetime totals.

## Known residual risks

- The directive-scoped all-time path expands JSONB daily contributions and may cost more than the aggregate fast path for very large groups; it runs only when client/model directives are present, and client-only filters avoid model expansion.
- A live PostgreSQL query plan was not available locally because `DATABASE_URL` is unset; mandatory remote checks remain the final proof before merge.
- Historical rows without per-source attribution are excluded from directive-scoped totals by design, so filtered all-time totals can be lower than the unfiltered board.
- The PR is ready for review, not merge-ready, until required remote CI passes on the final SHA.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all-time group leaderboard filtering so directive-filtered boards count only the matching client/model share from daily usage instead of crediting each user's entire lifetime total.

- Filtered all-time boards now aggregate `daily_breakdown.source_breakdown`, matching how period boards scope usage; legacy rows without attribution contribute nothing.
- Repeated directive values OR within a category, client and model filters intersect inside the same contribution, and SQL wildcard characters stay escaped.
- Unfiltered and plain-text-only all-time requests keep the existing aggregate path, so legacy totals remain visible.
- Member search is now case-insensitive across both username and display name, applied after rank assignment so ranks are unchanged.

<sup>Written for commit 372f2b6f2c2c8b227ec5c35e17656dae78c21b4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

