### PR TITLE
fix: close eleven defects found by adversarial review

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -212,6 +212,12 @@ async fn call_rpc(port: u16) -> Result<QuotaSummary> {
     // RPC client in `crate::antigravity` is built the same way.
     let client = reqwest::Client::builder()
         .no_proxy()
+        // Redirects are refused for the same reason the proxy is: discovery
+        // probes ports that may belong to anything, and reqwest follows up to
+        // ten redirects by default. A stale or hostile local listener answering
+        // 307 with an external URL would carry the request off loopback, and
+        // the remote answer would then be accepted as a quota summary.
+        .redirect(reqwest::redirect::Policy::none())
         .timeout(PROBE_TIMEOUT)
         .build()?;
     let response = client

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -135,7 +135,7 @@ fn output_for_group(group: QuotaGroup) -> UsageOutput {
         credential_source: None,
         plan: None,
         email: None,
-        metrics: group.buckets.into_iter().map(metric).collect(),
+        metrics: group.buckets.into_iter().filter_map(metric).collect(),
         reset_credits: None,
         credit_status: None,
         spend_control: None,
@@ -157,13 +157,25 @@ fn slug(name: &str) -> String {
         .to_string()
 }
 
-fn metric(bucket: QuotaBucket) -> UsageMetric {
+/// Build a metric for one bucket, or `None` when the server did not say how
+/// much is left.
+///
+/// Defaulting a missing `remainingFraction` to zero renders as "100% used" --
+/// a full-exhaustion warning invented out of an absent field. Version skew or a
+/// partial response is exactly when that would fire, so a bucket that cannot
+/// state its own remainder is dropped instead of being reported as spent. A
+/// group whose buckets all drop shows no rows rather than a false alarm.
+fn metric(bucket: QuotaBucket) -> Option<UsageMetric> {
     // The wire format reports what is **left**; `UsageMetric` leads with what
     // has been used. Getting this backwards turns "7% left" into "7% used",
     // which is the most dangerous way to be wrong about a quota.
-    let remaining = bucket.remaining_fraction.unwrap_or(0.0).clamp(0.0, 1.0) * 100.0;
+    let remaining = bucket
+        .remaining_fraction
+        .filter(|fraction| fraction.is_finite())?
+        .clamp(0.0, 1.0)
+        * 100.0;
 
-    UsageMetric {
+    Some(UsageMetric {
         // `displayName` reads "Weekly Limit Remaining", which is too long for a
         // card once the group name is also shown; `window` is the short form.
         label: bucket
@@ -174,7 +186,7 @@ fn metric(bucket: QuotaBucket) -> UsageMetric {
         remaining_percent: remaining,
         remaining_label: None,
         resets_at: bucket.reset_time,
-    }
+    })
 }
 
 /// Byte ceiling for one quota response.
@@ -192,7 +204,16 @@ fn metric(bucket: QuotaBucket) -> UsageMetric {
 const MAX_QUOTA_BODY_BYTES: usize = 1024 * 1024;
 
 async fn call_rpc(port: u16) -> Result<QuotaSummary> {
-    let client = reqwest::Client::builder().timeout(PROBE_TIMEOUT).build()?;
+    // `.no_proxy()` because this only ever targets 127.0.0.1: the default
+    // builder honours HTTP_PROXY/system proxy settings, which would send a
+    // loopback quota request to a remote host unless the user happens to have
+    // a matching NO_PROXY. That both leaks quota metadata and lets the proxy
+    // forge the unauthenticated response that port discovery trusts. The IDE
+    // RPC client in `crate::antigravity` is built the same way.
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .timeout(PROBE_TIMEOUT)
+        .build()?;
     let response = client
         .post(format!("http://127.0.0.1:{port}{RPC_PATH}"))
         // Connect-RPC rejects the request without this header.
@@ -348,7 +369,8 @@ mod tests {
             window: Some("weekly".to_string()),
             remaining_fraction: Some(0.414_529_86),
             reset_time: Some("2026-08-29T03:58:44Z".to_string()),
-        });
+        })
+        .expect("a bucket that states its remainder yields a metric");
 
         assert_eq!(m.label, "weekly");
         assert!((m.remaining_percent - 41.452_986).abs() < 1e-6);
@@ -362,7 +384,8 @@ mod tests {
             window: None,
             remaining_fraction: Some(1.0),
             reset_time: None,
-        });
+        })
+        .expect("a bucket that states its remainder yields a metric");
         assert_eq!(m.label, "Weekly Limit Remaining");
     }
 
@@ -374,10 +397,62 @@ mod tests {
                 window: None,
                 remaining_fraction: Some(fraction),
                 reset_time: None,
-            });
+            })
+            .expect("a finite fraction yields a metric");
             assert!((0.0..=100.0).contains(&m.remaining_percent));
             assert!((0.0..=100.0).contains(&m.used_percent));
         }
