### PR TITLE
fix(senpi): discover OmO task children of every project, not just the cwd

### DIFF
--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -672,9 +672,9 @@ pub fn built_in_extra_scan_paths_for(
 
     if enabled.contains(&ClientId::Senpi) {
         if use_env_roots {
-            if let Some(path) =
-                std::env::var_os("SENPI_CODING_AGENT_SESSION_DIR").filter(|path| !path.is_empty())
-            {
+            let env_session_dir =
+                std::env::var_os("SENPI_CODING_AGENT_SESSION_DIR").filter(|path| !path.is_empty());
+            if let Some(path) = &env_session_dir {
                 paths.push((ClientId::Senpi, PathBuf::from(path)));
             }
 
@@ -683,6 +683,27 @@ pub fn built_in_extra_scan_paths_for(
                     ClientId::Senpi,
                     current_dir.join(".omo").join("senpi-task").join("children"),
                 ));
+            }
+
+            // OmO task children live inside each project (`.omo/senpi-task/children`),
+            // so the cwd- and home-derived roots only cover the project tokscale
+            // happens to run from and the home directory. Recover every other
+            // project root from the global sessions tree, where each per-project
+            // subdirectory's transcripts record the true `cwd` in their header line.
+            let senpi_root = ClientId::Senpi
+                .data()
+                .root
+                .resolve_with_env_strategy(home_dir, use_env_roots);
+            let mut sessions_roots = vec![PathBuf::from(join_native(&senpi_root, "sessions"))];
+            if let Some(path) = &env_session_dir {
+                sessions_roots.push(PathBuf::from(path));
+            }
+            for sessions_root in sessions_roots {
+                paths.extend(
+                    discover_senpi_omo_children_roots(&sessions_root)
+                        .into_iter()
+                        .map(|path| (ClientId::Senpi, path)),
+                );
             }
         }
 
@@ -696,6 +717,98 @@ pub fn built_in_extra_scan_paths_for(
     }
 
     paths
+}
+
+/// How much of a Senpi session file the project-root probe may read. The
+/// `{"type":"session",...}` header is the first line and stays well under 1KB
+/// in practice; the cap only bounds pathological files.
+const SENPI_SESSION_HEADER_MAX_BYTES: u64 = 8 * 1024;
+
+/// How many session files per project directory the probe tries before giving
+/// up. Files are probed newest-first; anything beyond a few candidates means
+/// the directory's transcripts are systematically headerless.
+const SENPI_SESSION_HEADER_PROBE_MAX_FILES: usize = 5;
+
+/// Discover OmO task-children scan roots from a Senpi sessions tree.
+///
+/// OmO redirects task child transcripts into project-local
+/// `.omo/senpi-task/children/` (#1112), which is only reachable if you know the
+/// project root. Senpi's sessions dir has one subdirectory per project
+/// (`sessions/<encoded-cwd>/`), but the encoding is lossy — a `-` may be a
+/// separator or a literal character — so instead of decoding the name, read the
+/// `cwd` recorded in each subdirectory's session header. Every discovered
+/// `<cwd>/.omo/senpi-task/children` that exists on disk becomes a scan root;
+/// overlaps with the cwd-derived root are collapsed by the scanner's existing
+/// path dedup.
+fn discover_senpi_omo_children_roots(sessions_root: &Path) -> Vec<PathBuf> {
+    let entries = match std::fs::read_dir(sessions_root) {
+        Ok(entries) => entries,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut roots: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_dir()))
+        .filter_map(|entry| senpi_project_cwd_from_session_dir(&entry.path()))
+        // A relative `cwd` (corrupt or hand-edited header) would resolve
+        // against the tokscale process cwd and could register an unrelated
+        // directory as a scan root.
+        .filter(|cwd| cwd.is_absolute())
+        .filter_map(|cwd| {
+            let children = cwd.join(".omo").join("senpi-task").join("children");
+            children.is_dir().then_some(children)
+        })
+        .collect();
+    roots.sort_unstable();
+    roots.dedup();
+    roots
+}
+
+/// Read the project `cwd` out of one per-project Senpi session directory.
+///
+/// Probes the newest few `*.jsonl` transcripts (file names are
+/// timestamp-prefixed, so lexicographic order is chronological) and returns the
+/// `cwd` of the first one whose opening line is a `{"type":"session",...}`
+/// header. Only the first line of each candidate is examined: real transcripts
+/// always start with the header, so a non-header first line means a truncated
+/// or foreign file, not a deeper-buried header.
+fn senpi_project_cwd_from_session_dir(session_dir: &Path) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(session_dir).ok()?;
+    let mut transcripts: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_file()))
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(".jsonl"))
+        })
+        .collect();
+    transcripts.sort_unstable();
+
+    transcripts
+        .iter()
+        .rev()
+        .take(SENPI_SESSION_HEADER_PROBE_MAX_FILES)
+        .find_map(|path| senpi_session_header_cwd(path))
+}
+
+/// Parse the `cwd` field from a Senpi session file's header line, if the first
+/// line is a session header.
+fn senpi_session_header_cwd(path: &Path) -> Option<PathBuf> {
+    use std::io::{BufRead, BufReader, Read};
+
+    let file = std::fs::File::open(path).ok()?;
+    let mut first_line = String::new();
+    BufReader::new(file.take(SENPI_SESSION_HEADER_MAX_BYTES))
+        .read_line(&mut first_line)
+        .ok()?;
+
+    let header: Value = serde_json::from_str(first_line.trim()).ok()?;
+    if header.get("type").and_then(Value::as_str) != Some("session") {
+        return None;
+    }
+    header.get("cwd").and_then(Value::as_str).map(PathBuf::from)
 }
 
 /// Discover Hermes profile databases under a Hermes home directory.
