### PR TITLE
test(frontend): make high-water replays prove they were not frozen

### DIFF
--- a/packages/frontend/__tests__/lib/parserHighWater.test.ts
+++ b/packages/frontend/__tests__/lib/parserHighWater.test.ts
@@ -5,6 +5,7 @@ import {
   planParserHighWaterSubmission,
   SUPPORTED_VERSIONED_PARSERS,
   type ParserClientHighWaterState,
+  type ParserHighWaterPlan,
 } from "../../src/lib/db/parserHighWater";
 import {
   mergeClientBreakdownsWithRegressionGuard,
@@ -90,6 +91,21 @@ function next(
     incomingDays,
     state,
   });
+}
+
+/**
+ * Assert a replay credited nothing *because there was nothing to credit*.
+ *
+ * `increments` alone cannot carry that meaning: a frozen plan returns
+ * `{ mode: "freeze", increments: {} }`, so asserting an empty increment map
+ * passes just as happily when the state was rejected on read. Those two
+ * outcomes could not be further apart -- one is correct idempotency, the other
+ * is a user whose high-water stopped accepting anything at all -- so the mode
+ * has to be checked alongside it.
+ */
+function expectCreditedNothing(plan: ParserHighWaterPlan) {
+  expect(plan.increments).toEqual({});
+  expect(plan.mode).not.toBe("freeze");
 }
 
 describe("non-destructive parser generation high-water", () => {
@@ -303,7 +319,7 @@ describe("non-destructive parser generation high-water", () => {
       cost: 0.5,
       messages: 1,
     });
-    expect(replay.increments).toEqual({});
+    expectCreditedNothing(replay);
   });
 
   it("normalizes old nested models that predate the reasoning bucket", () => {
@@ -337,7 +353,7 @@ describe("non-destructive parser generation high-water", () => {
     expect(
       first.nextState?.days["2026-07-01"].models["model-a"].reasoning
     ).toBe(0);
-    expect(replay.increments).toEqual({});
+    expectCreditedNothing(replay);
   });
 
   it("is idempotent when the same v2 full snapshot is replayed", () => {
@@ -347,7 +363,7 @@ describe("non-destructive parser generation high-water", () => {
       snapshot(contribution("2026-07-01", 100))
     );
 
-    expect(replay.increments).toEqual({});
+    expectCreditedNothing(replay);
     expect(replay.nextState).toEqual(first.nextState);
   });
 
@@ -679,7 +695,7 @@ describe("non-destructive parser generation high-water", () => {
         0
       )
     ).toBe(260);
-    expect(replay.increments).toEqual({});
+    expectCreditedNothing(replay);
   });
 
   it("recovers suppressed growth while migrating a legacy envelope state", () => {
@@ -730,7 +746,7 @@ describe("non-destructive parser generation high-water", () => {
     ).toBe(20);
     expect(migrated.nextState?.aggregate.tokens).toBe(260);
     expect(migrated.nextState?.aggregate.messages).toBe(3);
-    expect(replay.increments).toEqual({});
+    expectCreditedNothing(replay);
   });
 
   it("spends provable lifetime growth when bucket budgets are jointly infeasible", () => {
@@ -755,7 +771,7 @@ describe("non-destructive parser generation high-water", () => {
     expect(grown.increments["2026-07-01"].models["model-a"].input).toBe(10);
     expect(grown.increments["2026-07-01"].models["model-b"].output).toBe(10);
     expect(grown.nextState?.aggregate.tokens).toBe(25);
-    expect(replay.increments).toEqual({});
+    expectCreditedNothing(replay);
   });
 
   it("prefers genuine observed growth before deterministic residual capacity", () => {
@@ -838,7 +854,7 @@ describe("non-destructive parser generation high-water", () => {
 
     expect(grown.increments["2026-07-02"].models["model-a"].input).toBe(50);
     expect(grown.increments["2026-07-02"].tokens).toBe(50);
-    expect(replay.increments).toEqual({});
+    expectCreditedNothing(replay);
   });
 
   it("does not reserve cross-cell inclusive growth for an unsupported cache shift", () => {
@@ -906,7 +922,7 @@ describe("non-destructive parser generation high-water", () => {
     expect(grown.increments["2026-07-01"].models["a-cache-shift"]).toBeUndefined();
     expect(grown.increments["2026-07-01"].models["z-growing"].input).toBe(50);
     expect(grown.increments["2026-07-01"].tokens).toBe(50);
-    expect(replay.increments).toEqual({});
+    expectCreditedNothing(replay);
   });
 
   it("caps cell-supported cache moves by aggregate cache growth", () => {
@@ -954,7 +970,7 @@ describe("non-destructive parser generation high-water", () => {
     expect(grown.increments["2026-07-01"].models["a-cache-move"]).toBeUndefined();
     expect(grown.increments["2026-07-01"].models["z-input-growth"].input).toBe(50);
     expect(grown.increments["2026-07-01"].tokens).toBe(50);
-    expect(replay.increments).toEqual({});
+    expectCreditedNothing(replay);
   });
 
   it("allows genuine fully-cached inclusive-input growth", () => {


### PR DESCRIPTION
Nine replay assertions checked only `increments` being empty. A frozen
plan returns `{ mode: "freeze", increments: {} }`, so every one of them
passed just as happily when the state had been rejected on read -- and
those two outcomes are opposites. One is correct idempotency; the other is
a user whose high-water quietly stopped accepting anything.

Forcing `validState` to reject and diffing the failures shows the gap is
real but narrow: 29 tests fail without the mode check, 31 with it. The two
it uniquely catches are `normalizes old nested models that predate the
reasoning bucket` and `preserves scalar usage not represented by a partial
nested-model map` -- exactly the tests that exist to prove
`normalizeStateDays` is lossless, and therefore exactly the ones that must
be able to tell "lossless" apart from "rejected".

No behaviour change, and no live defect behind this: all 60 pass unmodified
against the current source, so no path presently writes a state that its
own `validState` refuses.

Constraint: `increments: {}` is ambiguous between success and freeze, so mode must be asserted alongside it
Rejected: Assert `nextState` equality everywhere instead | only one replay compares whole states, and the rest have no stable expected state to compare against
Confidence: high
Scope-risk: narrow
Directive: Do not collapse expectCreditedNothing back to a bare increments check -- the freeze case is invisible without the mode assertion

---

Found while reviewing #1220 after the fact. No behaviour change — this
hardens the tests only.

**Evidence:** forcing `validState` to reject and diffing the failures shows the
gap is real but narrow: 29 tests fail without the mode check, 31 with it. The
two it uniquely catches are the tests that exist to prove `normalizeStateDays`
is lossless — and therefore exactly the ones that must be able to tell
"lossless" apart from "rejected".

All 60 pass unmodified against the current source, so **there is no live
defect** behind this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the high-water replay tests so they can tell "credited nothing" apart from "frozen". A frozen plan returns `{ mode: "freeze", increments: {} }`, so the old assertions passed even when the state had been rejected on read.

- Adds an `expectCreditedNothing` helper that asserts the mode is not freeze alongside empty increments.
- Forcing `validState` to reject shows 29 tests fail without the check, 31 with it; the two newly caught are the lossless-normalization tests.
- No behavior change and no live defect — all 60 pass against the current source.

<sup>Written for commit 7921924d973348f6450b5c4bd681e8a0e97576de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


