### PR TITLE
fix(senpi): discover home OmO child sessions

### DIFF
--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -670,19 +670,29 @@ pub fn built_in_extra_scan_paths_for(
         );
     }
 
-    if enabled.contains(&ClientId::Senpi) && use_env_roots {
-        if let Some(path) =
-            std::env::var_os("SENPI_CODING_AGENT_SESSION_DIR").filter(|path| !path.is_empty())
-        {
-            paths.push((ClientId::Senpi, PathBuf::from(path)));
+    if enabled.contains(&ClientId::Senpi) {
+        if use_env_roots {
+            if let Some(path) =
+                std::env::var_os("SENPI_CODING_AGENT_SESSION_DIR").filter(|path| !path.is_empty())
+            {
+                paths.push((ClientId::Senpi, PathBuf::from(path)));
+            }
+
+            if let Ok(current_dir) = std::env::current_dir() {
+                paths.push((
+                    ClientId::Senpi,
+                    current_dir.join(".omo").join("senpi-task").join("children"),
+                ));
+            }
         }
 
-        if let Ok(current_dir) = std::env::current_dir() {
-            paths.push((
-                ClientId::Senpi,
-                current_dir.join(".omo").join("senpi-task").join("children"),
-            ));
-        }
+        paths.push((
+            ClientId::Senpi,
+            Path::new(home_dir)
+                .join(".omo")
+                .join("senpi-task")
+                .join("children"),
+        ));
     }
 
     paths
@@ -7146,11 +7156,101 @@ mod tests {
 
     #[test]
     #[serial]
+    fn built_in_paths_include_home_omo_children() {
+        let home_dir = TempDir::new().unwrap();
+        let other_dir = TempDir::new().unwrap();
+        let child_session = setup_mock_senpi_omo_child(home_dir.path());
+        let mut env =
+            EnvGuard::capture(&["SENPI_CODING_AGENT_DIR", "SENPI_CODING_AGENT_SESSION_DIR"]);
+        env.remove("SENPI_CODING_AGENT_DIR");
+        env.remove("SENPI_CODING_AGENT_SESSION_DIR");
+        let _current_dir = CurrentDirGuard::set(other_dir.path());
+
+        let result =
+            scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
+
+        let files = result.get(ClientId::Senpi);
+        assert_eq!(
+            files.len(),
+            1,
+            "home-directory OmO child sessions must be auto-discovered"
+        );
+        assert_eq!(files[0].canonicalize().unwrap(), child_session);
+    }
+
+    #[test]
+    #[serial]
+    fn home_omo_children_are_discovered_when_env_roots_disabled() {
+        let home_dir = TempDir::new().unwrap();
+        let project_dir = TempDir::new().unwrap();
+        let child_session = setup_mock_senpi_omo_child(home_dir.path());
+        let project_children = project_dir.path().join(".omo/senpi-task/children");
+        let redirected_agent = TempDir::new().unwrap();
+        let mut env =
+            EnvGuard::capture(&["SENPI_CODING_AGENT_DIR", "SENPI_CODING_AGENT_SESSION_DIR"]);
+        env.set("SENPI_CODING_AGENT_DIR", redirected_agent.path());
+        env.set("SENPI_CODING_AGENT_SESSION_DIR", &project_children);
+        let _current_dir = CurrentDirGuard::set(project_dir.path());
+
+        let result = scan_all_clients_with_env_strategy(
+            home_dir.path().to_str().unwrap(),
+            &["senpi".to_string()],
+            false,
+        );
+
+        let files = result.get(ClientId::Senpi);
+        assert_eq!(
+            files.len(),
+            1,
+            "an explicit home must discover its OmO children without using environment roots"
+        );
+        assert_eq!(files[0].canonicalize().unwrap(), child_session);
+    }
+
+    #[test]
+    #[serial]
+    fn home_omo_children_are_deduplicated_with_env_override() {
+        let home_dir = TempDir::new().unwrap();
+        let other_dir = TempDir::new().unwrap();
+        let child_session = setup_mock_senpi_omo_child(home_dir.path());
+        let children_dir = home_dir.path().join(".omo/senpi-task/children");
+        let mut env =
+            EnvGuard::capture(&["SENPI_CODING_AGENT_DIR", "SENPI_CODING_AGENT_SESSION_DIR"]);
+        env.remove("SENPI_CODING_AGENT_DIR");
+        env.set("SENPI_CODING_AGENT_SESSION_DIR", &children_dir);
+        let _current_dir = CurrentDirGuard::set(other_dir.path());
+        let enabled = HashSet::from([ClientId::Senpi]);
+
+        let matching_roots =
+            built_in_extra_scan_paths_for(home_dir.path().to_str().unwrap(), &enabled, true)
+                .into_iter()
+                .filter(|(client_id, path)| *client_id == ClientId::Senpi && path == &children_dir)
+                .count();
+        assert_eq!(
+            matching_roots, 2,
+            "home discovery and the explicit override must both register the child root"
+        );
+
+        let result =
+            scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
+        let files = result.get(ClientId::Senpi);
+        assert_eq!(
+            files.len(),
+            1,
+            "overlapping home and environment roots must not duplicate child usage"
+        );
+        assert_eq!(files[0].canonicalize().unwrap(), child_session);
+    }
+
+    #[test]
+    #[serial]
     fn test_senpi_discovers_omo_task_children_in_current_project() {
         let home_dir = TempDir::new().unwrap();
         let project_dir = TempDir::new().unwrap();
         let child_session = setup_mock_senpi_omo_child(project_dir.path());
-        let mut env = EnvGuard::capture(&["SENPI_CODING_AGENT_SESSION_DIR"]);
+        let mut env =
+            EnvGuard::capture(&["SENPI_CODING_AGENT_DIR", "SENPI_CODING_AGENT_SESSION_DIR"]);
+        env.remove("SENPI_CODING_AGENT_DIR");
         env.remove("SENPI_CODING_AGENT_SESSION_DIR");
         let _current_dir = CurrentDirGuard::set(project_dir.path());
 
@@ -7175,7 +7275,9 @@ mod tests {
         let redirected_sessions = TempDir::new().unwrap();
         let redirected_session = redirected_sessions.path().join("redirected.jsonl");
         File::create(&redirected_session).unwrap();
-        let mut env = EnvGuard::capture(&["SENPI_CODING_AGENT_SESSION_DIR"]);
+        let mut env =
+            EnvGuard::capture(&["SENPI_CODING_AGENT_DIR", "SENPI_CODING_AGENT_SESSION_DIR"]);
+        env.remove("SENPI_CODING_AGENT_DIR");
         env.set("SENPI_CODING_AGENT_SESSION_DIR", redirected_sessions.path());
         let _current_dir = CurrentDirGuard::set(project_dir.path());
 
@@ -7201,7 +7303,9 @@ mod tests {
         let children_dir = project_dir.path().join(".omo/senpi-task/children");
         let task_dir = children_dir.join("task-123");
         let exact_session_dir = task_dir.join("sessions/task-123");
-        let mut env = EnvGuard::capture(&["SENPI_CODING_AGENT_SESSION_DIR"]);
+        let mut env =
+            EnvGuard::capture(&["SENPI_CODING_AGENT_DIR", "SENPI_CODING_AGENT_SESSION_DIR"]);
+        env.remove("SENPI_CODING_AGENT_DIR");
         let _current_dir = CurrentDirGuard::set(project_dir.path());
 
         for env_root in [
@@ -7240,7 +7344,9 @@ mod tests {
             &symlink_root,
         )
         .unwrap();
-        let mut env = EnvGuard::capture(&["SENPI_CODING_AGENT_SESSION_DIR"]);
+        let mut env =
+            EnvGuard::capture(&["SENPI_CODING_AGENT_DIR", "SENPI_CODING_AGENT_SESSION_DIR"]);
+        env.remove("SENPI_CODING_AGENT_DIR");
         env.set("SENPI_CODING_AGENT_SESSION_DIR", &symlink_root);
         let _current_dir = CurrentDirGuard::set(project_dir.path());
 

--- a/crates/tokscale-core/src/sessions/senpi.rs
+++ b/crates/tokscale-core/src/sessions/senpi.rs
@@ -9,8 +9,9 @@
 //! `subagent-<name>-<id>` marker.
 //!
 //! OmO task children are senpi sessions too. The scanner honors
-//! `SENPI_CODING_AGENT_SESSION_DIR` and discovers the current project's
-//! `.omo/senpi-task/children` tree so their redirected sessions are counted.
+//! `SENPI_CODING_AGENT_SESSION_DIR` and discovers `.omo/senpi-task/children`
+//! under both the supplied home and current project so redirected sessions are
+//! counted.
 
 use super::pi::parse_pi_format_file;
 use super::UnifiedMessage;


### PR DESCRIPTION
## Summary

- discover Senpi/OmO child transcripts under `<home>/.omo/senpi-task/children`, including explicit `--home` scans from another working directory
- preserve `SENPI_CODING_AGENT_SESSION_DIR` and current-project discovery when environment roots are enabled
- retain per-client canonical-path deduplication for overlapping roots and make Senpi scanner tests independent of host environment variables
- update Senpi session documentation to match all discovered child roots

Closes #1244.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p tokscale-core --all-targets -- -D warnings`
- `cargo test -p tokscale-core --lib scanner::tests::built_in_paths_include_home_omo_children -- --exact`
- `cargo test -p tokscale-core --lib scanner::tests::home_omo_children_are_discovered_when_env_roots_disabled -- --exact`
- `cargo test -p tokscale-core --lib scanner::tests::home_omo_children_are_deduplicated_with_env_override -- --exact`
- `cargo test -p tokscale-core --lib scanner::tests::test_senpi`
- `cargo test -p tokscale-core --lib sessions::senpi`
- `cargo test -p tokscale-core` in a non-root Linux container: 1965 library tests passed, 0 failed, with every integration and doc-test target passing
- Rust LSP diagnostics: no diagnostics on either changed file

Manual CLI proof from a cwd outside the fixture home with both Senpi overrides unset:

```console
tokscale models --json --client senpi --home <fixture-home> --no-spinner
```

The isolated child transcript reported input 101, output 202, cache read 303, cache write 404, and one message. `tokscale --help` exited 0; an invalid client exited 2 with clap's invalid-value error.

Windows note: the local full-core run passed 1965 tests and hit the existing OS 1314 directory-symlink privilege limitation in the unchanged MiCode symlink test; the non-root Linux full suite above passed cleanly without skipping or weakening it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Senpi/OmO child session discovery so child transcripts under `<home>/.omo/senpi-task/children` are found even when scanning from another working directory or when environment roots are disabled.

- Adds the home-directory child root for all Senpi scans; `SENPI_CODING_AGENT_SESSION_DIR` and current-project discovery still apply.
- Overlapping home and environment roots are deduplicated via canonical paths, so an explicit override pointing at the same child root counts once.
- Senpi scanner tests no longer depend on host environment variables, and the session docs now list the home child root.

Closes #1244.

<sup>Written for commit e30c9aa40e307bb61f6b31656d29d6559566bd58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

