### PR TITLE
fix(cli): surface the cause behind a failed network request

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -6029,14 +6029,19 @@ fn run_submit_command(
             let status = resp.status();
             let body: SubmitResponse =
                 rt.block_on(async { resp.json().await })
-                    .unwrap_or_else(|_| SubmitResponse {
+                    .unwrap_or_else(|err| SubmitResponse {
                         submission_id: None,
                         username: None,
                         metrics: None,
                         warnings: None,
+                        // Same reason as the transport arm below: reqwest's
+                        // Display for a decode failure is the bare "error
+                        // decoding response body", and the serde cause naming
+                        // the offending field is only reachable via `source()`.
                         error: Some(format!(
-                            "Server returned {} with unparseable response",
-                            status
+                            "Server returned {} with unparseable response: {}",
+                            status,
+                            tokscale_core::pricing::describe_error(&err)
                         )),
                         details: None,
                     });
@@ -6111,10 +6116,17 @@ fn run_submit_command(
             }
         }
         Err(err) => {
+            // `err` alone renders every transport failure as the same
+            // "error sending request for url (...)" line, which is what left
+            // #1238 undiagnosable: a proxy rejecting the certificate, a
+            // refused connection and a DNS failure were indistinguishable in
+            // the output the reporter could paste. The cause hangs off
+            // `source()`, so walk it.
+            let described = tokscale_core::pricing::describe_error(&err);
             eprintln!("\n  {}", "Error: Failed to connect to server.".red());
-            eprintln!("{}\n", format!("  {}", err).bright_black());
+            eprintln!("{}\n", format!("  {}", described).bright_black());
             if mode == SubmitMode::Autosubmit {
-                return Err(anyhow::anyhow!("Failed to connect to server: {err}"));
+                return Err(anyhow::anyhow!("Failed to connect to server: {described}"));
             }
             std::process::exit(1);
         }

--- a/crates/tokscale-core/src/pricing/fetch.rs
+++ b/crates/tokscale-core/src/pricing/fetch.rs
@@ -29,7 +29,12 @@ pub(crate) async fn get_with_retry(
                 }
                 last_error = Some(format!("{source} HTTP {status}"));
             }
-            Err(error) => last_error = Some(format!("{source} network error: {error}")),
+            Err(error) => {
+                last_error = Some(format!(
+                    "{source} network error: {}",
+                    super::describe_error(&error)
+                ))
+            }
         }
 
         if attempt < MAX_RETRIES - 1 {
@@ -38,4 +43,57 @@ pub(crate) async fn get_with_retry(
     }
 
     Err(last_error.unwrap_or_else(|| format!("{source} fetch ended without a response")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reserve a port, then release it, so a connect to it is refused rather
+    /// than timing out. Binding first is what makes the port reliably free:
+    /// hardcoding one would race any other listener on the machine.
+    fn refused_url() -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral port");
+        let port = listener.local_addr().expect("read the bound port").port();
+        drop(listener);
+        format!("http://127.0.0.1:{port}/pricing.json")
+    }
+
+    // @keep: this is the #1238 regression, and the assertion is deliberately
+    // not on reqwest's or hyper's wording.
+    //
+    // `reqwest::Error`'s Display for a send failure is "error sending request
+    // for url (...)" no matter what went wrong underneath, so a rejected
+    // certificate, a refused connection and a DNS failure all print the same
+    // line. #1238 arrived with exactly that line and could not be triaged from
+    // it. What this pins is the property that made triage possible: the
+    // message `get_with_retry` returns must carry more than Display does.
+    #[tokio::test]
+    async fn network_error_carries_the_cause_display_alone_would_drop() {
+        let url = refused_url();
+        let client = pricing_client().expect("build the pricing client");
+
+        let message = get_with_retry(&client, &url, "TestSource")
+            .await
+            .expect_err("a connect to a closed port must fail");
+
+        assert!(
+            message.starts_with("TestSource network error: "),
+            "the source label must still lead the message, got: {message}"
+        );
+
+        // The bare Display, which is what this code used to print. Anchoring on
+        // "longer than Display" rather than on the literal cause text keeps a
+        // dependency bump from reddening this test for rewording its prose.
+        let displayed = reqwest::Client::new()
+            .get(&url)
+            .send()
+            .await
+            .expect_err("a connect to a closed port must fail")
+            .to_string();
+        assert!(
+            message.len() > format!("TestSource network error: {displayed}").len(),
+            "describe_error must add the source chain beyond Display, got: {message}"
+        );
+    }
 }

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -36,7 +36,13 @@ const EXCLUDED_LITELLM_PREFIXES: &[&str] = &["github_copilot/"];
 /// that message, which is why it was impossible to tell a transport failure
 /// from an upstream schema change and the reporter guessed at TLS. Printing the
 /// chain makes the next such report actionable.
-pub(crate) fn describe_error(error: &(dyn std::error::Error + 'static)) -> String {
+///
+/// The same terseness hides transport failures. `send()` renders every one of
+/// them as "error sending request for url (...)", so a certificate rejected by
+/// an intercepting proxy, a refused connection and a DNS failure are one
+/// string. #1238 was reported against a Windows firewall with exactly that
+/// line, and neither the reporter nor I could tell which of the three it was.
+pub fn describe_error(error: &(dyn std::error::Error + 'static)) -> String {
     let mut parts = vec![error.to_string()];
     let mut source = error.source();
     while let Some(inner) = source {


### PR DESCRIPTION
## Summary

- Walk the `source()` chain when printing a failed network request, instead of `reqwest::Error`'s Display alone.
- Applied at the three sites that printed one bare: the pricing fetch retry loop, submit's connect failure, and submit's response decode.
- Add a regression pinning that the message carries more than Display does.

Diagnostics only — no behavioural change to scanning, pricing or submission.

## Why

`reqwest::Error`'s Display for a send failure is the same string no matter what went wrong underneath:

```
error sending request for url (https://tokscale.ai/api/submit)
```

A certificate rejected by an intercepting proxy, a refused connection and a DNS failure all render as that line. What separates them lives in `source()`, which `{}` never walks.

#1238 was filed from a Windows machine running Socket Firewall with exactly that output, and it cannot be triaged from it — the reporter could not tell whether the firewall was blocking by policy or breaking TLS, and neither could I. Asking them to reproduce under `curl -v` is asking them to do work the tool should have done.

`describe_error` already existed for this. It was added in #1002, where the identical terseness in a *decode* error made a schema change look like a TLS failure. The helper was just never applied to the transport path.

## What changed

`describe_error` becomes `pub` (it was `pub(crate)` in `tokscale-core::pricing`) so the CLI can reach it, and is called at:

| site | was |
|---|---|
| `pricing/fetch.rs:32` | `format!("{source} network error: {error}")` |
| `main.rs:6118` | `format!("  {}", err)` on submit connect failure |
| `main.rs:6035` | `unwrap_or_else(\|_\| ...)` discarding the decode cause entirely |

The last one dropped the error on the floor with `|_|`, so a malformed submit response reported only "Server returned {status} with unparseable response" — the same #1002 shape.

## Verification

The regression binds a port, releases it, and asserts the message `get_with_retry` returns carries more than Display. Validated against the pre-fix code rather than assumed: reverting the `fetch.rs` hunk fails it with

```
describe_error must add the source chain beyond Display, got:
TestSource network error: error sending request for url (http://127.0.0.1:53792/pricing.json)
```

which is the reporter's line with a different host.

Assertions are anchored on "longer than Display" and on the source label, not on reqwest's or hyper's prose, so a dependency bump rewording its messages cannot redden this without a real defect.

Full gate green on this branch:

```
cargo fmt --check                                              FMT=0
cargo test --workspace                                         TEST=0
cargo clippy --locked --workspace --all-features               CLIPPY_BARE=0
cargo clippy --locked --workspace --all-features --all-targets CLIPPY_TARGETS=0
```

Both clippy forms, since neither is a superset: the bare pass catches `dead_code` that `--all-targets` ungates, and `--all-targets` catches lints in test code the bare pass never sees.

## What this does not do

It does not fix #1238. Whether Socket Firewall is enforcing an allowlist or breaking TLS is still unknown — this is what makes the next report answerable. Two things already ruled out: tokscale uses `rustls-tls-native-roots`, so it reads the Windows certificate store rather than a bundled root list, and the pricing and submit clients do not call `.no_proxy()`, so proxy environment variables are honored.

The more serious half of #1238 — the same local data submitting different token totals depending on whether a live pricing fetch succeeded — is unrelated to this PR and tracked there and in #1201.

Refs #1238, #1002.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes failed network requests print the underlying cause, so a certificate rejected by a proxy, a refused connection, and a DNS failure no longer show the same "error sending request for url (...)" line. This is what made #1238 impossible to triage, since the reporter's firewall output was identical for policy blocks and TLS breakage.

**Bug Fixes**
- The `describe_error` helper, previously used only for decode errors, now also walks the source chain on the pricing fetch retry loop, submit's connect failure, and submit's response decode.
- Submit's unparseable-response path previously dropped the decode error entirely; it is now included in the message.
- `describe_error` is now `pub` so the CLI can use it.
- Adds a regression test pinning that network error messages carry more than `reqwest`'s bare Display string.

<sup>Written for commit 4c162578f44ccfdf1b946050b87648642fee0250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

