### PR TITLE
perf(copilot): move request DOMs out of session lines instead of cloning

### DIFF
--- a/crates/tokscale-core/src/sessions/copilot_vscode.rs
+++ b/crates/tokscale-core/src/sessions/copilot_vscode.rs
@@ -30,25 +30,34 @@ fn parse_file(path: &Path) -> Vec<UnifiedMessage> {
         if trimmed.is_empty() {
             continue;
         }
-        let Ok(obj) = serde_json::from_str::<Value>(trimmed) else {
+        let Ok(mut obj) = serde_json::from_str::<Value>(trimmed) else {
             continue;
         };
         let kind = obj.get("kind").and_then(Value::as_i64).unwrap_or(-1);
         match kind {
             0 => {
-                if let Some(arr) = obj.pointer("/v/requests").and_then(Value::as_array) {
-                    requests.extend(arr.iter().cloned());
+                // Move the requests out of the line rather than cloning them.
+                // `obj` is dropped at the end of this iteration, so a clone
+                // holds the whole session DOM twice at its peak -- on a large
+                // agent session that doubling is measured in gigabytes.
+                if let Some(slot) = obj.pointer_mut("/v/requests") {
+                    if let Value::Array(arr) = slot.take() {
+                        requests.extend(arr);
+                    }
                 }
             }
             1 => {
-                if let Some(k) = obj.get("k").and_then(Value::as_array) {
+                // The payload is taken out of the line before the path is read
+                // so it can be moved into the request rather than cloned. A
+                // streamed response body arrives through this arm, and `obj`
+                // is dropped at the end of the iteration either way.
+                let value = obj.get_mut("v").map(Value::take);
+                if let (Some(value), Some(k)) = (value, obj.get("k").and_then(Value::as_array)) {
                     if k.first().and_then(Value::as_str) == Some("requests") {
                         if let Some(index) = k.get(1).and_then(|v| v.as_u64()).map(|u| u as usize) {
                             // Dropping out-of-range updates is intentional: padding placeholders would mint timestamp-0 messages.
                             if let Some(req) = requests.get_mut(index) {
-                                if let Some(value) = obj.get("v") {
-                                    apply_update(req, &k[2..], value.clone());
-                                }
+                                apply_update(req, &k[2..], value);
                             }
                         }
                     }
@@ -63,8 +72,8 @@ fn parse_file(path: &Path) -> Vec<UnifiedMessage> {
                     let is_requests =
                         k.len() == 1 && k.first().and_then(Value::as_str) == Some("requests");
                     if is_requests {
-                        if let Some(arr) = obj.get("v").and_then(Value::as_array) {
-                            requests.extend(arr.iter().cloned());
+                        if let Some(Value::Array(arr)) = obj.get_mut("v").map(Value::take) {
+                            requests.extend(arr);
                         }
                     }
                 }
@@ -85,37 +94,30 @@ fn parse_file(path: &Path) -> Vec<UnifiedMessage> {
 const MAX_PATH_ARRAY_INDEX: usize = 4096;
 
 fn apply_update(target: &mut Value, path: &[Value], value: Value) {
-    if path.is_empty() {
+    // The last path segment is split off so the terminal write can move the
+    // payload instead of cloning it. Only one write ever happens per call, but
+    // when that write lives inside the descent loop the payload has to be
+    // cloned to satisfy the borrow checker -- and the payload here is a whole
+    // response-metadata blob.
+    let Some((last, parents)) = path.split_last() else {
         *target = value;
         return;
-    }
+    };
 
     let mut current = target;
-    for i in 0..path.len() {
-        let key = &path[i];
-        let is_last = i == path.len() - 1;
-
+    for key in parents {
         if let Some(k_str) = key.as_str() {
             if !current.is_object() {
                 *current = serde_json::Value::Object(serde_json::Map::new());
             }
-            if is_last {
-                current
-                    .as_object_mut()
-                    .unwrap()
-                    .insert(k_str.to_string(), value.clone());
-            } else {
-                let obj = current.as_object_mut().unwrap();
-                if !obj.contains_key(k_str) {
-                    obj.insert(
-                        k_str.to_string(),
-                        serde_json::Value::Object(serde_json::Map::new()),
-                    );
-                }
+            let obj = current.as_object_mut().unwrap();
+            if !obj.contains_key(k_str) {
+                obj.insert(
+                    k_str.to_string(),
+                    serde_json::Value::Object(serde_json::Map::new()),
+                );
             }
-            if !is_last {
-                current = current.get_mut(k_str).unwrap();
-            }
+            current = obj.get_mut(k_str).unwrap();
         } else if let Some(k_idx) = key.as_u64() {
             if k_idx > MAX_PATH_ARRAY_INDEX as u64 {
                 return;
@@ -124,27 +126,40 @@ fn apply_update(target: &mut Value, path: &[Value], value: Value) {
             if !current.is_array() {
                 *current = serde_json::Value::Array(Vec::new());
             }
-            if is_last {
-                let arr = current.as_array_mut().unwrap();
-                if idx < arr.len() {
-                    arr[idx] = value.clone();
-                } else {
-                    while arr.len() < idx {
-                        arr.push(serde_json::Value::Null);
-                    }
-                    arr.push(value.clone());
-                }
-            } else {
-                let arr = current.as_array_mut().unwrap();
-                while arr.len() <= idx {
-                    arr.push(serde_json::Value::Null);
-                }
+            let arr = current.as_array_mut().unwrap();
+            while arr.len() <= idx {
+                arr.push(serde_json::Value::Null);
             }
-            if !is_last {
-                current = current.get_mut(idx).unwrap();
-            }
+            current = &mut arr[idx];
         } else {
             return;
+        }
+    }
+
+    if let Some(k_str) = last.as_str() {
+        if !current.is_object() {
+            *current = serde_json::Value::Object(serde_json::Map::new());
+        }
+        current
+            .as_object_mut()
+            .unwrap()
+            .insert(k_str.to_string(), value);
+    } else if let Some(k_idx) = last.as_u64() {
+        if k_idx > MAX_PATH_ARRAY_INDEX as u64 {
+            return;
+        }
+        let idx = k_idx as usize;
+        if !current.is_array() {
+            *current = serde_json::Value::Array(Vec::new());
+        }
+        let arr = current.as_array_mut().unwrap();
+        if idx < arr.len() {
+            arr[idx] = value;
+        } else {
+            while arr.len() < idx {
+                arr.push(serde_json::Value::Null);
+            }
+            arr.push(value);
         }
     }
 }
@@ -510,5 +525,120 @@ mod tests {
         assert_eq!(m1.model_id, "gpt-5.6-luna");
         assert_eq!(m1.tokens.input, 15000);
         assert_eq!(m1.tokens.output, 250);
+    }
+
+    fn path(segments: &[Value]) -> Vec<Value> {
+        segments.to_vec()
+    }
+
+    #[test]
+    fn apply_update_replaces_the_root_on_an_empty_path() {
+        let mut target = serde_json::json!({"a": 1});
+        apply_update(&mut target, &[], serde_json::json!("replaced"));
+        assert_eq!(target, serde_json::json!("replaced"));
+    }
+
+    #[test]
+    fn apply_update_creates_missing_object_segments() {
+        let mut target = serde_json::json!({});
+        apply_update(
+            &mut target,
+            &path(&[
+                Value::from("result"),
+                Value::from("metadata"),
+                Value::from("outputTokens"),
+            ]),
+            serde_json::json!(143),
+        );
+        assert_eq!(
+            target,
+            serde_json::json!({"result": {"metadata": {"outputTokens": 143}}})
+        );
+    }
+
+    #[test]
+    fn apply_update_overwrites_a_non_object_segment_it_must_descend_through() {
+        let mut target = serde_json::json!({"result": 7});
+        apply_update(
+            &mut target,
+            &path(&[Value::from("result"), Value::from("metadata")]),
+            serde_json::json!("x"),
+        );
+        assert_eq!(target, serde_json::json!({"result": {"metadata": "x"}}));
+    }
+
+    #[test]
+    fn apply_update_pads_an_array_when_the_terminal_index_is_past_the_end() {
+        let mut target = serde_json::json!({"response": ["a"]});
+        apply_update(
+            &mut target,
+            &path(&[Value::from("response"), Value::from(3)]),
+            serde_json::json!("d"),
+        );
+        assert_eq!(
+            target,
+            serde_json::json!({"response": ["a", null, null, "d"]})
+        );
+    }
+
+    #[test]
+    fn apply_update_overwrites_an_in_range_array_index() {
+        let mut target = serde_json::json!({"response": ["a", "b", "c"]});
+        apply_update(
+            &mut target,
+            &path(&[Value::from("response"), Value::from(1)]),
+            serde_json::json!("B"),
+        );
+        assert_eq!(target, serde_json::json!({"response": ["a", "B", "c"]}));
+    }
+
+    #[test]
+    fn apply_update_pads_an_array_it_descends_through() {
+        let mut target = serde_json::json!({});
+        apply_update(
+            &mut target,
+            &path(&[Value::from("response"), Value::from(2), Value::from("kind")]),
+            serde_json::json!("markdownContent"),
+        );
+        assert_eq!(
+            target,
+            serde_json::json!({"response": [null, null, {"kind": "markdownContent"}]})
+        );
+    }
+
+    #[test]
+    fn apply_update_drops_an_oversized_terminal_index_instead_of_padding() {
+        let mut target = serde_json::json!({"response": []});
+        apply_update(
+            &mut target,
+            &path(&[
+                Value::from("response"),
+                Value::from(MAX_PATH_ARRAY_INDEX as u64 + 1),
+            ]),
+            serde_json::json!("boom"),
+        );
+        assert_eq!(target, serde_json::json!({"response": []}));
+    }
+
+    #[test]
+    fn apply_update_drops_an_oversized_intermediate_index_instead_of_padding() {
+        let mut target = serde_json::json!({"response": []});
+        apply_update(
+            &mut target,
+            &path(&[
+                Value::from("response"),
+                Value::from(MAX_PATH_ARRAY_INDEX as u64 + 1),
+                Value::from("kind"),
+            ]),
+            serde_json::json!("boom"),
+        );
+        assert_eq!(target, serde_json::json!({"response": []}));
+    }
+
+    #[test]
+    fn apply_update_ignores_a_path_segment_that_is_neither_a_key_nor_an_index() {
+        let mut target = serde_json::json!({"a": 1});
+        apply_update(&mut target, &path(&[Value::Null]), serde_json::json!("x"));
+        assert_eq!(target, serde_json::json!({"a": 1}));
     }
 }


### PR DESCRIPTION
The VSCode chat session parser held every request twice at its peak. A `kind:0` line carries the whole session snapshot and a `kind:2` line an append batch; both were copied out with `extend(arr.iter().cloned())` while the source line was still alive, and `apply_update` cloned each `kind:1` payload — a full response-metadata blob — into the target.

Every one of those lines is dropped at the end of its loop iteration, so the copy bought nothing. Taking the values instead removes the doubling.

### Why this shows up as an OOM

Two things make the Copilot lane the memory driver rather than message count:

- A real VSCode session runs **~226 KB of JSON per request** (measured: 6 requests in a 1,355,295-byte file). `UnifiedMessage` is 320 bytes and costs ~950 B/message in practice, so 400k messages is 0.43 GB — the accumulated messages are not the problem.
- `parse_copilot_vscode_sessions` is serial, so **peak tracks the largest single session file**, not the corpus. One big agent session sets the high-water mark.

### Measured

Peak RSS on a synthetic session at that density:

| requests | JSON | before | after | |
|---|---|---|---|---|
| 50 | 10.8 MB | 113.7 MB (10.5×) | 72.4 MB (6.6×) | −36% |
| 100 | 21.6 MB | 171.5 MB (7.9×) | 114.2 MB (5.2×) | −33% |
| 200 | 43.2 MB | 288.0 MB (6.6×) | 194.1 MB (4.4×) | −33% |
| 400 | 86.5 MB | 521.2 MB (6.0×) | 354.5 MB (4.0×) | −32% |

Marginal cost falls from **5.38× to 3.73×** per byte of session JSON. What remains is the line buffer plus its `serde_json` DOM; getting under that needs field projection (keep only the six fields `request_to_message` reads), not further deduplication, so it is left for a separate change.

### Verification

- `submit --dry-run` output is byte-identical between the old and new binaries across a 504-file corpus (fat sessions + dense ones).
- The array-index half of `apply_update` — padding, in-range overwrite, and the `MAX_PATH_ARRAY_INDEX` guard — had no coverage, and it is the half this rewrites. The nine added tests were run against the **original** body first and pass on both, so they pin existing behaviour rather than the new implementation.
- Full suite green; `cargo clippy` green in both CI's bare form and `--all-targets`; `cargo fmt --check` clean.

Refs #1209

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces peak memory in the VSCode copilot session parser by moving request DOMs out of session lines instead of cloning them, cutting peak RSS ~33-36% on large sessions (521 MB → 354 MB at 400 requests). Addresses issue #1209.

- The parser previously held every request twice at its peak: a `kind:0` line carries the whole session snapshot, `kind:1` response-metadata blobs get cloned into the target, and `kind:2` append batches are copied, while each source line is dropped at the end of its iteration anyway.
- `apply_update` now splits off the terminal path segment and moves the payload into place; the array-index branch (padding, in-range overwrite, and the `MAX_PATH_ARRAY_INDEX` guard) is covered by nine new tests that pass against both the old and new implementations.
- `submit --dry-run` output is byte-identical across a 504-file corpus.
- The remaining memory driver is the line buffer plus its `serde_json` DOM; field projection is left for a separate change.

<sup>Written for commit 3eb39f2f847f2ea9bbd0e98a142ca412aa8c4cd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

