### PR TITLE
feat(clients): add Unsloth Studio usage parsing

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -93,6 +93,7 @@
 | <img width="48px" src="https://github.com/user-attachments/assets/7246e920-f3f8-4b6e-847e-030ae04e86c2" alt="Gajae-Code" /> | [gajae-code (gjc)](https://github.com/Yeachan-Heo/gajae-code) | `~/.gjc/agent/sessions/`（`GJC_CODING_AGENT_DIR`、`GJC_CONFIG_DIR`、`PI_CONFIG_DIR` でオーバーライド可能；Linux/macOS では `$XDG_DATA_HOME/gjc/sessions/` も解決） |
 | <img width="48px" src=".github/assets/client-cherrystudio.png" alt="Cherry Studio" /> | [Cherry Studio](https://cherry-ai.com/) | `%APPDATA%\CherryStudio\Data\Agents\.claude\projects\*.jsonl` と旧 `%APPDATA%\CherryStudio\.claude\projects\*.jsonl`（macOS: `~/Library/Application Support/CherryStudio/Data/Agents/.claude/projects/`；Linux: `$XDG_CONFIG_HOME/CherryStudio/Data/Agents/.claude/projects/`；Agent/Claude Code モードのトランスクリプト、V2 ルート優先・旧ルートは移行前履歴） |
 | <img width="48px" src="https://github.com/lmstudio-ai.png" alt="LM Studio" /> | [LM Studio](https://lmstudio.ai/) | `~/.lmstudio/server-logs/**/*.log`（`LM_STUDIO_HOME` 対応、Chat Completions と Responses API の最終応答 usage のみ。プロンプトと応答本文は保持せず、ローカル推論のコストは $0） |
+| <img width="48px" src="https://github.com/unslothai.png" alt="Unsloth Studio" /> | [Unsloth Studio](https://github.com/unslothai/unsloth) | `$UNSLOTH_STUDIO_HOME/studio.db`（フォールバック: `~/.unsloth/studio/studio.db`。内部チャットと認証済み API の正確な推論使用量を読み取り、メッセージ本文は読み取らない。トレーニング指標は対象外で、ローカル推論のコストは $0） |
 | <img width="48px" src=".github/assets/client-jcode.png" alt="Jcode" /> | [Jcode](https://github.com/1jehuang/jcode) | `~/.jcode/sessions/session_*.json` + `session_*.journal.jsonl` サイドカー（`JCODE_HOME` で上書き可） |
 | <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/mimocode/mimocode.db`（XDG データディレクトリ；SQLite） |
 | <img width="48px" src="https://github.com/JetBrains.png" alt="Junie" /> | [Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/*/events.jsonl` |
@@ -181,7 +182,7 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
   - 設定可能なカラーテーマのGitHubスタイル貢献グラフ
   - リアルタイムフィルタリングとソート
   - ゼロフリッカーレンダリング
-- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Prime Agent、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Kimi Work、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic、Cherry Studio、LM Studio、fx、Oh My Piの使用量を追跡
+- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Prime Agent、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Kimi Work、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic、Cherry Studio、LM Studio、Unsloth Studio、fx、Oh My Piの使用量を追跡
 - **リアルタイム価格** - 1時間ディスクキャッシュ付きでLiteLLMから現在の価格を取得；OpenRouter自動フォールバックと新規モデル向けCursor価格サポート
 - **詳細な内訳** - 入力、出力、キャッシュ読み書き、推論トークン追跡
 - **ネイティブRustコア** - 10倍高速な処理のため、すべての解析と集計をRustで実行
@@ -417,7 +418,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-利用可能な値: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `prime-agent`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`, `cherrystudio`, `lmstudio`。
+利用可能な値: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `prime-agent`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`, `cherrystudio`, `lmstudio`, `unsloth`。
 
 > **破壊的変更 (v4.0.0)**: クライアント単位のブール型フラグ（`--opencode`、`--claude`、`--codex` など）は削除され、現在はエラーになります。代わりに正規の `--client`/`-c` フラグを使用してください — 例: `tokscale --client opencode,claude`。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -93,6 +93,7 @@
 | <img width="48px" src="https://github.com/user-attachments/assets/7246e920-f3f8-4b6e-847e-030ae04e86c2" alt="Gajae-Code" /> | [gajae-code (gjc)](https://github.com/Yeachan-Heo/gajae-code) | `~/.gjc/agent/sessions/` (`GJC_CODING_AGENT_DIR`, `GJC_CONFIG_DIR`, `PI_CONFIG_DIR`로 오버라이드 가능; Linux/macOS에서는 `$XDG_DATA_HOME/gjc/sessions/`도 확인) |
 | <img width="48px" src=".github/assets/client-cherrystudio.png" alt="Cherry Studio" /> | [Cherry Studio](https://cherry-ai.com/) | `%APPDATA%\CherryStudio\Data\Agents\.claude\projects\*.jsonl` 및 기존 `%APPDATA%\CherryStudio\.claude\projects\*.jsonl` (macOS: `~/Library/Application Support/CherryStudio/Data/Agents/.claude/projects/`; Linux: `$XDG_CONFIG_HOME/CherryStudio/Data/Agents/.claude/projects/`; Agent/Claude Code 모드 전사, V2 루트 우선·기존 루트는 미이전 기록) |
 | <img width="48px" src="https://github.com/lmstudio-ai.png" alt="LM Studio" /> | [LM Studio](https://lmstudio.ai/) | `~/.lmstudio/server-logs/**/*.log` (`LM_STUDIO_HOME` 지원, Chat Completions 및 Responses API의 최종 응답 usage만 사용하며 프롬프트와 응답 본문은 보관하지 않음, 로컬 추론 비용은 $0) |
+| <img width="48px" src="https://github.com/unslothai.png" alt="Unsloth Studio" /> | [Unsloth Studio](https://github.com/unslothai/unsloth) | `$UNSLOTH_STUDIO_HOME/studio.db` (폴백: `~/.unsloth/studio/studio.db`; 내부 채팅 및 인증된 API의 정확한 추론 사용량을 읽으며 메시지 본문은 읽지 않음; 학습 지표는 제외하고 로컬 추론 비용은 $0) |
 | <img width="48px" src=".github/assets/client-jcode.png" alt="Jcode" /> | [Jcode](https://github.com/1jehuang/jcode) | `~/.jcode/sessions/session_*.json` + `session_*.journal.jsonl` 사이드카 (`JCODE_HOME`으로 재정의 가능) |
 | <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/mimocode/mimocode.db` (XDG 데이터 디렉토리; SQLite) |
 | <img width="48px" src="https://github.com/JetBrains.png" alt="Junie" /> | [Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/*/events.jsonl` |
@@ -179,7 +180,7 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
   - 설정 가능한 색상 테마의 GitHub 스타일 기여 그래프
   - 실시간 필터링 및 정렬
   - 깜빡임 없는 렌더링
-- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Prime Agent, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Kimi Work, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic, Cherry Studio, LM Studio, fx, Oh My Pi 사용량 통합 추적
+- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Prime Agent, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Kimi Work, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic, Cherry Studio, LM Studio, Unsloth Studio, fx, Oh My Pi 사용량 통합 추적
 - **실시간 가격 반영** - LiteLLM에서 최신 가격을 가져와(디스크 캐시 1시간) 비용 계산; OpenRouter 자동 폴백 및 신규 모델용 Cursor 가격 지원
 - **상세 분석** - 입력, 출력, 캐시 읽기/쓰기, 추론 토큰까지 추적
 - **네이티브 Rust 코어** - 모든 파싱과 집계를 Rust로 처리해 최대 10배 빠른 성능
@@ -413,7 +414,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-가능한 값: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `prime-agent`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`, `cherrystudio`, `lmstudio`.
+가능한 값: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `prime-agent`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`, `cherrystudio`, `lmstudio`, `unsloth`.
 
 > **Breaking change (v4.0.0):** 클라이언트별 boolean 플래그(`--opencode`, `--claude`, `--codex` 등)는 제거되었으며 이제 오류를 발생시킵니다. 대신 정식 `--client`/`-c` 플래그를 사용하세요 — 예: `tokscale --client opencode,claude`.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@
 | <img width="48px" src="https://github.com/user-attachments/assets/7246e920-f3f8-4b6e-847e-030ae04e86c2" alt="Gajae-Code" /> | [gajae-code (gjc)](https://github.com/Yeachan-Heo/gajae-code) | `~/.gjc/agent/sessions/` (override via `GJC_CODING_AGENT_DIR`, `GJC_CONFIG_DIR`, `PI_CONFIG_DIR`; `$XDG_DATA_HOME/gjc/sessions/` on Linux/macOS) |
 | <img width="48px" src=".github/assets/client-cherrystudio.png" alt="Cherry Studio" /> | [Cherry Studio](https://cherry-ai.com/) | `%APPDATA%\CherryStudio\Data\Agents\.claude\projects\*.jsonl` and legacy `%APPDATA%\CherryStudio\.claude\projects\*.jsonl` (macOS: `~/Library/Application Support/CherryStudio/Data/Agents/.claude/projects/`; Linux: `$XDG_CONFIG_HOME/CherryStudio/Data/Agents/.claude/projects/`; Agent / Claude Code mode transcripts; V2 root preferred, legacy keeps untransferred history) |
 | <img width="48px" src="https://github.com/lmstudio-ai.png" alt="LM Studio" /> | [LM Studio](https://lmstudio.ai/) | `~/.lmstudio/server-logs/**/*.log` (`LM_STUDIO_HOME` supported; Chat Completions and Responses API final-response usage only; prompts and responses are not retained; local inference cost is $0) |
+| <img width="48px" src="https://github.com/unslothai.png" alt="Unsloth Studio" /> | [Unsloth Studio](https://github.com/unslothai/unsloth) | `$UNSLOTH_STUDIO_HOME/studio.db` (fallback: `~/.unsloth/studio/studio.db`; exact internal-chat and authenticated API inference usage; message content is not read; training metrics are excluded; local inference cost is $0) |
 | <img width="48px" src=".github/assets/client-jcode.png" alt="Jcode" /> | [Jcode](https://github.com/1jehuang/jcode) | `~/.jcode/sessions/session_*.json` + `session_*.journal.jsonl` sidecars (override via `JCODE_HOME`) |
 | <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/mimocode/mimocode.db` (XDG data dir; SQLite) |
 | <img width="48px" src="https://github.com/JetBrains.png" alt="Junie" /> | [Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/*/events.jsonl` |
@@ -179,7 +180,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with configurable color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Prime Agent, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Kimi Work, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic, Cherry Studio, LM Studio, fx, and Oh My Pi
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Prime Agent, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Kimi Work, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic, Cherry Studio, LM Studio, Unsloth Studio, fx, and Oh My Pi
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -415,7 +416,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `prime-agent`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`, `cherrystudio`, `lmstudio`.
+Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `prime-agent`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`, `cherrystudio`, `lmstudio`, `unsloth`.
 
 > **Breaking change (v4.0.0):** The per-client boolean flags (`--opencode`, `--claude`, `--codex`, etc.) have been removed and now error. Use the canonical `--client`/`-c` flag instead — e.g. `tokscale --client opencode,claude`.
 
@@ -1121,7 +1122,7 @@ The frontend provides a GitHub-style contribution graph visualization:
 - **Interactive tooltips**: Hover for detailed daily breakdowns
 - **Day breakdown panel**: Click to see per-source and per-model details
 - **Year filtering**: Navigate between years
-- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, MiniMax Code, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Prime Agent, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic, Cherry Studio, LM Studio)
+- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, MiniMax Code, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Prime Agent, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic, Cherry Studio, LM Studio, Unsloth)
 - **Stats panel**: Total cost, tokens, active days, streaks
 - **FOUC prevention**: Theme applied before React hydrates (no flash)
 
@@ -1543,6 +1544,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Devin Desktop | Linux: `~/.config/Devin/User/acp-events/`; macOS: `~/Library/Application Support/Devin/User/acp-events/` | `%APPDATA%\Devin\User\acp-events\` | Parses ACP usage events; the CLI database resolves matching session titles when present |
 | Augment Code | `~/.augment/sessions/` | `%USERPROFILE%\.augment\sessions\` | Parses Auggie CLI session JSON snapshots (`*.json`); join key is top-level `sessionId` |
 | Synthetic | Re-attributed from other sources | Re-attributed from other sources | Detects `hf:` model prefix + `synthetic` provider |
+| Unsloth Studio | `$UNSLOTH_STUDIO_HOME/studio.db` (fallback: `~/.unsloth/studio/studio.db`) | `%UNSLOTH_STUDIO_HOME%\studio.db` (fallback: `%USERPROFILE%\.unsloth\studio\studio.db`) | Reads exact inference counters from internal assistant metadata and the content-free authenticated API usage table; never selects prompts or responses; excludes training metrics |
 | MiniMax Code | `~/.config/tokscale/headless/mcode/` | `%APPDATA%\tokscale\headless\mcode\` | Headless capture only; Tokscale reads its own capture directory rather than MiniMax Code's shared Desktop/Runtime store, which does not identify the originating surface. Override the root with `TOKSCALE_HEADLESS_DIR` |
 
 > **Devin Desktop agent support**: Local usage parsing works for ACP-connected agents (e.g. Cascade/Windsurf, claude-code, opencode) that emit `usage_update` events in the NDJSON stream. The default **devin-cloud** agent does not emit local `usage_update` events — its usage stays server-side and cannot be tracked by tokscale without an account-level API.
@@ -1829,6 +1831,12 @@ Session JSONL format with model_change events and assistant messages:
 Location: `$HERMES_HOME/state.db` (fallback: `~/.hermes/state.db`) plus standard profile databases at `$HERMES_HOME/profiles/*/state.db` (or sibling `~/.hermes/profiles/*/state.db` when `HERMES_HOME` points at an active profile)
 
 Hermes stores session-level usage in a SQLite `sessions` table. Tokscale imports rows where `model` is present and token or cost totals are non-zero, uses `started_at` as the timestamp, preserves `message_count`, and prefers `actual_cost_usd` over `estimated_cost_usd`.
+
+### Unsloth Studio
+
+Location: `$UNSLOTH_STUDIO_HOME/studio.db` (fallback: `~/.unsloth/studio/studio.db`)
+
+Tokscale reads exact inference counters from Unsloth Studio's durable SQLite database. Internal Studio responses come from `contextUsage` metadata on completed assistant messages; authenticated external API calls come from the content-free `api_usage_events` table. The queries do not select message bodies, prompts, responses, credentials, or response previews. Stable message and request IDs prevent double-counting across overlapping scan roots, and SQLite WAL changes invalidate the source cache. Local inference is recorded at $0. Training `num_tokens` metrics are intentionally excluded because they measure training progress rather than prompt/completion usage.
 
 ### Pi
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -94,6 +94,7 @@
 | <img width="48px" src="https://github.com/user-attachments/assets/7246e920-f3f8-4b6e-847e-030ae04e86c2" alt="Gajae-Code" /> | [gajae-code (gjc)](https://github.com/Yeachan-Heo/gajae-code) | `~/.gjc/agent/sessions/`（可通过 `GJC_CODING_AGENT_DIR`、`GJC_CONFIG_DIR`、`PI_CONFIG_DIR` 覆盖；Linux/macOS 上 `$XDG_DATA_HOME/gjc/sessions/` 亦支持） |
 | <img width="48px" src=".github/assets/client-cherrystudio.png" alt="Cherry Studio" /> | [Cherry Studio](https://cherry-ai.com/) | `%APPDATA%\CherryStudio\Data\Agents\.claude\projects\*.jsonl` 及旧版 `%APPDATA%\CherryStudio\.claude\projects\*.jsonl`（macOS: `~/Library/Application Support/CherryStudio/Data/Agents/.claude/projects/`；Linux: `$XDG_CONFIG_HOME/CherryStudio/Data/Agents/.claude/projects/`；Agent/Claude Code 模式转录，V2 目录优先，旧目录保留未迁移历史） |
 | <img width="48px" src="https://github.com/lmstudio-ai.png" alt="LM Studio" /> | [LM Studio](https://lmstudio.ai/) | `~/.lmstudio/server-logs/**/*.log`（支持 `LM_STUDIO_HOME`；仅读取 Chat Completions 和 Responses API 最终响应的 usage，不保存提示词或响应正文；本地推理成本为 $0） |
+| <img width="48px" src="https://github.com/unslothai.png" alt="Unsloth Studio" /> | [Unsloth Studio](https://github.com/unslothai/unsloth) | `$UNSLOTH_STUDIO_HOME/studio.db`（回退：`~/.unsloth/studio/studio.db`；精确读取内部聊天和已认证 API 的推理用量；不读取消息正文；排除训练指标；本地推理成本为 $0） |
 | <img width="48px" src=".github/assets/client-jcode.png" alt="Jcode" /> | [Jcode](https://github.com/1jehuang/jcode) | `~/.jcode/sessions/session_*.json` + `session_*.journal.jsonl` sidecar（可通过 `JCODE_HOME` 覆盖） |
 | <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/mimocode/mimocode.db`（XDG 数据目录；SQLite） |
 | <img width="48px" src="https://github.com/JetBrains.png" alt="Junie" /> | [Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/*/events.jsonl` |
@@ -179,7 +180,7 @@
   - 支持可配置颜色主题的 GitHub 风格贡献图
   - 实时筛选和排序
   - 零闪烁渲染
-- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Prime Agent、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Kimi Work、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic、Cherry Studio、LM Studio、fx 和 Oh My Pi 的使用情况
+- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Prime Agent、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Kimi Work、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic、Cherry Studio、LM Studio、Unsloth Studio、fx 和 Oh My Pi 的使用情况
 - **实时定价** - 从 LiteLLM 获取当前价格，带 1 小时磁盘缓存；OpenRouter 自动回退和新模型的 Cursor 定价支持
 - **详细分解** - 输入、输出、缓存读写和推理 Token 跟踪
 - **原生 Rust 核心** - 所有解析和聚合在 Rust 中完成，处理速度提升 10 倍
@@ -414,7 +415,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-可用值：`opencode`、`claude`、`codex`、`copilot`、`gemini`、`cursor`、`amp`、`codebuff`、`droid`、`openclaw`、`hermes`、`pi`、`prime-agent`、`kimchi`、`kimi`、`qwen`、`roocode`、`kilocode`、`kilo`、`mux`、`crush`、`goose`、`antigravity`、`antigravity-cli`、`zed`、`kiro`、`trae`、`warp`、`cline`、`gjc`、`grok`、`jcode`、`micode`、`commandcode`、`junie`、`zcode`、`opencodereview`、`codebuddy`、`augment`、`synthetic`、`cherrystudio`、`lmstudio`。
+可用值：`opencode`、`claude`、`codex`、`copilot`、`gemini`、`cursor`、`amp`、`codebuff`、`droid`、`openclaw`、`hermes`、`pi`、`prime-agent`、`kimchi`、`kimi`、`qwen`、`roocode`、`kilocode`、`kilo`、`mux`、`crush`、`goose`、`antigravity`、`antigravity-cli`、`zed`、`kiro`、`trae`、`warp`、`cline`、`gjc`、`grok`、`jcode`、`micode`、`commandcode`、`junie`、`zcode`、`opencodereview`、`codebuddy`、`augment`、`synthetic`、`cherrystudio`、`lmstudio`、`unsloth`。
 
 > **破坏性变更（v4.0.0）**：单客户端布尔选项（`--opencode`、`--claude`、`--codex` 等）已被移除，现在会直接报错。请改用规范的 `--client`/`-c` 选项——例如 `tokscale --client opencode,claude`。
 

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1096,6 +1096,7 @@ pub enum ClientFilter {
     Fx,
     Omp,
     LmStudio,
+    Unsloth,
     Synthetic,
 }
 
@@ -1157,6 +1158,7 @@ impl ClientFilter {
             Self::Fx => "fx",
             Self::Omp => "omp",
             Self::LmStudio => "lmstudio",
+            Self::Unsloth => "unsloth",
             Self::Synthetic => "synthetic",
         }
     }
@@ -1221,6 +1223,7 @@ impl ClientFilter {
             Self::Fx => Some(ClientId::Fx),
             Self::Omp => Some(ClientId::Omp),
             Self::LmStudio => Some(ClientId::LmStudio),
+            Self::Unsloth => Some(ClientId::Unsloth),
             Self::Synthetic => None,
         }
     }
@@ -1281,6 +1284,7 @@ impl ClientFilter {
             ClientId::Fx => Self::Fx,
             ClientId::Omp => Self::Omp,
             ClientId::LmStudio => Self::LmStudio,
+            ClientId::Unsloth => Self::Unsloth,
         }
     }
 

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -62,6 +62,8 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
     ClientUi { hotkey: 'Y' },
     // LM Studio: uppercase `L` stays mnemonic while lowercase `l` belongs to Kilo.
     ClientUi { hotkey: 'L' },
+    // Unsloth: uppercase `U` stays mnemonic while lowercase `u` belongs to Grok Build.
+    ClientUi { hotkey: 'U' },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1651,6 +1651,7 @@ mod tests {
         assert_eq!(clients[48], ClientId::Fx);
         assert_eq!(clients[49], ClientId::Omp);
         assert_eq!(clients[50], ClientId::LmStudio);
+        assert_eq!(clients[51], ClientId::Unsloth);
     }
 
     #[test]
@@ -1707,6 +1708,7 @@ mod tests {
             "Fx",
             "Oh My Pi",
             "LM Studio",
+            "Unsloth",
         ];
 
         assert_eq!(expected.len(), ClientId::COUNT);
@@ -1755,6 +1757,7 @@ mod tests {
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Fx), 'X');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Omp), 'Y');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::LmStudio), 'L');
+        assert_eq!(crate::tui::client_ui::hotkey(ClientId::Unsloth), 'U');
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -781,6 +781,7 @@ pub fn get_client_color(client: &str) -> Color {
         "jcode" => Color::Rgb(245, 158, 11),       // #F59E0B Jcode amber
         "junie" => Color::Rgb(123, 97, 255),       // #7B61FF Junie violet
         "prime-agent" => Color::Rgb(108, 99, 255), // #6C63FF Prime violet
+        "unsloth" => Color::Rgb(88, 204, 2),       // #58CC02 Unsloth green
         _ => Color::Rgb(136, 136, 136),            // #888888
     }
 }

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -1021,6 +1021,24 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    // Unsloth Studio persists exact inference usage in a single SQLite
+    // database. Internal chats store scalar usage in assistant-message
+    // metadata, while authenticated external API calls are copied into a
+    // content-free usage table. Training throughput is intentionally separate.
+    Unsloth = 51 => {
+        id: "unsloth",
+        display: "Unsloth",
+        logo: Some("https://github.com/unslothai.png"),
+        root: PathRoot::EnvVar {
+            var: "UNSLOTH_STUDIO_HOME",
+            fallback_relative: ".unsloth/studio",
+        },
+        relative: "studio.db",
+        pattern: "studio.db",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -1136,7 +1154,7 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 51);
+        assert_eq!(ClientId::COUNT, 52);
     }
 
     #[test]
@@ -1762,6 +1780,32 @@ mod tests {
         assert!(client.data().parse_local);
         assert!(client.data().submit_default);
         assert!(!client.data().headless);
+    }
+
+    #[test]
+    #[serial]
+    fn test_unsloth_client_registered_with_studio_home_override() {
+        let mut env = EnvGuard::capture(&["UNSLOTH_STUDIO_HOME"]);
+        env.set("UNSLOTH_STUDIO_HOME", "/custom/unsloth-studio");
+
+        let client = ClientId::from_str("unsloth").expect("Unsloth should be registered");
+        assert_eq!(client, ClientId::Unsloth);
+        assert_eq!(client.display_name(), "Unsloth");
+        assert_eq!(client.data().relative_path, "studio.db");
+        assert_eq!(client.data().pattern, "studio.db");
+        assert_eq!(
+            client.data().resolve_path("/tmp/home"),
+            native_join(std::path::Path::new("/custom/unsloth-studio"), "studio.db")
+        );
+        assert_eq!(
+            client
+                .data()
+                .resolve_path_with_env_strategy("/tmp/home", false),
+            native_join(
+                std::path::Path::new("/tmp/home"),
+                ".unsloth/studio/studio.db"
+            )
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2607,6 +2607,36 @@ fn parse_all_messages_streaming<S: MessageSink>(
         sessions::lmstudio::parse_lmstudio_file,
     );
 
+    // Unsloth Studio stores both internal chat usage and authenticated API
+    // receipts in a live SQLite database. Use the SQLite-aware fingerprint so
+    // WAL-only writes invalidate the cache, then dedupe configured overlapping
+    // roots by the stable message/request identities emitted by the parser.
+    let unsloth_outcomes: Vec<CachedParseOutcome> = scan_result
+        .get(ClientId::Unsloth)
+        .par_iter()
+        .map(|db_path| {
+            load_or_parse_sqlite_source(
+                message_cache::CacheIdentity::for_client(ClientId::Unsloth),
+                db_path,
+                &source_cache,
+                pricing,
+                sessions::unsloth::parse_unsloth_sqlite,
+            )
+        })
+        .collect();
+    let mut unsloth_seen = HashSet::new();
+    for outcome in unsloth_outcomes {
+        all_messages.extend(
+            outcome
+                .messages
+                .into_iter()
+                .filter(|message| should_keep_deduped_message(&mut unsloth_seen, message)),
+        );
+        if let Some(entry) = outcome.cache_entry {
+            source_cache.insert(entry);
+        }
+    }
+
     // ZCode (Z.ai GLM-5.2 ADE) JSONL sessions. Token usage may be embedded
     // from the API response; otherwise estimated from content.
     let zcode_messages: Vec<UnifiedMessage> = scan_result
@@ -5258,6 +5288,21 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let lmstudio_count = summed_parsed_message_count(&lmstudio_msgs);
     counts.set(ClientId::LmStudio, lmstudio_count);
     messages.extend(lmstudio_msgs);
+
+    let unsloth_msgs_raw: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::Unsloth)
+        .par_iter()
+        .flat_map(|path| sessions::unsloth::parse_unsloth_sqlite(path))
+        .collect();
+    let mut unsloth_seen: HashSet<String> = HashSet::new();
+    let unsloth_msgs: Vec<ParsedMessage> = unsloth_msgs_raw
+        .into_iter()
+        .filter(|message| should_keep_deduped_message(&mut unsloth_seen, message))
+        .map(|message| unified_to_parsed(&message))
+        .collect();
+    let unsloth_count = summed_parsed_message_count(&unsloth_msgs);
+    counts.set(ClientId::Unsloth, unsloth_count);
+    messages.extend(unsloth_msgs);
 
     let mcode_msgs: Vec<ParsedMessage> = scan_result
         .get(ClientId::Mcode)
@@ -8053,6 +8098,133 @@ mod tests {
             Some(&pricing),
         );
         assert_eq!(warm, cold);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_unsloth_lane_reads_sqlite_and_invalidates_on_wal_changes() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let studio_root = source_home.path().join(".unsloth/studio");
+        std::fs::create_dir_all(&studio_root).unwrap();
+        let db_path = studio_root.join("studio.db");
+
+        {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                r#"
+                CREATE TABLE chat_threads (
+                    id TEXT PRIMARY KEY,
+                    model_id TEXT
+                );
+                CREATE TABLE chat_messages (
+                    id TEXT PRIMARY KEY,
+                    thread_id TEXT NOT NULL,
+                    role TEXT NOT NULL,
+                    metadata_json TEXT,
+                    created_at INTEGER NOT NULL
+                );
+                CREATE TABLE api_usage_events (
+                    id TEXT PRIMARY KEY,
+                    subject TEXT NOT NULL,
+                    endpoint TEXT NOT NULL,
+                    model TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    prompt_tokens INTEGER NOT NULL,
+                    completion_tokens INTEGER NOT NULL,
+                    total_tokens INTEGER NOT NULL,
+                    created_at INTEGER NOT NULL
+                );
+                INSERT INTO chat_threads (id, model_id)
+                VALUES ('thread-1', 'fixture-local-model');
+                INSERT INTO chat_messages (id, thread_id, role, metadata_json, created_at)
+                VALUES (
+                    'message-1',
+                    'thread-1',
+                    'assistant',
+                    '{"contextUsage":{"promptTokens":100,"completionTokens":40,"totalTokens":140,"cachedTokens":25,"modelId":"fixture-local-model"}}',
+                    1788000000
+                );
+                INSERT INTO api_usage_events (
+                    id, subject, endpoint, model, status,
+                    prompt_tokens, completion_tokens, total_tokens, created_at
+                ) VALUES (
+                    'request-1', 'private-user', '/v1/chat/completions',
+                    'fixture-local-model', 'completed', 8, 2, 10, 1788000100
+                );
+                "#,
+            )
+            .unwrap();
+        }
+
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "fixture-local-model".into(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(1.0),
+                output_cost_per_token: Some(1.0),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new(litellm, HashMap::new());
+        let clients = ["unsloth".to_string()];
+
+        let cold = parse_all_messages_with_pricing(
+            source_home.path().to_str().unwrap(),
+            &clients,
+            Some(&pricing),
+        );
+        assert_eq!(cold.len(), 2);
+        assert_eq!(
+            cold.iter()
+                .map(|message| message.tokens.total())
+                .sum::<i64>(),
+            150
+        );
+        assert!(cold
+            .iter()
+            .all(|message| message.cost == 0.0 && message.has_authoritative_cost()));
+
+        let warm = parse_all_messages_with_pricing(
+            source_home.path().to_str().unwrap(),
+            &clients,
+            Some(&pricing),
+        );
+        assert_eq!(warm, cold);
+
+        let writer = rusqlite::Connection::open(&db_path).unwrap();
+        writer.pragma_update(None, "journal_mode", "WAL").unwrap();
+        writer.pragma_update(None, "wal_autocheckpoint", 0).unwrap();
+        writer
+            .execute(
+                "INSERT INTO chat_messages (id, thread_id, role, metadata_json, created_at) VALUES (?1, ?2, 'assistant', ?3, ?4)",
+                rusqlite::params![
+                    "message-2",
+                    "thread-1",
+                    r#"{"contextUsage":{"promptTokens":9,"completionTokens":1,"totalTokens":10,"modelId":"fixture-local-model"}}"#,
+                    1_788_000_200_i64,
+                ],
+            )
+            .unwrap();
+        assert!(db_path.with_file_name("studio.db-wal").exists());
+
+        let refreshed = parse_all_messages_with_pricing(
+            source_home.path().to_str().unwrap(),
+            &clients,
+            Some(&pricing),
+        );
+        assert_eq!(refreshed.len(), 3);
+        assert_eq!(
+            refreshed
+                .iter()
+                .map(|message| message.tokens.total())
+                .sum::<i64>(),
+            160
+        );
+        assert!(refreshed
+            .iter()
+            .all(|message| message.cost == 0.0 && message.has_authoritative_cost()));
     }
 
     /// MiMo Code records carry an authoritative per-message cost. The micode

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -548,6 +548,7 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 "session-usage.json" => file_name == "session-usage.json",
                 "chat-messages.json" => file_name == "chat-messages.json",
                 "workbuddy.db" => file_name == "workbuddy.db",
+                "studio.db" => file_name == "studio.db",
                 "sessions.db" => file_name == "sessions.db",
                 "state.db" => file_name == "state.db",
                 "threads.db" => file_name == "threads.db",
@@ -2751,6 +2752,56 @@ mod tests {
 
         assert_eq!(
             result.get(ClientId::LmStudio).as_slice(),
+            std::slice::from_ref(&expected)
+        );
+        assert_eq!(result.total_files(), 1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_discovers_unsloth_database() {
+        let mut env = EnvGuard::capture(&["UNSLOTH_STUDIO_HOME"]);
+        env.remove("UNSLOTH_STUDIO_HOME");
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let studio_root = home.join(".unsloth/studio");
+        fs::create_dir_all(&studio_root).unwrap();
+        let expected = studio_root.join("studio.db");
+        File::create(&expected).unwrap();
+        File::create(studio_root.join("studio.db-wal")).unwrap();
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["unsloth".to_string()],
+            false,
+        );
+
+        assert_eq!(
+            result.get(ClientId::Unsloth).as_slice(),
+            std::slice::from_ref(&expected)
+        );
+        assert_eq!(result.total_files(), 1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_honors_unsloth_studio_home() {
+        let dir = TempDir::new().unwrap();
+        let studio_root = dir.path().join("custom-studio");
+        fs::create_dir_all(&studio_root).unwrap();
+        let expected = studio_root.join("studio.db");
+        File::create(&expected).unwrap();
+        let mut env = EnvGuard::capture(&["UNSLOTH_STUDIO_HOME"]);
+        env.set("UNSLOTH_STUDIO_HOME", studio_root.to_str().unwrap());
+
+        let result = scan_all_clients_with_env_strategy(
+            dir.path().to_str().unwrap(),
+            &["unsloth".to_string()],
+            true,
+        );
+
+        assert_eq!(
+            result.get(ClientId::Unsloth).as_slice(),
             std::slice::from_ref(&expected)
         );
         assert_eq!(result.total_files(), 1);

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -53,6 +53,7 @@ pub mod senpi;
 pub mod synthetic;
 pub(crate) mod tencent_buddy;
 pub mod trae;
+pub mod unsloth;
 pub(crate) mod utils;
 pub mod warp;
 pub mod workbuddy;

--- a/crates/tokscale-core/src/sessions/unsloth.rs
+++ b/crates/tokscale-core/src/sessions/unsloth.rs
@@ -1,0 +1,406 @@
+//! Unsloth Studio inference usage parser.
+//!
+//! Unsloth Studio stores durable chat and API usage in `studio.db` beneath
+//! `$UNSLOTH_STUDIO_HOME` (normally `~/.unsloth/studio`). Internal Studio
+//! responses keep usage in assistant-message metadata; authenticated external
+//! API requests are copied into the content-free `api_usage_events` table.
+//! Neither query selects message content, prompts, or response previews.
+
+use super::utils::{open_readonly_sqlite_opt, sqlite_for_each_row_on, timestamp_secs_to_ms};
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use rusqlite::Connection;
+use serde::Deserialize;
+use std::path::Path;
+
+const CLIENT_ID: &str = "unsloth";
+const STUDIO_AGENT: &str = "Unsloth";
+const API_AGENT: &str = "Unsloth API";
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ContextUsage {
+    #[serde(default)]
+    prompt_tokens: i64,
+    #[serde(default)]
+    completion_tokens: i64,
+    #[serde(default)]
+    total_tokens: i64,
+    #[serde(default)]
+    cached_tokens: i64,
+    #[serde(default)]
+    cache_write_tokens: i64,
+    #[serde(default)]
+    reasoning_tokens: i64,
+    #[serde(default)]
+    model_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MessageMetadata {
+    #[serde(default)]
+    context_usage: Option<ContextUsage>,
+}
+
+fn non_blank(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}
+
+fn normalized_tokens(
+    prompt_tokens: i64,
+    completion_tokens: i64,
+    total_tokens: i64,
+    cached_tokens: i64,
+    cache_write_tokens: i64,
+    reasoning_tokens: i64,
+) -> Option<TokenBreakdown> {
+    let prompt = prompt_tokens.max(0);
+    let completion = completion_tokens.max(0);
+    let cache_read = cached_tokens.max(0).min(prompt);
+    let cache_write = cache_write_tokens
+        .max(0)
+        .min(prompt.saturating_sub(cache_read));
+    let reasoning = reasoning_tokens.max(0).min(completion);
+    let total = total_tokens.max(0).max(prompt.saturating_add(completion));
+    if total == 0 {
+        return None;
+    }
+
+    Some(TokenBreakdown {
+        input: total
+            .saturating_sub(completion)
+            .saturating_sub(cache_read)
+            .saturating_sub(cache_write),
+        output: completion.saturating_sub(reasoning),
+        cache_read,
+        cache_write,
+        reasoning,
+    })
+}
+
+fn parse_internal_chat_usage(db_path: &Path, conn: &Connection) -> Vec<UnifiedMessage> {
+    // `content_json` is deliberately absent. The metadata block carries exact
+    // scalar usage and the model that produced the assistant response.
+    let query = r#"
+        SELECT
+            m.id,
+            m.thread_id,
+            m.created_at,
+            m.metadata_json,
+            t.model_id
+        FROM chat_messages m
+        LEFT JOIN chat_threads t ON t.id = m.thread_id
+        WHERE m.role = 'assistant'
+        ORDER BY m.created_at, m.id
+        "#;
+
+    let mut messages = Vec::new();
+    sqlite_for_each_row_on(
+        conn,
+        db_path,
+        query,
+        Some("Unsloth Studio chat usage"),
+        &mut |row| {
+            let message_id: String = row.get(0)?;
+            let thread_id: String = row.get(1)?;
+            let created_at: i64 = row.get(2)?;
+            let metadata_json: Option<String> = row.get(3)?;
+            let thread_model: Option<String> = row.get(4)?;
+
+            let Some(metadata) = metadata_json
+                .as_deref()
+                .and_then(|value| serde_json::from_str::<MessageMetadata>(value).ok())
+            else {
+                return Ok(());
+            };
+            let Some(usage) = metadata.context_usage else {
+                return Ok(());
+            };
+            let Some(tokens) = normalized_tokens(
+                usage.prompt_tokens,
+                usage.completion_tokens,
+                usage.total_tokens,
+                usage.cached_tokens,
+                usage.cache_write_tokens,
+                usage.reasoning_tokens,
+            ) else {
+                return Ok(());
+            };
+            let timestamp = timestamp_secs_to_ms(created_at as f64);
+            if timestamp <= 0 || message_id.trim().is_empty() {
+                return Ok(());
+            }
+
+            let model = non_blank(usage.model_id)
+                .or_else(|| non_blank(thread_model))
+                .unwrap_or_else(|| "unknown".to_string());
+            let session_id = if thread_id.trim().is_empty() {
+                format!("unsloth:chat:{message_id}")
+            } else {
+                thread_id
+            };
+            let mut message = UnifiedMessage::new_with_dedup(
+                CLIENT_ID,
+                model,
+                CLIENT_ID,
+                session_id,
+                timestamp,
+                tokens,
+                0.0,
+                Some(format!("unsloth:chat:{message_id}")),
+            );
+            message.agent = Some(STUDIO_AGENT.to_string());
+            message.is_turn_start = true;
+            message.mark_provider_reported_cost();
+            messages.push(message);
+            Ok(())
+        },
+    );
+    messages
+}
+
+fn parse_external_api_usage(db_path: &Path, conn: &Connection) -> Vec<UnifiedMessage> {
+    // Older Studio builds do not have this table. Probe silently so their
+    // internal chat usage still imports without a warning on every scan.
+    let query = r#"
+        SELECT
+            id,
+            endpoint,
+            model,
+            prompt_tokens,
+            completion_tokens,
+            total_tokens,
+            created_at
+        FROM api_usage_events
+        ORDER BY created_at, id
+        "#;
+
+    let mut messages = Vec::new();
+    sqlite_for_each_row_on(conn, db_path, query, None, &mut |row| {
+        let id: String = row.get(0)?;
+        let endpoint: String = row.get(1)?;
+        let model: String = row.get(2)?;
+        let prompt_tokens: i64 = row.get(3)?;
+        let completion_tokens: i64 = row.get(4)?;
+        let total_tokens: i64 = row.get(5)?;
+        let created_at: i64 = row.get(6)?;
+
+        let Some(tokens) =
+            normalized_tokens(prompt_tokens, completion_tokens, total_tokens, 0, 0, 0)
+        else {
+            return Ok(());
+        };
+        let timestamp = timestamp_secs_to_ms(created_at as f64);
+        if timestamp <= 0 || id.trim().is_empty() {
+            return Ok(());
+        }
+
+        let model = non_blank(Some(model)).unwrap_or_else(|| "unknown".to_string());
+        let mut message = UnifiedMessage::new_with_dedup(
+            CLIENT_ID,
+            model,
+            CLIENT_ID,
+            "unsloth:api".to_string(),
+            timestamp,
+            tokens,
+            0.0,
+            Some(format!("unsloth:api:{id}")),
+        );
+        message.agent = Some(API_AGENT.to_string());
+        message.session_title = non_blank(Some(endpoint));
+        message.is_turn_start = true;
+        message.mark_provider_reported_cost();
+        messages.push(message);
+        Ok(())
+    });
+    messages
+}
+
+/// Parse durable Unsloth Studio inference usage without selecting chat content.
+pub fn parse_unsloth_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
+    let Some(conn) = open_readonly_sqlite_opt(db_path) else {
+        return Vec::new();
+    };
+
+    let mut messages = parse_internal_chat_usage(db_path, &conn);
+    messages.extend(parse_external_api_usage(db_path, &conn));
+    messages
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::{params, Connection};
+
+    fn create_database(path: &Path, include_api_usage: bool) -> Connection {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE chat_threads (
+                id TEXT PRIMARY KEY,
+                model_id TEXT
+            );
+            CREATE TABLE chat_messages (
+                id TEXT PRIMARY KEY,
+                thread_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                metadata_json TEXT,
+                created_at INTEGER NOT NULL
+            );
+            "#,
+        )
+        .unwrap();
+        if include_api_usage {
+            conn.execute_batch(
+                r#"
+                CREATE TABLE api_usage_events (
+                    id TEXT PRIMARY KEY,
+                    subject TEXT NOT NULL,
+                    endpoint TEXT NOT NULL,
+                    model TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    prompt_tokens INTEGER NOT NULL,
+                    completion_tokens INTEGER NOT NULL,
+                    total_tokens INTEGER NOT NULL,
+                    created_at INTEGER NOT NULL
+                );
+                "#,
+            )
+            .unwrap();
+        }
+        conn
+    }
+
+    #[test]
+    fn returns_empty_for_missing_database() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(parse_unsloth_sqlite(&dir.path().join("missing.db")).is_empty());
+    }
+
+    #[test]
+    fn parses_internal_chat_and_content_free_api_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("studio.db");
+        let conn = create_database(&db_path, true);
+        conn.execute(
+            "INSERT INTO chat_threads (id, model_id) VALUES (?1, ?2)",
+            params!["thread-1", "thread-fallback"],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO chat_messages (id, thread_id, role, metadata_json, created_at) VALUES (?1, ?2, 'assistant', ?3, ?4)",
+            params![
+                "message-1",
+                "thread-1",
+                r#"{"contextUsage":{"promptTokens":100,"completionTokens":40,"totalTokens":140,"cachedTokens":30,"cacheWriteTokens":10,"reasoningTokens":5,"modelId":"unsloth/Qwen-test"}}"#,
+                1_788_000_000_123_i64,
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO api_usage_events (id, subject, endpoint, model, status, prompt_tokens, completion_tokens, total_tokens, created_at) VALUES (?1, ?2, ?3, ?4, 'completed', ?5, ?6, ?7, ?8)",
+            params![
+                "request-1",
+                "private-user",
+                "/v1/chat/completions",
+                "unsloth/local-api-model",
+                20_i64,
+                7_i64,
+                27_i64,
+                1_788_000_100_i64,
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_unsloth_sqlite(&db_path);
+        assert_eq!(messages.len(), 2);
+
+        let chat = &messages[0];
+        assert_eq!(chat.model_id, "unsloth/Qwen-test");
+        assert_eq!(chat.session_id, "thread-1");
+        assert_eq!(chat.timestamp, 1_788_000_000_123);
+        assert_eq!(chat.tokens.input, 60);
+        assert_eq!(chat.tokens.output, 35);
+        assert_eq!(chat.tokens.cache_read, 30);
+        assert_eq!(chat.tokens.cache_write, 10);
+        assert_eq!(chat.tokens.reasoning, 5);
+        assert_eq!(chat.tokens.total(), 140);
+        assert_eq!(chat.dedup_key.as_deref(), Some("unsloth:chat:message-1"));
+        assert_eq!(chat.agent.as_deref(), Some(STUDIO_AGENT));
+        assert!(chat.is_turn_start);
+        assert_eq!(chat.cost, 0.0);
+
+        let api = &messages[1];
+        assert_eq!(api.model_id, "unsloth/local-api-model");
+        assert_eq!(api.timestamp, 1_788_000_100_000);
+        assert_eq!(api.tokens.input, 20);
+        assert_eq!(api.tokens.output, 7);
+        assert_eq!(api.tokens.total(), 27);
+        assert_eq!(api.agent.as_deref(), Some(API_AGENT));
+        assert_eq!(api.session_title.as_deref(), Some("/v1/chat/completions"));
+        assert_eq!(api.dedup_key.as_deref(), Some("unsloth:api:request-1"));
+        assert_eq!(api.session_id, "unsloth:api");
+    }
+
+    #[test]
+    fn older_schema_without_api_table_still_parses_chat_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("studio.db");
+        let conn = create_database(&db_path, false);
+        conn.execute(
+            "INSERT INTO chat_threads (id, model_id) VALUES ('thread-1', 'fallback-model')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO chat_messages (id, thread_id, role, metadata_json, created_at) VALUES (?1, ?2, 'assistant', ?3, ?4)",
+            params![
+                "message-1",
+                "thread-1",
+                r#"{"contextUsage":{"promptTokens":5,"completionTokens":3,"totalTokens":8}}"#,
+                1_788_000_000_i64,
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_unsloth_sqlite(&db_path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "fallback-model");
+        assert_eq!(messages[0].tokens.total(), 8);
+    }
+
+    #[test]
+    fn skips_user_messages_malformed_metadata_and_zero_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("studio.db");
+        let conn = create_database(&db_path, false);
+        for (id, role, metadata) in [
+            (
+                "user-1",
+                "user",
+                r#"{"contextUsage":{"promptTokens":10,"totalTokens":10}}"#,
+            ),
+            ("assistant-bad", "assistant", "not-json"),
+            (
+                "assistant-zero",
+                "assistant",
+                r#"{"contextUsage":{"promptTokens":0,"completionTokens":0,"totalTokens":0}}"#,
+            ),
+        ] {
+            conn.execute(
+                "INSERT INTO chat_messages (id, thread_id, role, metadata_json, created_at) VALUES (?1, 'thread-1', ?2, ?3, ?4)",
+                params![id, role, metadata, 1_788_000_000_i64],
+            )
+            .unwrap();
+        }
+        drop(conn);
+
+        assert!(parse_unsloth_sqlite(&db_path).is_empty());
+    }
+}

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -80,6 +80,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   fx: "Fx",
   omp: "Oh My Pi",
   lmstudio: "LM Studio",
+  unsloth: "Unsloth",
 };
 
 // Client logos from GitHub CDN (public repo)
@@ -143,6 +144,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
   fx: `${GITHUB_CDN_BASE}/client-fx.png`,
   omp: "https://github.com/can1357.png",
   lmstudio: "https://github.com/lmstudio-ai.png",
+  unsloth: "https://github.com/unslothai.png",
 };
 
 export const SOURCE_COLORS: Record<ClientType, string> = {
@@ -199,6 +201,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   fx: "#0070F3",
   omp: "#E11D48",
   lmstudio: "#6C5CE7",
+  unsloth: "#58CC02",
 };
 
 // Derived values

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -52,6 +52,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "fx",
   "omp",
   "lmstudio",
+  "unsloth",
 ] as const;
 
 export type CcMirrorClientType = `cc-mirror/${string}`;


### PR DESCRIPTION
## Summary

- Add Unsloth Studio as a parse-local client across the Rust core, CLI/TUI, and frontend registry, displayed as `Unsloth` in the app.
- Read exact internal-chat usage from completed assistant metadata and authenticated external API usage from the content-free `api_usage_events` table in `$UNSLOTH_STUDIO_HOME/studio.db` (fallback: `~/.unsloth/studio/studio.db`).
- Preserve input, output, cache-read, cache-write, and reasoning token categories; deduplicate stable message and request IDs; and invalidate cached scans when SQLite WAL state changes.
- Avoid selecting prompts, responses, credentials, previews, or other message content. Training metrics are excluded, and local inference is reported at $0.
- Support older database schemas without the API usage table and document the integration in the maintained English, Japanese, Korean, and Simplified Chinese READMEs.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p tokscale-core --all-features --all-targets -- -D warnings`
- `cargo test -p tokscale-core unsloth --lib` (8 passed)
- Core regression suite (1,946 passed, 2 ignored; one Windows symlink-permission test excluded)
- CLI unit suite (1,182 passed, 1 ignored)
- Applicable CLI integration suite (159 passed; six host-sensitive Windows timezone/Hermes cases excluded after reproducing them outside this change)
- `bun run --cwd packages/frontend typecheck`
- Frontend test suite (951 passed, 6 skipped)
- Real-database smoke test: 130 input, 6,545 cache-read, and 2,887 output tokens across 6 messages (9,562 total), exactly matching the source counters


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Unsloth Studio as a new trackable client, reading exact inference usage from its local SQLite database without touching message content.

**New Features**
- Adds `unsloth` to the CLI client list, TUI hotkey `U`, and frontend source registry.
- Reads internal chat usage from assistant-message metadata and authenticated API usage from the `api_usage_events` table.
- Falls back to `~/.unsloth/studio/studio.db` when `$UNSLOTH_STUDIO_HOME` is unset.
- Deduplicates stable message/request IDs and refreshes cached scans when SQLite WAL state changes.
- Skips training metrics and reports local inference at $0.
- Supports older database schemas without the API usage table and updates all four READMEs.

<sup>Written for commit 5870b0ae7c852a38e69f6b0820a1543862ceb6b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

