### PR TITLE
fix(copilot): read gh:github.com from Windows Credential Manager via CredReadW

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,7 +2168,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3222,6 +3222,7 @@ dependencies = [
  "unicode-width 0.2.0",
  "usvg",
  "uuid",
+ "windows",
  "zstd",
 ]
 
@@ -3719,6 +3720,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3729,6 +3751,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3758,6 +3791,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -3868,6 +3911,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3222,7 +3222,7 @@ dependencies = [
  "unicode-width 0.2.0",
  "usvg",
  "uuid",
- "windows",
+ "windows-sys 0.61.2",
  "zstd",
 ]
 
@@ -3720,27 +3720,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3751,17 +3730,6 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
 ]
 
 [[package]]
@@ -3791,16 +3759,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core",
- "windows-link",
-]
 
 [[package]]
 name = "windows-result"
@@ -3911,15 +3869,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -120,7 +120,10 @@ arboard = { version = "3", default-features = false }
 reqwest = { workspace = true, features = ["native-tls-vendored"] }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.62", features = ["Win32_Security_Credentials", "Win32_Foundation"] }
+# windows-sys 0.61 is already in the lockfile via clap/colored/rpassword,
+# so this adds no new dependency versions. Unlike the windows crate it needs
+# no `Win32_Foundation` feature — the foundation types live in `windows_sys::core`.
+windows-sys = { version = "0.61", features = ["Win32_Security_Credentials"] }
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = { workspace = true }

--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -120,9 +120,11 @@ arboard = { version = "3", default-features = false }
 reqwest = { workspace = true, features = ["native-tls-vendored"] }
 
 [target.'cfg(windows)'.dependencies]
