### PR TITLE
perf(copilot): stream VS Code messages into submit fold

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -835,31 +835,43 @@ fn flush_lane<S: MessageSink>(
     context: &FlushContext<'_>,
     sink: &mut S,
 ) {
-    for mut message in buffer.drain(..) {
-        if !context.include_all
-            && !retain_for_requested_clients(
-                &message.client,
-                &message.model_id,
-                &message.provider_id,
-                &context.requested,
-            )
-        {
-            continue;
-        }
-
-        if context.include_synthetic {
-            sessions::synthetic::normalize_synthetic_gateway_fields(
-                &mut message.model_id,
-                &mut message.provider_id,
-            );
-        }
-
-        if let Some(timezone) = &context.timezone {
-            message.rebucket_date(timezone);
-        }
-
-        sink.accept(message);
+    for message in buffer.drain(..) {
+        flush_message(message, context, sink);
     }
+}
+
+/// Apply the parse tail to one message and release it into the consumer.
+///
+/// Most parsers still hand back a lane buffer, but sources with their own
+/// streaming boundary can call this directly without rebuilding that buffer.
+fn flush_message<S: MessageSink>(
+    mut message: UnifiedMessage,
+    context: &FlushContext<'_>,
+    sink: &mut S,
+) {
+    if !context.include_all
+        && !retain_for_requested_clients(
+            &message.client,
+            &message.model_id,
+            &message.provider_id,
+            &context.requested,
+        )
+    {
+        return;
+    }
+
+    if context.include_synthetic {
+        sessions::synthetic::normalize_synthetic_gateway_fields(
+            &mut message.model_id,
+            &mut message.provider_id,
+        );
+    }
+
+    if let Some(timezone) = &context.timezone {
+        message.rebucket_date(timezone);
+    }
+
+    sink.accept(message);
 }
 
 fn parse_all_messages_with_pricing_with_cache_policy(
@@ -2102,31 +2114,37 @@ fn parse_all_messages_streaming<S: MessageSink>(
             .filter(|m| m.client == "copilot")
             .filter_map(|m| m.dedup_key.clone())
             .collect();
-        let existing_copilot_session_timestamps: HashSet<(String, i64)> = all_messages
-            .iter()
-            .filter(|m| m.client == "copilot")
-            .map(|m| (m.session_id.clone(), m.timestamp))
-            .collect();
-        let vscode_msgs = sessions::copilot_vscode::parse_copilot_vscode_sessions(
+        let mut existing_copilot_session_timestamps: HashMap<String, HashSet<i64>> = HashMap::new();
+        for message in all_messages.iter().filter(|m| m.client == "copilot") {
+            existing_copilot_session_timestamps
+                .entry(message.session_id.clone())
+                .or_default()
+                .insert(message.timestamp);
+        }
+
+        // These are the only rows the VS Code lane consults. Once their keys
+        // and timestamps are projected above, keeping the full OTEL/desktop
+        // messages alive serves no purpose. Release them before parsing the
+        // request-heavy source, then feed each VS Code message through the same
+        // tail instead of rebuilding `all_messages`.
+        flush_lane(&mut all_messages, &flush_context, sink);
+        sessions::copilot_vscode::parse_copilot_vscode_sessions_into(
             &scan_result.copilot_vscode_sessions,
-        );
-        all_messages.extend(
-            vscode_msgs
-                .into_iter()
-                .filter(|m| {
-                    let key_unique = m
-                        .dedup_key
-                        .as_deref()
-                        .map(|k| !existing_dedup_keys.contains(k))
-                        .unwrap_or(true);
-                    let session_ts_unique = !existing_copilot_session_timestamps
-                        .contains(&(m.session_id.clone(), m.timestamp));
-                    key_unique && session_ts_unique
-                })
-                .map(|mut message| {
-                    apply_pricing_if_available(&mut message, pricing);
-                    message
-                }),
+            &mut |mut message| {
+                let key_unique = message
+                    .dedup_key
+                    .as_deref()
+                    .is_none_or(|key| !existing_dedup_keys.contains(key));
+                let session_timestamp_unique = existing_copilot_session_timestamps
+                    .get(message.session_id.as_str())
+                    .is_none_or(|timestamps| !timestamps.contains(&message.timestamp));
+                if !key_unique || !session_timestamp_unique {
+                    return;
+                }
+
+                apply_pricing_if_available(&mut message, pricing);
+                flush_message(message, &flush_context, sink);
+            },
         );
     }
 
@@ -4047,7 +4065,11 @@ async fn generate_graph_with_loaded_pricing(
 /// `validate_priced_messages` verbatim rather than reimplementing their pricing
 /// rules, which is the part that would quietly diverge. Peak cost is one batch,
 /// not the corpus.
-const GRAPH_SINK_BATCH: usize = 65_536;
+// A batch holds full `UnifiedMessage` values, including their separately
+// allocated strings. 65,536 made the buffer itself hundreds of megabytes on
+// Copilot-heavy profiles. 4,096 amortises the existing pricing validators
+// while placing a small, corpus-independent ceiling on this part of submit.
+const GRAPH_SINK_BATCH: usize = 4_096;
 
 /// Folds a graph report as messages arrive instead of collecting them.
 ///
@@ -5872,11 +5894,12 @@ mod tests {
         parse_all_messages_with_pricing_with_env_strategy, parse_local_clients, parsed_to_unified,
         paths, pricing, retain_for_requested_clients, scanner, select_local_parse_pricing,
         sessions, unified_to_parsed, validate_priced_messages, ClientId, GraphPricingRequirement,
-        GroupBy, LocalParseOptions, MonthlyReportV2, MonthlyUsage, MonthlyUsageV2, ReportOptions,
-        SourceCachePolicy, TokenBreakdown, UnifiedMessage, UnpricedSubmissionExclusion,
-        AMBIGUOUS_MODEL_PRICING_REASON, INCOMPLETE_MODEL_PRICING_REASON,
-        MISSING_MODEL_PRICING_REASON, ROUTING_LABEL_UNPRICED_REASON, UNKNOWN_WORKSPACE_LABEL,
-        UNVERIFIED_MODEL_IDENTITY_REASON, UNVERIFIED_PROVIDER_IDENTITY_REASON,
+        GraphSink, GroupBy, LocalParseOptions, MessageSink, MonthlyReportV2, MonthlyUsage,
+        MonthlyUsageV2, ReportOptions, SourceCachePolicy, TokenBreakdown, UnifiedMessage,
+        UnpricedSubmissionExclusion, AMBIGUOUS_MODEL_PRICING_REASON, GRAPH_SINK_BATCH,
+        INCOMPLETE_MODEL_PRICING_REASON, MISSING_MODEL_PRICING_REASON,
+        ROUTING_LABEL_UNPRICED_REASON, UNKNOWN_WORKSPACE_LABEL, UNVERIFIED_MODEL_IDENTITY_REASON,
+        UNVERIFIED_PROVIDER_IDENTITY_REASON,
     };
     // Kept as its own statement rather than folded into the list above: that list
     // is edited by nearly every PR that touches this file, and sharing it made
@@ -5885,6 +5908,70 @@ mod tests {
     use serial_test::serial;
     use std::collections::{HashMap, HashSet};
     use std::io::Write;
+
+    #[test]
+    fn graph_sink_keeps_only_one_bounded_pricing_batch() {
+        let mut sink = GraphSink::new(None, None, GraphPricingRequirement::Lenient);
+        for timestamp in 1..=(GRAPH_SINK_BATCH * 2 + 1) {
+            sink.accept(UnifiedMessage::new(
+                "copilot",
+                "gpt-4o",
+                "openai",
+                "bounded",
+                timestamp as i64,
+                TokenBreakdown {
+                    input: 1,
+                    ..Default::default()
+                },
+                0.0,
+            ));
+        }
+
+        assert_eq!(sink.buffer.len(), 1);
+        assert_eq!(sink.spans.len(), GRAPH_SINK_BATCH * 2);
+    }
+
+    #[test]
+    fn submission_merges_exclusions_across_bounded_batches() {
+        let messages: Vec<UnifiedMessage> = (0..=GRAPH_SINK_BATCH)
+            .map(|offset| {
+                UnifiedMessage::new(
+                    "copilot",
+                    "unlisted-model",
+                    "github-copilot",
+                    "bounded",
+                    1_736_510_400_000 + offset as i64,
+                    TokenBreakdown {
+                        input: 2,
+                        output: 1,
+                        ..Default::default()
+                    },
+                    0.0,
+                )
+            })
+            .collect();
+        let pricing = pricing::PricingService::new(unrelated_litellm_dataset(), HashMap::new());
+
+        let graph = build_graph_from_messages(
+            messages,
+            Some(&pricing),
+            GraphPricingRequirement::Submission,
+            std::time::Instant::now(),
+            &crate::bucket_tz::BucketTimezone::Local,
+        )
+        .expect("unpriced rows should be excluded across every batch");
+
+        assert!(graph.contributions.is_empty());
+        assert_eq!(graph.unpriced_submission_exclusions.len(), 1);
+        assert_eq!(
+            graph.unpriced_submission_exclusions[0].message_count,
+            GRAPH_SINK_BATCH + 1
+        );
+        assert_eq!(
+            graph.unpriced_submission_exclusions[0].total_tokens,
+            (GRAPH_SINK_BATCH as i64 + 1) * 3
+        );
+    }
 
     #[test]
     fn token_breakdown_add_assign_includes_every_field() {

--- a/crates/tokscale-core/src/sessions/copilot_vscode.rs
+++ b/crates/tokscale-core/src/sessions/copilot_vscode.rs
@@ -7,18 +7,36 @@ use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 pub fn parse_copilot_vscode_sessions(paths: &[PathBuf]) -> Vec<UnifiedMessage> {
-    paths.iter().flat_map(|path| parse_file(path)).collect()
+    let mut messages = Vec::new();
+    parse_copilot_vscode_sessions_into(paths, &mut |message| messages.push(message));
+    messages
 }
 
-fn parse_file(path: &Path) -> Vec<UnifiedMessage> {
+/// Parse VS Code Copilot sessions into an incremental consumer.
+///
+/// The production submit path folds each message as it arrives. Keeping that
+/// consumer here, at the parser boundary, avoids materialising a second vector
+/// containing one `UnifiedMessage` per request after the request projection has
+/// already accumulated the session. The collecting wrapper above remains for
+/// callers that genuinely need ownership of the complete result.
+pub(crate) fn parse_copilot_vscode_sessions_into(
+    paths: &[PathBuf],
+    on_message: &mut dyn FnMut(UnifiedMessage),
+) {
+    for path in paths {
+        parse_file_into(path, on_message);
+    }
+}
+
+fn parse_file_into(path: &Path, on_message: &mut dyn FnMut(UnifiedMessage)) {
     let session_id = match path.file_stem().and_then(|s| s.to_str()) {
         Some(stem) => stem.to_string(),
-        None => return Vec::new(),
+        None => return,
     };
 
     let file = match std::fs::File::open(path) {
         Ok(f) => f,
-        Err(_) => return Vec::new(),
+        Err(_) => return,
     };
 
     let workspace = read_workspace_for_file(path);
@@ -95,10 +113,14 @@ fn parse_file(path: &Path) -> Vec<UnifiedMessage> {
         }
     }
 
-    requests
-        .iter()
-        .filter_map(|req| request_to_message(req, &session_id, &workspace))
-        .collect()
+    // Consume requests instead of borrowing the whole vector while building a
+    // second corpus-sized result. Each projected JSON value is released as
+    // soon as its message has been folded by the caller.
+    for request in requests {
+        if let Some(message) = request_to_message(&request, &session_id, &workspace) {
+            on_message(message);
+        }
+    }
 }
 
 /// Drop everything from a request that [`request_to_message`] does not read.
@@ -517,6 +539,44 @@ mod tests {
         assert_eq!(
             m.dedup_key.as_deref(),
             Some(format!("copilot-vscode:{}:1783918304896", uuid).as_str())
+        );
+    }
+
+    #[test]
+    fn streaming_parser_preserves_path_and_request_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("chatSessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let first = sessions_dir.join("first.jsonl");
+        let second = sessions_dir.join("second.jsonl");
+
+        write_jsonl(
+            &first,
+            &[
+                r#"{"kind":0,"v":{"requests":[{"timestamp":1000,"modelId":"copilot/gpt-4o","promptTokens":11},{"timestamp":2000,"modelId":"copilot/gpt-4o","promptTokens":22}]}}"#,
+            ],
+        );
+        write_jsonl(
+            &second,
+            &[
+                r#"{"kind":2,"k":["requests"],"v":[{"timestamp":3000,"modelId":"copilot/gpt-4o","promptTokens":33}]}"#,
+            ],
+        );
+
+        let mut emitted = Vec::new();
+        parse_copilot_vscode_sessions_into(&[first, second], &mut |message| {
+            // Keep only a tiny projection: the streaming API must not require
+            // its consumer to retain each full message.
+            emitted.push((message.session_id, message.timestamp, message.tokens.input));
+        });
+
+        assert_eq!(
+            emitted,
+            vec![
+                ("first".to_string(), 1000, 11),
+                ("first".to_string(), 2000, 22),
+                ("second".to_string(), 3000, 33),
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary

- Stream projected Copilot VS Code messages directly into the submit fold instead of materializing a second `Vec<UnifiedMessage>` for the entire lane.
- Release already parsed Copilot OTEL/desktop messages after projecting the deduplication state needed by the VS Code lane.
- Reduce the submission pricing batch from 65,536 to 4,096 full messages so this buffer has a smaller, corpus-independent ceiling.
- Preserve the collecting parser wrapper for callers that genuinely need an owned result.

Related to #1209. This PR intentionally does not close that issue: the latest reporter evidence identifies the Copilot CLI OTEL parser under `~/.copilot/otel` as the primary OOM path, while this change removes a separate retained-message peak in the VS Code and submit aggregation path.

## Why

The streaming submit fold removed the final whole-corpus aggregation buffer, but the Copilot path could still retain the complete OTEL/desktop lane while building a second vector containing every VS Code request message. On request-heavy histories, each `UnifiedMessage` also owns several separately allocated strings, so keeping both collections alive extends a significant fixed per-request cost through the scan.

The submit sink also buffered 65,536 complete messages before applying the existing pricing validators. That preserved accounting behavior, but allowed the supposedly bounded buffer itself to grow to hundreds of megabytes on Copilot-heavy profiles.

This change moves the streaming boundary to the VS Code parser consumer, flushes the earlier Copilot rows once only their deduplication projections remain necessary, and retains the existing filtering, timezone, pricing, validation, sessionization, and exclusion-merging logic.

## Diff scope

- `crates/tokscale-core/src/sessions/copilot_vscode.rs`: adds a callback-based parser path that emits messages in stable file/request order, while retaining the existing collecting API as a wrapper.
- `crates/tokscale-core/src/lib.rs`: flushes the prior Copilot lane before VS Code parsing, streams accepted VS Code messages through the shared parse tail, stores session timestamps without cloning `(String, timestamp)` pairs per lookup, and lowers the `GraphSink` pricing batch to 4,096.
- Adds regression tests for emission order, bounded batch retention, and submission-exclusion aggregation across batch boundaries.
- No CLI surface, frontend behavior, database schema, cache format, workflow, dependency, or release configuration changed.

## Branch integrity

- Base: `main`
- Validated base SHA: `7ad8827a25cc8086f91a2ec4aa385f2d664085cc`
- Head SHA: `7f2ddddf456013eada3b7d0b73341faf07b9cb5c`
- Ahead/behind: `0 behind / 1 ahead`
- Merge base: `7ad8827a25cc8086f91a2ec4aa385f2d664085cc`
- `origin/main` is an ancestor of the head; diff proof was computed against the freshly fetched base.

## Commit integrity

- One logical commit: `7f2ddddf456013eada3b7d0b73341faf07b9cb5c perf(copilot): stream VS Code messages into submit fold`
- The final diff contains only the two intended core source/test files listed above.
- Ledger: not applicable — this change family does not require a ledger record.
- Version: not applicable at PR stage — the repository publish workflow synchronizes runtime package versions.

## Diff hygiene

- `git diff --check origin/main...HEAD`: PASS, no output.

## Validation mode and proof

Validation mode: Mode 3 — this changes shared submission aggregation and memory lifetime on a high-volume runtime source.

- `cargo fmt --all -- --check`: PASS.
- `cargo check -p tokscale-core`: PASS.
- `cargo test -p tokscale-core --lib`: PASS — 1,941 passed, 2 ignored, 0 failed.
- `cargo test -p tokscale-core copilot_vscode --lib`: PASS — 23 passed.
- `cargo test -p tokscale-core graph_sink_keeps_only_one_bounded_pricing_batch --lib`: PASS.
- `cargo test -p tokscale-core submission_merges_exclusions_across_bounded_batches --lib`: PASS.
- Workspace Clippy was not run successfully: the narrower core all-target run reaches a pre-existing `needless_lifetimes` warning in unmodified `sessions/pi.rs`.
- Required remote CI: pending until the PR is published. This PR is ready for review, not merge-ready until required checks and review gates pass on the final SHA.

## Migration notes

Not applicable — no database, cache-format, or persisted-data migration changed.

## CI context confirmation

- No workflow files or CI context names changed.
- Pending — required repository CI can run only after the PR is published.

## Runtime safety

- VS Code messages preserve input path order and request order.
- Deduplication keys and per-session timestamps are projected before the earlier Copilot messages are released.
- Every streamed message passes through the same client filter, synthetic normalization, timezone rebucketing, pricing, and sink logic used by collected lanes.
- Pricing exclusions are merged across batch boundaries; reducing batch size does not change the final accounting result.
- No new blocking locks, background workers, or unbounded queues were introduced.
- No accounting invariant regression introduced.

## Documentation integrity

Not applicable — no user-facing commands, public API, operational procedure, or runbook changed.

## Rollback plan

- Rollback: revert this PR.
- DB downgrade: not applicable.
- Data repair: not applicable.
- Operational caveats: none known.

## Known residual risks

- This does not change the Copilot CLI OTEL parser used by the #1209 reporter. Its whole-file JSON retention and parallel multi-file parsing require a separate two-pass/bounded-concurrency change.
- The VS Code parser still retains its projected request values for one session before emitting messages; this PR removes the second full-message vector and the cross-lane overlap, not every per-session allocation.
- No end-user RSS benchmark is claimed for this isolated diff; correctness and the bounded-buffer invariant are covered by tests, while remote platform CI remains pending until publication.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams copilot VS Code messages directly into the submit fold instead of building a second `Vec<UnifiedMessage>` for the entire lane, and shrinks the pricing batch from 65,536 to 4,096 to keep peak memory small on request-heavy histories.

**Impact**
- The VS Code parser now emits messages through a callback, releasing each projected request once folded; the collecting API remains for callers that need owned results.
- The earlier copilot OTEL/desktop rows are flushed after their dedup keys and session timestamps are projected, removing the cross-lane retention overlap.
- All filtering, pricing, validation, sessionization, and exclusion-merging logic stays identical; accounting results are unchanged across the smaller batch boundary.
- This reduces a separate retained-message peak in the VS Code and submit path but does not fix the Copilot CLI OTEL parser under `~/.copilot/otel` identified in #1209.

<sup>Written for commit 7f2ddddf456013eada3b7d0b73341faf07b9cb5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

