### PR TITLE
fix(dsh): key summaries by compaction id

### DIFF
--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -1505,6 +1505,48 @@ fn write_dsh_seeded_pair_without_seed_length(base: &Path) {
     }
 }
 
+/// Two unrelated summaries with identical local coordinates but distinct
+/// compaction UUIDs, plus one parent/child replay sharing a UUID. This is the
+/// complete #1187 collision boundary: retain two calls from the first leg and
+/// collapse the copied call from the second.
+fn write_dsh_compaction_identity_fixture(base: &Path) {
+    let fixtures = [
+        (
+            "unrelated-a",
+            r#"{"type":"session","id":"unrelated-a","createdAt":1,"cwd":"/tmp/dsh-workspace"}"#,
+            r#"{"type":"compaction/summary","seq":4,"time":1786669450002,"data":{"compactionId":"compact-a","message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20}}}"#,
+        ),
+        (
+            "unrelated-b",
+            r#"{"type":"session","id":"unrelated-b","createdAt":2,"cwd":"/tmp/dsh-workspace"}"#,
+            r#"{"type":"compaction/summary","seq":4,"time":1786669450002,"data":{"compactionId":"compact-b","message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20}}}"#,
+        ),
+        (
+            "fork-parent",
+            r#"{"type":"session","id":"fork-parent","createdAt":3,"cwd":"/tmp/dsh-workspace"}"#,
+            r#"{"type":"compaction/summary","seq":9,"time":1786669450003,"data":{"compactionId":"compact-copied","message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":30,"outputTokens":40}}}"#,
+        ),
+        (
+            "fork-child",
+            r#"{"type":"session","id":"fork-child","createdAt":4,"cwd":"/tmp/dsh-workspace","parentSession":"fork-parent"}"#,
+            r#"{"type":"compaction/summary","seq":9,"time":1786669450003,"data":{"compactionId":"compact-copied","message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":30,"outputTokens":40}}}"#,
+        ),
+    ];
+
+    for (session_id, header, summary) in fixtures {
+        let dir = dsh_sessions_root(base)
+            .join("-tmp-dsh-workspace")
+            .join(session_id);
+        fs::create_dir_all(&dir).unwrap();
+        let payload = format!("{header}\n{summary}\n");
+        fs::write(
+            dir.join("session.jsonl.zstd"),
+            zstd::encode_all(payload.as_bytes(), 3).unwrap(),
+        )
+        .unwrap();
+    }
+}
+
 fn write_jcode_session(base: &Path) {
     let sessions_dir = base.join(".jcode/sessions");
     fs::create_dir_all(&sessions_dir).unwrap();
@@ -2476,6 +2518,28 @@ fn test_dsh_repeated_message_ids_across_transcripts_count_once_cold_and_warm_cac
         assert_eq!(json["totalMessages"].as_i64(), Some(1), "{pass} cache pass");
         assert_eq!(json["totalInput"].as_i64(), Some(2885), "{pass} cache pass");
         assert_eq!(json["totalOutput"].as_i64(), Some(2), "{pass} cache pass");
+    }
+}
+
+#[test]
+fn test_dsh_compaction_identity_is_global_cold_and_warm_cache() {
+    let tmp = create_empty_fixture_dir();
+    write_dsh_compaction_identity_fixture(tmp.path());
+
+    for pass in ["cold", "warm"] {
+        let output = cmd_with_home(tmp.path())
+            .args(["models", "--json", "--client", "dsh", "--no-spinner"])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{pass} cache pass failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(json["totalMessages"].as_i64(), Some(3), "{pass} cache pass");
+        assert_eq!(json["totalInput"].as_i64(), Some(50), "{pass} cache pass");
+        assert_eq!(json["totalOutput"].as_i64(), Some(80), "{pass} cache pass");
     }
 }
 

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1254,7 +1254,11 @@ fn parser_version(client: ClientId) -> u32 {
         // request model. Finished DSH transcripts are append-only and keep the
         // same fingerprint, so only this bump replaces cached alias/substitute
         // attribution and its derived pricing.
-        ClientId::Dsh => 4,
+        // v4->v5: compaction summaries now use their globally stable
+        // `data.compactionId` before the per-transcript `seq` fallback. Reparse
+        // released v4 rows so unrelated summaries with otherwise identical
+        // call data are no longer collapsed across files (#1187).
+        ClientId::Dsh => 5,
         // First version of the fx (vercel-labs) usage-v2.json parser. Entries
         // are versioned from the start so later parser changes have an
         // obvious local counter to bump, like every other client here.
@@ -3377,11 +3381,11 @@ mod tests {
     }
 
     #[test]
-    fn test_dsh_served_model_parser_version_invalidates_v3_entries() {
+    fn test_dsh_compaction_identity_parser_version_invalidates_v4_entries() {
         // A finished transcript is never rewritten when attribution starts
-        // preferring the provider-reported response model, so its fingerprint
-        // remains valid and only the parser version can retire the old row.
-        assert_eq!(parser_version(ClientId::Dsh), 4);
+        // preferring compactionId, so its fingerprint remains valid and only
+        // the parser version can retire the seq-keyed row released in v4.14.0.
+        assert_eq!(parser_version(ClientId::Dsh), 5);
     }
 
     #[test]
@@ -3395,7 +3399,7 @@ mod tests {
 "#,
         );
         let current_identity = CacheIdentity::for_client(ClientId::Dsh);
-        assert_eq!(current_identity.parser_version, 4);
+        assert_eq!(current_identity.parser_version, 5);
         let stale_identity = CacheIdentity {
             namespace: current_identity.namespace,
             parser_version: 3,
@@ -3456,7 +3460,87 @@ mod tests {
 
         let warm = SourceMessageCache::load();
         let cached = warm.get(current_identity, source.path()).unwrap();
-        assert_eq!(cached.parser_version, 4);
+        assert_eq!(cached.parser_version, 5);
+        assert_eq!(cached.messages, rebuilt);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn dsh_v4_shards_are_reparsed_with_global_compaction_identity() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let source = write_temp_file(
+            br#"{"type":"session","id":"session-summary","createdAt":1,"cwd":"/work"}
+{"type":"compaction/summary","seq":4,"time":1786669450002,"data":{"compactionId":"compact-global","message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20}}}
+"#,
+        );
+        let current_identity = CacheIdentity::for_client(ClientId::Dsh);
+        assert_eq!(current_identity.parser_version, 5);
+        let stale_identity = CacheIdentity {
+            namespace: current_identity.namespace,
+            parser_version: 4,
+        };
+        let fingerprint = SourceFingerprint::from_path(source.path()).unwrap();
+        let mut stale_message = UnifiedMessage::new(
+            current_identity.namespace,
+            "m",
+            "p",
+            "session-summary",
+            1786669450002,
+            crate::TokenBreakdown {
+                input: 10,
+                output: 20,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            0.0,
+        );
+        stale_message.dedup_key =
+            Some("dsh:summary:seq:4:1786669450002:p:m:10:20:0:0:0".to_string());
+        let stale_entry = CachedSourceEntry::new(
+            stale_identity,
+            source.path(),
+            fingerprint.clone(),
+            vec![stale_message],
+            Vec::new(),
+            None,
+        );
+        let stale_path = cache_shard_path(current_identity, source.path());
+        ensure_cache_dir(stale_path.parent().unwrap()).unwrap();
+        write_shard_with_limit(
+            &stale_path,
+            stale_identity,
+            &[stale_entry],
+            MAX_CACHE_SHARD_BYTES,
+        )
+        .unwrap();
+
+        let mut cache = SourceMessageCache::load();
+        assert!(
+            cache.get(current_identity, source.path()).is_none(),
+            "a released v4 seq-keyed row must not survive the parser change"
+        );
+
+        let rebuilt = crate::sessions::dsh::parse_dsh_file(source.path());
+        assert_eq!(rebuilt.len(), 1);
+        assert_eq!(
+            rebuilt[0].dedup_key.as_deref(),
+            Some("dsh:summary:cmp:compact-global:1786669450002:p:m:10:20:0:0:0")
+        );
+        cache.insert(CachedSourceEntry::new(
+            current_identity,
+            source.path(),
+            fingerprint,
+            rebuilt.clone(),
+            Vec::new(),
+            None,
+        ));
+        cache.save_if_dirty();
+
+        let warm = SourceMessageCache::load();
+        let cached = warm.get(current_identity, source.path()).unwrap();
+        assert_eq!(cached.parser_version, 5);
         assert_eq!(cached.messages, rebuilt);
     }
 

--- a/crates/tokscale-core/src/sessions/dsh.rs
+++ b/crates/tokscale-core/src/sessions/dsh.rs
@@ -343,18 +343,33 @@ pub fn parse_dsh_file(path: &Path) -> Vec<UnifiedMessage> {
                 // keys differ, and the cross-file pass -- which only collapses
                 // identical keys -- bills the summarize call twice.
                 //
-                // `seq` is the other field a fork copies verbatim (see the
-                // boundary check above), so it stands in for the missing id and
-                // stays identical across the copy. It is unique within a file,
-                // and pairing it with the timestamp, routing and buckets already
-                // in the key means an accidental merge would need two unrelated
-                // sessions to agree on all of them at millisecond resolution.
+                // Summaries carry their own per-call UUID on
+                // `data.compactionId`, and a fork copies it verbatim. Prefer it
+                // before `seq`: sequence numbers restart in every transcript,
+                // so unrelated summaries can otherwise collapse when their
+                // timestamp, routing and usage happen to agree (#1187).
+                //
+                // Keep `seq` as the final cross-file fallback for older or
+                // damaged summaries without a compaction id. It remains better
+                // than the session id for the seedLength-less fork handled by
+                // #1173, because the fork copies the sequence number too.
                 let identity = value
                     .pointer("/data/message/id")
                     .and_then(Value::as_str)
                     .map(str::trim)
                     .filter(|id| !id.is_empty())
                     .map(|id| format!("msg:{id}"))
+                    .or_else(|| {
+                        if !is_summary {
+                            return None;
+                        }
+                        value
+                            .pointer("/data/compactionId")
+                            .and_then(Value::as_str)
+                            .map(str::trim)
+                            .filter(|id| !id.is_empty())
+                            .map(|id| format!("cmp:{id}"))
+                    })
                     .or_else(|| {
                         value
                             .get("seq")
@@ -654,9 +669,6 @@ mod tests {
         assert!(first.is_turn_start);
         assert_eq!(first.workspace_key.as_deref(), Some("E:/repo/proj"));
         assert_eq!(first.workspace_label.as_deref(), Some("proj"));
-        // This row carries no `message.id`, so the key falls back to `seq`
-        // rather than the session id: a fork copies `seq` verbatim, so the key
-        // survives the copy and the cross-file pass can collapse the two.
         // This row carries no `message.id`, so the key falls back to `seq`
         // rather than the session id: a fork copies `seq` verbatim, so the key
         // survives the copy and the cross-file pass can still collapse the two.
@@ -1002,7 +1014,7 @@ mod tests {
         // `dsh:summary:sid:parent...` and `dsh:summary:sid:child...`; the
         // cross-file pass only collapses identical keys, so the summarize call
         // was billed twice.
-        let row = r#"{"type":"compaction/summary","seq":4,"time":1786669450002,"data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20}}}"#;
+        let row = r#"{"type":"compaction/summary","seq":4,"time":1786669450002,"data":{"compactionId":"1ad33c8f-5255-4158-b607-7555f3c26cd0","message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20}}}"#;
         let parent = write_zstd_session(&[
             r#"{"type":"session","id":"96cf59c9-b347-48b9-b234-a5200913ad05","createdAt":1,"cwd":"/work"}"#,
             row,
@@ -1024,11 +1036,59 @@ mod tests {
         );
         assert_eq!(
             parent_messages[0].dedup_key.as_deref(),
-            Some("dsh:summary:seq:4:1786669450002:p:m:10:20:0:0:0")
+            Some(
+                "dsh:summary:cmp:1ad33c8f-5255-4158-b607-7555f3c26cd0:1786669450002:p:m:10:20:0:0:0"
+            )
         );
         assert_eq!(
             parent_messages[0].dedup_key, child_messages[0].dedup_key,
             "a copied summary must collapse across the fork, or its cost is counted twice"
+        );
+    }
+
+    #[test]
+    fn distinct_compaction_ids_keep_otherwise_identical_summaries() {
+        let first = write_zstd_session(&[
+            r#"{"type":"session","id":"session-a","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"compaction/summary","seq":4,"time":1786669450002,"data":{"compactionId":"compact-a","message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20,"cacheReadTokens":30}}}"#,
+        ]);
+        let second = write_zstd_session(&[
+            r#"{"type":"session","id":"session-b","createdAt":2,"cwd":"/work"}"#,
+            r#"{"type":"compaction/summary","seq":4,"time":1786669450002,"data":{"compactionId":"compact-b","message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20,"cacheReadTokens":30}}}"#,
+        ]);
+
+        let first_messages = parse_dsh_file(first.path());
+        let second_messages = parse_dsh_file(second.path());
+
+        assert_eq!(first_messages.len(), 1);
+        assert_eq!(second_messages.len(), 1);
+        assert_eq!(
+            first_messages[0].dedup_key.as_deref(),
+            Some("dsh:summary:cmp:compact-a:1786669450002:p:m:10:20:30:0:0")
+        );
+        assert_eq!(
+            second_messages[0].dedup_key.as_deref(),
+            Some("dsh:summary:cmp:compact-b:1786669450002:p:m:10:20:30:0:0")
+        );
+        assert_ne!(
+            first_messages[0].dedup_key, second_messages[0].dedup_key,
+            "globally distinct summarize calls must both survive lane dedup"
+        );
+    }
+
+    #[test]
+    fn summary_without_compaction_id_keeps_seq_fallback() {
+        let file = write_zstd_session(&[
+            r#"{"type":"session","id":"legacy-summary","createdAt":1,"cwd":"/work"}"#,
+            r#"{"type":"compaction/summary","seq":9,"time":1786669450002,"data":{"message":{"source":{"provider":"p","model":"m"}},"usage":{"inputTokens":10,"outputTokens":20}}}"#,
+        ]);
+
+        let messages = parse_dsh_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("dsh:summary:seq:9:1786669450002:p:m:10:20:0:0:0")
         );
     }
 


### PR DESCRIPTION
## Summary

- Key DSH `compaction/summary` usage by its globally stable `data.compactionId` before considering transcript-local sequence numbers.
- Keep the existing `seq` identity as a compatibility fallback for legacy or damaged summaries that do not carry a compaction ID.
- Bump the DSH parser cache identity from 4 to 5 so released seq-keyed rows are reparsed instead of remaining silently undercounted.
- Add parser, cache-migration, and cold/warm CLI regressions that prove distinct summarize calls survive while a copied fork summary still collapses.

Fixes #1187.

## Why

Sequence numbers restart in every DSH transcript. Before this change, an idless compaction summary used `seq` as its primary cross-file identity, so two unrelated summarize calls could collapse when their local sequence, millisecond timestamp, provider, model, and token buckets matched. That loses real usage.

The same event already carries a per-call `data.compactionId`. DSH copies that UUID verbatim when a fork replays the parent summary, which gives the deduplicator exactly the property it needs: unrelated calls remain distinct, while the same billed call copied into another transcript retains one identity. The previous `seq` fallback remains necessary for older summaries without a compaction ID and continues to protect the seedLength-less fork case introduced by #1173.

## Diff scope

- `crates/tokscale-core/src/sessions/dsh.rs`: prefer a trimmed, non-empty `data.compactionId` for compaction summaries after `message.id` and before `seq`; retain the legacy sequence fallback; add direct regressions for distinct summaries, copied summaries, and missing IDs.
- `crates/tokscale-core/src/message_cache.rs`: bump the DSH parser version from 4 to 5 and verify a released v4 seq-keyed shard is rejected, reparsed with `cmp:` identity, and persisted under v5.
- `crates/tokscale-cli/tests/cli_tests.rs`: exercise the complete collision boundary through the CLI on both cold and warm cache passes.
- No database schema, dependency, CLI surface, frontend behavior, workflow, release configuration, or unrelated parser changed.

## Branch integrity

- Base: `main`
- Validated base SHA: `7ad8827a25cc8086f91a2ec4aa385f2d664085cc`
- Head SHA: `1c39c7800796bf3b1d11438a9b649bc36521087f`
- Ahead/behind: 0 behind / 1 ahead
- Merge base: `7ad8827a25cc8086f91a2ec4aa385f2d664085cc`
- `origin/main` is an ancestor of the branch; all diff proof was computed against the freshly fetched base.

## Commit integrity

- One atomic commit: `1c39c7800796bf3b1d11438a9b649bc36521087f fix(dsh): key summaries by compaction id`
- The final diff contains only the DSH identity change, its source-cache migration, and directly related tests.
- Ledger: not applicable — this change family does not require a ledger record.
- Version: release manifests are unchanged; the repository publish workflow owns synchronized package version bumps.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: three intended modified files.
- `git diff --check origin/main...HEAD`: PASS, no output.

## Validation mode and proof

Validation mode: Mode 3 — cross-session usage identity and persisted source-cache interpretation directly affect accounting totals.

- `cargo fmt --all -- --check`: PASS.
- `cargo check -p tokscale-core -p tokscale-cli`: PASS.
- `cargo test -p tokscale-core dsh --lib`: PASS, 35 passed.
- `cargo test -p tokscale-cli --test cli_tests dsh`: PASS, 5 passed after the new fixture.
- `cargo test -p tokscale-core --lib`: PASS on the final repeat, 1941 passed and 2 ignored.
- `cargo test -p tokscale-cli --test cli_tests`: PASS, 174 passed.
- The first full core run had one unrelated Antigravity timestamp test failure; that test passed in isolation, and the complete core suite then passed on repeat. No Antigravity file is changed by this branch.
- Clippy is not reported as passing: the workspace baseline reaches a pre-existing `sessions/pi.rs` `needless_lifetimes` finding outside this diff.

## Cache and migration notes

- This is an application cache migration, not a database migration.
- DSH parser identity changes from v4 to v5 because completed transcripts can retain the same source fingerprint while their deduplication meaning changes.
- Existing v4 DSH cache rows are invalidated and rebuilt once from the original transcript; they are not translated in place.
- The migration is now user-facing because DSH shipped before this fix. The one-time reparse is required to recover summaries that v4 could have collapsed.
- Database downgrade and data repair are not applicable; source transcripts remain authoritative.

## CI context confirmation

- CI workflow files and context names are unchanged.
- Pending — required GitHub CI starts after this PR is created and must pass on the final SHA before merge.
- The PR is ready for review, not merge-ready, until required remote checks and review gates pass.

## Runtime safety

- `message.id` remains the highest-priority identity when present.
- `compactionId` is used only for `compaction/summary` rows and only when it is a non-empty string after trimming.
- Summaries without a usable compaction ID retain the existing `seq` fallback, preserving compatibility with old or damaged transcripts.
- A forked copy with the same compaction UUID still collapses; unrelated summaries with different UUIDs cannot collide merely because their transcript-local coordinates match.
- No new lock, queue, background worker, network access, or unbounded collection is introduced.
- No accounting invariant regression introduced.

## Documentation integrity

Not applicable — no command, configuration, data location, public API, or operational runbook changed.

## Rollback plan

- Rollback: `git revert <post_merge_commit_sha>` after merge.
- Database downgrade: not applicable.
- Data repair: not applicable.
- Operational caveat: reverting restores seq-first summary identity and causes the active parser cache identity to rebuild again.

## Known residual risks

- Legacy summaries without `compactionId` still depend on the existing composite `seq` fallback and retain its theoretical cross-file collision boundary.
- The first DSH read after upgrading performs a one-time cache reparse for affected shards.
- Required remote CI has not run because the PR has not yet been created.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1187 so DSH compaction summaries are keyed by their globally stable `data.compactionId` before transcript-local `seq`, which stops unrelated summarize calls from collapsing while copied fork summaries still deduplicate. The DSH parser cache identity bumps 4→5, so released v4 seq-keyed rows are invalidated and reparsed once from source transcripts.

**Notes**
- Summaries without a usable `compactionId` keep the `seq` fallback for legacy or damaged transcripts.
- `message.id` remains the highest-priority identity when present.

<sup>Written for commit 1c39c7800796bf3b1d11438a9b649bc36521087f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

