### PR TITLE
fix(opencode): namespace idless legacy message keys

### DIFF
--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -1166,6 +1166,21 @@ fn add_reasoning_only_opencode_message(base: &Path) {
     fs::write(session.join("reasoning-msg.json"), message).unwrap();
 }
 
+fn add_same_named_idless_opencode_messages(base: &Path) {
+    let root = base.join(".local/share/opencode/storage/message");
+    for (session_id, input, output) in [("idless-session-a", 13, 2), ("idless-session-b", 17, 3)] {
+        let session = root.join(session_id);
+        fs::create_dir_all(&session).unwrap();
+        fs::write(
+            session.join("same-name.json"),
+            format!(
+                r#"{{"sessionID":"{session_id}","role":"assistant","modelID":"gpt-4o","providerID":"openai","tokens":{{"input":{input},"output":{output},"reasoning":0,"cache":{{"read":0,"write":0}}}},"time":{{"created":1700000000000}}}}"#
+            ),
+        )
+        .unwrap();
+    }
+}
+
 fn write_fireworks_pricing_cache(base: &Path) {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -2213,6 +2228,28 @@ fn test_models_with_client_filter_opencode() {
     let entries = json["entries"].as_array().unwrap();
     for entry in entries {
         assert_eq!(entry["client"].as_str().unwrap(), "opencode");
+    }
+}
+
+#[test]
+fn test_opencode_same_named_idless_files_survive_cold_and_warm_cache() {
+    let tmp = create_empty_fixture_dir();
+    add_same_named_idless_opencode_messages(tmp.path());
+
+    for pass in ["cold", "warm"] {
+        let output = cmd_with_home(tmp.path())
+            .args(["models", "--json", "--client", "opencode", "--no-spinner"])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{pass} cache pass failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(json["totalMessages"].as_i64(), Some(2), "{pass} cache pass");
+        assert_eq!(json["totalInput"].as_i64(), Some(30), "{pass} cache pass");
+        assert_eq!(json["totalOutput"].as_i64(), Some(5), "{pass} cache pass");
     }
 }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -770,14 +770,28 @@ fn parse_all_messages_with_pricing_with_env_strategy(
 /// lanes are scanned and the SQLite lane runs first, so every migrated file is
 /// parsed only for its message to be dropped by the dedup filter that follows.
 ///
-/// The file stem is the message id, which is exactly the dedup key the SQLite
-/// lane inserted, so the duplicate can be recognized from the path alone —
-/// before the file is opened. On a migrated install that skips nearly the whole
-/// directory (#1209); unmigrated files miss the set and are still parsed.
-fn opencode_json_superseded_by_sqlite(path: &Path, sqlite_keys: &HashSet<String>) -> bool {
-    path.file_stem()
-        .and_then(|stem| stem.to_str())
-        .is_some_and(|stem| sqlite_keys.contains(stem))
+/// The file stem is the message id and its parent directory is the session id.
+/// Requiring both preserves the pre-open migration fast path from #1209 while
+/// preventing an id-less file in another session from being suppressed merely
+/// because its local filename matches an unrelated SQLite id (#1198).
+fn opencode_json_superseded_by_sqlite(
+    path: &Path,
+    sqlite_locations: &HashMap<String, HashSet<String>>,
+) -> bool {
+    let Some(message_id) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return false;
+    };
+    let Some(session_id) = path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+    else {
+        return false;
+    };
+
+    sqlite_locations
+        .get(session_id)
+        .is_some_and(|message_ids| message_ids.contains(message_id))
 }
 
 /// Receives fully-transformed messages as each client lane finishes, so the
@@ -1866,6 +1880,7 @@ fn parse_all_messages_streaming<S: MessageSink>(
     // Parse OpenCode: prefer SQLite, collapse forked SQLite history there, then
     // suppress legacy JSON overlap by message identity.
     let mut opencode_seen: HashSet<String> = HashSet::new();
+    let mut opencode_sqlite_locations: HashMap<String, HashSet<String>> = HashMap::new();
 
     for db_path in &scan_result.opencode_dbs {
         let CachedParseOutcome {
@@ -1878,12 +1893,18 @@ fn parse_all_messages_streaming<S: MessageSink>(
         // both `opencode.db` and `opencode-<channel>.db` if the user
         // switches channels mid-session. `discover_opencode_dbs` returns
         // paths in sorted order, so the first-seen copy is deterministic.
-        all_messages.extend(messages.into_iter().filter(|message| {
-            message
-                .dedup_key
-                .as_ref()
-                .is_none_or(|key| opencode_seen.insert(key.clone()))
-        }));
+        for message in messages {
+            if let Some(key) = message.dedup_key.as_ref() {
+                opencode_sqlite_locations
+                    .entry(message.session_id.clone())
+                    .or_default()
+                    .insert(key.clone());
+                if !opencode_seen.insert(key.clone()) {
+                    continue;
+                }
+            }
+            all_messages.push(message);
+        }
 
         if let Some(entry) = cache_entry {
             source_cache.insert(entry);
@@ -1893,7 +1914,7 @@ fn parse_all_messages_streaming<S: MessageSink>(
     let opencode_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::OpenCode)
         .par_iter()
-        .filter(|path| !opencode_json_superseded_by_sqlite(path, &opencode_seen))
+        .filter(|path| !opencode_json_superseded_by_sqlite(path, &opencode_sqlite_locations))
         .filter_map(|path| {
             Some(load_or_parse_source(
                 message_cache::CacheIdentity::for_client(ClientId::OpenCode),
@@ -4776,6 +4797,7 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
 
     let opencode_count: i32 = {
         let mut seen: HashSet<String> = HashSet::new();
+        let mut sqlite_locations: HashMap<String, HashSet<String>> = HashMap::new();
         let mut count: i32 = 0;
 
         for db_path in &scan_result.opencode_dbs {
@@ -4784,6 +4806,12 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
                     .into_iter()
                     .filter_map(|msg| {
                         let key = msg.dedup_key.clone().unwrap_or_default();
+                        if !key.is_empty() {
+                            sqlite_locations
+                                .entry(msg.session_id.clone())
+                                .or_default()
+                                .insert(key.clone());
+                        }
                         // Dedup across multiple channel-suffixed dbs: the
                         // same session can end up in both `opencode.db` and
                         // `opencode-<channel>.db` if the user switches
@@ -4803,7 +4831,7 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
         let json_msgs: Vec<(String, ParsedMessage)> = scan_result
             .get(ClientId::OpenCode)
             .par_iter()
-            .filter(|path| !opencode_json_superseded_by_sqlite(path, &seen))
+            .filter(|path| !opencode_json_superseded_by_sqlite(path, &sqlite_locations))
             .filter_map(|path| {
                 let msg = sessions::opencode::parse_opencode_file(path)?;
                 let key = msg.dedup_key.clone().unwrap_or_default();
@@ -10264,32 +10292,43 @@ mod tests {
 
     #[test]
     fn test_opencode_json_superseded_by_sqlite_matches_on_message_id() {
-        let mut sqlite_keys: HashSet<String> = HashSet::new();
-        sqlite_keys.insert("msg_migrated".to_string());
+        let mut sqlite_locations: HashMap<String, HashSet<String>> = HashMap::new();
+        sqlite_locations.insert(
+            "ses_1".to_string(),
+            HashSet::from(["msg_migrated".to_string()]),
+        );
 
         // The legacy file is named after the message id the migration copied
         // into SQLite, so the duplicate is recognizable from the path alone.
         assert!(opencode_json_superseded_by_sqlite(
             std::path::Path::new("/s/storage/message/ses_1/msg_migrated.json"),
-            &sqlite_keys
+            &sqlite_locations
         ));
 
         // A file the migration never reached has no row to shadow it.
         assert!(!opencode_json_superseded_by_sqlite(
             std::path::Path::new("/s/storage/message/ses_1/msg_unmigrated.json"),
-            &sqlite_keys
+            &sqlite_locations
+        ));
+
+        // A stem is not globally unique. Another session's id-less file must
+        // be parsed and receive its path-scoped fallback instead of being
+        // discarded by the migration fast path.
+        assert!(!opencode_json_superseded_by_sqlite(
+            std::path::Path::new("/s/storage/message/ses_2/msg_migrated.json"),
+            &sqlite_locations
         ));
 
         // Without any SQLite db every file has to be read.
         assert!(!opencode_json_superseded_by_sqlite(
             std::path::Path::new("/s/storage/message/ses_1/msg_migrated.json"),
-            &HashSet::new()
+            &HashMap::new()
         ));
 
-        // Only the stem participates: the session directory is not a message id.
+        // Neither coordinate may be borrowed from a different path level.
         assert!(!opencode_json_superseded_by_sqlite(
             std::path::Path::new("/s/storage/message/msg_migrated/other.json"),
-            &sqlite_keys
+            &sqlite_locations
         ));
     }
 
@@ -10336,6 +10375,126 @@ mod tests {
             r#"{"id":"msg_unmigrated","sessionID":"ses_1","role":"assistant","modelID":"claude-sonnet-4","providerID":"anthropic","cost":0.02,"tokens":{"input":7,"output":3,"reasoning":0,"cache":{"read":0,"write":0}},"time":{"created":1700000001000}}"#,
         )
         .unwrap();
+    }
+
+    /// SQLite holds one globally identified message. Two different legacy
+    /// sessions reuse that id as a local filename but omit the embedded id,
+    /// while a third JSON file carries the real embedded id and is a true
+    /// duplicate of SQLite.
+    fn write_opencode_idless_collision_fixture(source_home: &std::path::Path) {
+        let db_dir = source_home.join(".local/share/opencode");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        let conn = create_opencode_sqlite_db(&db_dir.join("opencode.db"));
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params![
+                "shared-id",
+                "sqlite-session",
+                build_opencode_sqlite_payload(
+                    1_700_000_000_000.0,
+                    1_700_000_000_500.0,
+                    100,
+                    10,
+                    0,
+                    0,
+                    0,
+                    0.01,
+                )
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let root = source_home.join(".local/share/opencode/storage/message");
+        for (session, input) in [("legacy-a", 7), ("legacy-b", 11)] {
+            let dir = root.join(session);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("shared-id.json"),
+                format!(
+                    r#"{{"sessionID":"{session}","role":"assistant","modelID":"claude-sonnet-4","providerID":"anthropic","tokens":{{"input":{input},"output":1,"reasoning":0,"cache":{{"read":0,"write":0}}}},"time":{{"created":1700000001000}}}}"#
+                ),
+            )
+            .unwrap();
+        }
+
+        let embedded_dir = root.join("legacy-embedded-copy");
+        std::fs::create_dir_all(&embedded_dir).unwrap();
+        std::fs::write(
+            embedded_dir.join("different-filename.json"),
+            r#"{"id":"shared-id","sessionID":"legacy-embedded-copy","role":"assistant","modelID":"claude-sonnet-4","providerID":"anthropic","tokens":{"input":100,"output":10,"reasoning":0,"cache":{"read":0,"write":0}},"time":{"created":1700000000000}}"#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_keeps_same_named_idless_opencode_files() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        write_opencode_idless_collision_fixture(source_home.path());
+
+        for pass in ["cold", "warm"] {
+            let messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["opencode".to_string()],
+                None,
+            );
+
+            assert_eq!(messages.len(), 3, "{pass} cache pass");
+            assert_eq!(
+                messages
+                    .iter()
+                    .map(|message| message.tokens.input)
+                    .sum::<i64>(),
+                118,
+                "{pass} cache pass"
+            );
+            let keys: HashSet<&str> = messages
+                .iter()
+                .filter_map(|message| message.dedup_key.as_deref())
+                .collect();
+            assert!(keys.contains("shared-id"), "{pass} cache pass");
+            assert_eq!(
+                keys.iter()
+                    .filter(|key| key.starts_with("legacy-json-path:"))
+                    .count(),
+                2,
+                "{pass} cache pass"
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_local_clients_keeps_same_named_idless_opencode_files() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        write_opencode_idless_collision_fixture(source_home.path());
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(source_home.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["opencode".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+
+        assert_eq!(parsed.counts.get(ClientId::OpenCode), 3);
+        assert_eq!(parsed.messages.len(), 3);
+        assert_eq!(
+            parsed
+                .messages
+                .iter()
+                .map(|message| message.input)
+                .sum::<i64>(),
+            118
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1273,7 +1273,11 @@ fn parser_version(client: ClientId) -> u32 {
         // the legacy `session` join for workspace and title. A database that
         // carries both tables is byte-identical before and after, so only the
         // version bump discards entries still holding the old attribution.
-        ClientId::OpenCode => 2,
+        // v2 -> v3: id-less legacy JSON messages now carry a canonical
+        // path-scoped key instead of a globally colliding filename stem. The
+        // source bytes and fingerprint do not change, so invalidate cached v2
+        // rows to make same-named files in different sessions survive (#1198).
+        ClientId::OpenCode => 3,
         _ => 1,
     }
 }
@@ -3361,11 +3365,95 @@ mod tests {
     }
 
     #[test]
-    fn test_opencode_session_v2_metadata_parser_version_invalidates_v1_entries() {
-        // A database holding both `session` and `session_v2` does not change on
-        // disk when the parser starts preferring the newer table, so the
-        // fingerprint keeps matching and only this bump forces the reparse.
-        assert_eq!(parser_version(ClientId::OpenCode), 2);
+    fn test_opencode_path_identity_parser_version_invalidates_v2_entries() {
+        // An id-less JSON file does not change on disk when its fallback key
+        // becomes path-scoped, so only this bump retires the colliding v2 key.
+        assert_eq!(parser_version(ClientId::OpenCode), 3);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn opencode_v2_shards_reparse_idless_json_with_path_identity() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let source_root = TempDir::new().unwrap();
+        let source = source_root.path().join("session-a/shared-name.json");
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::write(
+            &source,
+            br#"{"sessionID":"session-a","role":"assistant","modelID":"m","providerID":"p","tokens":{"input":10,"output":20,"reasoning":0,"cache":{"read":0,"write":0}},"time":{"created":1700000000000}}"#,
+        )
+        .unwrap();
+
+        let current_identity = CacheIdentity::for_client(ClientId::OpenCode);
+        assert_eq!(current_identity.parser_version, 3);
+        let stale_identity = CacheIdentity {
+            namespace: current_identity.namespace,
+            parser_version: 2,
+        };
+        let fingerprint = SourceFingerprint::from_path(&source).unwrap();
+        let mut stale_message = UnifiedMessage::new(
+            current_identity.namespace,
+            "m",
+            "p",
+            "session-a",
+            1_700_000_000_000,
+            crate::TokenBreakdown {
+                input: 10,
+                output: 20,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            0.0,
+        );
+        stale_message.dedup_key = Some("shared-name".to_string());
+        let stale_entry = CachedSourceEntry::new(
+            stale_identity,
+            &source,
+            fingerprint.clone(),
+            vec![stale_message],
+            Vec::new(),
+            None,
+        );
+        let stale_path = cache_shard_path(current_identity, &source);
+        ensure_cache_dir(stale_path.parent().unwrap()).unwrap();
+        write_shard_with_limit(
+            &stale_path,
+            stale_identity,
+            &[stale_entry],
+            MAX_CACHE_SHARD_BYTES,
+        )
+        .unwrap();
+
+        let mut cache = SourceMessageCache::load();
+        assert!(
+            cache.get(current_identity, &source).is_none(),
+            "the globally colliding v2 fallback must not survive the parser bump"
+        );
+
+        let rebuilt = crate::sessions::opencode::parse_opencode_file(&source)
+            .into_iter()
+            .collect::<Vec<_>>();
+        assert_eq!(rebuilt.len(), 1);
+        assert!(rebuilt[0]
+            .dedup_key
+            .as_deref()
+            .is_some_and(|key| key.starts_with("legacy-json-path:")));
+        cache.insert(CachedSourceEntry::new(
+            current_identity,
+            &source,
+            fingerprint,
+            rebuilt.clone(),
+            Vec::new(),
+            None,
+        ));
+        cache.save_if_dirty();
+
+        let warm = SourceMessageCache::load();
+        let cached = warm.get(current_identity, &source).unwrap();
+        assert_eq!(cached.parser_version, 3);
+        assert_eq!(cached.messages, rebuilt);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -88,12 +88,15 @@ pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
 
     let session_id = msg.session_id.unwrap_or_else(|| "unknown".to_string());
 
-    // Use message ID from JSON or derive from filename for deduplication
-    let dedup_key = msg.id.or_else(|| {
-        path.file_stem()
-            .and_then(|s| s.to_str())
-            .map(|s| s.to_string())
-    });
+    // Embedded message ids are globally stable across the legacy JSON and
+    // SQLite representations, so keep them unnamespaced for overlap and fork
+    // dedup. A filename is only unique inside its session directory; make the
+    // no-id fallback path-scoped so same-named files in separate sessions do
+    // not silently collapse (#1198). Canonicalization also keeps one physical
+    // file reached through two path spellings on one key. If a non-UTF-8 path
+    // cannot be represented, leave the key absent: retaining both candidates
+    // is safer than inventing a lossy identity that can undercount.
+    let dedup_key = msg.id.or_else(|| legacy_json_path_dedup_key(path));
     let cost = reported_cost(msg.cost).unwrap_or(0.0);
 
     let mut unified = UnifiedMessage::new_with_agent(
@@ -127,6 +130,13 @@ pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
         unified.mark_provider_reported_cost();
     }
     Some(unified)
+}
+
+fn legacy_json_path_dedup_key(path: &Path) -> Option<String> {
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    canonical
+        .to_str()
+        .map(|path| format!("legacy-json-path:{path}"))
 }
 
 // =============================================================================
@@ -838,9 +848,9 @@ mod tests {
         assert_eq!(msg.duration_ms, Some(1234));
     }
 
-    /// JSON dedup_key falls back to file stem when msg.id is absent
+    /// JSON dedup_key falls back to a path-scoped identity when msg.id is absent.
     #[test]
-    fn test_dedup_key_falls_back_to_file_stem() {
+    fn test_dedup_key_falls_back_to_canonical_file_path() {
         let json = r#"{
             "sessionID": "ses_001",
             "role": "assistant",
@@ -863,9 +873,44 @@ mod tests {
         let msg = parse_opencode_file(&file_path).expect("Should parse");
         assert_eq!(
             msg.dedup_key,
-            Some("msg_fallback_999".to_string()),
-            "dedup_key should fall back to file stem when id is missing"
+            legacy_json_path_dedup_key(&file_path),
+            "an id-less message must use the file's canonical location"
         );
+        assert!(msg
+            .dedup_key
+            .as_deref()
+            .is_some_and(|key| key.starts_with("legacy-json-path:")));
+    }
+
+    #[test]
+    fn same_named_idless_files_in_different_sessions_have_distinct_keys() {
+        let json = r#"{
+            "sessionID": "embedded-session-is-not-the-fallback",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "tokens": {
+                "input": 100,
+                "output": 50,
+                "reasoning": 0,
+                "cache": { "read": 0, "write": 0 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+        let root = tempfile::tempdir().unwrap();
+        let first = root.path().join("session-a/same-name.json");
+        let second = root.path().join("session-b/same-name.json");
+        std::fs::create_dir_all(first.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(second.parent().unwrap()).unwrap();
+        std::fs::write(&first, json).unwrap();
+        std::fs::write(&second, json).unwrap();
+
+        let first = parse_opencode_file(&first).unwrap();
+        let second = parse_opencode_file(&second).unwrap();
+
+        assert_ne!(first.dedup_key, second.dedup_key);
+        assert!(first.dedup_key.is_some());
+        assert!(second.dedup_key.is_some());
     }
 
     /// Non-assistant messages are skipped (no dedup_key produced)


### PR DESCRIPTION
## Summary

- Give id-less legacy OpenCode JSON messages a canonical path-scoped identity instead of a globally colliding filename stem.
- Keep real embedded message IDs unnamespaced so intended deduplication across SQLite, legacy JSON, forks, and channel databases remains unchanged.
- Tighten the pre-open SQLite migration fast path to require both session ID and message ID before suppressing a legacy JSON file.
- Bump the OpenCode parser cache identity from 2 to 3 so already cached stem-keyed messages are rebuilt with the corrected identity.
- Add parser, cache, full aggregation, local-client, and cold/warm CLI regressions for same-named files in different sessions.

Fixes #1198.

## Why

The legacy OpenCode scanner walks `storage/message/<session>/<file>.json` recursively. When a JSON message had no embedded `id`, the parser used only the filename stem as its deduplication key. That stem is local to a directory, not globally unique, so two real assistant messages in different sessions with the same filename silently collapsed and undercounted usage.

There was a second path with the same assumption: the SQLite-first migration optimization skipped a JSON file before opening it whenever its stem appeared anywhere in the SQLite key set. An unrelated id-less file in another session could therefore be discarded even before receiving a corrected fallback identity.

This change separates the two identity classes deliberately. A real embedded message ID remains global because it identifies the same migrated message across sources. An id-less legacy row uses the canonical physical file location because that is the only stable identity the source provides.

## Diff scope

- `crates/tokscale-core/src/sessions/opencode.rs`: replace the bare-stem fallback with `legacy-json-path:<canonical path>`; preserve embedded IDs; fail open with no dedup key if a path cannot be represented losslessly; add direct same-name regressions.
- `crates/tokscale-core/src/lib.rs`: index SQLite identities by session and message ID for the pre-open migration check; preserve the existing global embedded-ID dedup set; cover both streaming aggregation and `parse_local_clients` on cold and warm caches.
- `crates/tokscale-core/src/message_cache.rs`: bump OpenCode parser identity from 2 to 3 and prove a v2 stem-keyed shard is rejected, reparsed, and persisted with path identity.
- `crates/tokscale-cli/tests/cli_tests.rs`: verify two same-named id-less files in separate sessions both contribute to CLI totals on cold and warm passes.
- No database schema, dependency, CLI surface, frontend behavior, workflow, release configuration, or unrelated client parser changed.

## Branch integrity

- Base: `main`
- Validated base SHA: `7ad8827a25cc8086f91a2ec4aa385f2d664085cc`
- Head SHA: `32063a8d77c69d46de791b9eaa5c6c8d0fc0c17a`
- Ahead/behind: 0 behind / 1 ahead
- Merge base: `7ad8827a25cc8086f91a2ec4aa385f2d664085cc`
- `origin/main` is an ancestor of the branch; all diff proof was computed against the freshly fetched base.

## Commit integrity

- One atomic commit: `32063a8d77c69d46de791b9eaa5c6c8d0fc0c17a fix(opencode): namespace idless legacy message keys`
- The final diff contains only OpenCode identity handling, its source-cache migration, and directly related tests.
- Ledger: not applicable — this change family does not require a ledger record.
- Version: release manifests are unchanged; the repository publish workflow owns synchronized package version bumps.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: four intended modified files.
- `git diff --check origin/main...HEAD`: PASS, no output.


## Validation mode and proof

Validation mode: Mode 3 — deduplication identity and persisted source-cache interpretation directly affect usage-accounting totals.

- `cargo fmt --all -- --check`: PASS.
- `cargo check -p tokscale-core -p tokscale-cli`: PASS.
- `cargo test -p tokscale-core opencode --lib`: PASS, 127 passed and 1 ignored.
- `cargo test -p tokscale-core --lib`: PASS, 1942 passed and 2 ignored.
- `cargo test -p tokscale-cli --test cli_tests opencode_same_named_idless`: PASS, 1 passed.
- `cargo test -p tokscale-cli --test cli_tests`: PASS, 174 passed.
- Clippy is not reported as passing: the workspace baseline reaches a pre-existing `sessions/pi.rs` `needless_lifetimes` finding outside this diff.

## Cache and migration notes

- This is an application source-cache migration, not a database migration.
- OpenCode parser identity changes from v2 to v3 because an unchanged JSON file can retain its fingerprint while its fallback deduplication identity changes.
- Existing v2 OpenCode shards are invalidated and rebuilt once from the original SQLite/JSON sources; they are not translated in place.
- Embedded IDs remain byte-for-byte compatible, while only id-less legacy rows receive the new path namespace.
- Database downgrade and data repair are not applicable; source data remains authoritative.

## CI context confirmation

- CI workflow files and context names are unchanged.
- Pending — required GitHub CI starts after this PR is created and must pass on the final SHA before merge.
- The PR is ready for review, not merge-ready, until required remote checks and review gates pass.

## Runtime safety

- Canonicalization makes two path spellings of the same physical legacy file converge on one identity.
- If canonicalization fails, the original path is used; if that path is not valid UTF-8, the parser leaves the dedup key absent rather than inventing a lossy key that could undercount.
- The SQLite fast path now suppresses a JSON file only when its parent session and filename stem match a known SQLite location.
- Global deduplication by real embedded message ID remains unchanged.
- The session-location index is proportional to the already parsed OpenCode SQLite identities and is released after the OpenCode lane; it adds memory overhead but does not add a queue, background worker, lock, or extra database scan.
- No accounting invariant regression introduced.

## Documentation integrity

Not applicable — no command, configuration, data location, public API, or operational runbook changed.

## Rollback plan

- Rollback: `git revert <post_merge_commit_sha>` after merge.
- Database downgrade: not applicable.
- Data repair: not applicable.
- Operational caveat: reverting restores globally colliding stem identities and causes the active parser cache identity to rebuild again.

## Known residual risks

- Moving an id-less legacy file changes its fallback identity because the source provides no embedded stable ID; this is preferable to collapsing unrelated messages that share a basename.
- The first OpenCode read after upgrading performs a one-time cache reparse for affected shards.
- The additional session-location index temporarily duplicates SQLite identity strings during the OpenCode lane.
- Required remote CI has not run because the PR has not yet been created.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenCode usage undercounting where two id-less legacy JSON messages with the same filename in different sessions collapsed into one message because the filename stem alone was used as the dedup key.

**Bug Fixes**
- Id-less messages now use a canonical path-scoped dedup key (`legacy-json-path:<path>`) instead of the bare filename stem; embedded message IDs stay unnamespaced so cross-source dedup is unchanged.
- The SQLite migration fast path now requires both session ID and filename stem to match a known SQLite row before suppressing a legacy JSON file.
- The OpenCode parser cache version bumps from 2 to 3, invalidating cached stem-keyed entries for a one-time rebuild.
- Adds regressions for same-named id-less files across sessions covering streaming aggregation, `parse_local_clients`, and cold/warm CLI passes.

Fixes #1198.

<sup>Written for commit 32063a8d77c69d46de791b9eaa5c6c8d0fc0c17a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