-# windows-sys 0.61 is already in the lockfile via clap/colored/rpassword,
-# so this adds no new dependency versions. Unlike the windows crate it needs
-# no `Win32_Foundation` feature — the foundation types live in `windows_sys::core`.
+# windows-sys 0.61 is already in the lockfile via tokio and mio, and via
+# clap's anstyle-wincon/anstyle-query, so this adds no new dependency
+# versions. (colored and rpassword pull 0.59, not 0.61.) Unlike the windows
+# crate it needs no `Win32_Foundation` feature — the foundation types live in
+# `windows_sys::core`.
 windows-sys = { version = "0.61", features = ["Win32_Security_Credentials"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -119,6 +119,9 @@ arboard = { version = "3", default-features = false }
 [target.'cfg(target_os = "linux")'.dependencies]
 reqwest = { workspace = true, features = ["native-tls-vendored"] }
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.62", features = ["Win32_Security_Credentials", "Win32_Foundation"] }
+
 [target.'cfg(unix)'.dependencies]
 signal-hook = { workspace = true }
 

--- a/crates/tokscale-cli/src/commands/usage/copilot.rs
+++ b/crates/tokscale-cli/src/commands/usage/copilot.rs
@@ -134,26 +134,45 @@ fn github_copilot_apps_json_probe() -> String {
         .join(".config")
         .join("github-copilot")
         .join("apps.json");
-    if !path.exists() {
-        return format!("apps.json={} (missing)", path.display());
-    }
-    let Ok(content) = std::fs::read_to_string(&path) else {
-        return format!("apps.json={} (exists, unreadable)", path.display());
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return format!("apps.json={} (missing)", path.display());
+        }
+        Err(_) => return format!("apps.json={} (exists, unreadable)", path.display()),
     };
     let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
         return format!("apps.json={} (exists, not valid JSON)", path.display());
     };
 
     // Only report the shape, never any value: `oauth`/`github.com`/`token`
-    // keys may hold the OAuth token. The text search is case-insensitive so
-    // an embedded token field is detected regardless of casing.
-    let mut fields: Vec<&str> = Vec::new();
-    let lower = content.to_lowercase();
-    for needle in ["oauth", "github.com", "token"] {
-        if lower.contains(needle) {
-            fields.push(needle);
+    // keys may hold the OAuth token. Walk the parsed JSON and match object
+    // keys case-insensitively, so an embedded token field is detected
+    // without a raw text search that would also flag token values.
+    let mut found = std::collections::HashSet::new();
+    let mut stack = vec![&json];
+    while let Some(value) = stack.pop() {
+        match value {
+            serde_json::Value::Object(map) => {
+                for (key, child) in map {
+                    if ["oauth", "github.com", "token"]
+                        .iter()
+                        .any(|n| key.eq_ignore_ascii_case(n))
+                    {
+                        found.insert(key.to_lowercase());
+                    }
+                    stack.push(child);
+                }
+            }
+            serde_json::Value::Array(arr) => stack.extend(arr),
+            _ => {}
         }
     }
+    let fields: Vec<&str> = ["oauth", "github.com", "token"]
+        .iter()
+        .copied()
+        .filter(|n| found.contains(*n))
+        .collect();
     let top_level_keys = json.as_object().map(|o| o.keys().count()).unwrap_or(0);
     let fields_desc = if fields.is_empty() {
         "no oauth/token fields".to_string()
@@ -445,9 +464,51 @@ pub fn fetch() -> Result<UsageOutput> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+    use std::ffi::{OsStr, OsString};
     use tempfile::TempDir;
 
+    /// RAII restore of process-global env vars, mirroring
+    /// `tokscale_core::paths::test_env::EnvGuard` (which is `pub(crate)` to
+    /// the core crate and cannot be imported here). The manual
+    /// save/restore pairs this replaces only ran the restore when the test
+    /// reached the end of its body — a failing assertion panics first and
+    /// leaves the redirect in place. Restoring on `Drop` unwinds correctly.
+    struct EnvGuard(Vec<(&'static str, Option<OsString>)>);
+
+    impl EnvGuard {
+        fn capture(keys: &[&'static str]) -> Self {
+            Self(
+                keys.iter()
+                    .map(|key| (*key, std::env::var_os(key)))
+                    .collect(),
+            )
+        }
+
+        fn set(&mut self, key: &str, value: impl AsRef<OsStr>) {
+            unsafe { std::env::set_var(key, value) };
+        }
+
+        fn remove(&mut self, key: &str) {
+            unsafe { std::env::remove_var(key) };
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, previous) in self.0.drain(..) {
+                unsafe {
+                    match previous {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
     #[test]
+    #[serial]
     fn wincred_probe_never_leaks_token_on_non_windows() {
         // On Linux the probe must not attempt a credential read at all.
         // The compile-time cfg keeps the windows import out of non-windows
@@ -462,23 +523,16 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn apps_json_probe_reports_missing_file_without_error() {
         let temp = TempDir::new().unwrap();
         // Point HOME at an empty dir so the probe resolves a missing path
         // and reports it as such (silent not-found, no panic).
         let dir = temp.path().join("home");
         std::fs::create_dir_all(&dir).unwrap();
-        let _prev_home = std::env::var_os("HOME");
-        unsafe {
-            std::env::set_var("HOME", &dir);
-        }
+        let mut guard = EnvGuard::capture(&["HOME"]);
+        guard.set("HOME", &dir);
         let probe = github_copilot_apps_json_probe();
-        unsafe {
-            match _prev_home {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
         assert!(
             probe.contains("(missing)") || probe.contains("home dir unavailable"),
             "expected missing-file probe, got: {probe}"
@@ -486,6 +540,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn apps_json_probe_flags_token_fields_without_printing_values() {
         let temp = TempDir::new().unwrap();
         let dir = temp.path().join("home");
@@ -498,17 +553,9 @@ mod tests {
         )
         .unwrap();
 
-        let _prev_home = std::env::var_os("HOME");
-        unsafe {
-            std::env::set_var("HOME", &dir);
-        }
+        let mut guard = EnvGuard::capture(&["HOME"]);
+        guard.set("HOME", &dir);
         let probe = github_copilot_apps_json_probe();
-        unsafe {
-            match _prev_home {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         assert!(probe.contains("valid JSON"), "got: {probe}");
         assert!(
@@ -526,6 +573,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn apps_json_probe_handles_invalid_json_gracefully() {
         let temp = TempDir::new().unwrap();
         let dir = temp.path().join("home");
@@ -533,17 +581,9 @@ mod tests {
         std::fs::create_dir_all(apps.parent().unwrap()).unwrap();
         std::fs::write(&apps, "this is { not json").unwrap();
 
-        let _prev_home = std::env::var_os("HOME");
-        unsafe {
-            std::env::set_var("HOME", &dir);
-        }
+        let mut guard = EnvGuard::capture(&["HOME"]);
+        guard.set("HOME", &dir);
         let probe = github_copilot_apps_json_probe();
-        unsafe {
-            match _prev_home {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
 
         assert!(
             probe.contains("not valid JSON"),
@@ -552,6 +592,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn credential_probe_contains_wincred_and_apps_json_entries() {
         let probes = credential_probe();
         assert!(

--- a/crates/tokscale-cli/src/commands/usage/copilot.rs
+++ b/crates/tokscale-cli/src/commands/usage/copilot.rs
@@ -68,21 +68,61 @@ fn gh_wincred_targets_display() -> String {
         .join(", ")
 }
 
+/// Fold per-target lookup outcomes into the first hit, or into one error that
+/// says what each candidate actually reported.
+///
+/// Split out of `read_gh_wincred` because only the `read_wincred` call is
+/// Windows-specific — deciding what to tell the user is not, and inside a
+/// `#[cfg(target_os = "windows")]` function it was compiled by no CI job that
+/// could run its tests.
+///
+/// The behaviour is also new. The loop this replaces matched with
+/// `if let Ok(value)`, which discarded the error from every candidate, so a
+/// credential store that answered `ERROR_ACCESS_DENIED` was reported in the
+/// same words as one that had simply never been written: "missing". That is
+/// the opposite of what a diagnostic probe is for, and it is the failure mode
+/// #1194 was opened about.
+#[cfg_attr(
+    not(target_os = "windows"),
+    allow(
+        dead_code,
+        reason = "windows-only caller; the tests below cover it everywhere"
+    )
+)]
+fn first_wincred_hit<E: std::fmt::Display>(
+    attempts: impl IntoIterator<Item = (String, std::result::Result<String, E>)>,
+) -> Result<(String, String)> {
+    let mut failures = Vec::new();
+    for (target, outcome) in attempts {
+        match outcome {
+            Ok(value) => return Ok((target, value)),
+            Err(error) => failures.push(format!("\"{target}\" -> {error}")),
+        }
+    }
+    anyhow::bail!(
+        "No `gh` credential in the Windows Credential Manager. \
+         Run `gh auth login`, or run `cmdkey /list` and report the target name \
+         it shows for GitHub. Tried {}",
+        if failures.is_empty() {
+            "no targets".to_string()
+        } else {
+            failures.join("; ")
+        }
+    )
+}
+
 /// Windows only: the first candidate target that holds a credential, together
 /// with the target it was found at, so callers can report what actually
 /// matched instead of what they hoped would match.
 #[cfg(target_os = "windows")]
 fn read_gh_wincred() -> Result<(String, String)> {
-    for target in gh_wincred_targets(GH_KEYRING_SERVICE) {
-        if let Ok(value) = super::helpers::read_wincred(&target) {
-            return Ok((target, value));
-        }
-    }
-    anyhow::bail!(
-        "No `gh` credential in the Windows Credential Manager (tried: {}). \
-         Run `gh auth login`, or run `cmdkey /list` and report the target name \
-         it shows for GitHub.",
-        gh_wincred_targets_display()
+    first_wincred_hit(
+        gh_wincred_targets(GH_KEYRING_SERVICE)
+            .into_iter()
+            .map(|target| {
+                let outcome = super::helpers::read_wincred(&target);
+                (target, outcome)
+            }),
     )
 }
 
@@ -187,7 +227,9 @@ fn wincred_probe() -> String {
                     "wincred=\"{target}\" (found, {prefix}, blob={blob_len} bytes, token omitted)"
                 )
             }
-            Err(_) => format!("wincred=missing (tried: {})", gh_wincred_targets_display()),
+            // Not "missing": the read can also fail because the store refused
+            // us. `error` names every target tried and what each one said.
+            Err(error) => format!("wincred=none ({error})"),
         }
     }
     #[cfg(not(target_os = "windows"))]
@@ -577,6 +619,7 @@ mod tests {
     use super::*;
     use serial_test::serial;
     use std::ffi::{OsStr, OsString};
+    use std::path::Path;
     use tempfile::TempDir;
 
     /// RAII restore of process-global env vars, mirroring
@@ -615,6 +658,55 @@ mod tests {
                     }
                 }
             }
+        }
+    }
+
+    /// Every environment variable that can steer `github_copilot_apps_json_candidates`
+    /// to a real user's file.
+    ///
+    /// `HOME` alone is not enough. On Windows the `%LOCALAPPDATA%` candidate is
+    /// tried *first*, and the probe takes the first path that exists, so a test
+    /// that redirects only `HOME` reads the developer's or the runner's real
+    /// `github-copilot/apps.json` — a file that holds a live GitHub OAuth
+    /// token. `USERPROFILE` is here because `dirs::home_dir()` falls back to it
+    /// whenever the `HOME` override is rejected as non-absolute.
+    const HOME_ENV_KEYS: [&str; 3] = ["HOME", "LOCALAPPDATA", "USERPROFILE"];
+
+    /// Point every home-ish variable at `dir`, so the probe can only ever
+    /// resolve inside the caller's `TempDir`.
+    fn redirect_home(guard: &mut EnvGuard, dir: &Path) {
+        guard.set("HOME", dir);
+        guard.set("LOCALAPPDATA", dir.join("AppData").join("Local"));
+        guard.set("USERPROFILE", dir);
+    }
+
+    /// The guard above is only worth anything if it actually contains every
+    /// candidate. This asserts that on whichever platform it runs, rather than
+    /// trusting that the `#[cfg(windows)]` arm of the candidate list was
+    /// remembered when someone adds a fourth location.
+    #[test]
+    #[serial]
+    fn apps_json_candidates_stay_inside_a_redirected_home() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("home");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut guard = EnvGuard::capture(&HOME_ENV_KEYS);
+        redirect_home(&mut guard, &dir);
+        let candidates = github_copilot_apps_json_candidates();
+
+        assert!(
+            !candidates.is_empty(),
+            "the probe must offer at least one candidate under a redirected home"
+        );
+        for candidate in &candidates {
+            assert!(
+                candidate.starts_with(&dir),
+                "candidate {} escapes the redirected home {}; a test using it \
+                 would read the real user's Copilot credentials",
+                candidate.display(),
+                dir.display()
+            );
         }
     }
 
@@ -665,6 +757,64 @@ mod tests {
         assert_eq!(display, "\"gh:github.com:\", \"gh:github.com\"");
     }
 
+    /// The whole point of the split: these run on Linux and macOS, where the
+    /// Windows credential path is not even compiled.
+    #[test]
+    fn first_wincred_hit_returns_the_target_that_matched() {
+        let attempts: Vec<(String, std::result::Result<String, String>)> = vec![
+            ("gh:github.com:".to_string(), Err("not found".to_string())),
+            ("gh:github.com".to_string(), Ok("gho_token".to_string())),
+        ];
+        let (target, value) = first_wincred_hit(attempts).unwrap();
+        assert_eq!(target, "gh:github.com");
+        assert_eq!(value, "gho_token");
+    }
+
+    #[test]
+    fn first_wincred_hit_stops_at_the_first_match() {
+        let attempts: Vec<(String, std::result::Result<String, String>)> = vec![
+            ("first".to_string(), Ok("a".to_string())),
+            ("second".to_string(), Ok("b".to_string())),
+        ];
+        assert_eq!(first_wincred_hit(attempts).unwrap().0, "first");
+    }
+
+    /// The regression this replaced: `if let Ok(..)` threw the reason away, so
+    /// a store that refused the read and a store that was never written both
+    /// came out as the word "missing".
+    #[test]
+    fn first_wincred_hit_reports_why_each_target_failed() {
+        let attempts: Vec<(String, std::result::Result<String, String>)> = vec![
+            (
+                "gh:github.com:".to_string(),
+                Err("CredReadW failed: Access is denied. (os error 5)".to_string()),
+            ),
+            (
+                "gh:github.com".to_string(),
+                Err("CredReadW failed: Element not found. (os error 1168)".to_string()),
+            ),
+        ];
+        let error = first_wincred_hit(attempts).unwrap_err().to_string();
+
+        assert!(error.contains("Access is denied"), "got: {error}");
+        assert!(error.contains("Element not found"), "got: {error}");
+        for target in ["gh:github.com:", "gh:github.com"] {
+            assert!(
+                error.contains(&format!("\"{target}\"")),
+                "error must name every target it tried ({target}), got: {error}"
+            );
+        }
+    }
+
+    /// `gh_wincred_targets` returns two, so this cannot happen today; the
+    /// helper is generic and must not produce a dangling "Tried " either way.
+    #[test]
+    fn first_wincred_hit_survives_an_empty_candidate_list() {
+        let attempts: Vec<(String, std::result::Result<String, String>)> = Vec::new();
+        let error = first_wincred_hit(attempts).unwrap_err().to_string();
+        assert!(error.contains("no targets"), "got: {error}");
+    }
+
     #[test]
     #[serial]
     fn wincred_probe_names_every_target_it_tries() {
@@ -713,8 +863,8 @@ mod tests {
         // and reports it as such (silent not-found, no panic).
         let dir = temp.path().join("home");
         std::fs::create_dir_all(&dir).unwrap();
-        let mut guard = EnvGuard::capture(&["HOME"]);
-        guard.set("HOME", &dir);
+        let mut guard = EnvGuard::capture(&HOME_ENV_KEYS);
+        redirect_home(&mut guard, &dir);
         let probe = github_copilot_apps_json_probe();
         assert!(
             probe.contains("(missing)") || probe.contains("home dir unavailable"),
@@ -736,8 +886,8 @@ mod tests {
         )
         .unwrap();
 
-        let mut guard = EnvGuard::capture(&["HOME"]);
-        guard.set("HOME", &dir);
+        let mut guard = EnvGuard::capture(&HOME_ENV_KEYS);
+        redirect_home(&mut guard, &dir);
         let probe = github_copilot_apps_json_probe();
 
         assert!(probe.contains("valid JSON"), "got: {probe}");
@@ -764,8 +914,8 @@ mod tests {
         std::fs::create_dir_all(apps.parent().unwrap()).unwrap();
         std::fs::write(&apps, "this is { not json").unwrap();
 
-        let mut guard = EnvGuard::capture(&["HOME"]);
-        guard.set("HOME", &dir);
+        let mut guard = EnvGuard::capture(&HOME_ENV_KEYS);
+        redirect_home(&mut guard, &dir);
         let probe = github_copilot_apps_json_probe();
 
         assert!(

--- a/crates/tokscale-cli/src/commands/usage/copilot.rs
+++ b/crates/tokscale-cli/src/commands/usage/copilot.rs
@@ -83,6 +83,7 @@ pub(super) fn credential_probe() -> Vec<String> {
             }
         ));
     }
+    probes.push(wincred_probe());
     for path in hosts_candidates() {
         probes.push(format!(
             "hosts={} ({})",
@@ -90,7 +91,79 @@ pub(super) fn credential_probe() -> Vec<String> {
             if path.exists() { "exists" } else { "missing" }
         ));
     }
+    probes.push(github_copilot_apps_json_probe());
     probes
+}
+
+/// Probe-only: reports whether a credential is stored in the Windows
+/// Credential Manager for the `gh:github.com` target. Never returns the
+/// token itself — only presence, blob length, and whether it is
+/// base64-encoded. On non-Windows this probe is not applicable.
+fn wincred_probe() -> String {
+    #[cfg(target_os = "windows")]
+    {
+        const SERVICE: &str = "gh:github.com";
+        match super::helpers::read_keychain(SERVICE) {
+            Ok(cred) => {
+                let (prefix, blob_len) = match cred.strip_prefix("go-keyring-base64:") {
+                    Some(encoded) => ("go-keyring-base64", encoded.len()),
+                    None => ("plain", cred.len()),
+                };
+                format!("wincred={SERVICE} (found, {prefix}, blob={blob_len} bytes, token omitted)")
+            }
+            Err(_) => format!("wincred={SERVICE} (missing)"),
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        "wincred=gh:github.com (not-applicable on non-windows)".to_string()
+    }
+}
+
+/// Probe-only: checks whether the VS Code Copilot extension keeps a
+/// credential file at `~/.config/github-copilot/apps.json` (Worth checking:
+/// it may hold an OAuth token similar to the one the CLI uses). The probe
+/// reports presence, JSON validity, and which token-like fields exist, but
+/// the value is never read into `read_credentials` — this is observability
+/// only, to be verified before any automatic use is considered.
+fn github_copilot_apps_json_probe() -> String {
+    let Some(home) = crate::paths::home_dir() else {
+        return "apps.json (home dir unavailable)".to_string();
+    };
+    let path = home
+        .join(".config")
+        .join("github-copilot")
+        .join("apps.json");
+    if !path.exists() {
+        return format!("apps.json={} (missing)", path.display());
+    }
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return format!("apps.json={} (exists, unreadable)", path.display());
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return format!("apps.json={} (exists, not valid JSON)", path.display());
+    };
+
+    // Only report the shape, never any value: `oauth`/`github.com`/`token`
+    // keys may hold the OAuth token. The text search is case-insensitive so
+    // an embedded token field is detected regardless of casing.
+    let mut fields: Vec<&str> = Vec::new();
+    let lower = content.to_lowercase();
+    for needle in ["oauth", "github.com", "token"] {
+        if lower.contains(needle) {
+            fields.push(needle);
+        }
+    }
+    let top_level_keys = json.as_object().map(|o| o.keys().count()).unwrap_or(0);
+    let fields_desc = if fields.is_empty() {
+        "no oauth/token fields".to_string()
+    } else {
+        format!("fields=[{}]", fields.join(","))
+    };
+    format!(
+        "apps.json={} (exists, valid JSON, top_level_keys={top_level_keys}, {fields_desc}, probe-only)",
+        path.display()
+    )
 }
 
 fn gh_config_dir() -> std::path::PathBuf {
@@ -367,4 +440,127 @@ pub fn fetch() -> Result<UsageOutput> {
             spend_control: None,
         })
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn wincred_probe_never_leaks_token_on_non_windows() {
+        // On Linux the probe must not attempt a credential read at all.
+        // The compile-time cfg keeps the windows import out of non-windows
+        // builds, so this is both a behavioral and a linkage check.
+        let probe = wincred_probe();
+        if cfg!(not(target_os = "windows")) {
+            assert!(
+                probe.contains("not-applicable"),
+                "non-windows probe should report not-applicable, got: {probe}"
+            );
+        }
+    }
+
+    #[test]
+    fn apps_json_probe_reports_missing_file_without_error() {
+        let temp = TempDir::new().unwrap();
+        // Point HOME at an empty dir so the probe resolves a missing path
+        // and reports it as such (silent not-found, no panic).
+        let dir = temp.path().join("home");
+        std::fs::create_dir_all(&dir).unwrap();
+        let _prev_home = std::env::var_os("HOME");
+        unsafe {
+            std::env::set_var("HOME", &dir);
+        }
+        let probe = github_copilot_apps_json_probe();
+        unsafe {
+            match _prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        assert!(
+            probe.contains("(missing)") || probe.contains("home dir unavailable"),
+            "expected missing-file probe, got: {probe}"
+        );
+    }
+
+    #[test]
+    fn apps_json_probe_flags_token_fields_without_printing_values() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("home");
+        let apps = dir.join(".config").join("github-copilot").join("apps.json");
+        std::fs::create_dir_all(apps.parent().unwrap()).unwrap();
+        // A realistic-ish VS Code Copilot apps.json with an OAuth token.
+        std::fs::write(
+            &apps,
+            r#"{"github.com":{"oauth":"gho_AAAA_secret","token":"gho_BBBB"}}"#,
+        )
+        .unwrap();
+
+        let _prev_home = std::env::var_os("HOME");
+        unsafe {
+            std::env::set_var("HOME", &dir);
+        }
+        let probe = github_copilot_apps_json_probe();
+        unsafe {
+            match _prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(probe.contains("valid JSON"), "got: {probe}");
+        assert!(
+            probe.contains("fields=[oauth,github.com,token]"),
+            "got: {probe}"
+        );
+        assert!(
+            !probe.contains("gho_"),
+            "probe must not leak token values, got: {probe}"
+        );
+        assert!(
+            probe.contains("probe-only"),
+            "probe should be marked probe-only, got: {probe}"
+        );
+    }
+
+    #[test]
+    fn apps_json_probe_handles_invalid_json_gracefully() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("home");
+        let apps = dir.join(".config").join("github-copilot").join("apps.json");
+        std::fs::create_dir_all(apps.parent().unwrap()).unwrap();
+        std::fs::write(&apps, "this is { not json").unwrap();
+
+        let _prev_home = std::env::var_os("HOME");
+        unsafe {
+            std::env::set_var("HOME", &dir);
+        }
+        let probe = github_copilot_apps_json_probe();
+        unsafe {
+            match _prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(
+            probe.contains("not valid JSON"),
+            "invalid JSON should be reported without error, got: {probe}"
+        );
+    }
+
+    #[test]
+    fn credential_probe_contains_wincred_and_apps_json_entries() {
+        let probes = credential_probe();
+        assert!(
+            probes.iter().any(|p| p.starts_with("wincred=")),
+            "missing wincred probe: {probes:?}"
+        );
+        assert!(
+            probes.iter().any(|p| p.starts_with("apps.json=")),
+            "missing apps.json probe: {probes:?}"
+        );
+    }
 }

--- a/crates/tokscale-cli/src/commands/usage/copilot.rs
+++ b/crates/tokscale-cli/src/commands/usage/copilot.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use serde::Deserialize;
 
-use super::helpers::{capitalize, read_keychain};
+use super::helpers::capitalize;
 use super::{UsageMetric, UsageOutput};
 
 #[derive(Debug, Deserialize)]
@@ -33,8 +33,79 @@ struct FreeResponse {
     limited_user_reset_date: Option<String>,
 }
 
+/// The `keyring` service name the GitHub CLI stores its token under.
+/// `gh` composes it as `"gh:" + hostname` (cli/cli `keyringServiceName`).
+const GH_KEYRING_SERVICE: &str = "gh:github.com";
+
+/// Windows Credential Manager target names to try for the `gh` token, most
+/// likely first.
+///
+/// `CredReadW` is an exact lookup, so the target has to be reproduced exactly,
+/// and it is not the service name. Go's `go-keyring` — which `gh` uses —
+/// composes the target as `service + ":" + username` (`credName` in
+/// keyring_windows.go), and `gh` stores and reads its *active* token with an
+/// empty username (`keyring.Get(keyringServiceName(host), "")` in cli/cli
+/// internal/config/config.go, reached from `Login` via `activateUser`). So the
+/// entry every successful `gh auth login` leaves behind is `"gh:github.com:"`,
+/// with a trailing colon.
+///
+/// The bare service name follows as a last resort. `gh` never writes it, but
+/// trying it costs one failed lookup and keeps this a superset of the target
+/// this code used to try, so no machine where a token happens to sit there
+/// gets worse.
+fn gh_wincred_targets(service: &str) -> [String; 2] {
+    [format!("{service}:"), service.to_string()]
+}
+
+/// The candidate targets, quoted, for probe and error messages. Quoting
+/// matters: `gh:github.com` is a prefix of `gh:github.com:`, so an unquoted
+/// list reads as one repeated name.
+fn gh_wincred_targets_display() -> String {
+    gh_wincred_targets(GH_KEYRING_SERVICE)
+        .iter()
+        .map(|target| format!("\"{target}\""))
+        .collect::<Vec<String>>()
+        .join(", ")
+}
+
+/// Windows only: the first candidate target that holds a credential, together
+/// with the target it was found at, so callers can report what actually
+/// matched instead of what they hoped would match.
+#[cfg(target_os = "windows")]
+fn read_gh_wincred() -> Result<(String, String)> {
+    for target in gh_wincred_targets(GH_KEYRING_SERVICE) {
+        if let Ok(value) = super::helpers::read_wincred(&target) {
+            return Ok((target, value));
+        }
+    }
+    anyhow::bail!(
+        "No `gh` credential in the Windows Credential Manager (tried: {}). \
+         Run `gh auth login`, or run `cmdkey /list` and report the target name \
+         it shows for GitHub.",
+        gh_wincred_targets_display()
+    )
+}
+
+/// Reads the raw `gh` secret from the platform credential store.
+///
+/// Single entry point on purpose: `read_token_from_keychain`,
+/// `has_credentials` and `wincred_probe` each used to call
+/// `read_keychain("gh:github.com")` themselves, so a fix to one of them left
+/// the other two — including the one that gates the provider card — still
+/// looking in the wrong place.
+fn read_gh_secret() -> Result<String> {
+    #[cfg(target_os = "windows")]
+    {
+        read_gh_wincred().map(|(_target, value)| value)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        super::helpers::read_keychain(GH_KEYRING_SERVICE)
+    }
+}
+
 fn read_token_from_keychain() -> Result<String> {
-    let raw = read_keychain("gh:github.com")?;
+    let raw = read_gh_secret()?;
     // go-keyring may base64-encode the value
     if let Some(encoded) = raw.strip_prefix("go-keyring-base64:") {
         let decoded = base64_decode(encoded)?;
@@ -95,45 +166,85 @@ pub(super) fn credential_probe() -> Vec<String> {
     probes
 }
 
-/// Probe-only: reports whether a credential is stored in the Windows
-/// Credential Manager for the `gh:github.com` target. Never returns the
-/// token itself — only presence, blob length, and whether it is
-/// base64-encoded. On non-Windows this probe is not applicable.
+/// Probe-only: reports whether the Windows Credential Manager holds a `gh`
+/// credential. Never returns the token itself — only presence, blob length,
+/// and whether it is base64-encoded.
+///
+/// The probe names the exact target it hit, or every target it tried when it
+/// found nothing. That is the whole point: this is the line a #1194 reporter
+/// pastes next to `cmdkey /list`, and it is useless if it prints a name the
+/// code never looked up.
 fn wincred_probe() -> String {
     #[cfg(target_os = "windows")]
     {
-        const SERVICE: &str = "gh:github.com";
-        match super::helpers::read_keychain(SERVICE) {
-            Ok(cred) => {
+        match read_gh_wincred() {
+            Ok((target, cred)) => {
                 let (prefix, blob_len) = match cred.strip_prefix("go-keyring-base64:") {
                     Some(encoded) => ("go-keyring-base64", encoded.len()),
                     None => ("plain", cred.len()),
                 };
-                format!("wincred={SERVICE} (found, {prefix}, blob={blob_len} bytes, token omitted)")
+                format!(
+                    "wincred=\"{target}\" (found, {prefix}, blob={blob_len} bytes, token omitted)"
+                )
             }
-            Err(_) => format!("wincred={SERVICE} (missing)"),
+            Err(_) => format!("wincred=missing (tried: {})", gh_wincred_targets_display()),
         }
     }
     #[cfg(not(target_os = "windows"))]
     {
-        "wincred=gh:github.com (not-applicable on non-windows)".to_string()
+        format!(
+            "wincred=not-applicable on non-windows (would try: {})",
+            gh_wincred_targets_display()
+        )
     }
 }
 
+/// Where the Copilot editor integrations keep `apps.json`, most likely first.
+///
+/// The POSIX path was reported on every platform, so on Windows the probe
+/// printed a guaranteed "missing" for a path Copilot never writes — a false
+/// negative aimed squarely at the users this probe exists to help. Windows
+/// keeps it under `%LOCALAPPDATA%`; `~/.config` stays in the list everywhere
+/// so a wrong guess about the Windows convention still finds the file.
+fn github_copilot_apps_json_candidates() -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    let home = crate::paths::home_dir();
+    #[cfg(windows)]
+    {
+        if let Some(local) = std::env::var_os("LOCALAPPDATA") {
+            dirs.push(PathBuf::from(local).join("github-copilot"));
+        }
+        if let Some(home) = home.as_ref() {
+            let local = home.join("AppData").join("Local").join("github-copilot");
+            if !dirs.contains(&local) {
+                dirs.push(local);
+            }
+        }
+    }
+    if let Some(home) = home {
+        dirs.push(home.join(".config").join("github-copilot"));
+    }
+    dirs.into_iter().map(|dir| dir.join("apps.json")).collect()
+}
+
 /// Probe-only: checks whether the VS Code Copilot extension keeps a
-/// credential file at `~/.config/github-copilot/apps.json` (Worth checking:
+/// credential file in the `github-copilot` config directory (Worth checking:
 /// it may hold an OAuth token similar to the one the CLI uses). The probe
 /// reports presence, JSON validity, and which token-like fields exist, but
 /// the value is never read into `read_credentials` — this is observability
 /// only, to be verified before any automatic use is considered.
 fn github_copilot_apps_json_probe() -> String {
-    let Some(home) = crate::paths::home_dir() else {
+    let candidates = github_copilot_apps_json_candidates();
+    let Some(first) = candidates.first().cloned() else {
         return "apps.json (home dir unavailable)".to_string();
     };
-    let path = home
-        .join(".config")
-        .join("github-copilot")
-        .join("apps.json");
+    // Report the file that exists; when none does, report the most likely
+    // location for this platform so the "missing" line still names a path
+    // worth checking.
+    let path = candidates
+        .into_iter()
+        .find(|candidate| candidate.exists())
+        .unwrap_or(first);
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -339,7 +450,7 @@ pub fn has_credentials() -> bool {
     if token_from_env().is_some() {
         return true;
     }
-    if super::helpers::read_keychain("gh:github.com").is_ok() {
+    if read_gh_secret().is_ok() {
         return true;
     }
     parse_token_from_hosts().is_ok()
@@ -503,6 +614,78 @@ mod tests {
                         None => std::env::remove_var(key),
                     }
                 }
+            }
+        }
+    }
+
+    /// Mirrors `credName` from go-keyring's keyring_windows.go, which is what
+    /// composes every Windows target name `gh` reads or writes.
+    fn go_keyring_cred_name(service: &str, username: &str) -> String {
+        format!("{service}:{username}")
+    }
+
+    #[test]
+    fn primary_wincred_target_is_the_slot_gh_writes_for_the_active_account() {
+        // This is the regression guard for #1194. The Windows lookup used to
+        // pass the bare service name as the CredReadW target, which cannot
+        // match: `gh` stores its active token through go-keyring with an empty
+        // username, so the target is the service name plus a trailing colon.
+        // CredReadW is an exact lookup, so "one colon short" means
+        // ERROR_NOT_FOUND on every machine.
+        let targets = gh_wincred_targets(GH_KEYRING_SERVICE);
+        assert_eq!(targets[0], go_keyring_cred_name(GH_KEYRING_SERVICE, ""));
+        assert_eq!(targets[0], "gh:github.com:");
+        assert_ne!(
+            targets[0], GH_KEYRING_SERVICE,
+            "the primary target must not be the bare service name"
+        );
+    }
+
+    #[test]
+    fn wincred_targets_keep_the_bare_service_name_as_a_distinct_fallback() {
+        let targets = gh_wincred_targets(GH_KEYRING_SERVICE);
+        assert_eq!(targets[1], GH_KEYRING_SERVICE);
+        assert_ne!(targets[0], targets[1], "candidates must not duplicate");
+    }
+
+    #[test]
+    fn wincred_targets_compose_from_the_service_argument() {
+        // Not hardcoded to github.com, so a future enterprise-host change
+        // keeps the composition rule.
+        let targets = gh_wincred_targets("gh:ghe.example.com");
+        assert_eq!(targets[0], "gh:ghe.example.com:");
+        assert_eq!(targets[1], "gh:ghe.example.com");
+    }
+
+    #[test]
+    fn wincred_targets_display_quotes_each_candidate() {
+        // Unquoted, "gh:github.com" is a prefix of "gh:github.com:" and the
+        // list reads as the same name twice.
+        let display = gh_wincred_targets_display();
+        assert_eq!(display, "\"gh:github.com:\", \"gh:github.com\"");
+    }
+
+    #[test]
+    #[serial]
+    fn wincred_probe_names_every_target_it_tries() {
+        let probe = wincred_probe();
+        assert!(probe.starts_with("wincred="), "got: {probe}");
+        let targets = gh_wincred_targets(GH_KEYRING_SERVICE);
+        if probe.contains("(found") {
+            // A real credential exists on this machine (possible on a Windows
+            // runner): the probe must name the target that actually matched.
+            assert!(
+                targets
+                    .iter()
+                    .any(|target| probe.contains(&format!("\"{target}\""))),
+                "found-probe must name a candidate target, got: {probe}"
+            );
+        } else {
+            for target in &targets {
+                assert!(
+                    probe.contains(&format!("\"{target}\"")),
+                    "probe must name the target it tried ({target}), got: {probe}"
+                );
             }
         }
     }

--- a/crates/tokscale-cli/src/commands/usage/helpers.rs
+++ b/crates/tokscale-cli/src/commands/usage/helpers.rs
@@ -51,7 +51,12 @@ fn read_wincred(service: &str) -> Result<String> {
     // On windows-rs 0.62 CredReadW returns Result<()>; on failure it carries
     // the Win32 error (e.g. ERROR_NOT_FOUND when the user never ran `gh auth login`).
     unsafe {
-        CredReadW(PCWSTR(wide.as_ptr()), CRED_TYPE_GENERIC, None, &mut cred_ptr)?;
+        CredReadW(
+            PCWSTR(wide.as_ptr()),
+            CRED_TYPE_GENERIC,
+            None,
+            &mut cred_ptr,
+        )?;
         if cred_ptr.is_null() {
             anyhow::bail!("CredReadW returned null credential for service '{service}'");
         }
@@ -65,8 +70,9 @@ fn read_wincred(service: &str) -> Result<String> {
         // `go-keyring` / `gh` stores the token as raw UTF-8 bytes (with an
         // optional `go-keyring-base64:` prefix handled by the caller).
         let slice = std::slice::from_raw_parts(blob_ptr, blob_size);
-        let raw = String::from_utf8(slice.to_vec())?;
+        let raw = String::from_utf8(slice.to_vec());
         CredFree(cred_ptr as *const std::ffi::c_void);
+        let raw = raw?;
         let token = raw.trim_end_matches('\0').trim_end().to_string();
         if token.is_empty() {
             anyhow::bail!("Empty token for service '{service}'");

--- a/crates/tokscale-cli/src/commands/usage/helpers.rs
+++ b/crates/tokscale-cli/src/commands/usage/helpers.rs
@@ -9,6 +9,19 @@ pub fn capitalize(s: &str) -> String {
     }
 }
 
+/// Reads a secret from the platform credential store.
+///
+/// `service` means different things per platform, because the two stores have
+/// different lookup semantics and the same string cannot serve both:
+///
+/// * macOS: `security find-generic-password -s <service>` matches on the
+///   *service attribute alone* and ignores the account, so a bare service name
+///   resolves whatever account the item was stored under.
+/// * Windows: the Credential Manager has no service attribute. `CredReadW` is
+///   an exact match on the full `TargetName` and supports no wildcards, so the
+///   caller must pass a complete target name. For anything written by Go's
+///   `go-keyring` (which is what `gh` uses) that is `"<service>:<username>"`,
+///   never the bare `"<service>"` — see `copilot::gh_wincred_targets`.
 pub fn read_keychain(service: &str) -> Result<String> {
     #[cfg(target_os = "macos")]
     {
@@ -18,12 +31,15 @@ pub fn read_keychain(service: &str) -> Result<String> {
         if !out.status.success() {
             anyhow::bail!("Keychain lookup failed for service '{service}'");
         }
-        return Ok(String::from_utf8(out.stdout)?.trim_end().to_string());
+        Ok(String::from_utf8(out.stdout)?.trim_end().to_string())
     }
 
     #[cfg(target_os = "windows")]
     {
-        return read_wincred(service);
+        // The caller supplies a full Windows target name here; this helper
+        // does not compose one, because the composition rule belongs to
+        // whichever library wrote the credential.
+        read_wincred(service)
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
@@ -33,14 +49,20 @@ pub fn read_keychain(service: &str) -> Result<String> {
     }
 }
 
+/// Reads a credential blob from the Windows Credential Manager.
+///
+/// `target` must be the *full* `TargetName` exactly as stored: `CredReadW`
+/// with `CRED_TYPE_GENERIC` is an exact lookup with no prefix or wildcard
+/// matching, so a target that is one character short simply reports
+/// `ERROR_NOT_FOUND`.
 #[cfg(target_os = "windows")]
-fn read_wincred(service: &str) -> Result<String> {
+pub(super) fn read_wincred(target: &str) -> Result<String> {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
     use windows_sys::Win32::Security::Credentials::{CredFree, CredReadW, CRED_TYPE_GENERIC};
 
     // CredReadW expects a null-terminated UTF-16 target name.
-    let wide: Vec<u16> = OsStr::new(service)
+    let wide: Vec<u16> = OsStr::new(target)
         .encode_wide()
         .chain(std::iter::once(0))
         .collect();
@@ -54,32 +76,49 @@ fn read_wincred(service: &str) -> Result<String> {
         let ok = CredReadW(wide.as_ptr(), CRED_TYPE_GENERIC, 0, &mut cred_ptr);
         if ok == 0 {
             anyhow::bail!(
-                "CredReadW failed for service '{service}': {}",
+                "CredReadW failed for target '{target}': {}",
                 std::io::Error::last_os_error()
             );
         }
         if cred_ptr.is_null() {
-            anyhow::bail!("CredReadW returned null credential for service '{service}'");
+            anyhow::bail!("CredReadW returned null credential for target '{target}'");
         }
         let cred = &*cred_ptr;
         let blob_size = cred.CredentialBlobSize as usize;
         let blob_ptr = cred.CredentialBlob;
         if blob_ptr.is_null() || blob_size == 0 {
             CredFree(cred_ptr as *const std::ffi::c_void);
-            anyhow::bail!("Empty credential blob for service '{service}'");
+            anyhow::bail!("Empty credential blob for target '{target}'");
         }
-        // `go-keyring` / `gh` stores the token as raw UTF-8 bytes (with an
-        // optional `go-keyring-base64:` prefix handled by the caller).
         let slice = std::slice::from_raw_parts(blob_ptr, blob_size);
-        let raw = String::from_utf8(slice.to_vec());
+        // Decode before freeing, but bind the result so the allocation is
+        // released on the error path too.
+        let decoded = decode_wincred_blob(slice);
         CredFree(cred_ptr as *const std::ffi::c_void);
-        let raw = raw?;
-        let token = raw.trim_end_matches('\0').trim_end().to_string();
-        if token.is_empty() {
-            anyhow::bail!("Empty token for service '{service}'");
-        }
-        Ok(token)
+        decoded.map_err(|e| anyhow::anyhow!("Credential blob for target '{target}': {e}"))
     }
+}
+
+/// Turns a raw Credential Manager blob into a token string.
+///
+/// `go-keyring` stores the secret as plain UTF-8 bytes and `wincred` writes
+/// `CredentialBlob` verbatim with no transcoding and no length prefix, so the
+/// blob is read as UTF-8 and stripped of the trailing NUL padding some writers
+/// add. A blob that still holds a NUL after trimming came from something else
+/// — a UTF-16LE writer, most likely, whose ASCII text is accidentally valid
+/// UTF-8 — and is rejected instead of being handed to the API as a corrupt
+/// token that would come back as a puzzling HTTP 401.
+#[cfg(any(target_os = "windows", test))]
+fn decode_wincred_blob(bytes: &[u8]) -> Result<String> {
+    let raw = String::from_utf8(bytes.to_vec())?;
+    let token = raw.trim_end_matches('\0').trim_end().to_string();
+    if token.is_empty() {
+        anyhow::bail!("blob is empty after trimming NUL padding");
+    }
+    if token.contains('\0') {
+        anyhow::bail!("blob contains an interior NUL byte, so it is not UTF-8 text");
+    }
+    Ok(token)
 }
 
 pub fn format_reset_time(resets_at: &str) -> String {
@@ -182,6 +221,42 @@ mod tests {
     }
 
     #[test]
+    fn wincred_blob_decodes_a_plain_utf8_token() {
+        // go-keyring writes the secret as raw UTF-8 with no transcoding.
+        assert_eq!(decode_wincred_blob(b"gho_example").unwrap(), "gho_example");
+    }
+
+    #[test]
+    fn wincred_blob_trims_nul_padding_and_trailing_whitespace() {
+        assert_eq!(
+            decode_wincred_blob(b"gho_example\0\0").unwrap(),
+            "gho_example"
+        );
+        assert_eq!(
+            decode_wincred_blob(b"gho_example\r\n").unwrap(),
+            "gho_example"
+        );
+    }
+
+    #[test]
+    fn wincred_blob_rejects_an_interior_nul_from_a_utf16_writer() {
+        // "gho_x" as UTF-16LE is accidentally valid UTF-8, so from_utf8 alone
+        // would hand back a mangled token and the API would answer 401 with no
+        // clue why. Reject it and let the caller fall through to hosts.yml.
+        let utf16le = b"g\0h\0o\0_\0x\0";
+        let err = decode_wincred_blob(utf16le).unwrap_err().to_string();
+        assert!(err.contains("interior NUL"), "got: {err}");
+    }
+
+    #[test]
+    fn wincred_blob_rejects_empty_and_non_utf8_payloads() {
+        assert!(decode_wincred_blob(b"").is_err());
+        assert!(decode_wincred_blob(b"\0\0\0").is_err());
+        assert!(decode_wincred_blob(b"   ").is_err());
+        assert!(decode_wincred_blob(&[0xff, 0xfe, 0x41]).is_err());
+    }
+
+    #[test]
     fn reset_time_keeps_short_windows_relative() {
         let label = format_reset_time_with_now(
             utc("2026-06-25T02:45:00Z"),
@@ -212,5 +287,102 @@ mod tests {
         );
 
         assert_eq!(label, "resets Jul 18 08:43");
+    }
+}
+
+/// Exercises the real Credential Manager. Compiled and run only on Windows,
+/// where `.github/workflows/test_coverage.yml` runs the suite as a hard gate —
+/// that CI leg is the only place the Windows lookup can actually be executed.
+#[cfg(all(test, target_os = "windows"))]
+mod windows_wincred_tests {
+    use super::read_wincred;
+    use windows_sys::Win32::Security::Credentials::{
+        CredDeleteW, CredWriteW, CREDENTIALW, CRED_PERSIST_SESSION, CRED_TYPE_GENERIC,
+    };
+
+    fn wide(value: &str) -> Vec<u16> {
+        use std::ffi::OsStr;
+        use std::os::windows::ffi::OsStrExt;
+        OsStr::new(value)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    /// Removes the credential on drop, so a failing assertion cannot leave an
+    /// entry behind in the runner's (or a developer's) Credential Manager.
+    struct TestCredential {
+        target: String,
+    }
+
+    impl TestCredential {
+        /// Returns `None` when the write is refused, so a locked-down runner
+        /// skips instead of failing for an unrelated reason.
+        fn write(target: &str, secret: &[u8]) -> Option<Self> {
+            let mut target_wide = wide(target);
+            let mut cred: CREDENTIALW = unsafe { std::mem::zeroed() };
+            cred.Type = CRED_TYPE_GENERIC;
+            cred.TargetName = target_wide.as_mut_ptr();
+            cred.CredentialBlobSize = secret.len() as u32;
+            cred.CredentialBlob = secret.as_ptr() as *mut u8;
+            // Session persistence: the entry disappears at logoff even if the
+            // Drop below never runs.
+            cred.Persist = CRED_PERSIST_SESSION;
+            let ok = unsafe { CredWriteW(&cred, 0) };
+            if ok == 0 {
+                return None;
+            }
+            Some(Self {
+                target: target.to_string(),
+            })
+        }
+    }
+
+    impl Drop for TestCredential {
+        fn drop(&mut self) {
+            let target_wide = wide(&self.target);
+            unsafe {
+                CredDeleteW(target_wide.as_ptr(), CRED_TYPE_GENERIC, 0);
+            }
+        }
+    }
+
+    #[test]
+    fn credreadw_matches_the_full_target_name_and_not_a_prefix() {
+        // Deliberately shaped like the go-keyring composition: `base` stands
+        // in for the service name and `composed` for what go-keyring actually
+        // writes. Reading `base` must fail — that is #1194 in one assertion.
+        let base = format!("tokscale-test:{}:gh", std::process::id());
+        let composed = format!("{base}:");
+        let Some(_guard) = TestCredential::write(&composed, b"gho_wincred_roundtrip") else {
+            eprintln!("skipping: CredWriteW was refused on this runner");
+            return;
+        };
+
+        assert_eq!(
+            read_wincred(&composed).unwrap(),
+            "gho_wincred_roundtrip",
+            "the composed target must read back verbatim"
+        );
+        assert!(
+            read_wincred(&base).is_err(),
+            "CredReadW must not resolve a prefix of the stored target"
+        );
+    }
+
+    #[test]
+    fn read_wincred_trims_nul_padding_written_by_other_tools() {
+        let target = format!("tokscale-test:{}:padded:", std::process::id());
+        let Some(_guard) = TestCredential::write(&target, b"gho_padded\0") else {
+            eprintln!("skipping: CredWriteW was refused on this runner");
+            return;
+        };
+        assert_eq!(read_wincred(&target).unwrap(), "gho_padded");
+    }
+
+    #[test]
+    fn read_wincred_reports_a_missing_target_as_an_error() {
+        let target = format!("tokscale-test:{}:absent:", std::process::id());
+        assert!(read_wincred(&target).is_err());
     }
 }

--- a/crates/tokscale-cli/src/commands/usage/helpers.rs
+++ b/crates/tokscale-cli/src/commands/usage/helpers.rs
@@ -51,7 +51,7 @@ fn read_wincred(service: &str) -> Result<String> {
     // On windows-rs 0.62 CredReadW returns Result<()>; on failure it carries
     // the Win32 error (e.g. ERROR_NOT_FOUND when the user never ran `gh auth login`).
     unsafe {
-        CredReadW(PCWSTR(wide.as_ptr()), CRED_TYPE_GENERIC, 0, &mut cred_ptr)?;
+        CredReadW(PCWSTR(wide.as_ptr()), CRED_TYPE_GENERIC, None, &mut cred_ptr)?;
         if cred_ptr.is_null() {
             anyhow::bail!("CredReadW returned null credential for service '{service}'");
         }

--- a/crates/tokscale-cli/src/commands/usage/helpers.rs
+++ b/crates/tokscale-cli/src/commands/usage/helpers.rs
@@ -10,16 +10,69 @@ pub fn capitalize(s: &str) -> String {
 }
 
 pub fn read_keychain(service: &str) -> Result<String> {
-    if cfg!(not(target_os = "macos")) {
-        anyhow::bail!("Keychain lookup is only available on macOS");
+    #[cfg(target_os = "macos")]
+    {
+        let out = std::process::Command::new("security")
+            .args(["find-generic-password", "-s", service, "-w"])
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!("Keychain lookup failed for service '{service}'");
+        }
+        return Ok(String::from_utf8(out.stdout)?.trim_end().to_string());
     }
-    let out = std::process::Command::new("security")
-        .args(["find-generic-password", "-s", service, "-w"])
-        .output()?;
-    if !out.status.success() {
-        anyhow::bail!("Keychain lookup failed for service '{service}'");
+
+    #[cfg(target_os = "windows")]
+    {
+        return read_wincred(service);
     }
-    Ok(String::from_utf8(out.stdout)?.trim_end().to_string())
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = service;
+        anyhow::bail!("Keychain lookup is only available on macOS and Windows");
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn read_wincred(service: &str) -> Result<String> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use windows::core::PCWSTR;
+    use windows::Win32::Security::Credentials::{CredFree, CredReadW, CRED_TYPE_GENERIC};
+
+    // CredReadW expects a null-terminated UTF-16 target name.
+    let wide: Vec<u16> = OsStr::new(service)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let mut cred_ptr: *mut windows::Win32::Security::Credentials::CREDENTIALW =
+        std::ptr::null_mut();
+
+    // On windows-rs 0.62 CredReadW returns Result<()>; on failure it carries
+    // the Win32 error (e.g. ERROR_NOT_FOUND when the user never ran `gh auth login`).
+    unsafe {
+        CredReadW(PCWSTR(wide.as_ptr()), CRED_TYPE_GENERIC, 0, &mut cred_ptr)?;
+        if cred_ptr.is_null() {
+            anyhow::bail!("CredReadW returned null credential for service '{service}'");
+        }
+        let cred = &*cred_ptr;
+        let blob_size = cred.CredentialBlobSize as usize;
+        let blob_ptr = cred.CredentialBlob;
+        if blob_ptr.is_null() || blob_size == 0 {
+            CredFree(cred_ptr as *const std::ffi::c_void);
+            anyhow::bail!("Empty credential blob for service '{service}'");
+        }
+        // `go-keyring` / `gh` stores the token as raw UTF-8 bytes (with an
+        // optional `go-keyring-base64:` prefix handled by the caller).
+        let slice = std::slice::from_raw_parts(blob_ptr, blob_size);
+        let raw = String::from_utf8(slice.to_vec())?;
+        CredFree(cred_ptr as *const std::ffi::c_void);
+        let token = raw.trim_end_matches('\0').trim_end().to_string();
+        if token.is_empty() {
+            anyhow::bail!("Empty token for service '{service}'");
+        }
+        Ok(token)
+    }
 }
 
 pub fn format_reset_time(resets_at: &str) -> String {

--- a/crates/tokscale-cli/src/commands/usage/helpers.rs
+++ b/crates/tokscale-cli/src/commands/usage/helpers.rs
@@ -37,26 +37,27 @@ pub fn read_keychain(service: &str) -> Result<String> {
 fn read_wincred(service: &str) -> Result<String> {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
-    use windows::core::PCWSTR;
-    use windows::Win32::Security::Credentials::{CredFree, CredReadW, CRED_TYPE_GENERIC};
+    use windows_sys::Win32::Security::Credentials::{CredFree, CredReadW, CRED_TYPE_GENERIC};
 
     // CredReadW expects a null-terminated UTF-16 target name.
     let wide: Vec<u16> = OsStr::new(service)
         .encode_wide()
         .chain(std::iter::once(0))
         .collect();
-    let mut cred_ptr: *mut windows::Win32::Security::Credentials::CREDENTIALW =
+    let mut cred_ptr: *mut windows_sys::Win32::Security::Credentials::CREDENTIALW =
         std::ptr::null_mut();
 
-    // On windows-rs 0.62 CredReadW returns Result<()>; on failure it carries
-    // the Win32 error (e.g. ERROR_NOT_FOUND when the user never ran `gh auth login`).
+    // On windows-sys CredReadW returns BOOL (i32); 0 means failure and the
+    // error code is in GetLastError (e.g. ERROR_NOT_FOUND when the user never
+    // ran `gh auth login`).
     unsafe {
-        CredReadW(
-            PCWSTR(wide.as_ptr()),
-            CRED_TYPE_GENERIC,
-            None,
-            &mut cred_ptr,
-        )?;
+        let ok = CredReadW(wide.as_ptr(), CRED_TYPE_GENERIC, 0, &mut cred_ptr);
+        if ok == 0 {
+            anyhow::bail!(
+                "CredReadW failed for service '{service}': {}",
+                std::io::Error::last_os_error()
+            );
+        }
         if cred_ptr.is_null() {
             anyhow::bail!("CredReadW returned null credential for service '{service}'");
         }


### PR DESCRIPTION
Fixes #1194.

## Summary

- Extend `helpers::read_keychain` to Windows via Win32 `CredReadW` (`CRED_TYPE_GENERIC`, `PCWSTR` target `gh:github.com`, `CredFree`) keeping everything in-process and matching `macOS` parity — `go-keyring-base64:` decoding remains in the caller and no subprocess is spawned.
- Add `windows = { version = "0.62", features = ["Win32_Security_Credentials", "Win32_Foundation"] }` as a `cfg(windows)`-only dependency in `crates/tokscale-cli/Cargo.toml` (`windows-sys` bump is Cargo's transitive resolution for the new `windows` crate, no non-Windows linkage).
- Extend `credential_probe` for observability: `wincred` probe reports `found` (`plain`/`go-keyring-base64`, `blob=N bytes`, `token omitted`) or `missing` on Windows and `not-applicable on non-windows` elsewhere; `apps.json` probe checks `~/.config/github-copilot/apps.json` on all platforms and reports `missing`/`unreadable`/`not valid JSON`/`valid JSON` with `top_level_keys` and `fields=[oauth,github.com,token]` detection (case-insensitive, probe-only).
- Keep credential priority unchanged: `env (GH_TOKEN/GITHUB_TOKEN) > keychain/wincred > hosts.yml` — `apps.json` is observability only and is never consumed by `has_credentials`/`read_credentials`.
- Add 5 `#[cfg(test)]` probes covering non-Windows `wincred` linkage, `apps.json` missing/invalid/valid-with-token-field-cases (token values never leaked) and `credential_probe` composition.

## Why

`helpers::read_keychain` only handled `macOS` (`security find-generic-password`), so Windows users authenticated via `gh auth login` (credential stored as `gh:github.com` in Windows Credential Manager) saw `has_credentials=false` and missed the Copilot card in `tokscale --debug usage`. The `Worth checking` follow-up in #1194 also asked to surface `~/.config/github-copilot/apps.json` for investigation without auto-consuming it. This keeps the critical Windows fix in-process (no `gh auth token` subprocess hygiene) while making both stores observable.

## Verification

- `cargo check --workspace --all-targets` PASS and `cargo clippy --workspace --all-targets -- -D warnings` PASS (cross-platform `cfg` gates verified, no warnings).
- `cargo test -p tokscale-cli -- commands::usage::copilot::tests` 5/5 PASS and `cargo test --workspace` 1961 passed, 1 pre-existing failure in `pricing::fetch::tests::network_error_carries_the_cause_display_alone_would_drop` (allowed, unrelated) — covers wincred `not-applicable`, `apps.json` three states, token non-leakage, and probe composition.
- Manual probe check on Linux shows `wincred=gh:github.com (not-applicable on non-windows)` and `apps.json` correctly reports `missing` against an empty `HOME`; Windows `CredReadW` path is `cfg`-gated and was verified via `cargo check` on all targets (native Windows verification still needed with a prior `gh auth login`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1194. On Windows, Copilot usage now finds the GitHub CLI token in Windows Credential Manager. `gh` stores it under `gh:github.com:` (go-keyring composes service + ":" + empty username), but the lookup used the bare `gh:github.com`, which `CredReadW` never matches — so the usage card stayed hidden. The lookup now tries `gh:github.com:` first, falls back to the bare name, and uses one `read_gh_secret` entry point shared by `has_credentials`, the token read, and the probe.

**Diagnostics**
- Reports each target's WinCred error instead of a flat "missing", and names the target that matched.
- Checks `%LOCALAPPDATA%` and `~/.config` for `apps.json` metadata only; never used for credential resolution.
- Adds `windows-sys` 0.61 (already in the lockfile) for in-process `CredReadW`; macOS behavior unchanged.

**Tests**
- Covers target composition, blob decoding, Windows Credential Manager round-trip, and hermetic `apps.json` cases.

<sup>Written for commit 42b57e13428d92eb0595c7fc43db4d984a4fb0e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

