### PR TITLE
perf(submit): fold the report during the parse instead of collecting every message

### DIFF
--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -40,21 +40,48 @@ pub fn aggregate_by_date(messages: Vec<UnifiedMessage>) -> Vec<DailyContribution
             },
         );
 
-    // Convert to sorted vector with pre-allocated capacity
-    let mut contributions: Vec<DailyContribution> = Vec::with_capacity(daily_map.len());
-    contributions.extend(
-        daily_map
-            .into_iter()
-            .map(|(date, acc)| acc.into_contribution(date)),
-    );
+    DailyFold { days: daily_map }.finish()
+}
 
-    // Sort by date
-    contributions.sort_by(|a, b| a.date.cmp(&b.date));
+/// Incremental form of [`aggregate_by_date`].
+///
+/// [`aggregate_by_date`] takes a `Vec<UnifiedMessage>`, which means the caller
+/// has already paid to materialize every message. Callers that receive
+/// messages one at a time can fold each one in and drop it immediately, so
+/// peak memory is the day map (a few hundred entries) rather than the corpus.
+///
+/// [`aggregate_by_date`] delegates its own tail here, so both paths produce
+/// byte-identical contributions.
+#[derive(Default)]
+pub struct DailyFold {
+    days: HashMap<String, DayAccumulator>,
+}
 
-    // Calculate intensities based on max cost
-    calculate_intensities(&mut contributions);
+impl DailyFold {
+    pub fn add(&mut self, message: &UnifiedMessage) {
+        self.days
+            .entry(message.date.clone())
+            .or_default()
+            .add_message(message);
+    }
 
-    contributions
+    pub fn finish(self) -> Vec<DailyContribution> {
+        // Convert to sorted vector with pre-allocated capacity
+        let mut contributions: Vec<DailyContribution> = Vec::with_capacity(self.days.len());
+        contributions.extend(
+            self.days
+                .into_iter()
+                .map(|(date, acc)| acc.into_contribution(date)),
+        );
+
+        // Sort by date
+        contributions.sort_by(|a, b| a.date.cmp(&b.date));
+
+        // Calculate intensities based on max cost
+        calculate_intensities(&mut contributions);
+
+        contributions
+    }
 }
 
 /// Aggregate messages into per-session contributions, keyed on `session_id`.

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -780,6 +780,88 @@ fn opencode_json_superseded_by_sqlite(path: &Path, sqlite_keys: &HashSet<String>
         .is_some_and(|stem| sqlite_keys.contains(stem))
 }
 