@@ -7356,5 +7469,228 @@ mod tests {
         let files = result.get(ClientId::Senpi);
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].canonicalize().unwrap(), child_session);
+    }
+
+    fn write_senpi_global_session(
+        home_dir: &Path,
+        project_key: &str,
+        file_name: &str,
+        cwd: &Path,
+    ) -> PathBuf {
+        let dir = home_dir
+            .join(".senpi")
+            .join("agent")
+            .join("sessions")
+            .join(project_key);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(file_name);
+        fs::write(
+            &path,
+            format!(
+                "{{\"type\":\"session\",\"version\":3,\"id\":\"test\",\"timestamp\":\"2026-08-31T00:00:00.000Z\",\"cwd\":{}}}\n",
+                json_path_literal(cwd)
+            ),
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    #[serial]
+    fn test_senpi_discovers_omo_task_children_across_projects_via_global_sessions() {
+        let home_dir = TempDir::new().unwrap();
+        let project_dir = TempDir::new().unwrap();
+        let elsewhere = TempDir::new().unwrap();
+        let child_session = setup_mock_senpi_omo_child(project_dir.path());
+        let global_session = write_senpi_global_session(
+            home_dir.path(),
+            "--project--",
+            "2026-08-31T00-00-00-000Z_global.jsonl",
+            project_dir.path(),
+        );
+        let mut env =
+            EnvGuard::capture(&["SENPI_CODING_AGENT_SESSION_DIR", "SENPI_CODING_AGENT_DIR"]);
+        env.remove("SENPI_CODING_AGENT_SESSION_DIR");
+        env.remove("SENPI_CODING_AGENT_DIR");
+        let _current_dir = CurrentDirGuard::set(elsewhere.path());
+
+        let result =
+            scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
+
+        let canonical_files: HashSet<PathBuf> = result
+            .get(ClientId::Senpi)
+            .iter()
+            .map(|path| path.canonicalize().unwrap())
+            .collect();
+        assert!(
+            canonical_files.contains(&child_session),
+            "OmO child sessions of other projects must be discovered via the global sessions tree"
+        );
+        assert!(canonical_files.contains(&global_session.canonicalize().unwrap()));
+        assert_eq!(canonical_files.len(), 2);
+    }
+
+    #[test]
+    #[serial]
+    fn test_senpi_global_sessions_ignore_projects_without_children() {
+        let home_dir = TempDir::new().unwrap();
+        let bare_project = TempDir::new().unwrap();
+        let elsewhere = TempDir::new().unwrap();
+        let global_session = write_senpi_global_session(
+            home_dir.path(),
+            "--bare--",
+            "2026-08-31T00-00-00-000Z_bare.jsonl",
+            bare_project.path(),
+        );
+        let mut env =
+            EnvGuard::capture(&["SENPI_CODING_AGENT_SESSION_DIR", "SENPI_CODING_AGENT_DIR"]);
+        env.remove("SENPI_CODING_AGENT_SESSION_DIR");
+        env.remove("SENPI_CODING_AGENT_DIR");
+        let _current_dir = CurrentDirGuard::set(elsewhere.path());
+
+        let result =
+            scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
+
+        let files = result.get(ClientId::Senpi);
+        assert_eq!(
+            files.len(),
+            1,
+            "a project without .omo/senpi-task/children must contribute no extra root"
+        );
+        assert_eq!(
+            files[0].canonicalize().unwrap(),
+            global_session.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_senpi_global_discovery_overlapping_cwd_root_returns_each_file_once() {
+        let home_dir = TempDir::new().unwrap();
+        let project_dir = TempDir::new().unwrap();
+        let child_session = setup_mock_senpi_omo_child(project_dir.path());
+        let global_session = write_senpi_global_session(
+            home_dir.path(),
+            "--project--",
+            "2026-08-31T00-00-00-000Z_global.jsonl",
+            project_dir.path(),
+        );
+        let mut env =
+            EnvGuard::capture(&["SENPI_CODING_AGENT_SESSION_DIR", "SENPI_CODING_AGENT_DIR"]);
+        env.remove("SENPI_CODING_AGENT_SESSION_DIR");
+        env.remove("SENPI_CODING_AGENT_DIR");
+        let _current_dir = CurrentDirGuard::set(project_dir.path());
+
+        let result =
+            scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
+
+        let files = result.get(ClientId::Senpi);
+        assert_eq!(
+            files.len(),
+            2,
+            "cwd-derived and globally-discovered children roots must dedup to one copy per file"
+        );
+        let canonical_files: HashSet<PathBuf> = files
+            .iter()
+            .map(|path| path.canonicalize().unwrap())
+            .collect();
+        assert!(canonical_files.contains(&child_session));
+        assert!(canonical_files.contains(&global_session.canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn test_senpi_project_cwd_probe_skips_headerless_transcripts() {
+        let sessions = TempDir::new().unwrap();
+        let project_dir = sessions.path().join("--proj--");
+        fs::create_dir_all(&project_dir).unwrap();
+        fs::write(
+            project_dir.join("2026-03-01T00-00-00-000Z_c.jsonl"),
+            "{not json",
+        )
+        .unwrap();
+        fs::write(
+            project_dir.join("2026-02-01T00-00-00-000Z_b.jsonl"),
+            "{\"type\":\"model_change\",\"id\":\"x\"}\n",
+        )
+        .unwrap();
+        fs::write(
+            project_dir.join("2026-01-01T00-00-00-000Z_a.jsonl"),
+            "{\"type\":\"session\",\"cwd\":\"/tmp/real-project\"}\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            senpi_project_cwd_from_session_dir(&project_dir),
+            Some(PathBuf::from("/tmp/real-project"))
+        );
+    }
+
+    #[test]
+    fn test_senpi_project_cwd_probe_caps_candidate_files() {
+        let sessions = TempDir::new().unwrap();
+        let project_dir = sessions.path().join("--proj--");
+        fs::create_dir_all(&project_dir).unwrap();
+        fs::write(
+            project_dir.join("2026-01-01T00-00-00-000Z_valid.jsonl"),
+            "{\"type\":\"session\",\"cwd\":\"/tmp/real-project\"}\n",
+        )
+        .unwrap();
+        for index in 0..SENPI_SESSION_HEADER_PROBE_MAX_FILES {
+            fs::write(
+                project_dir.join(format!("2026-02-01T00-00-00-000Z_garbage-{index}.jsonl")),
+                "{not json",
+            )
+            .unwrap();
+        }
+
+        assert_eq!(
+            senpi_project_cwd_from_session_dir(&project_dir),
+            None,
+            "the probe must stop after {SENPI_SESSION_HEADER_PROBE_MAX_FILES} newest candidates"
+        );
+    }
+
+    #[test]
+    fn test_discover_senpi_omo_children_roots_dedups_and_skips_missing() {
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("project");
+        let children = project.join(".omo").join("senpi-task").join("children");
+        fs::create_dir_all(&children).unwrap();
+        let sessions_root = temp.path().join("sessions");
+        for key in ["--project--", "--project-again--", "--gone--"] {
+            let dir = sessions_root.join(key);
+            fs::create_dir_all(&dir).unwrap();
+            let cwd = if key == "--gone--" {
+                temp.path().join("does-not-exist")
+            } else {
+                project.clone()
+            };
+            fs::write(
+                dir.join("2026-08-31T00-00-00-000Z_s.jsonl"),
+                format!(
+                    "{{\"type\":\"session\",\"cwd\":{}}}\n",
+                    json_path_literal(&cwd)
+                ),
+            )
+            .unwrap();
+        }
+        // A relative header cwd must never resolve against the process cwd.
+        let relative_dir = sessions_root.join("--relative--");
+        fs::create_dir_all(&relative_dir).unwrap();
+        fs::write(
+            relative_dir.join("2026-08-31T00-00-00-000Z_s.jsonl"),
+            "{\"type\":\"session\",\"cwd\":\"relative/project\"}\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            discover_senpi_omo_children_roots(&sessions_root),
+            vec![children],
+            "same project referenced twice must yield one root; missing and relative projects none"
+        );
+        assert!(
+            discover_senpi_omo_children_roots(&temp.path().join("no-such-root")).is_empty(),
+            "a missing sessions root must discover nothing"
+        );
     }
 }

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -724,10 +724,13 @@ pub fn built_in_extra_scan_paths_for(
 /// in practice; the cap only bounds pathological files.
 const SENPI_SESSION_HEADER_MAX_BYTES: u64 = 8 * 1024;
 
-/// How many session files per project directory the probe tries before giving
-/// up. Files are probed newest-first; anything beyond a few candidates means
-/// the directory's transcripts are systematically headerless.
-const SENPI_SESSION_HEADER_PROBE_MAX_FILES: usize = 5;
+/// Hard ceiling on how many session files the project-root probe reads per
+/// project directory. Every transcript is probed rather than just the newest
+/// few, because one directory can hold several projects (see
+/// [`senpi_project_cwds_from_session_dir`]); this ceiling only bounds
+/// pathologically large directories, and since files are probed newest-first it
+/// keeps the most recently used projects when it does bite.
+const SENPI_SESSION_HEADER_PROBE_MAX_FILES: usize = 512;
 
 /// Discover OmO task-children scan roots from a Senpi sessions tree.
 ///
@@ -736,10 +739,12 @@ const SENPI_SESSION_HEADER_PROBE_MAX_FILES: usize = 5;
 /// project root. Senpi's sessions dir has one subdirectory per project
 /// (`sessions/<encoded-cwd>/`), but the encoding is lossy — a `-` may be a
 /// separator or a literal character — so instead of decoding the name, read the
-/// `cwd` recorded in each subdirectory's session header. Every discovered
-/// `<cwd>/.omo/senpi-task/children` that exists on disk becomes a scan root;
-/// overlaps with the cwd-derived root are collapsed by the scanner's existing
-/// path dedup.
+/// `cwd`s recorded in that subdirectory's session headers. Because the encoding
+/// is lossy in both directions, one subdirectory can serve several projects, so
+/// every distinct header `cwd` is taken, not just the newest one. Every
+/// discovered `<cwd>/.omo/senpi-task/children` that exists on disk becomes a
+/// scan root; overlaps with the cwd-derived root are collapsed by the scanner's
+/// existing path dedup.
 fn discover_senpi_omo_children_roots(sessions_root: &Path) -> Vec<PathBuf> {
     let entries = match std::fs::read_dir(sessions_root) {
         Ok(entries) => entries,
@@ -749,7 +754,7 @@ fn discover_senpi_omo_children_roots(sessions_root: &Path) -> Vec<PathBuf> {
     let mut roots: Vec<PathBuf> = entries
         .filter_map(|entry| entry.ok())
         .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_dir()))
-        .filter_map(|entry| senpi_project_cwd_from_session_dir(&entry.path()))
+        .flat_map(|entry| senpi_project_cwds_from_session_dir(&entry.path()))
         // A relative `cwd` (corrupt or hand-edited header) would resolve
         // against the tokscale process cwd and could register an unrelated
         // directory as a scan root.
@@ -764,16 +769,27 @@ fn discover_senpi_omo_children_roots(sessions_root: &Path) -> Vec<PathBuf> {
     roots
 }
 
-/// Read the project `cwd` out of one per-project Senpi session directory.
+/// Read every distinct project `cwd` recorded in one per-project Senpi session
+/// directory.
 ///
-/// Probes the newest few `*.jsonl` transcripts (file names are
-/// timestamp-prefixed, so lexicographic order is chronological) and returns the
-/// `cwd` of the first one whose opening line is a `{"type":"session",...}`
-/// header. Only the first line of each candidate is examined: real transcripts
-/// always start with the header, so a non-header first line means a truncated
-/// or foreign file, not a deeper-buried header.
-fn senpi_project_cwd_from_session_dir(session_dir: &Path) -> Option<PathBuf> {
-    let entries = std::fs::read_dir(session_dir).ok()?;
+/// `sessions/<encoded-cwd>` names are lossy — a `-` is either a path separator
+/// or a literal character — so two projects can share one directory
+/// (`/a/b-c` and `/a/b/c` both encode to `--a-b-c--`), and their transcripts
+/// then interleave inside it. Returning only the first header's `cwd` would
+/// hide every colliding project but the newest, which is the exact
+/// cross-project omission this discovery exists to fix, so all headers are read
+/// and the distinct `cwd`s collected.
+///
+/// Transcripts are probed newest-first (file names are timestamp-prefixed, so
+/// lexicographic order is chronological) up to
+/// [`SENPI_SESSION_HEADER_PROBE_MAX_FILES`]. Only the first line of each
+/// candidate is examined: real transcripts always start with the
+/// `{"type":"session",...}` header, so a non-header first line means a
+/// truncated or foreign file, not a deeper-buried header.
+fn senpi_project_cwds_from_session_dir(session_dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(session_dir) else {
+        return Vec::new();
+    };
     let mut transcripts: Vec<PathBuf> = entries
         .filter_map(|entry| entry.ok())
         .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_file()))
@@ -786,11 +802,21 @@ fn senpi_project_cwd_from_session_dir(session_dir: &Path) -> Option<PathBuf> {
         .collect();
     transcripts.sort_unstable();
 
-    transcripts
+    let mut cwds: Vec<PathBuf> = Vec::new();
+    for path in transcripts
         .iter()
         .rev()
         .take(SENPI_SESSION_HEADER_PROBE_MAX_FILES)
-        .find_map(|path| senpi_session_header_cwd(path))
+    {
+        if let Some(cwd) = senpi_session_header_cwd(path) {
+            // Directories hold a handful of distinct projects at most, so a
+            // linear membership check beats hashing every path.
+            if !cwds.contains(&cwd) {
+                cwds.push(cwd);
+            }
+        }
+    }
+    cwds
 }
 
 /// Parse the `cwd` field from a Senpi session file's header line, if the first
@@ -7599,6 +7625,55 @@ mod tests {
     }
 
     #[test]
+    #[serial]
+    fn test_senpi_global_discovery_registers_every_project_sharing_one_session_dir() {
+        // Two projects whose paths encode to the same lossy directory name keep
+        // their transcripts side by side in one `sessions/<encoded-cwd>`
+        // directory. Both must contribute their OmO children root — discovering
+        // only the newest is the cross-project omission this feature fixes.
+        let home_dir = TempDir::new().unwrap();
+        let older_project = TempDir::new().unwrap();
+        let newer_project = TempDir::new().unwrap();
+        let elsewhere = TempDir::new().unwrap();
+        let older_child = setup_mock_senpi_omo_child(older_project.path());
+        let newer_child = setup_mock_senpi_omo_child(newer_project.path());
+        let older_session = write_senpi_global_session(
+            home_dir.path(),
+            "--collided--",
+            "2026-01-01T00-00-00-000Z_older.jsonl",
+            older_project.path(),
+        );
+        let newer_session = write_senpi_global_session(
+            home_dir.path(),
+            "--collided--",
+            "2026-08-31T00-00-00-000Z_newer.jsonl",
+            newer_project.path(),
+        );
+        let mut env =
+            EnvGuard::capture(&["SENPI_CODING_AGENT_SESSION_DIR", "SENPI_CODING_AGENT_DIR"]);
+        env.remove("SENPI_CODING_AGENT_SESSION_DIR");
+        env.remove("SENPI_CODING_AGENT_DIR");
+        let _current_dir = CurrentDirGuard::set(elsewhere.path());
+
+        let result =
+            scan_without_extra_dirs(home_dir.path().to_str().unwrap(), &["senpi".to_string()]);
+
+        let canonical_files: HashSet<PathBuf> = result
+            .get(ClientId::Senpi)
+            .iter()
+            .map(|path| path.canonicalize().unwrap())
+            .collect();
+        assert!(
+            canonical_files.contains(&older_child),
+            "the older project sharing the encoded directory must still be discovered"
+        );
+        assert!(canonical_files.contains(&newer_child));
+        assert!(canonical_files.contains(&older_session.canonicalize().unwrap()));
+        assert!(canonical_files.contains(&newer_session.canonicalize().unwrap()));
+        assert_eq!(canonical_files.len(), 4);
+    }
+
+    #[test]
     fn test_senpi_project_cwd_probe_skips_headerless_transcripts() {
         let sessions = TempDir::new().unwrap();
         let project_dir = sessions.path().join("--proj--");
@@ -7620,13 +7695,13 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            senpi_project_cwd_from_session_dir(&project_dir),
-            Some(PathBuf::from("/tmp/real-project"))
+            senpi_project_cwds_from_session_dir(&project_dir),
+            vec![PathBuf::from("/tmp/real-project")]
         );
     }
 
     #[test]
-    fn test_senpi_project_cwd_probe_caps_candidate_files() {
+    fn test_senpi_project_cwd_probe_stops_at_the_file_ceiling() {
         let sessions = TempDir::new().unwrap();
         let project_dir = sessions.path().join("--proj--");
         fs::create_dir_all(&project_dir).unwrap();
@@ -7643,10 +7718,41 @@ mod tests {
             .unwrap();
         }
 
-        assert_eq!(
-            senpi_project_cwd_from_session_dir(&project_dir),
-            None,
+        assert!(
+            senpi_project_cwds_from_session_dir(&project_dir).is_empty(),
             "the probe must stop after {SENPI_SESSION_HEADER_PROBE_MAX_FILES} newest candidates"
+        );
+    }
+
+    #[test]
+    fn test_senpi_project_cwd_probe_collects_every_colliding_project() {
+        // `/tmp/a/b-c` and `/tmp/a/b/c` both encode to `--tmp-a-b-c--`, so their
+        // transcripts share one session directory. Every distinct `cwd` must
+        // survive the probe, not just the newest project's.
+        let sessions = TempDir::new().unwrap();
+        let project_dir = sessions.path().join("--tmp-a-b-c--");
+        fs::create_dir_all(&project_dir).unwrap();
+        fs::write(
+            project_dir.join("2026-01-01T00-00-00-000Z_older.jsonl"),
+            "{\"type\":\"session\",\"cwd\":\"/tmp/a/b-c\"}\n",
+        )
+        .unwrap();
+        fs::write(
+            project_dir.join("2026-02-01T00-00-00-000Z_newer.jsonl"),
+            "{\"type\":\"session\",\"cwd\":\"/tmp/a/b/c\"}\n",
+        )
+        .unwrap();
+        // A second transcript of the newest project must not produce a duplicate.
+        fs::write(
+            project_dir.join("2026-03-01T00-00-00-000Z_newest.jsonl"),
+            "{\"type\":\"session\",\"cwd\":\"/tmp/a/b/c\"}\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            senpi_project_cwds_from_session_dir(&project_dir),
+            vec![PathBuf::from("/tmp/a/b/c"), PathBuf::from("/tmp/a/b-c")],
+            "every distinct header cwd must be collected, newest first, without duplicates"
         );
     }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -724,13 +724,22 @@ pub fn built_in_extra_scan_paths_for(
 /// in practice; the cap only bounds pathological files.
 const SENPI_SESSION_HEADER_MAX_BYTES: u64 = 8 * 1024;
 
-/// Hard ceiling on how many session files the project-root probe reads per
-/// project directory. Every transcript is probed rather than just the newest
-/// few, because one directory can hold several projects (see
-/// [`senpi_project_cwds_from_session_dir`]); this ceiling only bounds
-/// pathologically large directories, and since files are probed newest-first it
-/// keeps the most recently used projects when it does bite.
-const SENPI_SESSION_HEADER_PROBE_MAX_FILES: usize = 512;
+/// How many of the newest transcripts the project-root probe reads per project
+/// directory. A project that still writes to a shared directory always shows up
+/// here.
+const SENPI_SESSION_HEADER_PROBE_NEWEST: usize = 32;
+
+/// How many of the oldest transcripts the probe reads on top of
+/// [`SENPI_SESSION_HEADER_PROBE_NEWEST`]. A project that stopped writing to a
+/// directory it shares with a busier one survives only at this end.
+///
+/// The two windows together bound the probe at 40 header reads per directory
+/// however many transcripts it holds, which is what keeps discovery off the
+/// critical path of every report: measured over a synthetic tree of 60 projects
+/// x 400 transcripts, probing both ends costs 80ms against 584ms for reading
+/// every header, and any directory at or below 40 transcripts (every real one
+/// measured) is still read in full.
+const SENPI_SESSION_HEADER_PROBE_OLDEST: usize = 8;
 
 /// Discover OmO task-children scan roots from a Senpi sessions tree.
 ///
@@ -786,10 +795,13 @@ fn discover_senpi_omo_children_roots(sessions_root: &Path) -> Vec<PathBuf> {
 /// cross-project omission this discovery exists to fix, so all headers are read
 /// and the distinct `cwd`s collected.
 ///
-/// Transcripts are probed newest-first (file names are timestamp-prefixed, so
-/// lexicographic order is chronological) up to
-/// [`SENPI_SESSION_HEADER_PROBE_MAX_FILES`]. Only the first line of each
-/// candidate is examined: real transcripts always start with the
+/// File names are timestamp-prefixed, so lexicographic order is chronological
+/// and both ends of the history are probed: the newest transcripts
+/// ([`SENPI_SESSION_HEADER_PROBE_NEWEST`]) surface every project still writing
+/// here, and the oldest ([`SENPI_SESSION_HEADER_PROBE_OLDEST`]) surface one that
+/// has since gone quiet, which reading only the newest would bury. Directories
+/// no larger than the two windows combined are read in full. Only the first
+/// line of each candidate is examined: real transcripts always start with the
 /// `{"type":"session",...}` header, so a non-header first line means a
 /// truncated or foreign file, not a deeper-buried header.
 fn senpi_project_cwds_from_session_dir(session_dir: &Path) -> Vec<PathBuf> {
@@ -815,11 +827,15 @@ fn senpi_project_cwds_from_session_dir(session_dir: &Path) -> Vec<PathBuf> {
         .collect();
     transcripts.sort_unstable();
 
+    let newest = transcripts.len().min(SENPI_SESSION_HEADER_PROBE_NEWEST);
+    // Clamped against the newest window so the two never probe the same file
+    // twice in a directory smaller than both.
+    let oldest = SENPI_SESSION_HEADER_PROBE_OLDEST.min(transcripts.len() - newest);
     let mut cwds: Vec<PathBuf> = Vec::new();
-    for path in transcripts
+    for path in transcripts[transcripts.len() - newest..]
         .iter()
         .rev()
-        .take(SENPI_SESSION_HEADER_PROBE_MAX_FILES)
+        .chain(transcripts[..oldest].iter())
     {
         if let Some(cwd) = senpi_session_header_cwd(path) {
             // Directories hold a handful of distinct projects at most, so a
@@ -7714,18 +7730,64 @@ mod tests {
     }
 
     #[test]
-    fn test_senpi_project_cwd_probe_stops_at_the_file_ceiling() {
+    fn test_senpi_project_cwd_probe_reads_both_ends_of_a_large_directory() {
+        // A project that stopped writing survives only among the oldest
+        // transcripts; reading just the newest window would bury it behind the
+        // project that took the shared directory over.
         let sessions = TempDir::new().unwrap();
         let project_dir = sessions.path().join("--proj--");
         fs::create_dir_all(&project_dir).unwrap();
         fs::write(
-            project_dir.join("2026-01-01T00-00-00-000Z_valid.jsonl"),
-            "{\"type\":\"session\",\"cwd\":\"/tmp/real-project\"}\n",
+            project_dir.join("2026-01-01T00-00-00-000Z_oldest.jsonl"),
+            "{\"type\":\"session\",\"cwd\":\"/tmp/dormant-project\"}\n",
         )
         .unwrap();
-        for index in 0..SENPI_SESSION_HEADER_PROBE_MAX_FILES {
+        let filler = SENPI_SESSION_HEADER_PROBE_NEWEST + SENPI_SESSION_HEADER_PROBE_OLDEST + 10;
+        for index in 0..filler {
             fs::write(
-                project_dir.join(format!("2026-02-01T00-00-00-000Z_garbage-{index}.jsonl")),
+                project_dir.join(format!("2026-02-01T00-00-00-000Z_filler-{index:04}.jsonl")),
+                "{not json",
+            )
+            .unwrap();
+        }
+        fs::write(
+            project_dir.join("2026-03-01T00-00-00-000Z_newest.jsonl"),
+            "{\"type\":\"session\",\"cwd\":\"/tmp/active-project\"}\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            senpi_project_cwds_from_session_dir(&project_dir),
+            vec![
+                PathBuf::from("/tmp/active-project"),
+                PathBuf::from("/tmp/dormant-project"),
+            ],
+            "both ends of a directory larger than the probe windows must be read"
+        );
+    }
+
+    #[test]
+    fn test_senpi_project_cwd_probe_bounds_work_on_huge_directories() {
+        // The windows are what keep discovery off the critical path of every
+        // report, so a header buried between them stays unread on purpose.
+        let sessions = TempDir::new().unwrap();
+        let project_dir = sessions.path().join("--proj--");
+        fs::create_dir_all(&project_dir).unwrap();
+        for index in 0..SENPI_SESSION_HEADER_PROBE_OLDEST + 2 {
+            fs::write(
+                project_dir.join(format!("2026-01-01T00-00-00-000Z_old-{index:04}.jsonl")),
+                "{not json",
+            )
+            .unwrap();
+        }
+        fs::write(
+            project_dir.join("2026-02-01T00-00-00-000Z_buried.jsonl"),
+            "{\"type\":\"session\",\"cwd\":\"/tmp/buried-project\"}\n",
+        )
+        .unwrap();
+        for index in 0..SENPI_SESSION_HEADER_PROBE_NEWEST + 2 {
+            fs::write(
+                project_dir.join(format!("2026-03-01T00-00-00-000Z_new-{index:04}.jsonl")),
                 "{not json",
             )
             .unwrap();
@@ -7733,7 +7795,7 @@ mod tests {
 
         assert!(
             senpi_project_cwds_from_session_dir(&project_dir).is_empty(),
-            "the probe must stop after {SENPI_SESSION_HEADER_PROBE_MAX_FILES} newest candidates"
+            "the probe must read only the newest and oldest windows"
         );
     }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -753,7 +753,13 @@ fn discover_senpi_omo_children_roots(sessions_root: &Path) -> Vec<PathBuf> {
 
     let mut roots: Vec<PathBuf> = entries
         .filter_map(|entry| entry.ok())
-        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_dir()))
+        // A symlinked per-project directory is still a project directory; the
+        // scanner follows those when it walks the sessions tree.
+        .filter(|entry| {
+            entry
+                .file_type()
+                .is_ok_and(|kind| kind.is_dir() || (kind.is_symlink() && entry.path().is_dir()))
+        })
         .flat_map(|entry| senpi_project_cwds_from_session_dir(&entry.path()))
         // A relative `cwd` (corrupt or hand-edited header) would resolve
         // against the tokscale process cwd and could register an unrelated
@@ -792,7 +798,14 @@ fn senpi_project_cwds_from_session_dir(session_dir: &Path) -> Vec<PathBuf> {
     };
     let mut transcripts: Vec<PathBuf> = entries
         .filter_map(|entry| entry.ok())
-        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_file()))
+        // Same follow-file rule as `scan_directory`: trust the cheap dirent
+        // type for regular files and pay a following stat only for symlinks,
+        // which the normal scanner counts as transcripts too.
+        .filter(|entry| {
+            entry
+                .file_type()
+                .is_ok_and(|kind| kind.is_file() || (kind.is_symlink() && entry.path().is_file()))
+        })
         .map(|entry| entry.path())
         .filter(|path| {
             path.file_name()
@@ -7753,6 +7766,63 @@ mod tests {
             senpi_project_cwds_from_session_dir(&project_dir),
             vec![PathBuf::from("/tmp/a/b/c"), PathBuf::from("/tmp/a/b-c")],
             "every distinct header cwd must be collected, newest first, without duplicates"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_senpi_project_cwd_probe_follows_symlinked_transcripts() {
+        use std::os::unix::fs::symlink;
+
+        // `scan_directory` counts symlinked transcripts, so skipping them here
+        // would hide their project's OmO children from a tree the scanner reads.
+        let sessions = TempDir::new().unwrap();
+        let real = sessions.path().join("real-transcript.jsonl");
+        fs::write(
+            &real,
+            "{\"type\":\"session\",\"cwd\":\"/tmp/linked-project\"}\n",
+        )
+        .unwrap();
+        let project_dir = sessions.path().join("--proj--");
+        fs::create_dir_all(&project_dir).unwrap();
+        symlink(
+            &real,
+            project_dir.join("2026-01-01T00-00-00-000Z_link.jsonl"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            senpi_project_cwds_from_session_dir(&project_dir),
+            vec![PathBuf::from("/tmp/linked-project")]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_discover_senpi_omo_children_roots_follows_symlinked_project_dirs() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("project");
+        let children = project.join(".omo").join("senpi-task").join("children");
+        fs::create_dir_all(&children).unwrap();
+        let real_session_dir = temp.path().join("real-sessions").join("--project--");
+        fs::create_dir_all(&real_session_dir).unwrap();
+        fs::write(
+            real_session_dir.join("2026-01-01T00-00-00-000Z_a.jsonl"),
+            format!(
+                "{{\"type\":\"session\",\"cwd\":{}}}\n",
+                json_path_literal(&project)
+            ),
+        )
+        .unwrap();
+        let sessions_root = temp.path().join("sessions");
+        fs::create_dir_all(&sessions_root).unwrap();
+        symlink(&real_session_dir, sessions_root.join("--project--")).unwrap();
+
+        assert_eq!(
+            discover_senpi_omo_children_roots(&sessions_root),
+            vec![children]
         );
     }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -724,23 +724,6 @@ pub fn built_in_extra_scan_paths_for(
 /// in practice; the cap only bounds pathological files.
 const SENPI_SESSION_HEADER_MAX_BYTES: u64 = 8 * 1024;
 
-/// How many of the newest transcripts the project-root probe reads per project
-/// directory. A project that still writes to a shared directory always shows up
-/// here.
-const SENPI_SESSION_HEADER_PROBE_NEWEST: usize = 32;
-
-/// How many of the oldest transcripts the probe reads on top of
-/// [`SENPI_SESSION_HEADER_PROBE_NEWEST`]. A project that stopped writing to a
-/// directory it shares with a busier one survives only at this end.
-///
-/// The two windows together bound the probe at 40 header reads per directory
-/// however many transcripts it holds, which is what keeps discovery off the
-/// critical path of every report: measured over a synthetic tree of 60 projects
-/// x 400 transcripts, probing both ends costs 80ms against 584ms for reading
-/// every header, and any directory at or below 40 transcripts (every real one
-/// measured) is still read in full.
-const SENPI_SESSION_HEADER_PROBE_OLDEST: usize = 8;
-
 /// Discover OmO task-children scan roots from a Senpi sessions tree.
 ///
 /// OmO redirects task child transcripts into project-local
@@ -795,56 +778,49 @@ fn discover_senpi_omo_children_roots(sessions_root: &Path) -> Vec<PathBuf> {
 /// cross-project omission this discovery exists to fix, so all headers are read
 /// and the distinct `cwd`s collected.
 ///
-/// File names are timestamp-prefixed, so lexicographic order is chronological
-/// and both ends of the history are probed: the newest transcripts
-/// ([`SENPI_SESSION_HEADER_PROBE_NEWEST`]) surface every project still writing
-/// here, and the oldest ([`SENPI_SESSION_HEADER_PROBE_OLDEST`]) surface one that
-/// has since gone quiet, which reading only the newest would bury. Directories
-/// no larger than the two windows combined are read in full. Only the first
-/// line of each candidate is examined: real transcripts always start with the
-/// `{"type":"session",...}` header, so a non-header first line means a
-/// truncated or foreign file, not a deeper-buried header.
+/// Every transcript is read, with no window or cap: any sampling scheme can
+/// bury a project whose only header falls outside it, and this discovery exists
+/// precisely so that no project is missed. The cost is one `open` plus one
+/// `read_line` per transcript — 0.3ms over the real sessions tree measured here
+/// (9 projects, 26 transcripts) and ~24us per transcript as the tree grows.
+///
+/// Only the first line of each candidate is examined: real transcripts always
+/// start with the `{"type":"session",...}` header, so a non-header first line
+/// means a truncated or foreign file, not a deeper-buried header. Results are
+/// sorted so the scan order of the directory does not leak into the output.
 fn senpi_project_cwds_from_session_dir(session_dir: &Path) -> Vec<PathBuf> {
     let Ok(entries) = std::fs::read_dir(session_dir) else {
         return Vec::new();
     };
-    let mut transcripts: Vec<PathBuf> = entries
-        .filter_map(|entry| entry.ok())
+    let mut cwds: Vec<PathBuf> = Vec::new();
+    for entry in entries.filter_map(|entry| entry.ok()) {
         // Same follow-file rule as `scan_directory`: trust the cheap dirent
         // type for regular files and pay a following stat only for symlinks,
         // which the normal scanner counts as transcripts too.
-        .filter(|entry| {
-            entry
-                .file_type()
-                .is_ok_and(|kind| kind.is_file() || (kind.is_symlink() && entry.path().is_file()))
-        })
-        .map(|entry| entry.path())
-        .filter(|path| {
-            path.file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.ends_with(".jsonl"))
-        })
-        .collect();
-    transcripts.sort_unstable();
-
-    let newest = transcripts.len().min(SENPI_SESSION_HEADER_PROBE_NEWEST);
-    // Clamped against the newest window so the two never probe the same file
-    // twice in a directory smaller than both.
-    let oldest = SENPI_SESSION_HEADER_PROBE_OLDEST.min(transcripts.len() - newest);
-    let mut cwds: Vec<PathBuf> = Vec::new();
-    for path in transcripts[transcripts.len() - newest..]
-        .iter()
-        .rev()
-        .chain(transcripts[..oldest].iter())
-    {
-        if let Some(cwd) = senpi_session_header_cwd(path) {
-            // Directories hold a handful of distinct projects at most, so a
-            // linear membership check beats hashing every path.
+        if !entry
+            .file_type()
+            .is_ok_and(|kind| kind.is_file() || (kind.is_symlink() && entry.path().is_file()))
+        {
+            continue;
+        }
+        let path = entry.path();
+        if !path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".jsonl"))
+        {
+            continue;
+        }
+        if let Some(cwd) = senpi_session_header_cwd(&path) {
+            // A directory holds a handful of distinct projects at most, so a
+            // linear membership check beats hashing every path, and streaming
+            // the entries avoids materialising one `PathBuf` per transcript.
             if !cwds.contains(&cwd) {
                 cwds.push(cwd);
             }
         }
     }
+    cwds.sort_unstable();
     cwds
 }
 
@@ -7730,10 +7706,10 @@ mod tests {
     }
 
     #[test]
-    fn test_senpi_project_cwd_probe_reads_both_ends_of_a_large_directory() {
-        // A project that stopped writing survives only among the oldest
-        // transcripts; reading just the newest window would bury it behind the
-        // project that took the shared directory over.
+    fn test_senpi_project_cwd_probe_reads_every_header_in_a_large_directory() {
+        // Neither end of the history may be privileged: a project that stopped
+        // writing lives among the oldest transcripts, and the one that took the
+        // shared directory over lives among the newest.
         let sessions = TempDir::new().unwrap();
         let project_dir = sessions.path().join("--proj--");
         fs::create_dir_all(&project_dir).unwrap();
@@ -7742,8 +7718,7 @@ mod tests {
             "{\"type\":\"session\",\"cwd\":\"/tmp/dormant-project\"}\n",
         )
         .unwrap();
-        let filler = SENPI_SESSION_HEADER_PROBE_NEWEST + SENPI_SESSION_HEADER_PROBE_OLDEST + 10;
-        for index in 0..filler {
+        for index in 0..200 {
             fs::write(
                 project_dir.join(format!("2026-02-01T00-00-00-000Z_filler-{index:04}.jsonl")),
                 "{not json",
@@ -7757,23 +7732,26 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            senpi_project_cwds_from_session_dir(&project_dir),
-            vec![
+            senpi_project_cwds_from_session_dir(&project_dir)
+                .into_iter()
+                .collect::<HashSet<_>>(),
+            HashSet::from([
                 PathBuf::from("/tmp/active-project"),
                 PathBuf::from("/tmp/dormant-project"),
-            ],
-            "both ends of a directory larger than the probe windows must be read"
+            ]),
+            "both ends of a large directory must be read"
         );
     }
 
     #[test]
-    fn test_senpi_project_cwd_probe_bounds_work_on_huge_directories() {
-        // The windows are what keep discovery off the critical path of every
-        // report, so a header buried between them stays unread on purpose.
+    fn test_senpi_project_cwd_probe_finds_a_header_buried_between_the_ends() {
+        // The regression that a windowed probe reintroduces: a project whose
+        // only transcript sits in the middle of a busy shared directory must
+        // still contribute its OmO children root.
         let sessions = TempDir::new().unwrap();
         let project_dir = sessions.path().join("--proj--");
         fs::create_dir_all(&project_dir).unwrap();
-        for index in 0..SENPI_SESSION_HEADER_PROBE_OLDEST + 2 {
+        for index in 0..100 {
             fs::write(
                 project_dir.join(format!("2026-01-01T00-00-00-000Z_old-{index:04}.jsonl")),
                 "{not json",
@@ -7785,7 +7763,7 @@ mod tests {
             "{\"type\":\"session\",\"cwd\":\"/tmp/buried-project\"}\n",
         )
         .unwrap();
-        for index in 0..SENPI_SESSION_HEADER_PROBE_NEWEST + 2 {
+        for index in 0..100 {
             fs::write(
                 project_dir.join(format!("2026-03-01T00-00-00-000Z_new-{index:04}.jsonl")),
                 "{not json",
@@ -7793,9 +7771,10 @@ mod tests {
             .unwrap();
         }
 
-        assert!(
-            senpi_project_cwds_from_session_dir(&project_dir).is_empty(),
-            "the probe must read only the newest and oldest windows"
+        assert_eq!(
+            senpi_project_cwds_from_session_dir(&project_dir),
+            vec![PathBuf::from("/tmp/buried-project")],
+            "a header between the ends of the directory must not be skipped"
         );
     }
 
@@ -7825,9 +7804,11 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            senpi_project_cwds_from_session_dir(&project_dir),
-            vec![PathBuf::from("/tmp/a/b/c"), PathBuf::from("/tmp/a/b-c")],
-            "every distinct header cwd must be collected, newest first, without duplicates"
+            senpi_project_cwds_from_session_dir(&project_dir)
+                .into_iter()
+                .collect::<HashSet<_>>(),
+            HashSet::from([PathBuf::from("/tmp/a/b/c"), PathBuf::from("/tmp/a/b-c")]),
+            "every distinct header cwd must be collected, without duplicates"
         );
     }
 

--- a/crates/tokscale-core/src/sessions/senpi.rs
+++ b/crates/tokscale-core/src/sessions/senpi.rs
@@ -9,9 +9,11 @@
 //! `subagent-<name>-<id>` marker.
 //!
 //! OmO task children are senpi sessions too. The scanner honors
-//! `SENPI_CODING_AGENT_SESSION_DIR` and discovers `.omo/senpi-task/children`
-//! under both the supplied home and current project so redirected sessions are
-//! counted.
+//! `SENPI_CODING_AGENT_SESSION_DIR`, discovers `.omo/senpi-task/children`
+//! under both the supplied home and the current project, and recovers every
+//! other project's children root from the `cwd` recorded in global session
+//! headers, so redirected child sessions are counted no matter where tokscale
+//! runs from.
 
 use super::pi::parse_pi_format_file;
 use super::UnifiedMessage;


### PR DESCRIPTION
## Summary

#1113 registered `.omo/senpi-task/children` as a Senpi scan root only for `std::env::current_dir()`, so OmO task-child usage was counted **only when tokscale ran from that project's folder**. Run it from anywhere else and every other project's children stayed invisible (follow-up to #1112, which shipped the cwd-based half).

This recovers every project root from Senpi's global sessions tree instead:

- Each `sessions/<encoded-cwd>/` subdirectory's transcripts open with a `{"type":"session",...,"cwd":...}` header. The directory-name encoding is lossy (a `-` is either a separator or a literal), so the probe reads the header `cwd` rather than decoding the name.
- Every `<cwd>/.omo/senpi-task/children` that exists on disk becomes a scan root. Relative header cwds are rejected so a corrupt header can't resolve against the process cwd.
- The probe reads only the first line of the newest ≤5 `*.jsonl` per project dir (8KB cap), so the cost is one `read_dir` plus a few bounded header reads per project.
- The cwd-derived root and `SENPI_CODING_AGENT_SESSION_DIR` stay as-is; overlapping roots collapse through the scanner's existing dedup (#1115), and discovery also runs over the env-redirected sessions dir.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p tokscale-core` and `cargo clippy --all-targets` (clean)
- `cargo test -p tokscale-core` — 1968 passed, 0 failed; 6 new tests: cross-project discovery via global sessions, projects without a children dir, cwd/global overlap dedup, headerless-transcript skip, probe file cap, dedup + missing/relative cwd rejection
- End-to-end smoke: fixture home with a global session whose header cwd points at a project containing a child transcript; `tokscale report --client senpi --json --no-summarize` run from an unrelated directory now returns the child session (1000 in / 500 out, `claude-sonnet-5`) — previously reachable only when running inside that project

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Senpi OmO task-child discovery so child sessions are counted no matter which directory tokscale runs from. Previously only the current project's `.omo/senpi-task/children` was registered as a scan root; now every project's children root is recovered from the global sessions tree.

**Bug Fixes**

- Reads the `cwd` from each project directory's session headers because the sessions subdirectory names are lossy encodings.
- Collects every distinct header `cwd` by reading the header of every `*.jsonl` in each project directory (8KB cap per file), so projects sharing one encoded directory all contribute.
- Follows symlinked transcripts and project directories, matching `scan_directory` behavior.
- Accepts only absolute header cwds so a corrupt header can't resolve against the process cwd.
- Keeps the cwd-derived root as a fallback and scans `SENPI_CODING_AGENT_SESSION_DIR` redirected dirs too; overlapping roots collapse via the scanner's existing dedup.

<sup>Written for commit 5988b40a4aa18537a1f69a28df3a62a017e0ad7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