+    }
+
+    /// A bucket that does not say how much is left must not be rendered as
+    /// fully spent. Defaulting the absent value to zero remaining shows "100%
+    /// used" -- an exhaustion warning invented from a missing field, and
+    /// version skew or a truncated response is exactly when it would fire.
+    #[test]
+    fn a_bucket_without_a_usable_remainder_is_dropped_not_reported_as_spent() {
+        for fraction in [
+            None,
+            Some(f64::NAN),
+            Some(f64::INFINITY),
+            Some(f64::NEG_INFINITY),
+        ] {
+            let dropped = metric(QuotaBucket {
+                display_name: "Weekly Limit Remaining".to_string(),
+                window: Some("weekly".to_string()),
+                remaining_fraction: fraction,
+                reset_time: None,
+            });
+            assert!(
+                dropped.is_none(),
+                "remaining_fraction={fraction:?} must not render as a quota row"
+            );
+        }
+    }
+
+    /// The drop is per bucket: a group keeps the buckets that are readable.
+    #[test]
+    fn a_group_keeps_its_readable_buckets_when_one_is_unusable() {
+        let output = output_for_group(QuotaGroup {
+            display_name: "Gemini Models".to_string(),
+            buckets: vec![
+                QuotaBucket {
+                    display_name: "Weekly".to_string(),
+                    window: Some("weekly".to_string()),
+                    remaining_fraction: None,
+                    reset_time: None,
+                },
+                QuotaBucket {
+                    display_name: "Five Hour".to_string(),
+                    window: Some("5h".to_string()),
+                    remaining_fraction: Some(0.25),
+                    reset_time: None,
+                },
+            ],
+        });
+
+        assert_eq!(output.metrics.len(), 1);
+        assert_eq!(output.metrics[0].label, "5h");
+        assert!((output.metrics[0].used_percent - 75.0).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -9753,10 +9753,14 @@ mod tests {
     fn create_timed_opencode_db(db_path: &std::path::Path) -> rusqlite::Connection {
         let conn = rusqlite::Connection::open(db_path).unwrap();
         conn.execute_batch(
+            // `session.time_updated` matches the real schema: a rename moves it
+            // without touching a message row, so it is what the incremental
+            // scan watches to know cached titles and workspaces are still good.
             "CREATE TABLE session (
                  id TEXT PRIMARY KEY,
                  directory TEXT NOT NULL,
-                 title TEXT
+                 title TEXT,
+                 time_updated INTEGER NOT NULL
              );
              CREATE TABLE message (
                  id TEXT PRIMARY KEY,
@@ -9765,8 +9769,8 @@ mod tests {
                  time_updated INTEGER NOT NULL,
                  data TEXT NOT NULL
              );
-             INSERT INTO session (id, directory, title)
-             VALUES ('session-1', '/tmp/project', 'A session');",
+             INSERT INTO session (id, directory, title, time_updated)
+             VALUES ('session-1', '/tmp/project', 'A session', 500);",
         )
         .unwrap();
         conn

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -1768,22 +1768,35 @@ fn uses_openai_full_request_272k_pricing(result: &LookupResult, provider_id: Opt
 /// pricing table: https://docs.x.ai/developers/pricing.
 fn uses_xai_full_request_200k_pricing(result: &LookupResult, provider_id: Option<&str>) -> bool {
     let provider_id = normalize_provider_hint(provider_id);
-    if result.source != "LiteLLM"
-        || provider_id.is_some_and(|provider| {
-            provider_identity::canonical_provider(provider).as_deref() != Some("xai")
-        })
-    {
+    let hinted_xai = provider_id.is_some_and(|provider| {
+        provider_identity::canonical_provider(provider).as_deref() == Some("xai")
+    });
+    if provider_id.is_some() && !hinted_xai {
         return false;
     }
 
     let key = result.matched_key.trim().to_ascii_lowercase();
     let mut parts = key.split('/');
-    let (Some(provider), Some(model), None) = (parts.next(), parts.next(), parts.next()) else {
-        return false;
+    let identifies_xai_grok = match (parts.next(), parts.next(), parts.next()) {
+        // `xai/grok-*` from the upstream catalog.
+        (Some(provider), Some(model), None) => {
+            result.source == "LiteLLM"
+                && provider_identity::canonical_provider(provider).as_deref() == Some("xai")
+                && model.starts_with("grok-")
+        }
+        // A bare `grok-*` from the built-in Cursor table, which is how that
+        // table keys it. Those rows are transcribed from xAI's own published
+        // tariff -- the same numbers, including the >200K tier -- so billing
+        // them progressively while the upstream row bills request-wide made the
+        // identical request cost half as much depending on which dataset
+        // resolved it. The xAI hint is required, because a bare `grok-*` says
+        // nothing about who billed it.
+        (Some(model), None, None) => {
+            result.source == "Cursor" && hinted_xai && model.starts_with("grok-")
+        }
+        _ => false,
     };
-    if provider_identity::canonical_provider(provider).as_deref() != Some("xai")
-        || !model.starts_with("grok-")
-    {
+    if !identifies_xai_grok {
         return false;
     }
 

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -540,6 +540,57 @@ mod tests {
         )
     }
 
+    /// The same Grok request must cost the same whichever dataset priced it.
+    ///
+    /// xAI documents the >200K rate as request-wide. The upstream `xai/grok-*`
+    /// row was billed that way while the built-in Cursor row -- transcribed
+    /// from the same published tariff, and keyed bare as `grok-4.6` -- fell
+    /// through to progressive billing, halving the cost of a long request.
+    #[test]
+    fn cursor_grok_long_context_bills_request_wide_like_the_upstream_row() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let usage = TokenBreakdown {
+            input: 150_000,
+            output: 10_000,
+            cache_read: 50_000,
+            cache_write: 0,
+            reasoning: 0,
+        };
+
+        let resolved = service
+            .lookup_with_source_and_provider("grok-4.6", None, Some("xai"))
+            .expect("the built-in Cursor row prices grok-4.6");
+        assert_eq!(resolved.source, "Cursor");
+        assert_eq!(resolved.matched_key, "grok-4.6");
+
+        // 210K total crosses the boundary, so every bucket bills at the high
+        // rate: 150k*4 + 10k*12 + 50k*1 per million.
+        let cost = service.calculate_cost_with_provider("grok-4.6", Some("xai"), &usage);
+        assert!(
+            (cost - 0.770).abs() < 1e-9,
+            "request-wide pricing expected, got {cost}"
+        );
+    }
+
+    /// Without an xAI hint a bare `grok-*` says nothing about who billed it, so
+    /// the request-wide rule must not apply.
+    #[test]
+    fn an_unhinted_bare_grok_row_keeps_progressive_pricing() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let usage = TokenBreakdown {
+            input: 150_000,
+            output: 10_000,
+            cache_read: 50_000,
+            cache_write: 0,
+            reasoning: 0,
+        };
+        let cost = service.calculate_cost_with_provider("grok-4.6", Some("openrouter"), &usage);
+        assert!(
+            (cost - 0.770).abs() > 1e-9,
+            "an unrelated provider hint must not get request-wide pricing: {cost}"
+        );
+    }
+
     fn cache_read_usage() -> TokenBreakdown {
         TokenBreakdown {
             input: 1_000_000,

--- a/crates/tokscale-core/src/sessions/lmstudio.rs
+++ b/crates/tokscale-core/src/sessions/lmstudio.rs
@@ -36,6 +36,13 @@ const SERVER_LOG_WINDOW_BYTES: usize = 8 * 1024 * 1024;
 /// Bytes pulled from the log per read.
 const SERVER_LOG_CHUNK_BYTES: usize = 64 * 1024;
 
+/// How far past an eviction boundary the identity scan reads.
+///
+/// Enough to span a whole `"id"` / `"model"` field or a log header, so a field
+/// straddling the cut is still recovered. These are short: a response id is
+/// tens of bytes and a header under fifty.
+const IDENTITY_OVERLAP_BYTES: usize = 512;
+
 #[derive(Debug, Default, Deserialize)]
 struct PromptTokenDetails {
     #[serde(default, alias = "cache_read_tokens")]
@@ -223,24 +230,36 @@ fn last_json_string_field(bytes: &[u8], field: &[u8]) -> Option<String> {
     found
 }
 
+/// Timestamp of the last LM Studio log header in `bytes`.
+///
+/// Anchored to the header's shape -- `[<ts>]` at the start of a line and
+/// immediately followed by `[` -- rather than to any bracketed date. A model
+/// that prints `[2020-01-01 00:00:00]` in its answer lands *after* the real
+/// header in this region, so a last-match-wins scan over bare brackets would
+/// date the usage from the model's own output.
 fn last_log_timestamp(bytes: &[u8]) -> Option<i64> {
     let text = String::from_utf8_lossy(bytes);
-    let mut remainder = text.as_ref();
     let mut parsed = None;
-    while let Some(start) = remainder.find('[') {
-        let after = &remainder[start + 1..];
-        let Some(end) = after.find(']') else {
-            break;
+    for line in text.split('\n') {
+        let line = line.strip_prefix('\r').unwrap_or(line);
+        let Some(rest) = line.strip_prefix('[') else {
+            continue;
         };
-        let candidate = &after[..end];
-        if let Ok(naive) = NaiveDateTime::parse_from_str(candidate, "%Y-%m-%d %H:%M:%S") {
-            parsed = match Local.from_local_datetime(&naive) {
-                LocalResult::Single(value) => Some(value.timestamp_millis()),
-                LocalResult::Ambiguous(first, _) => Some(first.timestamp_millis()),
-                LocalResult::None => parsed,
-            };
+        let Some(end) = rest.find(']') else {
+            continue;
+        };
+        // The header always continues into its next bracketed field.
+        if !rest[end + 1..].starts_with('[') {
+            continue;
         }
-        remainder = &after[end + 1..];
+        let Ok(naive) = NaiveDateTime::parse_from_str(&rest[..end], "%Y-%m-%d %H:%M:%S") else {
+            continue;
+        };
+        parsed = match Local.from_local_datetime(&naive) {
+            LocalResult::Single(value) => Some(value.timestamp_millis()),
+            LocalResult::Ambiguous(first, _) => Some(first.timestamp_millis()),
+            LocalResult::None => parsed,
+        };
     }
     parsed
 }
@@ -348,6 +367,9 @@ fn parse_lmstudio_file_windowed(
     // window does not rescan what it has seen.
     let mut scanned_to = 0usize;
     let mut chunk = vec![0u8; chunk_bytes.max(1)];
+    // Identity recovered from bytes the window had to evict before the record
+    // they belong to was complete.
+    let mut carried = CarriedIdentity::default();
 
     loop {
         let read = reader.read(&mut chunk).unwrap_or(0);
@@ -385,6 +407,7 @@ fn parse_lmstudio_file_windowed(
             if let Some(message) = message_from_record(
                 &window[object_start..object_end],
                 &window[metadata_from..marker],
+                &carried,
                 path,
                 absolute_marker,
                 &session_id,
@@ -393,6 +416,7 @@ fn parse_lmstudio_file_windowed(
                 messages.push(message);
             }
             metadata_start = absolute_end;
+            carried.clear();
         }
 
         // Release what is behind the next record's metadata. Everything before
@@ -406,11 +430,26 @@ fn parse_lmstudio_file_windowed(
             window_start += keep_from;
         }
 
-        // A single record larger than the window would otherwise grow it
-        // without bound, which is the failure this window exists to prevent.
-        // Dropping it costs that one response and keeps the rest of the file.
+        // A response body longer than the window pushes its own header out of
+        // it. That header is where the response id, the model, and the log
+        // timestamp live, so evicting it blind would leave the record with an
+        // unknown model, the file's mtime for a date, and a path-derived dedup
+        // key -- which stops matching the same response in a mirrored log and
+        // drifts the date every time the file is appended to. The identity is
+        // therefore lifted out of the bytes on their way past.
         if window.len() > window_bytes {
             let overflow = window.len() - window_bytes;
+            // Read past the cut before dropping: the eviction boundary falls
+            // wherever the refill arithmetic puts it, which is happily in the
+            // middle of `"id":"chatcmpl-..."`. A field split across the cut
+            // would be in neither the evicted slice nor the retained window.
+            // The overlap only reaches forward into bytes that are still ahead
+            // of the current record's marker, so it cannot pick up a later
+            // record's identity.
+            let absorb_to = overflow
+                .saturating_add(IDENTITY_OVERLAP_BYTES)
+                .min(window.len());
+            carried.absorb(&window[..absorb_to]);
             window.drain(..overflow);
             window_start += overflow;
             metadata_start = metadata_start.max(window_start);
@@ -429,9 +468,56 @@ fn parse_lmstudio_file_windowed(
 ///
 /// Split out of the scan loop so the loop deals only in window arithmetic:
 /// this half sees two slices and never an offset it has to translate.
+/// Response identity rescued from window bytes before they were dropped.
+///
+/// A record's `id`, `model` and log timestamp sit ahead of its `usage` object,
+/// so a long response body can push them out of the window before the record
+/// completes. Keeping them here makes the result independent of where the
+/// buffer boundaries happened to fall.
+#[derive(Default)]
+struct CarriedIdentity {
+    response_id: Option<String>,
+    model: Option<String>,
+    timestamp: Option<i64>,
+}
+
+impl CarriedIdentity {
+    /// Take the identity out of bytes about to be discarded. Later bytes win,
+    /// matching the "last one before the usage object" rule applied to a window
+    /// that still holds them.
+    fn absorb(&mut self, bytes: &[u8]) {
+        if let Some(id) = response_id_in(bytes) {
+            self.response_id = Some(id);
+        }
+        if let Some(model) = model_in(bytes) {
+            self.model = Some(model);
+        }
+        if let Some(timestamp) = last_log_timestamp(bytes) {
+            self.timestamp = Some(timestamp);
+        }
+    }
+
+    fn clear(&mut self) {
+        *self = Self::default();
+    }
+}
+
+fn response_id_in(bytes: &[u8]) -> Option<String> {
+    last_json_string_field(bytes, b"id").filter(|value| {
+        ["chatcmpl-", "cmpl-", "resp_"]
+            .iter()
+            .any(|prefix| value.starts_with(prefix))
+    })
+}
+
+fn model_in(bytes: &[u8]) -> Option<String> {
+    last_json_string_field(bytes, b"model").filter(|value| !value.trim().is_empty())
+}
+
 fn message_from_record(
     usage_object: &[u8],
     metadata: &[u8],
+    carried: &CarriedIdentity,
     path: &Path,
     marker: usize,
     session_id: &str,
@@ -440,15 +526,15 @@ fn message_from_record(
     let usage = serde_json::from_slice::<UsagePayload>(usage_object).ok()?;
     let tokens = normalized_tokens(&usage)?;
 
-    let response_id = last_json_string_field(metadata, b"id").filter(|value| {
-        ["chatcmpl-", "cmpl-", "resp_"]
-            .iter()
-            .any(|prefix| value.starts_with(prefix))
-    });
-    let model = last_json_string_field(metadata, b"model")
-        .filter(|value| !value.trim().is_empty())
+    // What the window still holds is nearer the usage object than anything
+    // evicted, so it wins; the carried value is the fallback, not the default.
+    let response_id = response_id_in(metadata).or_else(|| carried.response_id.clone());
+    let model = model_in(metadata)
+        .or_else(|| carried.model.clone())
         .unwrap_or_else(|| "unknown".to_string());
-    let timestamp = last_log_timestamp(metadata).unwrap_or(fallback_timestamp);
+    let timestamp = last_log_timestamp(metadata)
+        .or(carried.timestamp)
+        .unwrap_or(fallback_timestamp);
     if timestamp <= 0 {
         return None;
     }
@@ -550,6 +636,67 @@ mod tests {
                 "window={window} chunk={chunk} changed the parse"
             );
         }
+    }
+
+    /// A response body long enough to evict its own header must still be
+    /// attributed to the right model, date and response id.
+    ///
+    /// Without carrying the identity past eviction the record falls back to an
+    /// unknown model, the file's mtime, and a path-derived dedup key -- which
+    /// stops matching the same response in a mirrored log and moves the date
+    /// every time the file is appended to.
+    #[test]
+    fn a_response_that_outgrows_the_window_keeps_its_identity() {
+        let mut file = NamedTempFile::new().unwrap();
+        // Header and identity first, then a body far longer than the window,
+        // then the usage object -- the real shape of a long completion.
+        let body = "b".repeat(4096);
+        write!(
+            file,
+            "[2026-07-09 10:00:00][INFO][fixture-model]\n\
+             Final response: {{\"id\":\"chatcmpl-far\",\"model\":\"big-model\",\
+             \"choices\":[{{\"text\":\"{body}\"}}],\
+             \"usage\":{{\"prompt_tokens\":31,\"completion_tokens\":7,\"total_tokens\":38}}}}\n"
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_lmstudio_file_windowed(file.path(), 512, 64);
+        assert_eq!(messages.len(), 1, "the record must survive eviction");
+        let message = &messages[0];
+        assert_eq!(
+            message.dedup_key.as_deref(),
+            Some("lmstudio:chatcmpl-far"),
+            "the response id must survive its own body"
+        );
+        assert_eq!(message.model_id, "big-model");
+        assert_eq!(message.tokens.input, 31);
+        // 2026-07-09 local, not the file's mtime.
+        assert_eq!(message.date, "2026-07-09");
+        // And the windowed parse agrees with the unwindowed one.
+        assert_eq!(messages, parse_lmstudio_file(file.path()));
+    }
+
+    /// A bracketed date inside the model's answer is not a log header.
+    #[test]
+    fn a_timestamp_printed_by_the_model_is_not_taken_as_the_log_time() {
+        let mut file = NamedTempFile::new().unwrap();
+        write!(
+            file,
+            "[2026-07-09 10:00:00][INFO][fixture-model]\n\
+             Final response: {{\"id\":\"chatcmpl-quoted\",\"model\":\"fixture-model\",\
+             \"choices\":[{{\"text\":\"the log said [2019-03-04 05:06:07] earlier\"}}],\
+             \"usage\":{{\"prompt_tokens\":12,\"completion_tokens\":3,\"total_tokens\":15}}}}\n"
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_lmstudio_file(file.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].date, "2026-07-09",
+            "the header dates the usage, not a date the model printed"
+        );
     }
 
     /// A record whose own bytes exceed the window is dropped, and only it.

--- a/crates/tokscale-core/src/sessions/lmstudio.rs
+++ b/crates/tokscale-core/src/sessions/lmstudio.rs
@@ -17,31 +17,24 @@ use std::path::Path;
 
 const USAGE_MARKER: &[u8] = b"\"usage\"";
 
-/// Ceiling on one server log read into memory.
+/// Bytes of one server log held in memory at a time.
 ///
 /// `server-logs/` accumulates every request and response the local server
-/// handled, including full prompt and completion bodies, and nothing rotates
-/// or truncates it -- a long-running server produces a single file that grows
-/// without bound. The parser only ever reads the `usage` objects out of it, so
-/// declining an oversized log costs the usage recorded in that one file and
-/// leaves every other log intact, which is the same outcome an unreadable file
-/// already produces here.
+/// handled, prompt and completion bodies included, and nothing rotates it -- a
+/// long-running server produces one file that grows without bound. Reading it
+/// whole puts that growth into the scan's peak.
 ///
-/// Sized to match the sibling parsers that made the same trade
-/// (`droid::MAX_TRANSCRIPT_BYTES`, `dsh::MAX_TRANSCRIPT_FILE_BYTES`).
-const MAX_SERVER_LOG_BYTES: u64 = 32 * 1024 * 1024;
+/// Refusing an oversized log is not an option either: these logs only grow, so
+/// every mature install would eventually cross any fixed ceiling and then lose
+/// *all* of its usage, past and future, with no diagnostic. The window instead
+/// bounds what one file costs while still reading every record in it.
+///
+/// A record is a `usage` object plus the log lines immediately before it, so
+/// records are local and a window this size holds many at once.
+const SERVER_LOG_WINDOW_BYTES: usize = 8 * 1024 * 1024;
 
-/// Read a server log, refusing one past [`MAX_SERVER_LOG_BYTES`].
-///
-/// Reads one byte past the ceiling rather than trusting `metadata().len()`:
-/// the log is appended to while the scan runs, so a size checked before the
-/// read is a size that can grow before the read finishes.
-fn read_server_log_bounded(path: &Path, max_bytes: u64) -> Option<Vec<u8>> {
-    let file = std::fs::File::open(path).ok()?;
-    let mut bytes = Vec::new();
-    file.take(max_bytes + 1).read_to_end(&mut bytes).ok()?;
-    (bytes.len() as u64 <= max_bytes).then_some(bytes)
-}
+/// Bytes pulled from the log per read.
+const SERVER_LOG_CHUNK_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Default, Deserialize)]
 struct PromptTokenDetails {
@@ -112,23 +105,45 @@ fn skip_ascii_whitespace(bytes: &[u8], mut index: usize) -> usize {
     index
 }
 
-fn usage_object_start(bytes: &[u8], from: usize) -> Option<(usize, usize)> {
+/// Find the next `"usage": {`, and report how far the scan is *certain* of.
+///
+/// The second value is the first offset that might still begin a match. A
+/// streaming caller must not advance its scan floor past it: `"usage"` is only
+/// accepted once a colon, any whitespace, and an opening brace follow, so a
+/// refill boundary landing anywhere in that run leaves a marker that this call
+/// rejects but a later one would accept. Advancing past it drops the record for
+/// good -- silently, because the bytes are then behind the window.
+fn scan_usage_object_start(bytes: &[u8], from: usize) -> (Option<(usize, usize)>, usize) {
     let mut cursor = from;
     while let Some(marker) = find_bytes(bytes, USAGE_MARKER, cursor) {
         cursor = marker + USAGE_MARKER.len();
         if marker > 0 && bytes[marker - 1] == b'\\' {
             continue;
         }
-        let mut value = skip_ascii_whitespace(bytes, cursor);
-        if bytes.get(value) != Some(&b':') {
+        let value = skip_ascii_whitespace(bytes, cursor);
+        // Ran out of buffer inside the run this match needs: undecidable here.
+        if value >= bytes.len() {
+            return (None, marker);
+        }
+        if bytes[value] != b':' {
             continue;
         }
-        value = skip_ascii_whitespace(bytes, value + 1);
-        if bytes.get(value) == Some(&b'{') {
-            return Some((marker, value));
+        let brace = skip_ascii_whitespace(bytes, value + 1);
+        if brace >= bytes.len() {
+            return (None, marker);
+        }
+        if bytes[brace] == b'{' {
+            return (Some((marker, brace)), marker);
         }
     }
-    None
+    // No marker matched. A marker split across the boundary could still start
+    // in the final `USAGE_MARKER.len() - 1` bytes.
+    (
+        None,
+        bytes
+            .len()
+            .saturating_sub(USAGE_MARKER.len().saturating_sub(1)),
+    )
 }
 
 fn balanced_object_end(bytes: &[u8], start: usize) -> Option<usize> {
@@ -298,63 +313,162 @@ fn fallback_dedup_key(path: &Path, marker: usize, model: &str, tokens: &TokenBre
 }
 
 pub fn parse_lmstudio_file(path: &Path) -> Vec<UnifiedMessage> {
-    let Some(bytes) = read_server_log_bounded(path, MAX_SERVER_LOG_BYTES) else {
+    parse_lmstudio_file_windowed(path, SERVER_LOG_WINDOW_BYTES, SERVER_LOG_CHUNK_BYTES)
+}
+
+/// [`parse_lmstudio_file`] with the buffer sizes injected.
+///
+/// The window and chunk are parameters purely so tests can drive the boundary
+/// arithmetic with a few hundred bytes instead of writing an 8 MiB fixture --
+/// the paths that matter here are "a record straddles a refill" and "a record
+/// exceeds the window", and both are about the boundary, not its size.
+fn parse_lmstudio_file_windowed(
+    path: &Path,
+    window_bytes: usize,
+    chunk_bytes: usize,
+) -> Vec<UnifiedMessage> {
+    let Ok(file) = std::fs::File::open(path) else {
         return Vec::new();
     };
+    let mut reader = std::io::BufReader::new(file);
     let fallback_timestamp = file_modified_timestamp_ms(path);
     let session_id = format!("lmstudio:{}", source_hash(path));
     let mut messages = Vec::new();
-    let mut cursor = 0usize;
-    let mut metadata_start = 0usize;
 
-    while let Some((marker, object_start)) = usage_object_start(&bytes, cursor) {
-        let Some(object_end) = balanced_object_end(&bytes, object_start) else {
-            break;
-        };
-        cursor = object_end;
-        let Ok(usage) = serde_json::from_slice::<UsagePayload>(&bytes[object_start..object_end])
-        else {
-            metadata_start = object_end;
-            continue;
-        };
-        let Some(tokens) = normalized_tokens(&usage) else {
-            metadata_start = object_end;
-            continue;
-        };
-        let metadata = &bytes[metadata_start..marker];
-        let response_id = last_json_string_field(metadata, b"id").filter(|value| {
-            ["chatcmpl-", "cmpl-", "resp_"]
-                .iter()
-                .any(|prefix| value.starts_with(prefix))
-        });
-        let model = last_json_string_field(metadata, b"model")
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or_else(|| "unknown".to_string());
-        let timestamp = last_log_timestamp(metadata).unwrap_or(fallback_timestamp);
-        if timestamp <= 0 {
-            metadata_start = object_end;
-            continue;
+    // `window` is the part of the log not yet turned into messages.
+    // `window_start` is its absolute offset in the file, which is what keeps
+    // `fallback_dedup_key` addressing the same byte it addressed when this
+    // parser read the whole file at once -- a shifted offset would mint new
+    // dedup keys for records already submitted.
+    let mut window: Vec<u8> = Vec::new();
+    let mut window_start = 0usize;
+    // Absolute offset where the metadata for the next record begins.
+    let mut metadata_start = 0usize;
+    // Absolute offset the marker search has already ruled out, so refilling the
+    // window does not rescan what it has seen.
+    let mut scanned_to = 0usize;
+    let mut chunk = vec![0u8; chunk_bytes.max(1)];
+
+    loop {
+        let read = reader.read(&mut chunk).unwrap_or(0);
+        if read > 0 {
+            window.extend_from_slice(&chunk[..read]);
         }
-        let dedup_key = response_id
-            .map(|id| format!("lmstudio:{id}"))
-            .unwrap_or_else(|| fallback_dedup_key(path, marker, &model, &tokens));
-        let mut message = UnifiedMessage::new_with_dedup(
-            "lmstudio",
-            model,
-            "lmstudio",
-            session_id.clone(),
-            timestamp,
-            tokens,
-            0.0,
-            Some(dedup_key),
-        );
-        message.mark_provider_reported_cost();
-        message.is_turn_start = true;
-        messages.push(message);
-        metadata_start = object_end;
+        let at_eof = read == 0;
+
+        // Drain every record the window now holds in full.
+        loop {
+            let scan_from = scanned_to.saturating_sub(window_start).min(window.len());
+            let (found, certain_to) = scan_usage_object_start(&window, scan_from);
+            let Some((marker, object_start)) = found else {
+                // Only what the scan is certain about may be retired; the rest
+                // has to be rescanned once more bytes arrive.
+                scanned_to = window_start + certain_to;
+                break;
+            };
+            let Some(object_end) = balanced_object_end(&window, object_start) else {
+                // The object is cut off by the window edge. Leave the scan
+                // floor *behind* the marker so the next refill re-finds it;
+                // at EOF it will never complete, so retire it instead.
+                scanned_to = if at_eof {
+                    window_start + window.len()
+                } else {
+                    window_start + marker
+                };
+                break;
+            };
+            scanned_to = window_start + object_end;
+
+            let absolute_marker = window_start + marker;
+            let absolute_end = window_start + object_end;
+            let metadata_from = metadata_start.saturating_sub(window_start).min(marker);
+            if let Some(message) = message_from_record(
+                &window[object_start..object_end],
+                &window[metadata_from..marker],
+                path,
+                absolute_marker,
+                &session_id,
+                fallback_timestamp,
+            ) {
+                messages.push(message);
+            }
+            metadata_start = absolute_end;
+        }
+
+        // Release what is behind the next record's metadata. Everything before
+        // it has already produced whatever messages it was going to.
+        let keep_from = metadata_start
+            .max(window_start)
+            .saturating_sub(window_start)
+            .min(window.len());
+        if keep_from > 0 {
+            window.drain(..keep_from);
+            window_start += keep_from;
+        }
+
+        // A single record larger than the window would otherwise grow it
+        // without bound, which is the failure this window exists to prevent.
+        // Dropping it costs that one response and keeps the rest of the file.
+        if window.len() > window_bytes {
+            let overflow = window.len() - window_bytes;
+            window.drain(..overflow);
+            window_start += overflow;
+            metadata_start = metadata_start.max(window_start);
+            scanned_to = scanned_to.max(window_start);
+        }
+
+        if at_eof {
+            break;
+        }
     }
 
     messages
+}
+
+/// Build one message from a `usage` object and the log text before it.
+///
+/// Split out of the scan loop so the loop deals only in window arithmetic:
+/// this half sees two slices and never an offset it has to translate.
+fn message_from_record(
+    usage_object: &[u8],
+    metadata: &[u8],
+    path: &Path,
+    marker: usize,
+    session_id: &str,
+    fallback_timestamp: i64,
+) -> Option<UnifiedMessage> {
+    let usage = serde_json::from_slice::<UsagePayload>(usage_object).ok()?;
+    let tokens = normalized_tokens(&usage)?;
+
+    let response_id = last_json_string_field(metadata, b"id").filter(|value| {
+        ["chatcmpl-", "cmpl-", "resp_"]
+            .iter()
+            .any(|prefix| value.starts_with(prefix))
+    });
+    let model = last_json_string_field(metadata, b"model")
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+    let timestamp = last_log_timestamp(metadata).unwrap_or(fallback_timestamp);
+    if timestamp <= 0 {
+        return None;
+    }
+
+    let dedup_key = response_id
+        .map(|id| format!("lmstudio:{id}"))
+        .unwrap_or_else(|| fallback_dedup_key(path, marker, &model, &tokens));
+    let mut message = UnifiedMessage::new_with_dedup(
+        "lmstudio",
+        model,
+        "lmstudio",
+        session_id.to_string(),
+        timestamp,
+        tokens,
+        0.0,
+        Some(dedup_key),
+    );
+    message.mark_provider_reported_cost();
+    message.is_turn_start = true;
+    Some(message)
 }
 
 #[cfg(test)]
@@ -363,34 +477,102 @@ mod tests {
     use std::io::Write;
     use tempfile::NamedTempFile;
 
+    /// One response preceded by `pad_bytes` of log filler, so a record is only
+    /// reachable by a parse that carries state across refills.
+    fn padded_log(index: usize, pad_bytes: usize) -> String {
+        format!(
+            "[filler] {}\n[2026-07-09 10:00:{:02}][INFO][fixture-model]\n\
+             Final response: {{\"id\":\"chatcmpl-{index}\",\"model\":\"fixture-model\",\
+             \"usage\":{{\"prompt_tokens\":{},\"completion_tokens\":5,\"total_tokens\":{}}}}}\n",
+            "p".repeat(pad_bytes),
+            index % 60,
+            10 + index,
+            15 + index,
+        )
+    }
+
+    /// Every record survives a log many times larger than the buffer holding
+    /// it, with records straddling refill boundaries.
+    ///
+    /// This is the regression that matters most in this file. Bounding the read
+    /// by *refusing* an oversized log turned "uses memory" into "loses every
+    /// record in that file, past and future, with no diagnostic" -- and these
+    /// logs only ever grow, so every mature install reaches it eventually.
     #[test]
-    fn reads_a_log_at_the_ceiling_and_refuses_one_past_it() {
-        let usage = br#"[2026-07-09 10:00:00][INFO][fixture-model]
-Final response: {"id":"chatcmpl-bound","model":"fixture-model","usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}
-"#;
+    fn reads_every_record_in_a_log_larger_than_the_window() {
+        let mut file = NamedTempFile::new().unwrap();
+        let records = 40;
+        for i in 0..records {
+            file.write_all(padded_log(i, 200).as_bytes()).unwrap();
+        }
+        file.flush().unwrap();
 
-        let mut at_ceiling = NamedTempFile::new().unwrap();
-        at_ceiling.write_all(usage).unwrap();
-        at_ceiling.flush().unwrap();
-        let size = at_ceiling.as_file().metadata().unwrap().len();
+        let size = file.as_file().metadata().unwrap().len() as usize;
+        // Deliberately far below the file: the window must not have to hold it.
+        let window = 512;
+        let chunk = 64;
+        assert!(size > window * 10, "fixture must dwarf the window");
+
+        let messages = parse_lmstudio_file_windowed(file.path(), window, chunk);
         assert_eq!(
-            read_server_log_bounded(at_ceiling.path(), size)
-                .as_deref()
-                .map(<[u8]>::len),
-            Some(usage.len()),
-            "a log exactly at the ceiling is still read"
+            messages.len(),
+            records,
+            "every record must survive a log the parse cannot hold at once"
         );
+        // Per-record values, so this also proves each usage object kept the
+        // metadata that preceded it rather than a neighbour's.
+        for (i, message) in messages.iter().enumerate() {
+            assert_eq!(message.tokens.input, 10 + i as i64);
+            assert_eq!(
+                message.dedup_key.as_deref(),
+                Some(&*format!("lmstudio:chatcmpl-{i}"))
+            );
+        }
+    }
 
+    /// Buffer sizes must not change what is parsed, only how much is resident.
+    #[test]
+    fn window_and_chunk_sizes_do_not_change_the_result() {
+        let mut file = NamedTempFile::new().unwrap();
+        for i in 0..12 {
+            file.write_all(padded_log(i, 300).as_bytes()).unwrap();
+        }
+        file.flush().unwrap();
+
+        let reference = parse_lmstudio_file(file.path());
+        assert_eq!(reference.len(), 12);
+        // Windows below one record length legitimately drop records, so
+        // the agreement claim only covers windows that can hold one.
+        for (window, chunk) in [(512, 1), (1024, 7), (4096, 64), (1 << 20, 1 << 16)] {
+            let windowed = parse_lmstudio_file_windowed(file.path(), window, chunk);
+            assert_eq!(
+                windowed, reference,
+                "window={window} chunk={chunk} changed the parse"
+            );
+        }
+    }
+
+    /// A record whose own bytes exceed the window is dropped, and only it.
+    #[test]
+    fn a_record_larger_than_the_window_does_not_take_the_file_with_it() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(padded_log(0, 32).as_bytes()).unwrap();
+        file.write_all(padded_log(1, 4096).as_bytes()).unwrap();
+        file.write_all(padded_log(2, 32).as_bytes()).unwrap();
+        file.flush().unwrap();
+
+        let keys: Vec<String> = parse_lmstudio_file_windowed(file.path(), 512, 64)
+            .into_iter()
+            .filter_map(|m| m.dedup_key)
+            .collect();
         assert!(
-            read_server_log_bounded(at_ceiling.path(), size - 1).is_none(),
-            "a log past the ceiling is refused rather than buffered"
+            keys.contains(&"lmstudio:chatcmpl-0".to_string()),
+            "records before an oversized one survive: {keys:?}"
         );
-
-        // Refusing the read leaves the file contributing nothing, which is the
-        // same outcome an unreadable file already produces here.
-        assert!(parse_lmstudio_file(at_ceiling.path())
-            .first()
-            .is_some_and(|message| message.tokens.input == 10));
+        assert!(
+            keys.contains(&"lmstudio:chatcmpl-2".to_string()),
+            "records after an oversized one survive: {keys:?}"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -2043,6 +2043,63 @@ mod tests {
         }
     }
 
+    /// Both generations scan into one message list and a cached message does
+    /// not record which produced it, so a session id present in both metadata
+    /// tables cannot be re-stamped without one generation overwriting the
+    /// other's title and workspace. A full scan is the correct answer there.
+    #[test]
+    fn test_incremental_rescan_refuses_a_session_id_shared_by_both_schemas() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = create_timed_v1_db(&db_path);
+        insert_timed_v1_message(&conn, "msg_a", 1_000, 11);
+        // A half-migrated database: the same session id in the v2 table too.
+        conn.execute_batch(
+            "CREATE TABLE session_v2 (
+                id TEXT PRIMARY KEY,
+                directory TEXT NOT NULL,
+                title TEXT,
+                time_updated INTEGER NOT NULL
+            );
+            CREATE TABLE session_message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                type TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );
+            INSERT INTO session_v2 (id, directory, title, time_updated)
+            VALUES ('ses_1', '/tmp/v2', 'V2 title', 500);",
+        )
+        .unwrap();
+        drop(conn);
+
+        let cold = scan_opencode_sqlite(&db_path);
+        let Some(state) = cold.incremental.clone() else {
+            // Refusing to mark at all is also a safe answer here.
+            return;
+        };
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "UPDATE session_v2 SET title = 'V2 renamed', time_updated = 9000 WHERE id = 'ses_1'",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE session SET title = 'V1 renamed', time_updated = 9000 WHERE id = 'ses_1'",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        assert!(
+            rescan_opencode_sqlite(&db_path, &state, cold.messages).is_none(),
+            "a session id in both metadata tables must force a full re-parse"
+        );
+    }
+
     #[test]
     fn test_incremental_rescan_refuses_a_row_that_lost_its_tokens() {
         // The row is still there, so the count guard sees nothing wrong, and

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -1791,7 +1791,8 @@ mod tests {
             "CREATE TABLE session (
                 id TEXT PRIMARY KEY,
                 directory TEXT NOT NULL,
-                title TEXT
+                title TEXT,
+                time_updated INTEGER NOT NULL
             );
             CREATE TABLE message (
                 id TEXT PRIMARY KEY,
@@ -1800,8 +1801,8 @@ mod tests {
                 time_updated INTEGER NOT NULL,
                 data TEXT NOT NULL
             );
-            INSERT INTO session (id, directory, title)
-            VALUES ('ses_1', '/tmp/project', 'A session');",
+            INSERT INTO session (id, directory, title, time_updated)
+            VALUES ('ses_1', '/tmp/project', 'A session', 500);",
         )
         .unwrap();
         conn
@@ -1999,6 +2000,47 @@ mod tests {
             )
             .unwrap();
         assert_eq!(changed, 1, "fixture row {id} should exist");
+    }
+
+    /// A rename touches the session row and nothing else, so the message
+    /// high-water does not move and the incremental scan reads no rows. Without
+    /// a metadata refresh the cached messages keep the old title forever, and a
+    /// cold parse disagrees with the cache indefinitely.
+    #[test]
+    fn test_incremental_rescan_picks_up_a_session_renamed_without_new_messages() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = create_timed_v1_db(&db_path);
+        insert_timed_v1_message(&conn, "msg_a", 1_000, 11);
+        insert_timed_v1_message(&conn, "msg_b", 2_000, 22);
+        drop(conn);
+
+        let cold = scan_opencode_sqlite(&db_path);
+        let state = cold.incremental.clone().unwrap();
+        assert_eq!(cold.messages[0].session_title.as_deref(), Some("A session"));
+
+        // Rename the session and move its directory. No message row changes.
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "UPDATE session SET title = 'Renamed session', directory = '/tmp/moved',
+                    time_updated = 9000 WHERE id = 'ses_1'",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let warm = rescan_opencode_sqlite(&db_path, &state, cold.messages)
+            .expect("a rename must not cost a full re-parse");
+        let full = scan_opencode_sqlite(&db_path);
+
+        assert_eq!(
+            by_dedup_key(&warm.messages),
+            by_dedup_key(&full.messages),
+            "a warm rescan must agree with a cold parse after a rename"
+        );
+        for message in &warm.messages {
+            assert_eq!(message.session_title.as_deref(), Some("Renamed session"));
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -2100,6 +2100,51 @@ mod tests {
         );
     }
 
+    /// A row that gains an embedded `$.id` changes dedup key, so the merge
+    /// cannot find the message it should replace. Appending instead would count
+    /// the same row twice while a cold parse counts it once.
+    ///
+    /// Two shapes, because the merge's content digest only catches one of them:
+    /// an identity-only rewrite has the same digest as the cached message, but
+    /// one that also changes usage does not.
+    #[test]
+    fn test_incremental_rescan_refuses_a_row_that_gained_an_embedded_id() {
+        for (label, output) in [("identity only", 11), ("identity and usage", 99)] {
+            let dir = tempfile::tempdir().unwrap();
+            let db_path = dir.path().join("opencode.db");
+            let conn = create_timed_v1_db(&db_path);
+            insert_timed_v1_message(&conn, "msg_a", 1_000, 11);
+            drop(conn);
+
+            let cold = scan_opencode_sqlite(&db_path);
+            let state = cold.incremental.clone().unwrap();
+            assert_eq!(cold.messages.len(), 1);
+            assert_eq!(cold.messages[0].dedup_key.as_deref(), Some("msg_a"));
+
+            // The row keeps its SQLite id but starts carrying its own id, which
+            // is the key the parser prefers.
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute(
+                "UPDATE message SET data = ?1, time_updated = 9000 WHERE id = 'msg_a'",
+                rusqlite::params![timed_v1_payload("embedded_a", output)],
+            )
+            .unwrap();
+            drop(conn);
+
+            let full = scan_opencode_sqlite(&db_path);
+            assert_eq!(full.messages.len(), 1, "{label}: a cold parse sees one row");
+
+            match rescan_opencode_sqlite(&db_path, &state, cold.messages) {
+                None => {}
+                Some(warm) => assert_eq!(
+                    by_dedup_key(&warm.messages),
+                    by_dedup_key(&full.messages),
+                    "{label}: a warm scan that proceeds must match a cold parse"
+                ),
+            }
+        }
+    }
+
     #[test]
     fn test_incremental_rescan_refuses_a_row_that_lost_its_tokens() {
         // The row is still there, so the count guard sees nothing wrong, and

--- a/crates/tokscale-core/src/sessions/opencode_schema.rs
+++ b/crates/tokscale-core/src/sessions/opencode_schema.rs
@@ -1601,10 +1601,17 @@ pub(crate) fn rescan_opencode_schema_sqlite(
 
         let (mark, stats) = match (cached_mark, stats) {
             (Some(mark), Some(stats)) => (mark, stats),
-            // The group's table was absent when the cache was written and
-            // still is, so it contributed nothing then and contributes
-            // nothing now.
+            // The group's table was absent when the cache was written, and the
+            // stats query still does not run. That is *usually* the same table
+            // still missing -- but the stats query also fails on a table that
+            // exists without `time_created`/`time_updated`, and the usage
+            // queries do not need those columns. Skipping such a table would
+            // omit its rows from every warm scan while a cold parse reads them,
+            // so the variants are probed before concluding it is absent.
             (None, None) => {
+                if group.iter().any(|query| conn.prepare(query).is_ok()) {
+                    return None;
+                }
                 marks.push(None);
                 continue;
             }

--- a/crates/tokscale-core/src/sessions/opencode_schema.rs
+++ b/crates/tokscale-core/src/sessions/opencode_schema.rs
@@ -18,6 +18,7 @@
 
 use super::utils::{
     open_readonly_sqlite_opt, sqlite_for_each_row_on, sqlite_for_each_row_on_with_params,
+    SqliteScan,
 };
 use super::{
     normalize_opencode_agent_name, normalize_workspace_key, workspace_label_from_key,
@@ -597,6 +598,35 @@ const OPENCODE_V1_METADATA_STATS: &[&str] = &[
     "",
 ];
 
+/// Changed rows that now key themselves by an embedded id different from their
+/// SQLite row id.
+///
+/// The dedup key is the payload's `$.id` when it has one and the row id
+/// otherwise, so a row that *gains* an id changes key. The merge looks the new
+/// key up, does not find it, and appends -- leaving the message keyed by the row
+/// id in place and counting the row twice, while a cold parse counts it once.
+///
+/// The merge's content digest catches this only when the rewrite changed nothing
+/// else; a rewrite that also moved the token counts has a different digest and
+/// slips through. Nothing in a cached message records which row produced it, so
+/// the two cannot be linked after the fact -- the collision is detected here and
+/// answered with a full scan.
+const OPENCODE_V2_REKEYED_QUERY: &str = r#"
+    SELECT sm.id
+    FROM session_message sm
+    WHERE sm.time_updated >= ?1
+      AND json_extract(sm.data, '$.id') IS NOT NULL
+      AND json_extract(sm.data, '$.id') <> sm.id
+"#;
+
+const OPENCODE_V1_REKEYED_QUERY: &str = r#"
+    SELECT m.id
+    FROM message m
+    WHERE m.time_updated >= ?1
+      AND json_extract(m.data, '$.id') IS NOT NULL
+      AND json_extract(m.data, '$.id') <> m.id
+"#;
+
 /// Incremental support for one entry of [`OpenCodeSchemaConfig::query_groups`].
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct OpenCodeIncrementalGroup {
@@ -610,6 +640,8 @@ pub(crate) struct OpenCodeIncrementalGroup {
     /// the whole group rather than one per variant: the variants differ only
     /// in the metadata join, which this does not read.
     disqualified: &'static str,
+    /// Changed rows whose dedup key moved off their row id.
+    rekeyed: &'static str,
     /// Session metadata changed since the mark, per variant.
     metadata: &'static [&'static str],
     /// Metadata-table high-water, per variant.
@@ -622,6 +654,7 @@ const OPENCODE_INCREMENTAL_GROUPS: &[OpenCodeIncrementalGroup] = &[
         queries: OPENCODE_V2_INCREMENTAL_QUERIES,
         stats: OPENCODE_V2_STATS_QUERY,
         disqualified: OPENCODE_V2_DISQUALIFIED_QUERY,
+        rekeyed: OPENCODE_V2_REKEYED_QUERY,
         metadata: OPENCODE_V2_METADATA_QUERIES,
         metadata_stats: OPENCODE_V2_METADATA_STATS,
     },
@@ -629,6 +662,7 @@ const OPENCODE_INCREMENTAL_GROUPS: &[OpenCodeIncrementalGroup] = &[
         queries: OPENCODE_V1_INCREMENTAL_QUERIES,
         stats: OPENCODE_V1_STATS_QUERY,
         disqualified: OPENCODE_V1_DISQUALIFIED_QUERY,
+        rekeyed: OPENCODE_V1_REKEYED_QUERY,
         metadata: OPENCODE_V1_METADATA_QUERIES,
         metadata_stats: OPENCODE_V1_METADATA_STATS,
     },
@@ -1079,10 +1113,10 @@ fn collect_rows(
     conn: &rusqlite::Connection,
     query: &str,
     on_row: &mut dyn FnMut(OpenCodeSchemaRow),
-) -> bool {
+) -> SqliteScan {
     // Quiet: these queries are schema probes — the caller tries each spelling
     // in turn, so a query the database does not understand is expected.
-    let scan = sqlite_for_each_row_on(conn, db_path, query, None, &mut |row| {
+    sqlite_for_each_row_on(conn, db_path, query, None, &mut |row| {
         let id: String = row.get(0)?;
         let session_id: String = row.get(1)?;
         let data_json: String = row.get(2)?;
@@ -1090,8 +1124,7 @@ fn collect_rows(
         let session_title: Option<String> = row.get(4)?;
         on_row((id, session_id, data_json, workspace_root, session_title));
         Ok(())
-    });
-    scan.prepared()
+    })
 }
 
 /// Run `query` with `since` bound to `?1`, handing every row to `on_row`.
@@ -1117,7 +1150,7 @@ fn collect_rows_since(
     // finished. `prepared()` also accepts a statement that failed while
     // stepping -- json_extract on a malformed payload, say -- and a truncated
     // delta read as a complete one keeps cached messages a cold parse drops.
-    scan.ran()
+    scan.completed()
 }
 
 /// Whether any row that stopped qualifying as usage backs a cached message.
@@ -1157,7 +1190,7 @@ fn disqualified_row_backs_cached_message(
         });
     // Completion required for the same reason as the delta: a probe that
     // stopped early has not proved the absence of a disqualified row.
-    scan.ran().then_some(hit)
+    scan.completed().then_some(hit)
 }
 
 /// Highest `time_updated` in a variant's metadata table, or `i64::MIN` when the
@@ -1175,7 +1208,7 @@ fn read_metadata_high_water(
         high_water = row.get::<_, Option<i64>>(0)?.unwrap_or(i64::MIN);
         Ok(())
     });
-    scan.ran().then_some(high_water)
+    scan.completed().then_some(high_water)
 }
 
 /// Re-apply session metadata that changed since `since` to already-cached
@@ -1217,7 +1250,7 @@ fn refresh_changed_session_metadata(
             changed.insert(session_id, (workspace_root, session_title));
             Ok(())
         });
-    if !scan.ran() || !usable {
+    if !scan.completed() || !usable {
         return None;
     }
 
@@ -1243,6 +1276,31 @@ fn refresh_changed_session_metadata(
     }
 
     read_metadata_high_water(db_path, conn, stats_query)
+}
+
+/// Whether a row that re-keyed itself still has a cached message under its old
+/// row-id key. See [`OPENCODE_V1_REKEYED_QUERY`] for why that is unsafe.
+fn rekeyed_row_backs_cached_message(
+    db_path: &Path,
+    conn: &rusqlite::Connection,
+    query: &str,
+    since: i64,
+    db_namespace: &str,
+    cached_keys: &std::collections::HashSet<&str>,
+) -> Option<bool> {
+    let mut hit = false;
+    let scan =
+        sqlite_for_each_row_on_with_params(conn, db_path, query, &[&since], None, &mut |row| {
+            if hit {
+                return Ok(());
+            }
+            let row_id: String = row.get(0)?;
+            let namespaced = format!("{db_namespace}:{row_id}");
+            hit =
+                cached_keys.contains(row_id.as_str()) || cached_keys.contains(namespaced.as_str());
+            Ok(())
+        });
+    scan.completed().then_some(hit)
 }
 
 /// Parse assistant turns out of a SQLite database that uses the OpenCode
@@ -1379,7 +1437,9 @@ fn read_table_stats(
             Ok(())
         },
     );
-    if scan.ran() {
+    // A truncated stats read yields a row count and high-waters that describe
+    // a prefix of the table, which is exactly the shape of a silent undercount.
+    if scan.completed() {
         stats
     } else {
         None
@@ -1423,18 +1483,30 @@ pub(crate) fn scan_opencode_schema_sqlite(
         let stats = incremental
             .and_then(|incremental| read_table_stats(db_path, &conn, incremental.stats, i64::MAX));
 
+        // `prepared()` selects the variant -- it is the schema probe, and a
+        // variant that prepared is the one this database understands, so
+        // falling through to an older query would read the wrong columns.
+        // `completed()` is a separate question: a variant that matched but
+        // stopped on a step error read only a prefix, and a mark written over
+        // that prefix would tell the next rescan those rows were already seen.
         let mut chosen = None;
+        let mut read_every_row = false;
         for (index, query) in group.iter().enumerate() {
-            if collect_rows(db_path, &conn, query, &mut |row| {
+            let scan = collect_rows(db_path, &conn, query, &mut |row| {
                 acc.ingest(row, &cfg, &db_namespace)
-            }) {
+            });
+            if scan.prepared() {
                 chosen = Some(index);
+                read_every_row = scan.completed();
                 break;
             }
         }
+        if chosen.is_some() && !read_every_row {
+            resumable = false;
+        }
 
         marks.push(match (chosen, stats) {
-            (Some(index), Some(stats)) => {
+            (Some(index), Some(stats)) if read_every_row => {
                 let metadata_high_water = cfg
                     .incremental_groups
                     .and_then(|groups| groups.get(group_index))
@@ -1565,6 +1637,20 @@ pub(crate) fn rescan_opencode_schema_sqlite(
             db_path,
             &conn,
             incremental.disqualified,
+            mark.updated_high_water,
+            &db_namespace,
+            &cached_keys,
+        ) != Some(false)
+        {
+            return None;
+        }
+
+        // A row whose key moved off its row id would be appended beside the
+        // message still keyed by that row id, counting it twice.
+        if rekeyed_row_backs_cached_message(
+            db_path,
+            &conn,
+            incremental.rekeyed,
             mark.updated_high_water,
             &db_namespace,
             &cached_keys,

--- a/crates/tokscale-core/src/sessions/opencode_schema.rs
+++ b/crates/tokscale-core/src/sessions/opencode_schema.rs
@@ -1113,7 +1113,11 @@ fn collect_rows_since(
             on_row((id, session_id, data_json, workspace_root, session_title));
             Ok(())
         });
-    scan.prepared()
+    // `ran()`, not `prepared()`: the delta is only complete if the statement
+    // finished. `prepared()` also accepts a statement that failed while
+    // stepping -- json_extract on a malformed payload, say -- and a truncated
+    // delta read as a complete one keeps cached messages a cold parse drops.
+    scan.ran()
 }
 
 /// Whether any row that stopped qualifying as usage backs a cached message.
@@ -1151,7 +1155,9 @@ fn disqualified_row_backs_cached_message(
                     .is_some_and(|id| cached_keys.contains(id));
             Ok(())
         });
-    scan.prepared().then_some(hit)
+    // Completion required for the same reason as the delta: a probe that
+    // stopped early has not proved the absence of a disqualified row.
+    scan.ran().then_some(hit)
 }
 
 /// Highest `time_updated` in a variant's metadata table, or `i64::MIN` when the
@@ -1169,7 +1175,7 @@ fn read_metadata_high_water(
         high_water = row.get::<_, Option<i64>>(0)?.unwrap_or(i64::MIN);
         Ok(())
     });
-    scan.prepared().then_some(high_water)
+    scan.ran().then_some(high_water)
 }
 
 /// Re-apply session metadata that changed since `since` to already-cached
@@ -1192,6 +1198,7 @@ fn refresh_changed_session_metadata(
     stats_query: &str,
     since: i64,
     cached: &mut [UnifiedMessage],
+    already_refreshed: &mut std::collections::HashSet<String>,
 ) -> Option<i64> {
     if query.is_empty() {
         return Some(i64::MIN);
@@ -1210,9 +1217,16 @@ fn refresh_changed_session_metadata(
             changed.insert(session_id, (workspace_root, session_title));
             Ok(())
         });
-    if !scan.prepared() || !usable {
+    if !scan.ran() || !usable {
         return None;
     }
+
+    // A session already re-stamped by another generation's table would be
+    // overwritten here with a different generation's metadata.
+    if changed.keys().any(|id| already_refreshed.contains(id)) {
+        return None;
+    }
+    already_refreshed.extend(changed.keys().cloned());
 
     if !changed.is_empty() {
         for message in cached.iter_mut() {
@@ -1592,6 +1606,15 @@ pub(crate) fn rescan_opencode_schema_sqlite(
     // `cached_keys` borrowed `cached_messages` for the probe above and is dead
     // from here, so the refresh can take it mutably.
     drop(cached_keys);
+    // Both generations are scanned into one message list, and a cached message
+    // does not record which group produced it. So a session id that exists in
+    // more than one generation's metadata table cannot be re-stamped safely:
+    // the later group would overwrite the earlier group's messages with its own
+    // title and workspace, and a cold parse would disagree. Refusing is rare --
+    // it needs the same id in both `session` and `session_v2`, which is the
+    // half-migrated database -- and a full scan is correct there.
+    let mut refreshed_sessions: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
     for (index, query, stats_query, since) in pending_metadata {
         // A rename moves session metadata without touching a message row, so
         // the cached messages are re-stamped rather than left stale.
@@ -1602,6 +1625,7 @@ pub(crate) fn rescan_opencode_schema_sqlite(
             stats_query,
             since,
             &mut cached_messages,
+            &mut refreshed_sessions,
         )?;
         if let Some(Some(mark)) = marks.get_mut(index) {
             mark.metadata_high_water = metadata_high_water;

--- a/crates/tokscale-core/src/sessions/opencode_schema.rs
+++ b/crates/tokscale-core/src/sessions/opencode_schema.rs
@@ -559,6 +559,44 @@ const OPENCODE_V1_DISQUALIFIED_QUERY: &str = r#"
                AND json_extract(m.data, '$.tokens') IS NOT NULL)
 "#;
 
+/// Session metadata that changed since a mark, one query per full variant and
+/// in the same order. An empty entry means that variant joins no metadata
+/// table, so there is nothing that can go stale.
+///
+/// Sessions are touched alongside their messages -- on a real 14 GB database
+/// `session` and `message` high-waters sit 36 ms apart -- so refusing an
+/// incremental scan whenever session metadata moved would refuse essentially
+/// every rescan. Re-reading only the changed session rows is cheap instead: 13
+/// of 23,556 rows changed over a day on that same database.
+const OPENCODE_V2_METADATA_QUERIES: &[&str] = &[
+    "SELECT s.id, NULLIF(s.directory, '') , s.title, s.time_updated FROM session_v2 s WHERE s.time_updated >= ?1",
+    "SELECT s.id, NULLIF(s.directory, '') , NULL, s.time_updated FROM session_v2 s WHERE s.time_updated >= ?1",
+    "SELECT s.id, NULLIF(s.directory, '') , s.title, s.time_updated FROM session s WHERE s.time_updated >= ?1",
+    "SELECT s.id, NULLIF(s.directory, '') , NULL, s.time_updated FROM session s WHERE s.time_updated >= ?1",
+    "",
+];
+
+const OPENCODE_V1_METADATA_QUERIES: &[&str] = &[
+    "SELECT s.id, NULLIF(s.directory, '') , s.title, s.time_updated FROM session s WHERE s.time_updated >= ?1",
+    "SELECT s.id, NULLIF(s.directory, '') , NULL, s.time_updated FROM session s WHERE s.time_updated >= ?1",
+    "",
+];
+
+/// Highest `time_updated` in the metadata table a variant joins.
+const OPENCODE_V2_METADATA_STATS: &[&str] = &[
+    "SELECT MAX(time_updated) FROM session_v2",
+    "SELECT MAX(time_updated) FROM session_v2",
+    "SELECT MAX(time_updated) FROM session",
+    "SELECT MAX(time_updated) FROM session",
+    "",
+];
+
+const OPENCODE_V1_METADATA_STATS: &[&str] = &[
+    "SELECT MAX(time_updated) FROM session",
+    "SELECT MAX(time_updated) FROM session",
+    "",
+];
+
 /// Incremental support for one entry of [`OpenCodeSchemaConfig::query_groups`].
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct OpenCodeIncrementalGroup {
@@ -572,6 +610,10 @@ pub(crate) struct OpenCodeIncrementalGroup {
     /// the whole group rather than one per variant: the variants differ only
     /// in the metadata join, which this does not read.
     disqualified: &'static str,
+    /// Session metadata changed since the mark, per variant.
+    metadata: &'static [&'static str],
+    /// Metadata-table high-water, per variant.
+    metadata_stats: &'static [&'static str],
 }
 
 /// Incremental support for [`OPENCODE_QUERY_GROUPS`], in the same order.
@@ -580,11 +622,15 @@ const OPENCODE_INCREMENTAL_GROUPS: &[OpenCodeIncrementalGroup] = &[
         queries: OPENCODE_V2_INCREMENTAL_QUERIES,
         stats: OPENCODE_V2_STATS_QUERY,
         disqualified: OPENCODE_V2_DISQUALIFIED_QUERY,
+        metadata: OPENCODE_V2_METADATA_QUERIES,
+        metadata_stats: OPENCODE_V2_METADATA_STATS,
     },
     OpenCodeIncrementalGroup {
         queries: OPENCODE_V1_INCREMENTAL_QUERIES,
         stats: OPENCODE_V1_STATS_QUERY,
         disqualified: OPENCODE_V1_DISQUALIFIED_QUERY,
+        metadata: OPENCODE_V1_METADATA_QUERIES,
+        metadata_stats: OPENCODE_V1_METADATA_STATS,
     },
 ];
 
@@ -1108,6 +1154,83 @@ fn disqualified_row_backs_cached_message(
     scan.prepared().then_some(hit)
 }
 
+/// Highest `time_updated` in a variant's metadata table, or `i64::MIN` when the
+/// variant joins none.
+fn read_metadata_high_water(
+    db_path: &Path,
+    conn: &rusqlite::Connection,
+    query: &str,
+) -> Option<i64> {
+    if query.is_empty() {
+        return Some(i64::MIN);
+    }
+    let mut high_water = i64::MIN;
+    let scan = sqlite_for_each_row_on(conn, db_path, query, None, &mut |row| {
+        high_water = row.get::<_, Option<i64>>(0)?.unwrap_or(i64::MIN);
+        Ok(())
+    });
+    scan.prepared().then_some(high_water)
+}
+
+/// Re-apply session metadata that changed since `since` to already-cached
+/// messages, returning the new metadata high-water.
+///
+/// A rename or a moved directory advances the session row's `time_updated`
+/// without touching any message row, so the incremental message scan cannot
+/// see it and the cached messages keep the old title and workspace forever.
+///
+/// Returns `None` when the refresh cannot be trusted -- the statement did not
+/// prepare, or a changed row no longer supplies a directory. The row's
+/// directory is only half the answer in that case: [`SchemaAccumulator::ingest`]
+/// falls back to the payload's own `path.root`, which is not available here
+/// without re-reading the message. A full scan is the honest answer, and it is
+/// rare: 13 of 23,556 session rows changed over a day on a real database.
+fn refresh_changed_session_metadata(
+    db_path: &Path,
+    conn: &rusqlite::Connection,
+    query: &str,
+    stats_query: &str,
+    since: i64,
+    cached: &mut [UnifiedMessage],
+) -> Option<i64> {
+    if query.is_empty() {
+        return Some(i64::MIN);
+    }
+
+    let mut changed: HashMap<String, (Option<String>, Option<String>)> = HashMap::new();
+    let mut usable = true;
+    let scan =
+        sqlite_for_each_row_on_with_params(conn, db_path, query, &[&since], None, &mut |row| {
+            let session_id: String = row.get(0)?;
+            let workspace_root: Option<String> = row.get(1)?;
+            let session_title: Option<String> = row.get(2)?;
+            if workspace_root.is_none() {
+                usable = false;
+            }
+            changed.insert(session_id, (workspace_root, session_title));
+            Ok(())
+        });
+    if !scan.prepared() || !usable {
+        return None;
+    }
+
+    if !changed.is_empty() {
+        for message in cached.iter_mut() {
+            let Some((workspace_root, session_title)) = changed.get(&message.session_id) else {
+                continue;
+            };
+            set_workspace_from_root(message, workspace_root.as_deref());
+            message.session_title = session_title
+                .as_deref()
+                .map(str::trim)
+                .filter(|title| !title.is_empty())
+                .map(str::to_string);
+        }
+    }
+
+    read_metadata_high_water(db_path, conn, stats_query)
+}
+
 /// Parse assistant turns out of a SQLite database that uses the OpenCode
 /// message schema, applying `cfg`'s per-client policy.
 ///
@@ -1144,6 +1267,10 @@ pub(crate) struct OpenCodeGroupMark {
     pub created_high_water: i64,
     /// Highest `time_updated`. The incremental scan reads from here.
     pub updated_high_water: i64,
+    /// Highest `time_updated` in the joined metadata table. A rename moves this
+    /// without touching a single message row, so the message high-water cannot
+    /// stand in for it. `i64::MIN` when the variant joins no metadata.
+    pub metadata_high_water: i64,
 }
 
 /// One mark per query group, in [`OpenCodeSchemaConfig::query_groups`] order.
@@ -1293,12 +1420,28 @@ pub(crate) fn scan_opencode_schema_sqlite(
         }
 
         marks.push(match (chosen, stats) {
-            (Some(index), Some(stats)) => Some(OpenCodeGroupMark {
-                query_digest: query_digest(group[index]),
-                row_count: stats.row_count,
-                created_high_water: stats.created_high_water,
-                updated_high_water: stats.updated_high_water,
-            }),
+            (Some(index), Some(stats)) => {
+                let metadata_high_water = cfg
+                    .incremental_groups
+                    .and_then(|groups| groups.get(group_index))
+                    .and_then(|incremental| incremental.metadata_stats.get(index))
+                    .and_then(|query| read_metadata_high_water(db_path, &conn, query));
+                match metadata_high_water {
+                    Some(metadata_high_water) => Some(OpenCodeGroupMark {
+                        query_digest: query_digest(group[index]),
+                        row_count: stats.row_count,
+                        created_high_water: stats.created_high_water,
+                        updated_high_water: stats.updated_high_water,
+                        metadata_high_water,
+                    }),
+                    // Without a metadata high-water a later rescan cannot tell
+                    // whether a rename happened, so this scan is not resumable.
+                    None => {
+                        resumable = false;
+                        None
+                    }
+                }
+            }
             (Some(_), None) => {
                 resumable = false;
                 None
@@ -1335,7 +1478,7 @@ pub(crate) fn rescan_opencode_schema_sqlite(
     db_path: &Path,
     cfg: OpenCodeSchemaConfig,
     cached_state: &OpenCodeIncrementalState,
-    cached_messages: Vec<UnifiedMessage>,
+    mut cached_messages: Vec<UnifiedMessage>,
 ) -> Option<OpenCodeSchemaScan> {
     let incremental_groups = cfg.incremental_groups?;
     if cached_state.groups.len() != cfg.query_groups.len() {
@@ -1353,6 +1496,8 @@ pub(crate) fn rescan_opencode_schema_sqlite(
     let mut marks: Vec<Option<OpenCodeGroupMark>> = Vec::with_capacity(cached_state.groups.len());
     // Borrowed for the disqualification probe below; `cached_messages` is not
     // consumed until the merge at the end of this function.
+    // (mark index, metadata query, metadata stats query, previous high-water)
+    let mut pending_metadata: Vec<(usize, &'static str, &'static str, i64)> = Vec::new();
     let cached_keys: std::collections::HashSet<&str> = cached_messages
         .iter()
         .filter_map(|message| message.dedup_key.as_deref())
@@ -1421,12 +1566,46 @@ pub(crate) fn rescan_opencode_schema_sqlite(
             return None;
         }
 
+        // The metadata refresh needs `cached_messages` mutably, and the
+        // disqualification probe borrows it immutably for the whole loop, so
+        // the refresh is deferred until both borrows can be released.
+        pending_metadata.push((
+            marks.len(),
+            incremental.metadata.get(chosen).copied().unwrap_or(""),
+            incremental
+                .metadata_stats
+                .get(chosen)
+                .copied()
+                .unwrap_or(""),
+            mark.metadata_high_water,
+        ));
+
         marks.push(Some(OpenCodeGroupMark {
             query_digest: mark.query_digest,
             row_count: stats.row_count,
             created_high_water: stats.created_high_water,
             updated_high_water: stats.updated_high_water,
+            metadata_high_water: mark.metadata_high_water,
         }));
+    }
+
+    // `cached_keys` borrowed `cached_messages` for the probe above and is dead
+    // from here, so the refresh can take it mutably.
+    drop(cached_keys);
+    for (index, query, stats_query, since) in pending_metadata {
+        // A rename moves session metadata without touching a message row, so
+        // the cached messages are re-stamped rather than left stale.
+        let metadata_high_water = refresh_changed_session_metadata(
+            db_path,
+            &conn,
+            query,
+            stats_query,
+            since,
+            &mut cached_messages,
+        )?;
+        if let Some(Some(mark)) = marks.get_mut(index) {
+            mark.metadata_high_water = metadata_high_water;
+        }
     }
 
     // A merge among the changed rows themselves is reproducible -- a full scan

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -314,11 +314,28 @@ pub(crate) enum SqliteScan {
     NotPrepared,
     /// The statement prepared but the query could not execute.
     NotExecuted,
+    /// Iteration started and then stopped on a step error, so the rows handed
+    /// to the sink are a prefix of the result, not the result.
+    ///
+    /// Separate from [`SqliteScan::Ran`] because the difference is invisible to
+    /// the sink -- it just sees fewer rows -- and a caller that resumes from a
+    /// high-water would treat the rows after the failure as already seen and
+    /// never read them again.
+    Incomplete,
 }
 
 impl SqliteScan {
-    /// True only when rows were iterated.
+    /// True when rows were iterated, complete or not.
     pub(crate) fn ran(self) -> bool {
+        matches!(self, SqliteScan::Ran | SqliteScan::Incomplete)
+    }
+
+    /// True only when every row was iterated.
+    ///
+    /// What incremental callers need: a partial result is indistinguishable
+    /// from a small one, and recording a high-water over it permanently skips
+    /// the rows the failure cut off.
+    pub(crate) fn completed(self) -> bool {
         matches!(self, SqliteScan::Ran)
     }
 
@@ -400,6 +417,7 @@ pub(crate) fn sqlite_for_each_row_on_with_params(
         }
     };
 
+    let mut stepped_off = false;
     loop {
         match rows.next() {
             Ok(Some(row)) => {
@@ -424,12 +442,17 @@ pub(crate) fn sqlite_for_each_row_on_with_params(
                         "Failed to decode session row"
                     );
                 }
+                stepped_off = true;
                 break;
             }
         }
     }
 
-    SqliteScan::Ran
+    if stepped_off {
+        SqliteScan::Incomplete
+    } else {
+        SqliteScan::Ran
+    }
 }
 
 /// Open `db_path` read-only, run `sql`, and hand every row to `sink`.


### PR DESCRIPTION
Four rounds of Codex adversarial review over the v4.15.0 work. These are
behaviour changes, each with a regression test.

## Fixed

**LM Studio — a regression I introduced in #1217.** The bound I added was
all-or-nothing: past 32 MiB the read returned nothing and the parser turned
that into an empty message set, losing every record in that file, past and
future, with no diagnostic. These logs are never rotated and only grow, so the
same comment that justified the bound also guaranteed every mature install
would eventually cross it. That is worse than the memory it saved.

The read is now a sliding window — bounded resident bytes, every record read.
A response body long enough to push its own header out of the window no longer
loses the record's id, model and timestamp; they are lifted out of the bytes on
their way past. A `[YYYY-MM-DD HH:MM:SS]` printed *by the model* is no longer
mistaken for the log header, which had been dating usage from the model's own
output.

**OpenCode incremental scan.** A rename moves the session row without touching
a message row, so cached titles and workspaces stayed stale indefinitely;
changed session rows are now re-read and re-applied. Re-applying rather than
forcing a full scan is the point — on the real 14.9 GB database the `session`
and `message` high-waters sit 36 ms apart, so refusing whenever metadata moved
would refuse essentially every rescan.

A session id present in both the v1 and v2 metadata tables now falls back to a
full scan, because a cached message records no provenance and the later group
would otherwise overwrite the earlier one's metadata. A query that died
mid-iteration no longer counts as a complete delta: `ran()` was true after a
step error, so `SqliteScan` gains `Incomplete` and the incremental paths ask
the new `completed()`. A row that gains an embedded `$.id` changes dedup key,
and the merge appended beside the message still keyed by the row id — counting
it twice where a cold parse counted it once.

**Antigravity.** The loopback RPC honoured the system proxy and followed
redirects, either of which takes a 127.0.0.1 request to a remote host that can
then forge the unauthenticated response port discovery trusts. A missing
`remainingFraction` was coerced to zero remaining and rendered as 100% used —
a full-exhaustion warning invented from an absent field, exactly when version
skew made it least true. Such buckets are dropped; readable buckets in the same
group survive.

**xAI pricing.** The same request cost half as much depending on which dataset
priced it. Reproduced before changing anything: 150k input, 50k cache read,
10k output resolves to `0.385` through the built-in Cursor row against `0.770`
through the upstream row. The cause was the key shape, not the source check —
that table keys the model bare as `grok-4.6` while the guard only accepted
`provider/model`.

## Still open

Three [high] findings remain in the OpenCode incremental scan: an embedded id
changing A → B, the SQL qualification predicate not matching the parser's, and
a non-monotonic `time_created` bypassing the deletion guard.

All three share one root cause — a cached message records nothing about the row
that produced it, so safety is inferred rather than checked. The convergent fix
is a row_id → dedup_key map in the incremental state (measured: 0.76 s to read
every row id, 13 MB, 5% of the cache shard ceiling), tracked in #1230.

**Exposure on real data is zero.** Of the 434,955 rows on the profiled 14.9 GB
database: no row carries an embedded `$.id`, and no assistant row with tokens
is missing modelID, time or cache.
