### PR TITLE
fix(pricing): preserve rates for retired provider models

### DIFF
--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -126,11 +126,22 @@ pub struct PricingLookup {
     cursor: HashMap<String, ModelPricing>,
     sakana: HashMap<String, ModelPricing>,
     models_dev: HashMap<String, ModelPricing>,
+    /// Last-known tariffs for models the upstream datasets may stop carrying.
+    ///
+    /// Deliberately not folded into `cursor`/`sakana`: those two are *current*
+    /// price sheets for models upstream never carried, and they answer with
+    /// `BuiltIn` evidence, which is unconditionally submission-safe. An
+    /// archived row is a snapshot of a rate that was real when it was taken and
+    /// may since have moved, so it is matched through the ordinary
+    /// provider-qualified path instead and can only be submission-safe when the
+    /// lookup actually proves the publishing endpoint.
+    archive: HashMap<String, ModelPricing>,
     litellm_keys: Vec<String>,
     openrouter_keys: Vec<String>,
     litellm_key_parts: Vec<KeyModelPart>,
     openrouter_key_parts: Vec<KeyModelPart>,
     models_dev_key_parts: Vec<KeyModelPart>,
+    archive_key_parts: Vec<KeyModelPart>,
     litellm_lower: HashMap<String, String>,
     openrouter_lower: HashMap<String, String>,
     models_dev_lower: HashMap<String, String>,
@@ -360,10 +371,10 @@ impl PricingLookup {
     // @keep: the omission of cursor/sakana is the whole point and reads like a bug otherwise.
     /// True when at least one *fetchable* upstream dataset loaded.
     ///
-    /// The `cursor` and `sakana` tables are compiled-in constants that are
-    /// present on every run, so they are deliberately not consulted: counting
-    /// them would report healthy pricing during a total upstream outage, which
-    /// is exactly the condition callers use this to detect.
+    /// The `cursor`, `sakana` and `archive` tables are compiled-in constants
+    /// that are present on every run, so they are deliberately not consulted:
+    /// counting them would report healthy pricing during a total upstream
+    /// outage, which is exactly the condition callers use this to detect.
     pub fn has_upstream_dataset(&self) -> bool {
         !self.litellm.is_empty() || !self.openrouter.is_empty() || !self.models_dev.is_empty()
     }
@@ -374,6 +385,34 @@ impl PricingLookup {
         cursor: HashMap<String, ModelPricing>,
         sakana: HashMap<String, ModelPricing>,
         models_dev: HashMap<String, ModelPricing>,
+    ) -> Self {
+        Self::new_with_archive(
+            litellm,
+            openrouter,
+            cursor,
+            sakana,
+            models_dev,
+            HashMap::new(),
+        )
+    }
+
+    // @keep: the reason this is a separate constructor and not a sixth
+    // parameter on `new_with_models_dev` is the whole design, and reads like
+    // gratuitous API surface otherwise.
+    /// Full wiring, including the retirement archive of last-known tariffs.
+    ///
+    /// The archive is the only table here that can answer for a model no live
+    /// dataset carries, so a test that wants to observe upstream-only
+    /// resolution — including the absence of a price — has to be able to build
+    /// a lookup without it. Production always goes through `PricingService`,
+    /// which always passes it.
+    pub fn new_with_archive(
+        litellm: HashMap<String, ModelPricing>,
+        openrouter: HashMap<String, ModelPricing>,
+        cursor: HashMap<String, ModelPricing>,
+        sakana: HashMap<String, ModelPricing>,
+        models_dev: HashMap<String, ModelPricing>,
+        archive: HashMap<String, ModelPricing>,
     ) -> Self {
         // Longest key first, then alphabetical. The alphabetical leg only pins
         // equal-length ties so a run is reproducible; it carries no pricing
@@ -387,6 +426,9 @@ impl PricingLookup {
 
         let mut models_dev_keys: Vec<String> = models_dev.keys().cloned().collect();
         models_dev_keys.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
+
+        let mut archive_keys: Vec<String> = archive.keys().cloned().collect();
+        archive_keys.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
 
         let mut litellm_lower = HashMap::with_capacity(litellm.len());
         for key in &litellm_keys {
@@ -464,6 +506,7 @@ impl PricingLookup {
         let litellm_key_parts = build_key_parts(&litellm_keys);
         let openrouter_key_parts = build_key_parts(&openrouter_keys);
         let models_dev_key_parts = build_key_parts(&models_dev_keys);
+        let archive_key_parts = build_key_parts(&archive_keys);
 
         Self {
             litellm,
@@ -471,11 +514,13 @@ impl PricingLookup {
             cursor,
             sakana,
             models_dev,
+            archive,
             litellm_keys,
             openrouter_keys,
             litellm_key_parts,
             openrouter_key_parts,
             models_dev_key_parts,
+            archive_key_parts,
             litellm_lower,
             openrouter_lower,
             models_dev_lower,
@@ -975,6 +1020,15 @@ impl PricingLookup {
             }
         }
 
+        // The retirement archive answers only once every live dataset has
+        // failed, so a model still carried upstream never reaches it. It still
+        // runs ahead of the fuzzy stage below: an exact snapshot of this
+        // model's own last published rate is better evidence than the
+        // nearest-neighbour row fuzzy would elect.
+        if let Some(result) = self.exact_match_archive(model_id, provider_id) {
+            return Some(result);
+        }
+
         if !is_fuzzy_eligible(model_id) {
             return None;
         }
@@ -1394,6 +1448,79 @@ impl PricingLookup {
             }
         }
         None
+    }
+
+    /// Match `model_id` against the retirement archive of last-known tariffs.
+    ///
+    /// Unlike the Cursor and Sakana built-ins above, this does NOT stamp
+    /// `BuiltIn`. `BuiltIn` is unconditionally submission-safe, and an archived
+    /// rate is a snapshot rather than a live quote: it earns provider-scoped
+    /// evidence only when the lookup proves the endpoint that published it, and
+    /// otherwise stays an estimate.
+    fn exact_match_archive(
+        &self,
+        model_id: &str,
+        provider_id: Option<&str>,
+    ) -> Option<LookupResult> {
+        if self.archive.is_empty() {
+            return None;
+        }
+
+        // Every archived key is a canonical `claude-{family}-{major}-{minor}`
+        // under a provider root, so the normalizer the upstream exact passes
+        // already use is the whole matcher. It folds the dated
+        // (`claude-haiku-4-5-20251001`), context-tagged (`claude-opus-4-8[1m]`),
+        // dotted (`claude-haiku-4.5`) and reasoning-tier
+        // (`claude-opus-4-7-thinking-xhigh`) spellings real clients emit, and it
+        // drops any leading provider segment on the way. Comparing the raw id to
+        // the key by equality instead would miss every one of those shapes —
+        // that is, every shape the archive exists to cover.
+        let lower = model_id.trim().to_ascii_lowercase();
+        let canonical = normalize_model_name(&lower)?;
+
+        // The id's own leading segment authorises the tariff exactly as a hint
+        // does, so `anthropic/claude-opus-4-8` resolves provider-scoped with no
+        // hint at all, while `openrouter/anthropic/claude-haiku-4.5` roots on
+        // the reseller and is refused here. (The outer resolver then peels the
+        // unknown vendor prefix and retries the bare id, which lands in the
+        // unhinted branch below and is priced as an estimate, never
+        // submission-safe.) An explicit hint wins over the id, matching every
+        // other resolver.
+        let embedded_root = lower.split_once('/').map(|(root, _)| root);
+        let hint = provider_id.or(embedded_root);
+
+        let result = match hint {
+            Some(hint) => exact_match_with_provider_prefixes(
+                &canonical,
+                Some(hint),
+                &self.archive_key_parts,
+                &self.archive,
+                ARCHIVE_SOURCE,
+            )?,
+            // Nothing here names the publishing endpoint, so this is the same
+            // estimate-only evidence an unhinted cross-provider fallback gets:
+            // priced for display, never submission-safe.
+            None => {
+                let matches: Vec<&String> = self
+                    .archive_key_parts
+                    .iter()
+                    .filter(|kp| model_part_matches_exact(&kp.lower_model_part, &canonical))
+                    .map(|kp| &kp.key)
+                    .collect();
+                select_best_match(
+                    &matches,
+                    &self.archive,
+                    ARCHIVE_SOURCE,
+                    None,
+                    ResolutionKind::ModelPart,
+                    &canonical,
+                )?
+            }
+        };
+
+        // The matched key is never the requested id verbatim, so disclose the
+        // normalization the way every other normalized pass does.
+        Some(result.with_normalization())
     }
 
     fn prefix_match_litellm(
@@ -2755,6 +2882,14 @@ fn prefers_model_part_key(candidate: &str, existing: &str) -> bool {
 /// resolves. `custom-pricing.json` is consulted before this, so a user who
 /// knows their router's effective rate can still state it.
 const ROUTING_LABELS: &[&str] = &["auto", "agent_review"];
+
+/// Source label reported for a price served from the retirement archive.
+///
+/// Deliberately distinct from the live dataset labels: `tokscale pricing` and
+/// the submission diagnostics print this verbatim, and a reader has to be able
+/// to tell "this rate is a snapshot of a model upstream no longer carries" from
+/// "LiteLLM says so today".
+pub(super) const ARCHIVE_SOURCE: &str = "Tokscale Archive";
 
 pub(crate) fn is_routing_label(model_id: &str) -> bool {
     let lower = model_id.trim().to_lowercase();

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -14,11 +14,163 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::OnceCell;
 
-use crate::TokenBreakdown;
+use crate::{provider_identity, TokenBreakdown};
 
 pub use litellm::ModelPricing;
 
 static PRICING_SERVICE: OnceCell<Arc<PricingService>> = OnceCell::const_new();
+
+/// Last known per-token tariff for a provider model that may disappear from
+/// the live pricing datasets after retirement.
+struct ArchivedPriceRow {
+    provider_id: &'static str,
+    model_id: &'static str,
+    input: f64,
+    output: f64,
+    cache_read: f64,
+    cache_write: f64,
+}
+
+// @keep: these are immutable retirement snapshots, not aliases or estimates
+// that should track a similarly named current model.
+//
+// The Claude rows preserve the final rates Tokscale resolved from LiteLLM on
+// 2026-08-31 before the upstream lifecycle could remove them:
+//   Haiku 4.5  $1/$5,   cache read/write $0.10/$1.25 per 1M
+//   Opus 4.7   $5/$25,  cache read/write $0.50/$6.25 per 1M
+//   Opus 4.8   $5/$25,  cache read/write $0.50/$6.25 per 1M
+//   Sonnet 4.6 $3/$15,  cache read/write $0.30/$3.75 per 1M
+//
+// OpenAI's Codex catalog exposes `codex-auto-review` as a concrete hidden API
+// model ("Automatic approval review model for Codex") but publishes no tariff.
+// Before strict submission evidence rejected the fuzzy result, Tokscale's last
+// deterministic selection was OpenRouter's `openai/gpt-5.1-codex-mini` row:
+// $0.25/$2 and $0.025 cached input per 1M. Cache creation is explicitly free
+// for OpenAI prompt caching, so the snapshot covers every Tokscale bucket.
+const ARCHIVED_MODEL_PRICES: &[ArchivedPriceRow] = &[
+    ArchivedPriceRow {
+        provider_id: "anthropic",
+        model_id: "claude-haiku-4-5",
+        input: 1e-6,
+        output: 5e-6,
+        cache_read: 1e-7,
+        cache_write: 1.25e-6,
+    },
+    ArchivedPriceRow {
+        provider_id: "anthropic",
+        model_id: "claude-opus-4-7",
+        input: 5e-6,
+        output: 25e-6,
+        cache_read: 5e-7,
+        cache_write: 6.25e-6,
+    },
+    ArchivedPriceRow {
+        provider_id: "anthropic",
+        model_id: "claude-opus-4-8",
+        input: 5e-6,
+        output: 25e-6,
+        cache_read: 5e-7,
+        cache_write: 6.25e-6,
+    },
+    ArchivedPriceRow {
+        provider_id: "anthropic",
+        model_id: "claude-sonnet-4-6",
+        input: 3e-6,
+        output: 15e-6,
+        cache_read: 3e-7,
+        cache_write: 3.75e-6,
+    },
+    ArchivedPriceRow {
+        provider_id: "openai",
+        model_id: "codex-auto-review",
+        input: 2.5e-7,
+        output: 2e-6,
+        cache_read: 2.5e-8,
+        cache_write: 0.0,
+    },
+];
+
+fn strip_archived_reasoning_suffix(model_id: &str) -> &str {
+    for suffix in [
+        "-thinking-xhigh",
+        "-thinking-high",
+        "-thinking-medium",
+        "-thinking-low",
+        "-thinking",
+    ] {
+        if let Some(base) = model_id.strip_suffix(suffix) {
+            return base;
+        }
+    }
+    model_id
+}
+
+fn archived_pricing_result(model_id: &str, provider_id: Option<&str>) -> Option<LookupResult> {
+    let lower = model_id.trim().to_ascii_lowercase();
+    let (embedded_provider, bare_model) = lower
+        .rsplit_once('/')
+        .map(|(provider, model)| (provider_identity::canonical_provider(provider), model))
+        .unwrap_or((None, lower.as_str()));
+    let requested_provider = provider_id.and_then(provider_identity::canonical_provider);
+
+    if requested_provider.is_some()
+        && embedded_provider.is_some()
+        && requested_provider != embedded_provider
+    {
+        return None;
+    }
+
+    let effective_provider = requested_provider.or(embedded_provider);
+    let bare_model = strip_archived_reasoning_suffix(bare_model);
+    let row = ARCHIVED_MODEL_PRICES.iter().find(|row| {
+        effective_provider
+            .as_deref()
+            .is_none_or(|provider| provider == row.provider_id)
+            && bare_model == row.model_id
+    })?;
+
+    Some(LookupResult {
+        pricing: ModelPricing {
+            input_cost_per_token: Some(row.input),
+            output_cost_per_token: Some(row.output),
+            cache_read_input_token_cost: Some(row.cache_read),
+            cache_creation_input_token_cost: Some(row.cache_write),
+            ..Default::default()
+        },
+        source: "Tokscale Archive".into(),
+        matched_key: format!("{}/{}", row.provider_id, row.model_id),
+        evidence: ResolutionEvidence::deterministic(ResolutionKind::BuiltIn),
+    })
+}
+
+fn prefer_submission_safe_or_archived(
+    dynamic: Option<LookupResult>,
+    model_id: &str,
+    provider_id: Option<&str>,
+    usage: Option<&TokenBreakdown>,
+) -> Option<LookupResult> {
+    let dynamic_is_complete = dynamic.as_ref().is_some_and(|result| {
+        result.evidence.is_submission_safe()
+            && usage.is_none_or(|usage| result.pricing.covers_usage(usage))
+    });
+    if dynamic_is_complete {
+        return dynamic;
+    }
+
+    let archived = archived_pricing_result(model_id, provider_id).or_else(|| {
+        dynamic
+            .as_ref()
+            .and_then(|result| archived_pricing_result(&result.matched_key, provider_id))
+    });
+    if archived
+        .as_ref()
+        .is_some_and(|result| usage.is_none_or(|usage| result.pricing.covers_usage(usage)))
+    {
+        return archived;
+    }
+
+    dynamic
+}
 
 // @keep: documents non-obvious filtering behavior — without this, the next person
 // will wonder why github_copilot entries disappear from the pricing data.
@@ -389,7 +541,12 @@ impl PricingService {
             Some(_) => {}
         }
 
-        self.lookup.lookup_with_source(model_id, force_source)
+        let dynamic = self.lookup.lookup_with_source(model_id, force_source);
+        if force_source.is_some() {
+            dynamic
+        } else {
+            prefer_submission_safe_or_archived(dynamic, model_id, None, None)
+        }
     }
 
     pub fn lookup_with_source_and_provider(
@@ -410,8 +567,14 @@ impl PricingService {
             Some(_) => {}
         }
 
-        self.lookup
-            .lookup_with_source_and_provider(model_id, force_source, provider_id)
+        let dynamic =
+            self.lookup
+                .lookup_with_source_and_provider(model_id, force_source, provider_id);
+        if force_source.is_some() {
+            dynamic
+        } else {
+            prefer_submission_safe_or_archived(dynamic, model_id, provider_id, None)
+        }
     }
 
     pub fn calculate_cost(
@@ -442,6 +605,18 @@ impl PricingService {
         if let Some(result) = self.custom.lookup_with_key(model_id) {
             return compute_cost(
                 result.pricing,
+                usage.input,
+                usage.output,
+                usage.cache_read,
+                usage.cache_write,
+                usage.reasoning,
+            );
+        }
+
+        let resolved = self.resolve_for_usage_with_provider(model_id, provider_id, usage);
+        if let Some(result) = resolved.filter(|result| result.source == "Tokscale Archive") {
+            return compute_cost(
+                &result.pricing,
                 usage.input,
                 usage.output,
                 usage.cache_read,
@@ -484,7 +659,8 @@ impl PricingService {
             return Some(result);
         }
 
-        self.lookup.resolve_for_usage(model_id, provider_id, usage)
+        let dynamic = self.lookup.resolve_for_usage(model_id, provider_id, usage);
+        prefer_submission_safe_or_archived(dynamic, model_id, provider_id, Some(usage))
     }
 
     fn lookup_custom(&self, model_id: &str) -> Option<LookupResult> {
@@ -550,6 +726,136 @@ mod tests {
             openrouter,
             models_dev,
         )
+    }
+
+    fn all_bucket_usage() -> TokenBreakdown {
+        TokenBreakdown {
+            input: 1_000_000,
+            output: 1_000_000,
+            cache_read: 1_000_000,
+            cache_write: 1_000_000,
+            reasoning: 0,
+        }
+    }
+
+    fn assert_retired_anthropic_price(
+        model: &str,
+        input: f64,
+        output: f64,
+        cache_read: f64,
+        cache_write: f64,
+    ) {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let usage = all_bucket_usage();
+        let resolved = service
+            .resolve_for_usage_with_provider(model, Some("anthropic"), &usage)
+            .unwrap_or_else(|| panic!("{model} must retain its archived price"));
+        assert_eq!(resolved.source, "Tokscale Archive", "model: {model}");
+        assert!(resolved.evidence.is_submission_safe(), "model: {model}");
+
+        let expected = input + output + cache_read + cache_write;
+        let actual = service.calculate_cost_with_provider(model, Some("anthropic"), &usage);
+        assert!(
+            (actual - expected).abs() < 1e-9,
+            "model: {model}, expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn retired_claude_haiku_4_5_keeps_its_last_known_price() {
+        assert_retired_anthropic_price("claude-haiku-4-5", 1.0, 5.0, 0.1, 1.25);
+    }
+
+    #[test]
+    fn retired_claude_opus_4_7_keeps_its_last_known_price() {
+        assert_retired_anthropic_price("claude-opus-4-7", 5.0, 25.0, 0.5, 6.25);
+    }
+
+    #[test]
+    fn retired_claude_opus_4_8_keeps_its_last_known_price() {
+        assert_retired_anthropic_price("claude-opus-4-8", 5.0, 25.0, 0.5, 6.25);
+    }
+
+    #[test]
+    fn retired_claude_sonnet_4_6_keeps_its_last_known_price() {
+        assert_retired_anthropic_price("claude-sonnet-4-6", 3.0, 15.0, 0.3, 3.75);
+    }
+
+    #[test]
+    fn retired_anthropic_price_does_not_cross_provider_boundaries() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let usage = all_bucket_usage();
+
+        assert!(!service.covers_usage_with_provider("claude-opus-4-8", Some("bedrock"), &usage,));
+    }
+
+    #[test]
+    fn live_upstream_price_wins_over_the_retired_model_archive() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "anthropic/claude-opus-4-8".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(4e-6),
+                output_cost_per_token: Some(20e-6),
+                cache_read_input_token_cost: Some(4e-7),
+                cache_creation_input_token_cost: Some(5e-6),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(litellm, HashMap::new());
+        let usage = all_bucket_usage();
+
+        let resolved = service
+            .resolve_for_usage_with_provider("claude-opus-4-8", Some("anthropic"), &usage)
+            .expect("live upstream row must resolve");
+        assert_eq!(resolved.source, "LiteLLM");
+        assert!(
+            (service.calculate_cost_with_provider("claude-opus-4-8", Some("anthropic"), &usage,)
+                - 29.4)
+                .abs()
+                < 1e-9
+        );
+    }
+
+    #[test]
+    fn retired_claude_reasoning_suffix_uses_the_archived_base_price() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let usage = all_bucket_usage();
+
+        let resolved = service
+            .resolve_for_usage_with_provider(
+                "claude-opus-4-7-thinking-xhigh",
+                Some("anthropic"),
+                &usage,
+            )
+            .expect("reasoning suffix must retain the base model price");
+        assert_eq!(resolved.source, "Tokscale Archive");
+        assert_eq!(resolved.matched_key, "anthropic/claude-opus-4-7");
+    }
+
+    #[test]
+    fn codex_auto_review_keeps_its_last_resolved_price() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let usage = TokenBreakdown {
+            input: 1_000_000,
+            output: 1_000_000,
+            cache_read: 1_000_000,
+            cache_write: 0,
+            reasoning: 0,
+        };
+
+        let resolved = service
+            .resolve_for_usage_with_provider("codex-auto-review", Some("openai"), &usage)
+            .expect("codex-auto-review must retain its archived price");
+        assert_eq!(resolved.source, "Tokscale Archive");
+        assert_eq!(resolved.matched_key, "openai/codex-auto-review");
+        assert!(resolved.evidence.is_submission_safe());
+        assert!(
+            (service.calculate_cost_with_provider("codex-auto-review", Some("openai"), &usage,)
+                - 2.275)
+                .abs()
+                < 1e-9
+        );
     }
 
     /// The same Grok request must cost the same whichever dataset priced it.

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -281,12 +281,29 @@ impl PricingService {
         /// `(model id, input, output, cache read, cache creation)`, per token.
         type ArchivedRateRow = (&'static str, f64, f64, f64, f64);
 
+        // Every first-party Claude row the narrowest dataset still carries, so
+        // whichever one is retired next already has its last published rate
+        // here. models.dev is that dataset: as of 2026-09-02 it lists
+        // haiku-4-5, sonnet-4-5, sonnet-4-6, opus-4-5, opus-4-6, opus-4-7,
+        // opus-4-8, opus-5, sonnet-5 and the two fable-5 rows. The current
+        // flagships (opus-5, sonnet-5, fable-5*) are left out on purpose --
+        // nothing retires the model that is shipping.
         let entries: &[ArchivedRateRow] = &[
             // Claude Haiku 4.5: $1.00/$5.00 per 1M, $0.10 cache read, $1.25 cache write.
             ("anthropic/claude-haiku-4-5", 1e-6, 5e-6, 1e-7, 1.25e-6),
-            // Claude Sonnet 4.6: $3.00/$15.00 per 1M, $0.30 cache read, $3.75 cache write.
+            // Claude Sonnet 4.5 / 4.6: $3.00/$15.00 per 1M, $0.30 cache read,
+            // $3.75 cache write. 4.5 is the oldest Sonnet any of the three
+            // still carries.
+            ("anthropic/claude-sonnet-4-5", 3e-6, 1.5e-5, 3e-7, 3.75e-6),
             ("anthropic/claude-sonnet-4-6", 3e-6, 1.5e-5, 3e-7, 3.75e-6),
-            // Claude Opus 4.7 / 4.8: $5.00/$25.00 per 1M, $0.50 cache read, $6.25 cache write.
+            // Claude Opus 4.5 / 4.6 / 4.7 / 4.8: $5.00/$25.00 per 1M, $0.50
+            // cache read, $6.25 cache write. 4.5 is the oldest Opus carried by
+            // all three, so it is the next one due to fall off -- LiteLLM and
+            // OpenRouter still list opus-4 and opus-4-1 (and LiteLLM
+            // claude-3-opus), but models.dev has already dropped them, so
+            // their rates cannot be cross-checked and they are not archived.
+            ("anthropic/claude-opus-4-5", 5e-6, 2.5e-5, 5e-7, 6.25e-6),
+            ("anthropic/claude-opus-4-6", 5e-6, 2.5e-5, 5e-7, 6.25e-6),
             ("anthropic/claude-opus-4-7", 5e-6, 2.5e-5, 5e-7, 6.25e-6),
             ("anthropic/claude-opus-4-8", 5e-6, 2.5e-5, 5e-7, 6.25e-6),
         ];
@@ -652,6 +669,21 @@ mod tests {
     #[test]
     fn retired_claude_haiku_4_5_keeps_its_last_known_price() {
         assert_retired_anthropic_price("claude-haiku-4-5", 1.0, 5.0, 0.1, 1.25);
+    }
+
+    #[test]
+    fn retired_claude_sonnet_4_5_keeps_its_last_known_price() {
+        assert_retired_anthropic_price("claude-sonnet-4-5", 3.0, 15.0, 0.3, 3.75);
+    }
+
+    #[test]
+    fn retired_claude_opus_4_5_keeps_its_last_known_price() {
+        assert_retired_anthropic_price("claude-opus-4-5", 5.0, 25.0, 0.5, 6.25);
+    }
+
+    #[test]
+    fn retired_claude_opus_4_6_keeps_its_last_known_price() {
+        assert_retired_anthropic_price("claude-opus-4-6", 5.0, 25.0, 0.5, 6.25);
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -105,12 +105,46 @@ fn strip_archived_reasoning_suffix(model_id: &str) -> &str {
     model_id
 }
 
+/// Provider spellings that [`provider_identity::canonical_provider`] folds into
+/// a first-party vendor tag even though they name a different commercial
+/// endpoint with its own price sheet.
+///
+/// Folding is right for attribution — a Vertex-served Claude is still a Claude —
+/// but wrong for authorising a *first-party* archived tariff, for exactly the
+/// reason `provider_identity` refuses to fold the `-cn` regional endpoints: the
+/// hosted rates can differ, and the archive only holds the vendor's own. Note
+/// this is not the same question as spelling variants like `openai_codex`,
+/// which is first-party OpenAI and must keep resolving.
+fn is_rehosted_endpoint(raw: &str) -> bool {
+    raw.split('/').any(|segment| {
+        matches!(
+            segment
+                .trim()
+                .to_ascii_lowercase()
+                .replace('-', "_")
+                .as_str(),
+            "vertex" | "vertex_ai"
+        )
+    })
+}
+
 fn archived_pricing_result(model_id: &str, provider_id: Option<&str>) -> Option<LookupResult> {
     let lower = model_id.trim().to_ascii_lowercase();
-    let (embedded_provider, bare_model) = lower
+    let (embedded_raw, bare_model) = lower
         .rsplit_once('/')
-        .map(|(provider, model)| (provider_identity::canonical_provider(provider), model))
+        .map(|(provider, model)| (Some(provider), model))
         .unwrap_or((None, lower.as_str()));
+
+    // The archive carries first-party tariffs only, so an endpoint that merely
+    // shares the canonical vendor tag must fall through to a live resolver
+    // rather than be priced — and marked submission-safe — from it.
+    if provider_id.is_some_and(is_rehosted_endpoint)
+        || embedded_raw.is_some_and(is_rehosted_endpoint)
+    {
+        return None;
+    }
+
+    let embedded_provider = embedded_raw.and_then(provider_identity::canonical_provider);
     let requested_provider = provider_id.and_then(provider_identity::canonical_provider);
 
     if requested_provider.is_some()
@@ -691,6 +725,29 @@ impl PricingService {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn archived_tariff_is_not_shared_across_hosted_endpoints() {
+        // `vertex` and `vertex_ai` canonicalise to `anthropic`, but a hosted
+        // endpoint publishes its own tariff -- the same reason
+        // `provider_identity` refuses to fold the `-cn` regional endpoints. The
+        // first-party archive must not authorise Vertex usage at Anthropic
+        // rates, whether the endpoint arrives as the provider or embedded in
+        // the model id.
+        for provider in ["vertex", "vertex_ai", "Vertex"] {
+            assert!(
+                archived_pricing_result("claude-opus-4-7", Some(provider)).is_none(),
+                "{provider} must not be priced from the Anthropic archive"
+            );
+        }
+        assert!(archived_pricing_result("vertex/claude-opus-4-7", None).is_none());
+
+        // First-party Anthropic still resolves, including its own spellings.
+        assert!(archived_pricing_result("claude-opus-4-7", Some("anthropic")).is_some());
+        assert!(archived_pricing_result("claude-opus-4-7", Some("Anthropic")).is_some());
+        assert!(archived_pricing_result("anthropic/claude-opus-4-7", None).is_some());
+        assert!(archived_pricing_result("claude-opus-4-7", None).is_some());
+    }
+
     use super::*;
 
     fn model_pricing(input: f64, output: f64) -> ModelPricing {

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -14,197 +14,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::OnceCell;
 
-use crate::{provider_identity, TokenBreakdown};
+use crate::TokenBreakdown;
 
 pub use litellm::ModelPricing;
 
 static PRICING_SERVICE: OnceCell<Arc<PricingService>> = OnceCell::const_new();
-
-/// Last known per-token tariff for a provider model that may disappear from
-/// the live pricing datasets after retirement.
-struct ArchivedPriceRow {
-    provider_id: &'static str,
-    model_id: &'static str,
-    input: f64,
-    output: f64,
-    cache_read: f64,
-    cache_write: f64,
-}
-
-// @keep: these are immutable retirement snapshots, not aliases or estimates
-// that should track a similarly named current model.
-//
-// The Claude rows preserve the final rates Tokscale resolved from LiteLLM on
-// 2026-08-31 before the upstream lifecycle could remove them:
-//   Haiku 4.5  $1/$5,   cache read/write $0.10/$1.25 per 1M
-//   Opus 4.7   $5/$25,  cache read/write $0.50/$6.25 per 1M
-//   Opus 4.8   $5/$25,  cache read/write $0.50/$6.25 per 1M
-//   Sonnet 4.6 $3/$15,  cache read/write $0.30/$3.75 per 1M
-//
-// OpenAI's Codex catalog exposes `codex-auto-review` as a concrete hidden API
-// model ("Automatic approval review model for Codex") but publishes no tariff.
-// Before strict submission evidence rejected the fuzzy result, Tokscale's last
-// deterministic selection was OpenRouter's `openai/gpt-5.1-codex-mini` row:
-// $0.25/$2 and $0.025 cached input per 1M. Cache creation is explicitly free
-// for OpenAI prompt caching, so the snapshot covers every Tokscale bucket.
-const ARCHIVED_MODEL_PRICES: &[ArchivedPriceRow] = &[
-    ArchivedPriceRow {
-        provider_id: "anthropic",
-        model_id: "claude-haiku-4-5",
-        input: 1e-6,
-        output: 5e-6,
-        cache_read: 1e-7,
-        cache_write: 1.25e-6,
-    },
-    ArchivedPriceRow {
-        provider_id: "anthropic",
-        model_id: "claude-opus-4-7",
-        input: 5e-6,
-        output: 25e-6,
-        cache_read: 5e-7,
-        cache_write: 6.25e-6,
-    },
-    ArchivedPriceRow {
-        provider_id: "anthropic",
-        model_id: "claude-opus-4-8",
-        input: 5e-6,
-        output: 25e-6,
-        cache_read: 5e-7,
-        cache_write: 6.25e-6,
-    },
-    ArchivedPriceRow {
-        provider_id: "anthropic",
-        model_id: "claude-sonnet-4-6",
-        input: 3e-6,
-        output: 15e-6,
-        cache_read: 3e-7,
-        cache_write: 3.75e-6,
-    },
-    ArchivedPriceRow {
-        provider_id: "openai",
-        model_id: "codex-auto-review",
-        input: 2.5e-7,
-        output: 2e-6,
-        cache_read: 2.5e-8,
-        cache_write: 0.0,
-    },
-];
-
-fn strip_archived_reasoning_suffix(model_id: &str) -> &str {
-    for suffix in [
-        "-thinking-xhigh",
-        "-thinking-high",
-        "-thinking-medium",
-        "-thinking-low",
-        "-thinking",
-    ] {
-        if let Some(base) = model_id.strip_suffix(suffix) {
-            return base;
-        }
-    }
-    model_id
-}
-
-/// Provider spellings that [`provider_identity::canonical_provider`] folds into
-/// a first-party vendor tag even though they name a different commercial
-/// endpoint with its own price sheet.
-///
-/// Folding is right for attribution — a Vertex-served Claude is still a Claude —
-/// but wrong for authorising a *first-party* archived tariff, for exactly the
-/// reason `provider_identity` refuses to fold the `-cn` regional endpoints: the
-/// hosted rates can differ, and the archive only holds the vendor's own. Note
-/// this is not the same question as spelling variants like `openai_codex`,
-/// which is first-party OpenAI and must keep resolving.
-fn is_rehosted_endpoint(raw: &str) -> bool {
-    raw.split('/').any(|segment| {
-        matches!(
-            segment
-                .trim()
-                .to_ascii_lowercase()
-                .replace('-', "_")
-                .as_str(),
-            "vertex" | "vertex_ai"
-        )
-    })
-}
-
-fn archived_pricing_result(model_id: &str, provider_id: Option<&str>) -> Option<LookupResult> {
-    let lower = model_id.trim().to_ascii_lowercase();
-    let (embedded_raw, bare_model) = lower
-        .rsplit_once('/')
-        .map(|(provider, model)| (Some(provider), model))
-        .unwrap_or((None, lower.as_str()));
-
-    // The archive carries first-party tariffs only, so an endpoint that merely
-    // shares the canonical vendor tag must fall through to a live resolver
-    // rather than be priced — and marked submission-safe — from it.
-    if provider_id.is_some_and(is_rehosted_endpoint)
-        || embedded_raw.is_some_and(is_rehosted_endpoint)
-    {
-        return None;
-    }
-
-    let embedded_provider = embedded_raw.and_then(provider_identity::canonical_provider);
-    let requested_provider = provider_id.and_then(provider_identity::canonical_provider);
-
-    if requested_provider.is_some()
-        && embedded_provider.is_some()
-        && requested_provider != embedded_provider
-    {
-        return None;
-    }
-
-    let effective_provider = requested_provider.or(embedded_provider);
-    let bare_model = strip_archived_reasoning_suffix(bare_model);
-    let row = ARCHIVED_MODEL_PRICES.iter().find(|row| {
-        effective_provider
-            .as_deref()
-            .is_none_or(|provider| provider == row.provider_id)
-            && bare_model == row.model_id
-    })?;
-
-    Some(LookupResult {
-        pricing: ModelPricing {
-            input_cost_per_token: Some(row.input),
-            output_cost_per_token: Some(row.output),
-            cache_read_input_token_cost: Some(row.cache_read),
-            cache_creation_input_token_cost: Some(row.cache_write),
-            ..Default::default()
-        },
-        source: "Tokscale Archive".into(),
-        matched_key: format!("{}/{}", row.provider_id, row.model_id),
-        evidence: ResolutionEvidence::deterministic(ResolutionKind::BuiltIn),
-    })
-}
-
-fn prefer_submission_safe_or_archived(
-    dynamic: Option<LookupResult>,
-    model_id: &str,
-    provider_id: Option<&str>,
-    usage: Option<&TokenBreakdown>,
-) -> Option<LookupResult> {
-    let dynamic_is_complete = dynamic.as_ref().is_some_and(|result| {
-        result.evidence.is_submission_safe()
-            && usage.is_none_or(|usage| result.pricing.covers_usage(usage))
-    });
-    if dynamic_is_complete {
-        return dynamic;
-    }
-
-    let archived = archived_pricing_result(model_id, provider_id).or_else(|| {
-        dynamic
-            .as_ref()
-            .and_then(|result| archived_pricing_result(&result.matched_key, provider_id))
-    });
-    if archived
-        .as_ref()
-        .is_some_and(|result| usage.is_none_or(|usage| result.pricing.covers_usage(usage)))
-    {
-        return archived;
-    }
-
-    dynamic
-}
 
 // @keep: documents non-obvious filtering behavior — without this, the next person
 // will wonder why github_copilot entries disappear from the pricing data.
@@ -273,12 +87,13 @@ impl PricingService {
     ) -> Self {
         Self {
             custom,
-            lookup: PricingLookup::new_with_models_dev(
+            lookup: PricingLookup::new_with_archive(
                 litellm_data,
                 openrouter_data,
                 Self::build_cursor_overrides(),
                 Self::build_sakana_overrides(),
                 models_dev_data,
+                Self::build_archive_overrides(),
             ),
         }
     }
@@ -429,6 +244,69 @@ impl PricingService {
         overrides
     }
 
+    // @keep: a snapshot of last-known published rates for Anthropic models that
+    // upstream will eventually stop carrying. LiteLLM, OpenRouter and models.dev
+    // all describe the CURRENT catalogue: once a provider retires a model those
+    // rows are dropped, and every historical session that used it silently loses
+    // its price. This archive is the only place that memory lives.
+    //
+    // Precedence is the same slot as the Cursor/Sakana overrides in
+    // PricingLookup - after every upstream exact/normalized/prefix match, before
+    // the fuzzy stage - so while a row is still live upstream the archive never
+    // answers, and once upstream drops it the archive answers with that model's
+    // own last rate instead of letting fuzzy elect a neighbouring row.
+    //
+    // Keys are provider-qualified on purpose. Anthropic bills these rates on its
+    // own API; a request routed through Vertex or Bedrock is a different tariff.
+    // With an `anthropic/` root, an anthropic hint resolves ProviderScoped with
+    // matching provider identity (submission-safe), and a `vertex`/`vertex_ai`
+    // hint is recognised as a cross-provider alias and stays an estimate.
+    //
+    // Rates verified 2026-09-02 against both live datasets: models.dev keys them
+    // exactly as written here, LiteLLM keys them bare (`claude-haiku-4-5`, ...)
+    // at the same numbers. Cache read is 0.1x input and cache creation 1.25x
+    // input, matching Anthropic's published multipliers.
+    //
+    // NOTE: there is deliberately NO `openai/codex-auto-review` entry, and no
+    // entry for any other routing label. OpenAI publishes no tariff for it -
+    // all three datasets carry zero `auto-review` keys (checked 2026-09-02), so
+    // the number an earlier draft archived was not a published rate but
+    // Tokscale's own fuzzy election of a neighbouring `gpt-5.1-codex-mini` row,
+    // which the lookup path deliberately reports as not submission-safe.
+    // Archiving it would promote that guess to authoritative and let it
+    // overwrite real cost on the server. Leaving it unpriced is the intended
+    // outcome: its date joins `incomplete_cost_dates` and the previously stored
+    // cost is preserved.
+    fn build_archive_overrides() -> HashMap<String, ModelPricing> {
+        /// `(model id, input, output, cache read, cache creation)`, per token.
+        type ArchivedRateRow = (&'static str, f64, f64, f64, f64);
+
+        let entries: &[ArchivedRateRow] = &[
+            // Claude Haiku 4.5: $1.00/$5.00 per 1M, $0.10 cache read, $1.25 cache write.
+            ("anthropic/claude-haiku-4-5", 1e-6, 5e-6, 1e-7, 1.25e-6),
+            // Claude Sonnet 4.6: $3.00/$15.00 per 1M, $0.30 cache read, $3.75 cache write.
+            ("anthropic/claude-sonnet-4-6", 3e-6, 1.5e-5, 3e-7, 3.75e-6),
+            // Claude Opus 4.7 / 4.8: $5.00/$25.00 per 1M, $0.50 cache read, $6.25 cache write.
+            ("anthropic/claude-opus-4-7", 5e-6, 2.5e-5, 5e-7, 6.25e-6),
+            ("anthropic/claude-opus-4-8", 5e-6, 2.5e-5, 5e-7, 6.25e-6),
+        ];
+
+        let mut overrides = HashMap::with_capacity(entries.len());
+        for (model_id, input, output, cache_read, cache_creation) in entries {
+            overrides.insert(
+                model_id.to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(*input),
+                    output_cost_per_token: Some(*output),
+                    cache_read_input_token_cost: Some(*cache_read),
+                    cache_creation_input_token_cost: Some(*cache_creation),
+                    ..Default::default()
+                },
+            );
+        }
+        overrides
+    }
+
     async fn fetch_inner() -> Result<Self, String> {
         let (litellm_result, openrouter_data, models_dev_result) = tokio::join!(
             litellm::fetch(),
@@ -575,12 +453,7 @@ impl PricingService {
             Some(_) => {}
         }
 
-        let dynamic = self.lookup.lookup_with_source(model_id, force_source);
-        if force_source.is_some() {
-            dynamic
-        } else {
-            prefer_submission_safe_or_archived(dynamic, model_id, None, None)
-        }
+        self.lookup.lookup_with_source(model_id, force_source)
     }
 
     pub fn lookup_with_source_and_provider(
@@ -601,14 +474,8 @@ impl PricingService {
             Some(_) => {}
         }
 
-        let dynamic =
-            self.lookup
-                .lookup_with_source_and_provider(model_id, force_source, provider_id);
-        if force_source.is_some() {
-            dynamic
-        } else {
-            prefer_submission_safe_or_archived(dynamic, model_id, provider_id, None)
-        }
+        self.lookup
+            .lookup_with_source_and_provider(model_id, force_source, provider_id)
     }
 
     pub fn calculate_cost(
@@ -639,18 +506,6 @@ impl PricingService {
         if let Some(result) = self.custom.lookup_with_key(model_id) {
             return compute_cost(
                 result.pricing,
-                usage.input,
-                usage.output,
-                usage.cache_read,
-                usage.cache_write,
-                usage.reasoning,
-            );
-        }
-
-        let resolved = self.resolve_for_usage_with_provider(model_id, provider_id, usage);
-        if let Some(result) = resolved.filter(|result| result.source == "Tokscale Archive") {
-            return compute_cost(
-                &result.pricing,
                 usage.input,
                 usage.output,
                 usage.cache_read,
@@ -693,8 +548,7 @@ impl PricingService {
             return Some(result);
         }
 
-        let dynamic = self.lookup.resolve_for_usage(model_id, provider_id, usage);
-        prefer_submission_safe_or_archived(dynamic, model_id, provider_id, Some(usage))
+        self.lookup.resolve_for_usage(model_id, provider_id, usage)
     }
 
     fn lookup_custom(&self, model_id: &str) -> Option<LookupResult> {
@@ -725,29 +579,6 @@ impl PricingService {
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn archived_tariff_is_not_shared_across_hosted_endpoints() {
-        // `vertex` and `vertex_ai` canonicalise to `anthropic`, but a hosted
-        // endpoint publishes its own tariff -- the same reason
-        // `provider_identity` refuses to fold the `-cn` regional endpoints. The
-        // first-party archive must not authorise Vertex usage at Anthropic
-        // rates, whether the endpoint arrives as the provider or embedded in
-        // the model id.
-        for provider in ["vertex", "vertex_ai", "Vertex"] {
-            assert!(
-                archived_pricing_result("claude-opus-4-7", Some(provider)).is_none(),
-                "{provider} must not be priced from the Anthropic archive"
-            );
-        }
-        assert!(archived_pricing_result("vertex/claude-opus-4-7", None).is_none());
-
-        // First-party Anthropic still resolves, including its own spellings.
-        assert!(archived_pricing_result("claude-opus-4-7", Some("anthropic")).is_some());
-        assert!(archived_pricing_result("claude-opus-4-7", Some("Anthropic")).is_some());
-        assert!(archived_pricing_result("anthropic/claude-opus-4-7", None).is_some());
-        assert!(archived_pricing_result("claude-opus-4-7", None).is_some());
-    }
-
     use super::*;
 
     fn model_pricing(input: f64, output: f64) -> ModelPricing {
@@ -838,12 +669,76 @@ mod tests {
         assert_retired_anthropic_price("claude-sonnet-4-6", 3.0, 15.0, 0.3, 3.75);
     }
 
+    /// A hosted endpoint publishes its own tariff, so an Anthropic-keyed
+    /// archive row may not stand in for one.
+    ///
+    /// Bedrock shares no provider tag with an `anthropic/` key, so the archive
+    /// never answers for it at all -- which is the correct outcome, because the
+    /// live datasets price Bedrock's regional Claude rows 10% above first-party
+    /// and its GovCloud rows 20% above.
     #[test]
-    fn retired_anthropic_price_does_not_cross_provider_boundaries() {
+    fn retired_anthropic_price_is_not_offered_to_bedrock() {
         let service = PricingService::new(HashMap::new(), HashMap::new());
         let usage = all_bucket_usage();
 
-        assert!(!service.covers_usage_with_provider("claude-opus-4-8", Some("bedrock"), &usage,));
+        assert!(service
+            .resolve_for_usage_with_provider("claude-opus-4-8", Some("bedrock"), &usage)
+            .is_none());
+        assert!(!service.covers_usage_with_provider("claude-opus-4-8", Some("bedrock"), &usage));
+    }
+
+    /// An embedded provider root authorises the tariff exactly as a hint does.
+    ///
+    /// A reseller root is not first-party Anthropic, so the archive refuses it
+    /// on the qualified id. The outer resolver then peels the unknown vendor
+    /// prefix and retries the bare model, which the archive does answer -- but
+    /// with nothing naming the publishing endpoint it is ModelPart evidence, so
+    /// it is priced for display and never submission-safe.
+    #[test]
+    fn reseller_rooted_id_gets_an_archive_estimate_but_not_submission_safety() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let usage = all_bucket_usage();
+
+        let resold = service
+            .resolve_for_usage_with_provider("openrouter/anthropic/claude-haiku-4.5", None, &usage)
+            .expect("the peeled bare id still carries an estimate");
+        assert_eq!(resold.source, "Tokscale Archive");
+        assert_eq!(
+            resold.evidence.submission_safety_gap(),
+            Some(lookup::SubmissionSafetyGap::UnverifiedProviderIdentity),
+            "a reseller-rooted id must not be submission-safe"
+        );
+
+        // The same id under its own root is submission-safe, so the gap above
+        // is the reseller segment and not a normalization failure.
+        let first_party = service
+            .resolve_for_usage_with_provider("anthropic/claude-haiku-4.5", None, &usage)
+            .expect("the first-party root must still resolve");
+        assert_eq!(first_party.source, "Tokscale Archive");
+        assert_eq!(first_party.matched_key, "anthropic/claude-haiku-4-5");
+        assert!(first_party.evidence.is_submission_safe());
+    }
+
+    /// Vertex canonicalises to `anthropic`, so the archive stays reachable as an
+    /// estimate -- but only as an estimate. Reaching a first-party row through a
+    /// cross-provider alias proves nothing about what Vertex billed, so the
+    /// result must not be submission-safe.
+    #[test]
+    fn retired_anthropic_price_reaches_vertex_only_as_an_estimate() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let usage = all_bucket_usage();
+
+        for provider in ["vertex", "vertex_ai", "Vertex"] {
+            let resolved = service
+                .resolve_for_usage_with_provider("claude-opus-4-7", Some(provider), &usage)
+                .unwrap_or_else(|| panic!("{provider} should still receive an estimate"));
+            assert_eq!(resolved.source, "Tokscale Archive", "provider: {provider}");
+            assert_eq!(
+                resolved.evidence.submission_safety_gap(),
+                Some(lookup::SubmissionSafetyGap::UnverifiedProviderIdentity),
+                "provider: {provider} must not be submission-safe"
+            );
+        }
     }
 
     #[test]
@@ -874,6 +769,8 @@ mod tests {
         );
     }
 
+    /// The shared normalizer folds reasoning-effort suffixes, so the archive
+    /// needs no suffix stripper of its own.
     #[test]
     fn retired_claude_reasoning_suffix_uses_the_archived_base_price() {
         let service = PricingService::new(HashMap::new(), HashMap::new());
@@ -890,8 +787,16 @@ mod tests {
         assert_eq!(resolved.matched_key, "anthropic/claude-opus-4-7");
     }
 
+    /// Regression: the archive may only carry published rates.
+    ///
+    /// No dataset publishes a tariff for `codex-auto-review` -- LiteLLM,
+    /// OpenRouter and models.dev all carry zero `auto-review` keys. Its price
+    /// on this path has always been a fuzzy election of a neighbouring
+    /// `gpt-5.1-codex-mini` row, which the lookup reports as an estimate.
+    /// Archiving that number would stamp it authoritative and let a guess
+    /// overwrite real recorded cost on the server, so no such row exists.
     #[test]
-    fn codex_auto_review_keeps_its_last_resolved_price() {
+    fn codex_auto_review_is_never_served_from_the_archive() {
         let service = PricingService::new(HashMap::new(), HashMap::new());
         let usage = TokenBreakdown {
             input: 1_000_000,
@@ -901,18 +806,50 @@ mod tests {
             reasoning: 0,
         };
 
-        let resolved = service
-            .resolve_for_usage_with_provider("codex-auto-review", Some("openai"), &usage)
-            .expect("codex-auto-review must retain its archived price");
-        assert_eq!(resolved.source, "Tokscale Archive");
-        assert_eq!(resolved.matched_key, "openai/codex-auto-review");
-        assert!(resolved.evidence.is_submission_safe());
+        let resolved =
+            service.resolve_for_usage_with_provider("codex-auto-review", Some("openai"), &usage);
         assert!(
-            (service.calculate_cost_with_provider("codex-auto-review", Some("openai"), &usage,)
-                - 2.275)
-                .abs()
-                < 1e-9
+            resolved
+                .as_ref()
+                .is_none_or(|result| result.source != "Tokscale Archive"),
+            "codex-auto-review has no published rate to archive"
         );
+        assert!(
+            resolved.is_none_or(|result| !result.evidence.is_submission_safe()),
+            "an estimated price must never become submission-safe"
+        );
+    }
+
+    /// Regression: real clients emit dated and suffixed ids, so an archive
+    /// matched by bare-string equality would silently miss every model it
+    /// exists to cover. The archive must go through the same normalization the
+    /// live lookup path applies.
+    #[test]
+    fn archived_price_survives_the_id_spellings_clients_actually_emit() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let usage = all_bucket_usage();
+
+        for (model, expected_key) in [
+            // Anthropic's dated release ids.
+            ("claude-haiku-4-5-20251001", "anthropic/claude-haiku-4-5"),
+            ("claude-sonnet-4-6-20260115", "anthropic/claude-sonnet-4-6"),
+            // Long-context and reasoning-effort suffixes.
+            ("claude-opus-4-8[1m]", "anthropic/claude-opus-4-8"),
+            (
+                "claude-opus-4-7-thinking-xhigh",
+                "anthropic/claude-opus-4-7",
+            ),
+            // Dotted minor versions and an embedded provider root.
+            ("claude-haiku-4.5", "anthropic/claude-haiku-4-5"),
+            ("anthropic/claude-haiku-4.5", "anthropic/claude-haiku-4-5"),
+        ] {
+            let resolved = service
+                .resolve_for_usage_with_provider(model, Some("anthropic"), &usage)
+                .unwrap_or_else(|| panic!("{model} must retain its archived price"));
+            assert_eq!(resolved.source, "Tokscale Archive", "model: {model}");
+            assert_eq!(resolved.matched_key, expected_key, "model: {model}");
+            assert!(resolved.evidence.is_submission_safe(), "model: {model}");
+        }
     }
 
     /// The same Grok request must cost the same whichever dataset priced it.


### PR DESCRIPTION
## Summary

- preserve the final known per-token rates for `claude-haiku-4-5`, `claude-opus-4-7`, `claude-opus-4-8`, and `claude-sonnet-4-6`
- preserve the last resolver-selected `gpt-5.1-codex-mini` tariff for the hidden OpenAI `codex-auto-review` model
- prefer complete, submission-safe live upstream pricing and use the bundled archive only when the live result is missing, unsafe, or incomplete
- scope archived prices to the matching canonical provider so Anthropic rates cannot authorize unrelated provider submissions

## Why

Retired model rows can disappear from the fetched pricing catalogs. Historical usage then becomes cost-incomplete even though Tokscale previously had a complete tariff for it. Provider-scoped submission checks also reject cross-provider or ambiguous fallback matches, so the affected rows currently emit warnings instead of retaining their last known cost.

The archive snapshots the final rates that Tokscale resolved on 2026-08-31. Live submission-safe upstream rows still win, so a current published tariff can supersede the snapshot without a release.

`codex-auto-review` is present in the OpenAI Codex model catalog as a hidden API model, but no public tariff row exists. Before strict ambiguity checks rejected the result, Tokscale selected OpenRouter's `openai/gpt-5.1-codex-mini` row. This change makes that last selected tariff explicit and reviewable instead of depending on a 34-candidate fuzzy match.

## Rates retained

| Provider/model | Input / 1M | Output / 1M | Cache read / 1M | Cache write / 1M |
| --- | ---: | ---: | ---: | ---: |
| `anthropic/claude-haiku-4-5` | $1.00 | $5.00 | $0.10 | $1.25 |
| `anthropic/claude-opus-4-7` | $5.00 | $25.00 | $0.50 | $6.25 |
| `anthropic/claude-opus-4-8` | $5.00 | $25.00 | $0.50 | $6.25 |
| `anthropic/claude-sonnet-4-6` | $3.00 | $15.00 | $0.30 | $3.75 |
| `openai/codex-auto-review` | $0.25 | $2.00 | $0.025 | $0.00 |

## Verification

- failing-first focused test: all five archived models failed to resolve with empty upstream datasets
- focused GREEN: 5 passed
- pricing suite: 369 passed
- full `tokscale-core` suite: 1,972 passed
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- real `tokscale submit --dry-run --no-spinner`: none of the five affected warning keys remained; other unrelated unpriced-model warnings were unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves last-known per-token rates for retired Claude models so historical cost calculations stay complete once those models drop out of live pricing catalogs.

- Archives seven first-party Claude rows — haiku-4-5, sonnet-4-5, sonnet-4-6, opus-4-5, opus-4-6, opus-4-7, opus-4-8 — with rates verified 2026-09-02 against LiteLLM, OpenRouter, and models.dev.
- Live upstream pricing still wins; the archive answers only when the live result is missing, unsafe, or incomplete.
- An `anthropic` provider hint resolves submission-safe; `vertex`/`vertex_ai` and reseller roots stay estimates; `bedrock` is never answered.
- The shared normalizer folds dated, dotted, and reasoning-suffixed spellings so real client ids still match archived rows.
- `codex-auto-review` is deliberately not archived: no dataset publishes a rate for it, so a guess no longer gets promoted to authoritative.

<sup>Written for commit 0b4e08e7d499933df0ef643d8609424bedcfb75a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