+/// Receives fully-transformed messages as each client lane finishes, so the
+/// parse never has to hold every lane's messages at once.
+///
+/// The parse used to accumulate ~1M `UnifiedMessage` into one `Vec` and hand it
+/// back whole, which made peak memory the *sum* of every client lane (#1209).
+/// Draining into a sink between lanes makes it the *largest* lane instead.
+/// Callers that genuinely want the whole vector still get one: `Vec` is a sink.
+trait MessageSink {
+    fn accept(&mut self, message: UnifiedMessage);
+}
+
+impl MessageSink for Vec<UnifiedMessage> {
+    fn accept(&mut self, message: UnifiedMessage) {
+        self.push(message);
+    }
+}
+
+/// Inputs for the three whole-set passes that used to run once at the end of
+/// the parse. Each is stateless per message, so applying them at flush time is
+/// equivalent to applying them to the finished vector -- and it lets messages
+/// be released a lane at a time.
+struct FlushContext<'a> {
+    include_all: bool,
+    requested: HashSet<&'a str>,
+    include_synthetic: bool,
+    /// Re-keys every message onto the device's pinned bucketing timezone.
+    ///
+    /// The parsers derive `date` from `chrono::Local`, read afresh on every
+    /// scan, so which day a message lands in moves when the machine's zone
+    /// does. Fixing the day key here is what a rescan cannot then move.
+    ///
+    /// `Some` only when a zone is pinned: an unpinned device must report
+    /// exactly what it reported before, so the pass is skipped rather than
+    /// re-derived through `Local`.
+    ///
+    /// This used to be a whole-corpus `rebucket_days` pass that deliberately
+    /// ran *after* `save_if_dirty`. Flushing per lane necessarily re-keys most
+    /// messages before that write, which stays correct because a
+    /// `CachedSourceEntry` owns its own payload -- re-keying a drained message
+    /// cannot reach one -- and because `refresh_derived_fields` re-derives
+    /// `date` on every cache load, so no cached entry can carry a stale day
+    /// key regardless of when it was written.
+    timezone: Option<bucket_tz::BucketTimezone>,
+}
+
+/// Drain `buffer` into `sink`, applying the tail passes to each message.
+///
+/// The order is load-bearing and matches the original tail: filter BEFORE
+/// normalization, so `retain_for_requested_clients` still sees the original
+/// model/provider prefixes that `is_synthetic_gateway` relies on.
+fn flush_lane<S: MessageSink>(
+    buffer: &mut Vec<UnifiedMessage>,
+    context: &FlushContext<'_>,
+    sink: &mut S,
+) {
+    for mut message in buffer.drain(..) {
+        if !context.include_all
+            && !retain_for_requested_clients(
+                &message.client,
+                &message.model_id,
+                &message.provider_id,
+                &context.requested,
+            )
+        {
+            continue;
+        }
+
+        if context.include_synthetic {
+            sessions::synthetic::normalize_synthetic_gateway_fields(
+                &mut message.model_id,
+                &mut message.provider_id,
+            );
+        }
+
+        if let Some(timezone) = &context.timezone {
+            message.rebucket_date(timezone);
+        }
+
+        sink.accept(message);
+    }
+}
+
 fn parse_all_messages_with_pricing_with_cache_policy(
     home_dir: &str,
     clients: &[String],
@@ -788,6 +870,28 @@ fn parse_all_messages_with_pricing_with_cache_policy(
     scanner_settings: &scanner::ScannerSettings,
     cache_policy: SourceCachePolicy,
 ) -> Vec<UnifiedMessage> {
+    let mut messages: Vec<UnifiedMessage> = Vec::new();
+    parse_all_messages_streaming(
+        home_dir,
+        clients,
+        pricing,
+        use_env_roots,
+        scanner_settings,
+        cache_policy,
+        &mut messages,
+    );
+    messages
+}
+
+fn parse_all_messages_streaming<S: MessageSink>(
+    home_dir: &str,
+    clients: &[String],
+    pricing: Option<&pricing::PricingService>,
+    use_env_roots: bool,
+    scanner_settings: &scanner::ScannerSettings,
+    cache_policy: SourceCachePolicy,
+    sink: &mut S,
+) {
     #[derive(Debug)]
     struct CachedParseOutcome {
         messages: Vec<UnifiedMessage>,
@@ -1637,6 +1741,15 @@ fn parse_all_messages_with_pricing_with_cache_policy(
     let mut all_messages: Vec<UnifiedMessage> = Vec::new();
     let include_all = clients.is_empty();
     let include_synthetic = include_all || clients.iter().any(|c| c == "synthetic");
+    let flush_context = {
+        let timezone = bucket_tz::BucketTimezone::from_scanner_settings(scanner_settings);
+        FlushContext {
+            include_all,
+            requested: clients.iter().map(String::as_str).collect(),
+            include_synthetic,
+            timezone: timezone.is_pinned().then_some(timezone),
+        }
+    };
     let include_devin_cli = include_synthetic || clients.iter().any(|c| c == "devin-cli");
     let include_devin_desktop = include_synthetic || clients.iter().any(|c| c == "devin-desktop");
     // Freebuff and Codebuff share the manicode scan bucket in the scanner (the
@@ -1710,6 +1823,11 @@ fn parse_all_messages_with_pricing_with_cache_policy(
     }
 
     // Parse MiMo Code: SQLite database(s)
+    // OpenCode is the largest lane; release it before MiMo Code starts.
+    // `micode_indices` below stores indices into `all_messages`, so this must
+    // happen before the first one is recorded -- never inside that loop.
+    flush_lane(&mut all_messages, &flush_context, sink);
+
     let mut micode_indices: HashMap<String, usize> = HashMap::new();
 
     for db_path in &scan_result.micode_dbs {
@@ -1752,6 +1870,9 @@ fn parse_all_messages_with_pricing_with_cache_policy(
             source_cache.insert(entry);
         }
     }
+
+    // MiMo Code is done indexing into `all_messages`; release it.
+    flush_lane(&mut all_messages, &flush_context, sink);
 
     let claude_home = PathBuf::from(home_dir);
     let claude_outcomes: Vec<CachedParseOutcome> = scan_result
@@ -1816,6 +1937,7 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         }
     }
     all_messages.extend(claude_messages.into_iter().map(|(_, message)| message));
+    flush_lane(&mut all_messages, &flush_context, sink);
 
     let codex_outcomes: Vec<(PathBuf, CachedParseOutcome)> = scan_result
         .get(ClientId::Codex)
@@ -1844,6 +1966,12 @@ fn parse_all_messages_with_pricing_with_cache_policy(
             );
         }
     }
+
+    // Release Codex before Copilot. This has to sit ahead of the Copilot
+    // lane rather than after it: the desktop/vscode blocks below scan
+    // `all_messages` for `client == "copilot"` to dedup against OTEL rows, so
+    // copilot's own messages must still be buffered when they run.
+    flush_lane(&mut all_messages, &flush_context, sink);
 
     parse_cached_lane(
         &scan_result,
@@ -2141,6 +2269,7 @@ fn parse_all_messages_with_pricing_with_cache_policy(
     );
     apply_pricing_to_messages(&mut prime_agent_messages, pricing);
     all_messages.extend(prime_agent_messages);
+    flush_lane(&mut all_messages, &flush_context, sink);
 
     let kimchi_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Kimchi)
@@ -2883,58 +3012,14 @@ fn parse_all_messages_with_pricing_with_cache_policy(
         }
     }
 
-    // Filter BEFORE normalization so retain_for_requested_clients can see
-    // original model/provider prefixes (e.g. "accounts/fireworks/models/…")
-    // that is_synthetic_gateway relies on for gateway detection.
-    if !include_all {
-        let requested: HashSet<&str> = clients.iter().map(String::as_str).collect();
-        all_messages.retain(|msg| {
-            retain_for_requested_clients(&msg.client, &msg.model_id, &msg.provider_id, &requested)
-        });
-    }
-
-    if include_synthetic {
-        for msg in &mut all_messages {
-            sessions::synthetic::normalize_synthetic_gateway_fields(
-                &mut msg.model_id,
-                &mut msg.provider_id,
-            );
-        }
-    }
-
     if cache_policy == SourceCachePolicy::Persistent {
         source_cache.save_if_dirty();
     }
 
