### PR TITLE
chore: address review follow-ups for zai, unsloth, and pricing errors

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/zai.rs
+++ b/crates/tokscale-cli/src/commands/usage/zai.rs
@@ -72,6 +72,64 @@ pub fn has_credentials() -> bool {
         .is_ok()
 }
 
+/// Translate Z.ai's limit windows into the session/weekly/web-search metrics
+/// tokscale surfaces.
+///
+/// Z.ai encodes each window as an opaque `(unit, number)` code pair rather than
+/// a name: `(3, 5)` is the 5-hour rolling session window and `(6, 1)` is the
+/// 1-week window. Unrecognized codes are skipped rather than guessed at.
+fn build_metrics(
+    limits: &[Limit],
+    search_reset: Option<String>,
+    session_metric: &mut Option<UsageMetric>,
+    weekly_metric: &mut Option<UsageMetric>,
+    search_metric: &mut Option<UsageMetric>,
+) {
+    for limit in limits.iter() {
+        // Skip limits with no percentage rather than fabricating
+        // "0% used / 100% left" from a missing field.
+        let pct = match limit.percentage {
+            Some(p) => p.clamp(0.0, 100.0),
+            None => continue,
+        };
+
+        match limit.limit_type.as_deref() {
+            // V3 GLM Coding plans report the same (unit, number)
+            // windows as CREDIT_LIMIT instead of TOKENS_LIMIT. Prefer
+            // CREDIT_LIMIT so a plan that ever emits both for one
+            // window cannot silently last-write-wins.
+            Some("TOKENS_LIMIT") | Some("CREDIT_LIMIT") => {
+                let prefer = limit.limit_type.as_deref() == Some("CREDIT_LIMIT");
+                let (target, label) = match (limit.unit, limit.number) {
+                    (Some(3), Some(5)) => (&mut *session_metric, "Session"),
+                    (Some(6), Some(1)) => (&mut *weekly_metric, "Weekly"),
+                    _ => continue,
+                };
+                if target.is_none() || prefer {
+                    *target = Some(UsageMetric {
+                        label: label.to_string(),
+                        used_percent: pct,
+                        remaining_percent: 100.0 - pct,
+                        remaining_label: None,
+                        resets_at: None,
+                    });
+                }
+            }
+            Some("TIME_LIMIT") => {
+                let remaining_label = limit.remaining.map(|r| format!("{:.0} left", r));
+                *search_metric = Some(UsageMetric {
+                    label: "Web Search".into(),
+                    used_percent: pct,
+                    remaining_percent: 100.0 - pct,
+                    remaining_label,
+                    resets_at: search_reset.clone(),
+                });
+            }
+            _ => {}
+        }
+    }
+}
+
 pub fn fetch() -> Result<UsageOutput> {
     let api_key = std::env::var("ZAI_API_KEY")
         .or_else(|_| std::env::var("GLM_API_KEY"))
@@ -102,54 +160,20 @@ pub fn fetch() -> Result<UsageOutput> {
         let mut weekly_metric = None;
         let mut search_metric = None;
 
-        if let Some(limits) = quota.data.as_ref().and_then(|d| d.limits.as_ref()) {
-            for limit in limits.iter() {
-                // Skip limits with no percentage rather than fabricating
-                // "0% used / 100% left" from a missing field.
-                let pct = match limit.percentage {
-                    Some(p) => p.clamp(0.0, 100.0),
-                    None => continue,
-                };
+        let search_reset = sub
+            .as_ref()
+            .and_then(|s| s.data.as_ref())
+            .and_then(|d| d.first())
+            .and_then(|s| s.next_renew_time.clone());
 
-                match limit.limit_type.as_deref() {
-                    // V3 GLM Coding plans report the same (unit, number)
-                    // windows as CREDIT_LIMIT instead of TOKENS_LIMIT. Prefer
-                    // CREDIT_LIMIT so a plan that ever emits both for one
-                    // window cannot silently last-write-wins.
-                    Some("TOKENS_LIMIT") | Some("CREDIT_LIMIT") => {
-                        let prefer = limit.limit_type.as_deref() == Some("CREDIT_LIMIT");
-                        let (target, label) = match (limit.unit, limit.number) {
-                            (Some(3), Some(5)) => (&mut session_metric, "Session"),
-                            (Some(6), Some(1)) => (&mut weekly_metric, "Weekly"),
-                            _ => continue,
-                        };
-                        if target.is_none() || prefer {
-                            *target = Some(UsageMetric {
-                                label: label.to_string(),
-                                used_percent: pct,
-                                remaining_percent: 100.0 - pct,
-                                remaining_label: None,
-                                resets_at: None,
-                            });
-                        }
-                    }
-                    Some("TIME_LIMIT") => {
-                        let remaining_label = limit.remaining.map(|r| format!("{:.0} left", r));
-                        search_metric = Some(UsageMetric {
-                            label: "Web Search".into(),
-                            used_percent: pct,
-                            remaining_percent: 100.0 - pct,
-                            remaining_label,
-                            resets_at: sub
-                                .as_ref()
-                                .and_then(|s| s.data.as_ref())
-                                .and_then(|d| d.first())
-                                .and_then(|s| s.next_renew_time.clone()),
-                        });
-                    }
-                    _ => {}
-                }
-            }
+        if let Some(limits) = quota.data.as_ref().and_then(|d| d.limits.as_ref()) {
+            build_metrics(
+                limits,
+                search_reset,
+                &mut session_metric,
+                &mut weekly_metric,
+                &mut search_metric,
+            );
         }
 
         let mut metrics = Vec::new();
@@ -175,4 +199,72 @@ pub fn fetch() -> Result<UsageOutput> {
             spend_control: None,
         })
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn limit(kind: &str, unit: i64, number: i64, percentage: f64) -> Limit {
+        serde_json::from_value(serde_json::json!({
+            "type": kind,
+            "unit": unit,
+            "number": number,
+            "percentage": percentage,
+        }))
+        .expect("valid Limit fixture")
+    }
+
+    fn run(limits: &[Limit]) -> (Option<UsageMetric>, Option<UsageMetric>, Option<UsageMetric>) {
+        let mut session = None;
+        let mut weekly = None;
+        let mut search = None;
+        build_metrics(limits, None, &mut session, &mut weekly, &mut search);
+        (session, weekly, search)
+    }
+
+    #[test]
+    fn credit_limit_session_window_maps_to_session_metric() {
+        let (session, weekly, _) = run(&[limit("CREDIT_LIMIT", 3, 5, 40.0)]);
+        let session = session.expect("session metric present");
+        assert_eq!(session.label, "Session");
+        assert_eq!(session.used_percent, 40.0);
+        assert_eq!(session.remaining_percent, 60.0);
+        assert!(weekly.is_none());
+    }
+
+    #[test]
+    fn credit_limit_weekly_window_maps_to_weekly_metric() {
+        let (session, weekly, _) = run(&[limit("CREDIT_LIMIT", 6, 1, 25.0)]);
+        let weekly = weekly.expect("weekly metric present");
+        assert_eq!(weekly.label, "Weekly");
+        assert_eq!(weekly.used_percent, 25.0);
+        assert!(session.is_none());
+    }
+
+    #[test]
+    fn credit_limit_is_preferred_over_tokens_limit_for_same_window() {
+        // TOKENS_LIMIT first, then CREDIT_LIMIT: credit must win.
+        let (session, _, _) = run(&[
+            limit("TOKENS_LIMIT", 3, 5, 10.0),
+            limit("CREDIT_LIMIT", 3, 5, 90.0),
+        ]);
+        assert_eq!(session.expect("session metric present").used_percent, 90.0);
+
+        // Reversed order: CREDIT_LIMIT must not be clobbered by a later
+        // TOKENS_LIMIT for the same window.
+        let (session, _, _) = run(&[
+            limit("CREDIT_LIMIT", 3, 5, 90.0),
+            limit("TOKENS_LIMIT", 3, 5, 10.0),
+        ]);
+        assert_eq!(session.expect("session metric present").used_percent, 90.0);
+    }
+
+    #[test]
+    fn unrecognized_window_codes_are_skipped() {
+        let (session, weekly, search) = run(&[limit("CREDIT_LIMIT", 9, 9, 50.0)]);
+        assert!(session.is_none());
+        assert!(weekly.is_none());
+        assert!(search.is_none());
+    }
 }

--- a/crates/tokscale-cli/src/commands/usage/zai.rs
+++ b/crates/tokscale-cli/src/commands/usage/zai.rs
@@ -215,7 +215,13 @@ mod tests {
         .expect("valid Limit fixture")
     }
 
-    fn run(limits: &[Limit]) -> (Option<UsageMetric>, Option<UsageMetric>, Option<UsageMetric>) {
+    fn run(
+        limits: &[Limit],
+    ) -> (
+        Option<UsageMetric>,
+        Option<UsageMetric>,
+        Option<UsageMetric>,
+    ) {
         let mut session = None;
         let mut weekly = None;
         let mut search = None;

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -42,6 +42,12 @@ const EXCLUDED_LITELLM_PREFIXES: &[&str] = &["github_copilot/"];
 /// an intercepting proxy, a refused connection and a DNS failure are one
 /// string. #1238 was reported against a Windows firewall with exactly that
 /// line, and neither the reporter nor I could tell which of the three it was.
+///
+/// Callers must not pass errors from clients whose request URLs embed tokens or
+/// credentials in query parameters: `reqwest` includes the request URL verbatim
+/// in its `Display`, and this function prints that string unredacted, so any
+/// secret in the URL would leak into logs and error output. Current callers use
+/// header-based auth with parameter-free URLs, which is safe.
 pub fn describe_error(error: &(dyn std::error::Error + 'static)) -> String {
     let mut parts = vec![error.to_string()];
     let mut source = error.source();

--- a/crates/tokscale-core/src/sessions/unsloth.rs
+++ b/crates/tokscale-core/src/sessions/unsloth.rs
@@ -224,6 +224,10 @@ fn parse_external_api_usage(db_path: &Path, conn: &Connection) -> Vec<UnifiedMes
         let total_tokens: i64 = row.get(5)?;
         let created_at: i64 = row.get(6)?;
 
+        // `api_usage_events` records only prompt/completion/total counts, so
+        // cache_read, cache_write, and reasoning are passed as 0. This is
+        // intentional until Unsloth exposes those columns in the table; the
+        // chat/contextUsage path already carries them when present.
         let Some(tokens) =
             normalized_tokens(prompt_tokens, completion_tokens, total_tokens, 0, 0, 0)
         else {


### PR DESCRIPTION
## Summary

Follow-up nits gathered while reviewing the recently merged #1239 (Unsloth Studio), #1240 (network error surfacing), and #1241 (Z.ai CREDIT_LIMIT). No behavior change — this is test coverage, one behavior-preserving refactor, and documentation.

## Changes

**`zai` — testable window mapping + coverage (nit from #1241)**

The session/weekly window logic added in #1241 lived inline inside `fetch()`, unreachable without live network + env, so it had no unit tests. This extracts a pure `build_metrics(...)` function (a faithful move of the existing loop — `search_reset` is now computed once and threaded in as a parameter) and adds tests for:
- `CREDIT_LIMIT` `(3, 5)` → Session and `(6, 1)` → Weekly
- `CREDIT_LIMIT` preferred over `TOKENS_LIMIT` for the same window, in both orderings
- unrecognized `(unit, number)` codes skipped

It also documents the opaque `(unit, number)` window codes that were previously bare magic numbers.

**`unsloth` — document intentional zeroed buckets (nit from #1239)**

The `api_usage_events` lane passes `0` for cache_read/cache_write/reasoning because that table only records prompt/completion/total. Added a comment noting this is intentional until Unsloth exposes those columns; the chat/contextUsage path already carries them when present.

**`pricing` — document `describe_error` URL handling (nit from #1240)**

`describe_error` was made `pub` in #1240 and prints request URLs verbatim. Added a doc paragraph warning that callers must not pass it errors from clients that embed tokens/credentials in URL query parameters. Current callers use header-based auth with parameter-free URLs, which is safe.

## Dropped nits (verified stale/infeasible)

- **`pi.rs` `needless_lifetimes`** — clippy emits zero warnings after a forced recompile; the one explicit-lifetime fn is correctly not flagged.
- **Autosubmit error-cause test** — not feasible as a pure unit test (inline `reqwest` construction, no injectable seam). The load-bearing property is already tested at `pricing/fetch.rs` and `pricing/litellm.rs`.

## Testing

```
cargo build -p tokscale-cli -p tokscale-core   # clean
cargo test -p tokscale-cli zai                 # 4 new tests pass
cargo test -p tokscale-core unsloth            # 8 pass
cargo test -p tokscale-core describe_error     # existing regression test passes
cargo clippy -p tokscale-cli -p tokscale-core --lib   # no warnings
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses review follow-ups from the merged Z.ai, Unsloth, and pricing error changes without changing behavior.

**Changes**
- Extracts Z.ai's session/weekly window mapping from `fetch()` into `build_metrics` and adds tests for `CREDIT_LIMIT` windows and `CREDIT_LIMIT`-over-`TOKENS_LIMIT` preference.
- Documents Z.ai's opaque `(unit, number)` window codes.
- Notes that `api_usage_events` intentionally passes `0` for cache_read/write and reasoning until Unsloth exposes those columns.
- Documents that `describe_error` prints request URLs verbatim, so callers must not pass errors from clients that embed tokens or credentials in URL query parameters.

<sup>Written for commit 185c4e1d6aa2886f8696ad43cf836f30d1453002. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

