### PR TITLE
fix(zai): accept CREDIT_LIMIT for session/weekly windows on V3 GLM Coding plans

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/zai.rs
+++ b/crates/tokscale-cli/src/commands/usage/zai.rs
@@ -112,28 +112,25 @@ pub fn fetch() -> Result<UsageOutput> {
                 };
 
                 match limit.limit_type.as_deref() {
-                    Some("TOKENS_LIMIT") => {
-                        let metric = UsageMetric {
-                            label: String::new(),
-                            used_percent: pct,
-                            remaining_percent: 100.0 - pct,
-                            remaining_label: None,
-                            resets_at: None,
+                    // V3 GLM Coding plans report the same (unit, number)
+                    // windows as CREDIT_LIMIT instead of TOKENS_LIMIT. Prefer
+                    // CREDIT_LIMIT so a plan that ever emits both for one
+                    // window cannot silently last-write-wins.
+                    Some("TOKENS_LIMIT") | Some("CREDIT_LIMIT") => {
+                        let prefer = limit.limit_type.as_deref() == Some("CREDIT_LIMIT");
+                        let (target, label) = match (limit.unit, limit.number) {
+                            (Some(3), Some(5)) => (&mut session_metric, "Session"),
+                            (Some(6), Some(1)) => (&mut weekly_metric, "Weekly"),
+                            _ => continue,
                         };
-                        match (limit.unit, limit.number) {
-                            (Some(3), Some(5)) => {
-                                session_metric = Some(UsageMetric {
-                                    label: "Session".into(),
-                                    ..metric
-                                });
-                            }
-                            (Some(6), Some(1)) => {
-                                weekly_metric = Some(UsageMetric {
-                                    label: "Weekly".into(),
-                                    ..metric
-                                });
-                            }
-                            _ => {}
+                        if target.is_none() || prefer {
+                            *target = Some(UsageMetric {
+                                label: label.to_string(),
+                                used_percent: pct,
+                                remaining_percent: 100.0 - pct,
+                                remaining_label: None,
+                                resets_at: None,
+                            });
                         }
                     }
                     Some("TIME_LIMIT") => {


### PR DESCRIPTION
Fixes #1231.

## What

V3 GLM Coding plans (subscription `version: "V3"`) return quota entries typed `CREDIT_LIMIT` rather than `TOKENS_LIMIT`. The `(unit, number)` window pairs and `percentage` fields are unchanged, so every limit fell into the catch-all arm and Z.ai usage output showed the correct plan with empty `metrics`.

This accepts either type in the session/weekly arm:

```rust
Some("TOKENS_LIMIT") | Some("CREDIT_LIMIT") => { ... }
```

with a deterministic preference for `CREDIT_LIMIT` (`target.is_none() || prefer`) so a plan that ever emits both types for one window cannot last-write-wins. `TIME_LIMIT` handling is untouched.

## Verification

Built with stable 1.98.0 (`cargo build`, `cargo clippy`, `cargo fmt` clean) and run against a live V3 account (`level: max`, two `CREDIT_LIMIT` entries, `percentage: 1` for both windows):

**Before** — `tokscale usage --json`:

```json
{
  "provider": "Z.ai",
  "plan": "Max",
  "email": null,
  "metrics": []
}
```

**After:**

```json
{
  "provider": "Z.ai",
  "plan": "Max",
  "email": null,
  "metrics": [
    { "label": "Session", "used_percent": 1.0, "remaining_percent": 99.0, "remaining_label": null, "resets_at": null },
    { "label": "Weekly", "used_percent": 1.0, "remaining_percent": 99.0, "remaining_label": null, "resets_at": null }
  ]
}
```

Percentages match the API's `percentage` fields exactly; older `TOKENS_LIMIT` plans are unaffected since the arm is additive.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes usage metrics showing empty for Z.ai V3 GLM Coding plans by accepting `CREDIT_LIMIT` quota entries alongside `TOKENS_LIMIT`. Previously these plans matched no window and output the correct plan with empty `metrics`; now Session and Weekly percentages populate. Prefers `CREDIT_LIMIT` when both types appear for the same window so the last entry cannot silently win. `TIME_LIMIT` handling is unchanged, and existing `TOKENS_LIMIT` plans are unaffected since the arm is additive. Fixes #1231.

<sup>Written for commit db24ef4eaebea0c90305ed3039fcffd369bf1557. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