-    rebucket_days(&mut all_messages, scanner_settings);
-
-    all_messages
-}
-
-/// Re-key every message onto the device's pinned bucketing timezone.
-///
-/// The parsers derive `date` from `chrono::Local`, read afresh on every scan,
-/// so which day a message lands in changes when the machine's zone does. This
-/// is the one pass that knows the user's settings and sees every message, so it
-/// is where the day key gets fixed to something a rescan cannot move.
-///
-/// Runs after the source cache is written on purpose: the cache stores raw
-/// parser output and `refresh_derived_fields` re-derives `date` on every load,
-/// so cached entries never carry a stale day key past this point and changing
-/// the pinned zone needs no cache invalidation.
-///
-/// **No-op when nothing is pinned.** An unpinned device must report exactly
-/// what it reported before, so the pass is skipped rather than re-derived
-/// through `Local`.
-fn rebucket_days(messages: &mut [UnifiedMessage], scanner_settings: &scanner::ScannerSettings) {
-    let timezone = bucket_tz::BucketTimezone::from_scanner_settings(scanner_settings);
-    if !timezone.is_pinned() {
-        return;
-    }
-
-    for message in messages.iter_mut() {
-        message.rebucket_date(&timezone);
-    }
+    // retain/normalize/rebucket used to run here as three whole-set passes.
+    // They now run per message inside `flush_lane`, which is also where the
+    // messages are released.
+    flush_lane(&mut all_messages, &flush_context, sink);
 }
 
 fn dedupe_latest_trae_messages(mut messages: Vec<UnifiedMessage>) -> Vec<UnifiedMessage> {
@@ -5300,8 +5385,8 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     })
 }
 
-/// [`rebucket_days`] for the `ParsedMessage` lane. Same contract: no-op unless
-/// a zone is pinned.
+/// [`FlushContext::timezone`] for the `ParsedMessage` lane. Same contract:
+/// no-op unless a zone is pinned.
 fn rebucket_parsed_days(
     messages: &mut [ParsedMessage],
     scanner_settings: &scanner::ScannerSettings,

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4433,7 +4433,15 @@ fn validate_priced_messages(
 /// corpus and then retaining over it.
 fn message_passes_report_filter(message: &UnifiedMessage, options: &ReportOptions) -> bool {
     if let Some(year) = &options.year {
-        if !message.date.starts_with(&format!("{}-", year)) {
+        // Matching the prefix in place rather than building `format!("{year}-")`
+        // keeps this predicate allocation-free. The streaming path runs it once
+        // per parsed message, so an allocation here is one heap round-trip per
+        // message on a corpus this change exists to make cheap.
+        if !message
+            .date
+            .strip_prefix(year.as_str())
+            .is_some_and(|rest| rest.starts_with('-'))
+        {
             return false;
         }
     }
@@ -5733,8 +5741,8 @@ mod tests {
         dedupe_latest_trae_messages, exclude_unpriced_submission_messages,
         filter_messages_for_report, generate_graph_with_loaded_pricing, get_home_dir_string,
         is_generic_routing_label, merge_claude_cross_file_duplicate, message_cache,
-        normalize_model_for_grouping, opencode_json_superseded_by_sqlite,
-        parse_all_messages_with_pricing_with_cache_policy,
+        message_passes_report_filter, normalize_model_for_grouping,
+        opencode_json_superseded_by_sqlite, parse_all_messages_with_pricing_with_cache_policy,
         parse_all_messages_with_pricing_with_env_strategy, parse_local_clients, parsed_to_unified,
         paths, pricing, retain_for_requested_clients, scanner, select_local_parse_pricing,
         sessions, unified_to_parsed, validate_priced_messages, ClientId, GraphPricingRequirement,
@@ -15416,5 +15424,51 @@ mod tests {
         // Without verified cross-source dedup, both messages are preserved.
         let filtered = filter_messages_for_report(messages, &ReportOptions::default());
         assert_eq!(filtered.len(), 2);
+    }
+
+    /// The year filter compares the prefix in place rather than allocating
+    /// `format!("{year}-")` per message. The separator is load-bearing: without
+    /// it a truncated year like `202` would swallow every year it prefixes.
+    #[test]
+    fn year_filter_matches_on_the_full_year_and_its_separator() {
+        let dated = |date: &str| {
+            let mut message = UnifiedMessage::new(
+                "synthetic",
+                "gpt-4o",
+                "openai",
+                "session-1",
+                0,
+                TokenBreakdown::default(),
+                0.0,
+            );
+            message.date = date.to_string();
+            message
+        };
+
+        let options = ReportOptions {
+            year: Some("2026".to_string()),
+            ..Default::default()
+        };
+
+        assert!(message_passes_report_filter(&dated("2026-01-01"), &options));
+        assert!(message_passes_report_filter(&dated("2026-12-31"), &options));
+        assert!(!message_passes_report_filter(
+            &dated("2025-12-31"),
+            &options
+        ));
+        assert!(!message_passes_report_filter(
+            &dated("2027-01-01"),
+            &options
+        ));
+
+        // A partial year must not match the years it is a prefix of.
+        let truncated = ReportOptions {
+            year: Some("202".to_string()),
+            ..Default::default()
+        };
+        assert!(!message_passes_report_filter(
+            &dated("2026-01-01"),
+            &truncated
+        ));
     }
 }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3910,28 +3910,218 @@ async fn generate_graph_with_loaded_pricing(
         clients
     });
 
-    let all_messages = parse_all_messages_with_pricing_with_env_strategy(
+    let bucket_timezone =
+        bucket_tz::BucketTimezone::from_scanner_settings(&options.scanner_settings);
+
+    // Fold straight out of the parse. Collecting here and filtering afterwards
+    // is what made this path hold every message at once (#1209); the sink
+    // applies the same date filters per message and drops each one after it
+    // has landed in the day map and produced its session span.
+    let mut sink = GraphSink::new(Some(&options), pricing, pricing_requirement);
+    parse_all_messages_streaming_with_env_strategy(
         &home_dir,
         &clients,
         pricing,
         options.use_env_roots,
         &options.scanner_settings,
+        &mut sink,
     );
 
-    let filtered = filter_messages_for_report(all_messages, &options);
-
-    let bucket_timezone =
-        bucket_tz::BucketTimezone::from_scanner_settings(&options.scanner_settings);
-
-    build_graph_from_messages(
-        filtered,
-        pricing,
-        pricing_requirement,
-        start,
-        &bucket_timezone,
-    )
+    sink.finish(start, &bucket_timezone)
 }
 
+/// Messages buffered before a batch is folded away.
+///
+/// Batching lets the sink reuse `exclude_unpriced_submission_messages` and
+/// `validate_priced_messages` verbatim rather than reimplementing their pricing
+/// rules, which is the part that would quietly diverge. Peak cost is one batch,
+/// not the corpus.
+const GRAPH_SINK_BATCH: usize = 65_536;
+
+/// Folds a graph report as messages arrive instead of collecting them.
+///
+/// The submit path made three passes over every message -- unpriced exclusion,
+/// sessionization, daily aggregation -- and so had to keep ~1M of them alive at
+/// once (#1209). All three are per message, so each runs as the message
+/// arrives and the message is dropped: what survives is the day map, an
+/// 80-byte [`sessionize::SessionSpan`] per message, and a few counters.
+struct GraphSink<'a> {
+    /// `Some` when the sink is fed straight from the parse and must apply the
+    /// report's date filters itself; `None` when the caller already filtered.
+    filter: Option<&'a ReportOptions>,
+    pricing: Option<&'a pricing::PricingService>,
+    requirement: GraphPricingRequirement,
+    buffer: Vec<UnifiedMessage>,
+    daily: aggregator::DailyFold,
+    interner: sessionize::SpanInterner,
+    spans: Vec<sessionize::SessionSpan>,
+    /// Merged across batches by (provider, model); counts and tokens add.
+    exclusions: HashMap<(String, String), (usize, i64, &'static str)>,
+    /// First batch error, surfaced from `finish` so the outcome matches the
+    /// whole-corpus path's `?` on the first failure.
+    failure: Option<String>,
+}
+
+impl<'a> GraphSink<'a> {
+    fn new(
+        filter: Option<&'a ReportOptions>,
+        pricing: Option<&'a pricing::PricingService>,
+        requirement: GraphPricingRequirement,
+    ) -> Self {
+        Self {
+            filter,
+            pricing,
+            requirement,
+            buffer: Vec::new(),
+            daily: aggregator::DailyFold::default(),
+            interner: sessionize::SpanInterner::default(),
+            spans: Vec::new(),
+            exclusions: HashMap::new(),
+            failure: None,
+        }
+    }
+
+    fn drain_batch(&mut self) {
+        if self.buffer.is_empty() {
+            return;
+        }
+        let batch = std::mem::take(&mut self.buffer);
+
+        let batch = match self.requirement {
+            GraphPricingRequirement::Lenient => batch,
+            GraphPricingRequirement::Submission => {
+                let (submitted, exclusions) =
+                    exclude_unpriced_submission_messages(batch, self.pricing);
+                for exclusion in exclusions {
+                    let entry = self
+                        .exclusions
+                        .entry((exclusion.provider_id, exclusion.model_id))
+                        .or_insert((0, 0, exclusion.reason));
+                    entry.0 += exclusion.message_count;
+                    entry.1 = entry.1.saturating_add(exclusion.total_tokens);
+                }
+                if self.failure.is_none() {
+                    if let Err(error) = validate_priced_messages(&submitted, self.pricing) {
+                        self.failure = Some(error);
+                    }
+                }
+                submitted
+            }
+        };
+
+        for message in &batch {
+            self.daily.add(message);
+            if message.timestamp > 0 {
+                self.spans.push(sessionize::SessionSpan::from_message(
+                    message,
+                    &mut self.interner,
+                ));
+            }
+        }
+    }
+
+    fn finish(
+        mut self,
+        start: Instant,
+        bucket_timezone: &bucket_tz::BucketTimezone,
+    ) -> Result<GraphResult, String> {
+        self.drain_batch();
+
+        let mut unpriced_submission_exclusions: Vec<UnpricedSubmissionExclusion> = self
+            .exclusions
+            .into_iter()
+            .map(
+                |((provider_id, model_id), (message_count, total_tokens, reason))| {
+                    UnpricedSubmissionExclusion {
+                        provider_id,
+                        model_id,
+                        message_count,
+                        total_tokens,
+                        reason,
+                    }
+                },
+            )
+            .collect();
+        // `exclude_unpriced_submission_messages` emits these from a BTreeMap
+        // keyed the same way, so sorting here keeps the reported order stable.
+        unpriced_submission_exclusions
+            .sort_by(|a, b| (&a.provider_id, &a.model_id).cmp(&(&b.provider_id, &b.model_id)));
+
+        require_trustworthy_exclusions(self.pricing, &unpriced_submission_exclusions)?;
+        if let Some(failure) = self.failure {
+            return Err(failure);
+        }
+
+        let intervals = sessionize::sessionize_spans(
+            &self.spans,
+            &self.interner,
+            sessionize::DEFAULT_IDLE_GAP_MS,
+        );
+        let time_metrics =
+            sessionize::compute_time_metrics(&intervals, sessionize::DEFAULT_IDLE_GAP_MS);
+
+        // Keyed by the same zone the messages were rebucketed into. Active time
+        // is joined onto contributions by date below, so a mismatch here
+        // silently drops a day's active time rather than misplacing it.
+        let daily_active_time =
+            sessionize::compute_daily_active_time_in(&intervals, bucket_timezone);
+        let contributions = self.daily.finish();
+
+        let processing_time_ms = start.elapsed().as_millis() as u32;
+        let mut result = aggregator::generate_graph_result(contributions, processing_time_ms);
+        result.time_metrics = Some(time_metrics);
+        result.unpriced_submission_exclusions = unpriced_submission_exclusions;
+
+        for contribution in &mut result.contributions {
+            if let Some(&ms) = daily_active_time.get(&contribution.date) {
+                contribution.active_time_ms = Some(ms);
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+impl MessageSink for GraphSink<'_> {
+    fn accept(&mut self, message: UnifiedMessage) {
+        if let Some(options) = self.filter {
+            if !message_passes_report_filter(&message, options) {
+                return;
+            }
+        }
+        self.buffer.push(message);
+        if self.buffer.len() >= GRAPH_SINK_BATCH {
+            self.drain_batch();
+        }
+    }
+}
+
+fn parse_all_messages_streaming_with_env_strategy<S: MessageSink>(
+    home_dir: &str,
+    clients: &[String],
+    pricing: Option<&pricing::PricingService>,
+    use_env_roots: bool,
+    scanner_settings: &scanner::ScannerSettings,
+    sink: &mut S,
+) {
+    parse_all_messages_streaming(
+        home_dir,
+        clients,
+        pricing,
+        use_env_roots,
+        scanner_settings,
+        SourceCachePolicy::Persistent,
+        sink,
+    );
+}
+
+/// Collecting form of the submit-report build, retained as the test surface for
+/// [`GraphSink`]: it feeds an already-filtered `Vec` through the same sink the
+/// streaming path uses, so the sink's folding, exclusion-merging and ordering
+/// behaviour stay under test without a full parse. Production callers stream
+/// into [`GraphSink`] directly and never collect, which is why this is
+/// `#[cfg(test)]` rather than dead code.
+#[cfg(test)]
 fn build_graph_from_messages(
     filtered: Vec<UnifiedMessage>,
     pricing: Option<&pricing::PricingService>,
@@ -3939,38 +4129,15 @@ fn build_graph_from_messages(
     start: Instant,
     bucket_timezone: &bucket_tz::BucketTimezone,
 ) -> Result<GraphResult, String> {
-    let (filtered, unpriced_submission_exclusions) = match pricing_requirement {
-        GraphPricingRequirement::Lenient => (filtered, Vec::new()),
-        GraphPricingRequirement::Submission => {
-            let (submitted, exclusions) = exclude_unpriced_submission_messages(filtered, pricing);
-            require_trustworthy_exclusions(pricing, &exclusions)?;
-            validate_priced_messages(&submitted, pricing)?;
-            (submitted, exclusions)
-        }
-    };
-
-    let intervals = sessionize::sessionize(&filtered, sessionize::DEFAULT_IDLE_GAP_MS);
-    let time_metrics =
-        sessionize::compute_time_metrics(&intervals, sessionize::DEFAULT_IDLE_GAP_MS);
-
-    // Keyed by the same zone the messages were rebucketed into. Active time is
-    // joined onto contributions by date below, so a mismatch here silently
-    // drops a day's active time rather than misplacing it.
-    let daily_active_time = sessionize::compute_daily_active_time_in(&intervals, bucket_timezone);
-    let contributions = aggregator::aggregate_by_date(filtered);
-
-    let processing_time_ms = start.elapsed().as_millis() as u32;
-    let mut result = aggregator::generate_graph_result(contributions, processing_time_ms);
-    result.time_metrics = Some(time_metrics);
-    result.unpriced_submission_exclusions = unpriced_submission_exclusions;
-
-    for contribution in &mut result.contributions {
-        if let Some(&ms) = daily_active_time.get(&contribution.date) {
-            contribution.active_time_ms = Some(ms);
-        }
+    // `filtered` has already been through the report's date filters, so the
+    // sink applies none of its own. Delegating rather than duplicating keeps
+    // this path and the streaming one on identical aggregation code, and lets
+    // this function's tests stand as the sink's correctness proof.
+    let mut sink = GraphSink::new(None, pricing, pricing_requirement);
+    for message in filtered {
+        sink.accept(message);
     }
-
-    Ok(result)
+    sink.finish(start, bucket_timezone)
 }
 
 const ROUTING_LABEL_UNPRICED_REASON: &str =
@@ -4259,24 +4426,39 @@ fn validate_priced_messages(
     ))
 }
 
+/// Per-message form of [`filter_messages_for_report`].
+///
+/// The report filters are three stateless predicates on `date`, so a streaming
+/// caller can drop a message on arrival instead of materializing the whole
+/// corpus and then retaining over it.
+fn message_passes_report_filter(message: &UnifiedMessage, options: &ReportOptions) -> bool {
+    if let Some(year) = &options.year {
+        if !message.date.starts_with(&format!("{}-", year)) {
+            return false;
+        }
+    }
+
+    if let Some(since) = &options.since {
+        if message.date.as_str() < since.as_str() {
+            return false;
+        }
+    }
+
+    if let Some(until) = &options.until {
+        if message.date.as_str() > until.as_str() {
+            return false;
+        }
+    }
+
+    true
+}
+
 fn filter_messages_for_report(
     messages: Vec<UnifiedMessage>,
     options: &ReportOptions,
 ) -> Vec<UnifiedMessage> {
     let mut filtered = messages;
-
-    if let Some(year) = &options.year {
-        let year_prefix = format!("{}-", year);
-        filtered.retain(|m| m.date.starts_with(&year_prefix));
-    }
-
-    if let Some(since) = &options.since {
-        filtered.retain(|m| m.date.as_str() >= since.as_str());
-    }
-
-    if let Some(until) = &options.until {
-        filtered.retain(|m| m.date.as_str() <= until.as_str());
-    }
+    filtered.retain(|message| message_passes_report_filter(message, options));
     filtered
 }
 

--- a/crates/tokscale-core/src/sessionize.rs
+++ b/crates/tokscale-core/src/sessionize.rs
@@ -40,13 +40,74 @@ pub struct TimeMetrics {
     pub session_count: u32,
 }
 
-#[derive(Debug)]
-struct SessionMessageSpan<'a> {
-    msg: &'a UnifiedMessage,
-    start_ts: i64,
-    end_ts: i64,
+/// One message's entire contribution to sessionization, without the message.
+///
+/// `sessionize` reads exactly seven fields off a `UnifiedMessage`. Carrying the
+/// whole 320-byte struct (plus its ten heap-allocated strings) just to reach
+/// them is what forced the submit path to hold every message at once (#1209).
+/// This is 80 bytes flat with no heap allocation, so a span per message costs
+/// roughly a tenth of what the message did.
+///
+/// `client` and `session` are [`SpanInterner`] ids rather than strings: both
+/// repeat across every message of a session, so interning collapses ~1M string
+/// clones into one entry per distinct value.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionSpan {
+    pub client: u32,
+    pub session: u32,
+    /// The message timestamp.
+    pub start_ts: i64,
+    /// `start_ts` plus the message's duration, when it reports a positive one.
+    pub end_ts: i64,
+    pub tokens: TokenBreakdown,
+    pub cost: f64,
+    pub message_count: i32,
 }
 
+impl SessionSpan {
+    /// Project a message onto a span, interning its client and session id.
+    pub fn from_message(message: &UnifiedMessage, interner: &mut SpanInterner) -> Self {
+        let duration_ms = message.duration_ms.filter(|d| *d > 0).unwrap_or(0);
+        Self {
+            client: interner.intern(&message.client),
+            session: interner.intern(&message.session_id),
+            start_ts: message.timestamp,
+            end_ts: message.timestamp.saturating_add(duration_ms),
+            tokens: message.tokens.clone(),
+            cost: message.cost,
+            // Zero is intentional for attribution fragments split from one
+            // authoritative source row, matching the original `.max(0)`.
+            message_count: message.message_count.max(0),
+        }
+    }
+}
+
+/// String table backing [`SessionSpan`]'s `client` and `session` ids.
+///
+/// Only [`SessionInterval`] needs the strings back, and there is one interval
+/// per session rather than per message, so resolution happens a few thousand
+/// times instead of a million.
+#[derive(Debug, Default)]
+pub struct SpanInterner {
+    values: Vec<String>,
+    index: HashMap<String, u32>,
+}
+
+impl SpanInterner {
+    pub fn intern(&mut self, value: &str) -> u32 {
+        if let Some(id) = self.index.get(value) {
+            return *id;
+        }
+        let id = self.values.len() as u32;
+        self.values.push(value.to_string());
+        self.index.insert(value.to_string(), id);
+        id
+    }
+
+    pub fn resolve(&self, id: u32) -> &str {
+        self.values.get(id as usize).map_or("", String::as_str)
+    }
+}
 #[derive(Debug)]
 struct SessionBlock {
     start_ts: i64,
@@ -57,7 +118,7 @@ struct SessionBlock {
 }
 
 impl SessionBlock {
-    fn new(span: &SessionMessageSpan<'_>) -> Self {
+    fn new(span: &SessionSpan) -> Self {
         let mut block = Self {
             start_ts: span.start_ts,
             end_ts: span.end_ts,
@@ -69,16 +130,16 @@ impl SessionBlock {
         block
     }
 
-    fn add(&mut self, span: &SessionMessageSpan<'_>) {
+    fn add(&mut self, span: &SessionSpan) {
         self.end_ts = self.end_ts.max(span.end_ts);
         // Aggregate the complete breakdown so future token buckets cannot be
         // omitted from session totals.
-        self.tokens += &span.msg.tokens;
-        self.cost += span.msg.cost;
+        self.tokens += &span.tokens;
+        self.cost += span.cost;
         // Zero is intentional for attribution fragments split from one
         // authoritative source row; default construction already supplies one
         // for ordinary messages, so coercing zero here inflates session counts.
-        self.message_count += span.msg.message_count.max(0);
+        self.message_count += span.message_count;
     }
 }
 
@@ -92,49 +153,53 @@ impl SessionBlock {
 /// `active_duration_ms` by splitting a source session into separate active
 /// intervals.
 pub fn sessionize(messages: &[UnifiedMessage], idle_gap_ms: i64) -> Vec<SessionInterval> {
-    if messages.is_empty() {
+    let mut interner = SpanInterner::default();
+    let spans: Vec<SessionSpan> = messages
+        .iter()
+        .filter(|message| message.timestamp > 0)
+        .map(|message| SessionSpan::from_message(message, &mut interner))
+        .collect();
+    sessionize_spans(&spans, &interner, idle_gap_ms)
+}
+
+/// Derive session intervals from projected spans instead of whole messages.
+///
+/// Identical grouping and block-merging to [`sessionize`], which now delegates
+/// here -- callers that can produce spans during parsing never have to
+/// materialize the messages at all.
+pub fn sessionize_spans(
+    spans: &[SessionSpan],
+    interner: &SpanInterner,
+    idle_gap_ms: i64,
+) -> Vec<SessionInterval> {
+    if spans.is_empty() {
         return Vec::new();
     }
 
-    // Group by (client, session_id)
-    let mut groups: HashMap<(&str, &str), Vec<&UnifiedMessage>> = HashMap::new();
-    for msg in messages {
-        if msg.timestamp <= 0 {
+    // Group by (client, session)
+    let mut groups: HashMap<(u32, u32), Vec<&SessionSpan>> = HashMap::new();
+    for span in spans {
+        if span.start_ts <= 0 {
             continue;
         }
         groups
-            .entry((&msg.client, &msg.session_id))
+            .entry((span.client, span.session))
             .or_default()
-            .push(msg);
+            .push(span);
     }
 
     let mut intervals: Vec<SessionInterval> = Vec::with_capacity(groups.len());
 
-    for ((client, session_id), mut msgs) in groups {
-        msgs.sort_unstable_by_key(|m| m.timestamp);
-
-        let spans: Vec<SessionMessageSpan<'_>> = msgs
-            .into_iter()
-            .map(|msg| {
-                let duration_ms = msg
-                    .duration_ms
-                    .filter(|duration| *duration > 0)
-                    .unwrap_or(0);
-                SessionMessageSpan {
-                    msg,
-                    start_ts: msg.timestamp,
-                    end_ts: msg.timestamp.saturating_add(duration_ms),
-                }
-            })
-            .collect();
+    for ((client, session), mut group) in groups {
+        group.sort_unstable_by_key(|span| span.start_ts);
 
         let mut blocks: Vec<SessionBlock> = Vec::new();
-        for span in spans {
+        for span in group {
             match blocks.last_mut() {
                 Some(block) if span.start_ts <= block.end_ts.saturating_add(idle_gap_ms) => {
-                    block.add(&span);
+                    block.add(span);
                 }
-                _ => blocks.push(SessionBlock::new(&span)),
+                _ => blocks.push(SessionBlock::new(span)),
             }
         }
 
@@ -142,8 +207,8 @@ pub fn sessionize(messages: &[UnifiedMessage], idle_gap_ms: i64) -> Vec<SessionI
             let wall_duration_ms = block.end_ts.saturating_sub(block.start_ts);
 
             intervals.push(SessionInterval {
-                client: client.to_string(),
-                session_id: session_id.to_string(),
+                client: interner.resolve(client).to_string(),
+                session_id: interner.resolve(session).to_string(),
                 start_ts: block.start_ts,
                 end_ts: block.end_ts,
                 wall_duration_ms,


### PR DESCRIPTION
## Problem

`submit` parses every client into one shared `Vec<UnifiedMessage>` and then makes several whole-corpus passes over it — date filtering, unpriced exclusion, price validation, daily aggregation, sessionization. On a heavy profile that is ~1M messages resident in full, from the end of the parse until the report is generated.

`UnifiedMessage` is 320 bytes, of which ten `String`/`Option<String>` fields account for 240, each with its own heap allocation. A million of those is ~11.6M tiny blocks that all have to be live at once, because the next pass is always about to walk them again.

## What this does

The report is folded during the parse instead of after it. Four commits, each standing on its own:

1. **`MessageSink` + per-lane drain.** Each client lane drains into a sink at a flush point rather than appending to one shared `Vec`. Six flush points, placed to respect the cross-lane readers that exist: micode's absolute-index map (no drain between its first index write and the end of its loop), the three Copilot scans that re-read `all_messages` filtered to `client == "copilot"`, and `devin_cli_session_ids`, which is a separate `HashSet` a drain does not touch.
2. **`SessionSpan`.** Sessionization reads 7 fields, so it now takes an owned 80-byte projection with interned client/session ids instead of borrowing whole messages.
3. **`DailyFold`.** The incremental form of `aggregate_by_date`; the existing function delegates its tail to it.
4. **`GraphSink`.** The submit report folds as messages arrive. Date filters become a per-message predicate, the day map folds incrementally, spans accumulate as projections.

## Measured

Peak RSS, `/usr/bin/time -l`, alternating A/B runs:

| command | before | after | |
|---|---|---|---|
| `submit --dry-run` | 2.761 GB | 2.339 GB | **−15.3%** |
| `models` | 2.750 GB | 2.509 GB | −8.8% |

Alternating, because page-cache drift between a cold and a warm run moves the number by more than the effect being measured.

## Why commits 1–3 do not show up in that number

They measure as approximately nothing on their own, and an earlier version of this measured 130 MB *worse*. Both are worth stating, because a reviewer expecting the drain alone to pay is going to be confused.

Draining only helps if the sink is not itself a `Vec<UnifiedMessage>` — and for the wrapper that preserves the old collecting API, it is. Moving messages between two vectors leaves residency unchanged; the flush points on their own remove reallocation churn, nothing more. Peak becomes "largest lane" rather than "sum of lanes" only once the *consumer* folds, which is commit 4.

The regression in the earlier attempt was rayon dispatch: a `filter_map` fed to `ParallelExtend` has `opt_len() == None`, which takes the `ListVecConsumer` path — per-worker `Vec`s then `Vec::append` — instead of `special_extend`'s single contiguous in-place allocation. That added a third copy rather than removing one.

## Correctness

`GraphSink` batches (65,536) into the **existing** `exclude_unpriced_submission_messages` and `validate_priced_messages` rather than reimplementing their pricing rules, so the two cannot drift apart. Exclusions are merged by `(provider_id, model_id)` and re-sorted on the way out to preserve the original `BTreeMap` ordering, and `require_trustworthy_exclusions` still runs before a parse failure is surfaced, matching the original `?` order.

`build_graph_from_messages` is kept — now `#[cfg(test)]`, since the streaming path is the only production caller — and delegates through the same sink. Its 14 tests across 16 call sites therefore exercise the new path rather than the old one, and they are the right ones to have inherited: almost all of them are exclusion and pricing-failure cases (`submission_excludes_*`, `submission_without_any_pricing_data_still_fails`), which is exactly the part of `GraphSink` that had to preserve ordering and `?`-order semantics.

One note for anyone verifying this by diffing report output: **md5-comparing two runs is not a valid gate here.** The same binary, run twice over a frozen `--until` range, differs in 64 lines — `HashMap` iteration order (Rust reseeds `RandomState` per process) feeds a `sort_unstable_by_key` on a non-unique key. Live transcripts being appended mid-scan move it further. The test suite is the gate.

## Scope

**This does not fix #1209.** It removes the collected corpus, which turns out to have been sitting on top of the two things that now dominate peak: the parse's own per-lane buffers (OpenCode is ~1.4 GB standalone — its SQLite lane materialises every row before folding) and the ~420 MB cache entry map. Neither is touched here.

The other four report consumers — `get_model_report`, `get_monthly_report_v2`, `get_hourly_report`, `get_time_metrics_report` — still collect. They can take the same treatment; this PR does the submit path because that is the one being OOM-killed.

Refs #1209

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Folds the submit report during the parse instead of collecting every message, cutting peak RSS by ~15% on `submit --dry-run` and ~8.8% on `models`. Client lanes now drain into a sink at six points, and each message is dropped after contributing to the daily fold and sessionization, instead of staying resident in one shared `Vec<UnifiedMessage>` (~1M × 320 bytes, each with heap-allocated strings).

**Correctness**
- Pricing exclusion and validation run on 65,536-message batches reusing the existing functions, so their rules cannot drift; exclusions merge and re-sort to preserve the original `BTreeMap` ordering.
- The report's date filters now run per message; the year check compares the prefix in place instead of allocating per message, with a load-bearing separator check covered by a test.
- `build_graph_from_messages` now delegates through the same sink, so its 14 tests across 16 call sites exercise the new path.
- Do not verify by diffing output: the same binary differs by 64 lines across runs from `HashMap` iteration order, so the test suite is the gate.

**Scope**
- This does not fix #1209; peak is now dominated by the parse's per-lane buffers (OpenCode is ~1.4 GB standalone) and the ~420 MB cache entry map, neither touched here.
- The other four report consumers still collect and can take the same treatment; this PR only does the submit path that was being OOM-killed.

<sup>Written for commit ed4d75964c900fd53bdaf7dbc6d6c0155531cb3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

