### PR TITLE
fix(cursor): use native TLS for Cursor API client (#1250)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -831,6 +841,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1114,22 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1595,6 +1636,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,10 +1848,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -2277,9 +2389,11 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2291,6 +2405,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -2431,10 +2546,10 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.6.0",
 ]
 
 [[package]]
@@ -2520,12 +2635,25 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3025,6 +3153,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,26 +55,20 @@ anyhow = "1.0"
 libc = "0.2"
 
 # HTTP client (async)
-# Default to rustls rather than native-tls. `native-tls-vendored` statically
-# links a full OpenSSL into Linux artifacts that call `.use_native_tls()` (macOS
-# uses Security.framework and Windows schannel, so neither pays for it on those
-# targets) — the published linux-x64-gnu package was 25.8 MB against
-# darwin-arm64's 17.0 MB before #1138. `rustls-tls-native-roots`, not plain
+# rustls is the workspace default. `rustls-tls-native-roots`, not plain
 # `rustls-tls`: the latter trusts only the baked-in webpki root set, which
 # would silently break anyone behind a corporate MITM proxy or using a private
 # CA. Reading the OS trust store keeps today's behaviour.
 #
-# `native-tls` is also enabled so the Cursor API client can call
-# `.use_native_tls()` and pass Vercel bot protection that fingerprints rustls
-# (#1250). Other clients still construct a rustls client (`Client::new()` /
-# builder without `.use_native_tls()`). Cargo unifies reqwest features across
-# the graph, so this is a runtime default, not a separate crate.
-#
-# Do not put `native-tls-vendored` here: that feature is unified for every
-# target and statically links OpenSSL into linux-gnu (~25.8 MB). musl and
-# Android enable it on the member crates via target cfg instead; linux-gnu
-# links system libssl dynamically.
-reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots", "native-tls"], default-features = false }
+# `native-tls` is NOT listed here on purpose. reqwest's `native-tls` feature
+# implies `default-tls`, and `impl Default for TlsBackend` (reqwest
+# src/tls.rs) returns the native-tls backend whenever `default-tls` is on and
+# `http3` is off. Enabling it on this shared entry would therefore flip the
+# runtime TLS backend for every client in the workspace and for every target,
+# because Cargo unifies features across the graph. Only the Cursor client
+# needs native TLS (#1250), so the member crates opt in per target instead —
+# see the `[target.'cfg(...)'.dependencies]` blocks in crates/*/Cargo.toml.
+reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "fs"] }
 
 # For disk caching (XDG paths)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,14 +55,20 @@ anyhow = "1.0"
 libc = "0.2"
 
 # HTTP client (async)
-# rustls rather than native-tls. `native-tls-vendored` statically links a full
-# OpenSSL into every Linux artifact (macOS uses Security.framework and Windows
-# schannel, so neither ever paid for it) — the published linux-x64-gnu package
-# is 25.8 MB against darwin-arm64's 17.0 MB. `rustls-tls-native-roots`, not
-# plain `rustls-tls`: the latter trusts only the baked-in webpki root set, which
+# Default to rustls rather than native-tls. `native-tls-vendored` statically
+# links a full OpenSSL into Linux artifacts that call `.use_native_tls()` (macOS
+# uses Security.framework and Windows schannel, so neither pays for it on those
+# targets) — the published linux-x64-gnu package was 25.8 MB against
+# darwin-arm64's 17.0 MB before #1138. `rustls-tls-native-roots`, not plain
+# `rustls-tls`: the latter trusts only the baked-in webpki root set, which
 # would silently break anyone behind a corporate MITM proxy or using a private
 # CA. Reading the OS trust store keeps today's behaviour.
-reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots"], default-features = false }
+#
+# `native-tls` (+ `native-tls-vendored` for musl/cross Linux) is enabled
+# alongside rustls so the Cursor API client can opt into system TLS and avoid
+# Vercel bot protection that fingerprints rustls (#1250). Every other client
+# keeps the rustls default.
+reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots", "native-tls", "native-tls-vendored"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "fs"] }
 
 # For disk caching (XDG paths)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,17 @@ libc = "0.2"
 # would silently break anyone behind a corporate MITM proxy or using a private
 # CA. Reading the OS trust store keeps today's behaviour.
 #
-# `native-tls` (+ `native-tls-vendored` for musl/cross Linux) is enabled
-# alongside rustls so the Cursor API client can opt into system TLS and avoid
-# Vercel bot protection that fingerprints rustls (#1250). Every other client
-# keeps the rustls default.
-reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots", "native-tls", "native-tls-vendored"], default-features = false }
+# `native-tls` is also enabled so the Cursor API client can call
+# `.use_native_tls()` and pass Vercel bot protection that fingerprints rustls
+# (#1250). Other clients still construct a rustls client (`Client::new()` /
+# builder without `.use_native_tls()`). Cargo unifies reqwest features across
+# the graph, so this is a runtime default, not a separate crate.
+#
+# Do not put `native-tls-vendored` here: that feature is unified for every
+# target and statically links OpenSSL into linux-gnu (~25.8 MB). musl and
+# Android enable it on the member crates via target cfg instead; linux-gnu
+# links system libssl dynamically.
+reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots", "native-tls"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "fs"] }
 
 # For disk caching (XDG paths)

--- a/clippy.toml
+++ b/clippy.toml
@@ -7,4 +7,9 @@ disallowed-methods = [
     { path = "reqwest::Client::new", reason = "use tokscale_core::http::client() so the TLS backend is explicit (#1250)" },
     { path = "reqwest::Client::builder", reason = "use tokscale_core::http::client_builder() so the TLS backend is explicit (#1250)" },
     { path = "reqwest::ClientBuilder::new", reason = "use tokscale_core::http::client_builder() so the TLS backend is explicit (#1250)" },
+    # `Default` is a fourth door into the same room: reqwest implements it for
+    # both types and both impls just call `new()`, so `Client::default()` is a
+    # native-tls client exactly like `Client::new()` is.
+    { path = "reqwest::Client::default", reason = "use tokscale_core::http::client() so the TLS backend is explicit (#1250)" },
+    { path = "reqwest::ClientBuilder::default", reason = "use tokscale_core::http::client_builder() so the TLS backend is explicit (#1250)" },
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,10 @@
+# Only the Cursor client may pick a TLS backend of its own (#1250). reqwest's
+# `native-tls` feature implies `default-tls`, and `default-tls` alone decides
+# `TlsBackend::default()`, so an unqualified `reqwest::Client::new()` is a
+# *native-tls* client on every target where Cursor's opt-in applies. Route
+# everything else through `tokscale_core::http`, which pins rustls explicitly.
+disallowed-methods = [
+    { path = "reqwest::Client::new", reason = "use tokscale_core::http::client() so the TLS backend is explicit (#1250)" },
+    { path = "reqwest::Client::builder", reason = "use tokscale_core::http::client_builder() so the TLS backend is explicit (#1250)" },
+    { path = "reqwest::ClientBuilder::new", reason = "use tokscale_core::http::client_builder() so the TLS backend is explicit (#1250)" },
+]

--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -83,20 +83,41 @@ base64 = { workspace = true }
 # Cursor desktop state.vscdb accessToken import
 rusqlite = { workspace = true }
 
-# musl has no system OpenSSL to link; Android NDK builds do not ship one
-# either. linux-gnu keeps the workspace `native-tls` feature and links
-# libssl dynamically so the #1138 size win stays on that artifact.
-[target.'cfg(any(target_env = "musl", target_os = "android"))'.dependencies]
-reqwest = { workspace = true, features = ["native-tls-vendored"] }
-
+# Two unrelated Android exclusions share this table because TOML allows a
+# target only one `dependencies` table.
+#
+# reqwest: only the Cursor client needs native TLS (#1250) and it is opted
+# into per target, never on the workspace entry, because reqwest's
+# `native-tls` feature implies `default-tls` and `default-tls` alone decides
+# `TlsBackend::default()`. Under resolver = "2" a `[target.'cfg(...)']` block
+# is resolved per compilation target, so this does not leak into Android.
+# Android is excluded on purpose: openssl-src builds Android with `no-stdio`,
+# which stubs `BIO_new_file` and `BIO_s_file` and therefore the whole CA-file
+# loader, so a native-tls Android build would run against an empty trust
+# store and reject every certificate. Android keeps pure rustls and loses
+# Cursor login; `cursor.rs` gates `.use_native_tls()` on the identical cfg.
+#
 # arboard has no Android backend and fails to compile for
 # aarch64-linux-android. The clipboard module in tui/ provides a
 # no-op fallback on Android so the rest of the code stays portable.
 [target.'cfg(not(target_os = "android"))'.dependencies]
+reqwest = { workspace = true, features = ["native-tls"] }
 # The TUI yank key only ever calls `Clipboard::set_text`. `arboard`'s default
 # `image-data` feature pulls in `image` (with `tiff` on macOS) plus the
 # CoreGraphics / Win32 GDI bitmap paths for clipboard images nothing reads.
 arboard = { version = "3", default-features = false }
+
+# Vendor OpenSSL on every Linux target, gnu as well as musl. The Linux cross
+# builds run under cargo-zigbuild (.github/workflows/build-native.yml) and
+# that environment has no usable system OpenSSL: the x86_64 job cannot
+# preprocess Debian's multiarch /usr/include/openssl/macros.h through zigcc,
+# and the aarch64 job has no aarch64 OpenSSL on the runner at all. Vendoring
+# also keeps the published linux-gnu artifact from acquiring a hard runtime
+# dependency on the build host's libssl.so.3 soname. macOS and Windows are
+# absent from this list because native-tls uses Security.framework and
+# schannel there and never touches OpenSSL.
+[target.'cfg(target_os = "linux")'.dependencies]
+reqwest = { workspace = true, features = ["native-tls-vendored"] }
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = { workspace = true }

--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -83,6 +83,12 @@ base64 = { workspace = true }
 # Cursor desktop state.vscdb accessToken import
 rusqlite = { workspace = true }
 
+# musl has no system OpenSSL to link; Android NDK builds do not ship one
+# either. linux-gnu keeps the workspace `native-tls` feature and links
+# libssl dynamically so the #1138 size win stays on that artifact.
+[target.'cfg(any(target_env = "musl", target_os = "android"))'.dependencies]
+reqwest = { workspace = true, features = ["native-tls-vendored"] }
+
 # arboard has no Android backend and fails to compile for
 # aarch64-linux-android. The clipboard module in tui/ provides a
 # no-op fallback on Android so the rest of the code stays portable.

--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -2242,7 +2242,7 @@ fn antigravity_https_runtime() -> &'static tokio::runtime::Runtime {
 #[cfg(not(target_os = "windows"))]
 fn antigravity_https_client() -> &'static reqwest::Client {
     HTTPS_RPC_CLIENT.get_or_init(|| {
-        reqwest::Client::builder()
+        tokscale_core::http::client_builder()
             // Defensive only — this is NOT what fixed any reported hang, and the
             // earlier claim that it was (#1127) was wrong. `reqwest` is built
             // `default-features = false` without `http2`, so neither it nor

--- a/crates/tokscale-cli/src/auth.rs
+++ b/crates/tokscale-cli/src/auth.rs
@@ -236,7 +236,7 @@ pub async fn login() -> Result<()> {
     println!("\n  {}\n", "Tokscale - Login".cyan());
     println!("{}", "  Requesting authorization code...".bright_black());
 
-    let client = reqwest::Client::builder()
+    let client = tokscale_core::http::client_builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()?;
 
@@ -358,7 +358,7 @@ pub async fn login_with_token(token: &str) -> Result<()> {
     }
 
     let base_url = get_api_base_url();
-    let client = reqwest::Client::builder()
+    let client = tokscale_core::http::client_builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()?;
 

--- a/crates/tokscale-cli/src/commands/report.rs
+++ b/crates/tokscale-cli/src/commands/report.rs
@@ -959,7 +959,7 @@ fn minimax_chat(system_prompt: &str, user_prompt: &str) -> Result<String> {
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let client = reqwest::Client::builder()
+        let client = tokscale_core::http::client_builder()
             .timeout(BACKEND_TIMEOUT)
             .build()?;
         let body = serde_json::json!({

--- a/crates/tokscale-cli/src/commands/usage/amp.rs
+++ b/crates/tokscale-cli/src/commands/usage/amp.rs
@@ -146,7 +146,7 @@ pub fn fetch() -> Result<UsageOutput> {
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let client = reqwest::Client::new();
+        let client = tokscale_core::http::client();
         let resp = client
             .post("https://ampcode.com/api/internal")
             .header("Authorization", format!("Bearer {api_key}"))

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -210,7 +210,7 @@ async fn call_rpc(port: u16) -> Result<QuotaSummary> {
     // a matching NO_PROXY. That both leaks quota metadata and lets the proxy
     // forge the unauthenticated response that port discovery trusts. The IDE
     // RPC client in `crate::antigravity` is built the same way.
-    let client = reqwest::Client::builder()
+    let client = tokscale_core::http::client_builder()
         .no_proxy()
         // Redirects are refused for the same reason the proxy is: discovery
         // probes ports that may belong to anything, and reqwest follows up to

--- a/crates/tokscale-cli/src/commands/usage/claude.rs
+++ b/crates/tokscale-cli/src/commands/usage/claude.rs
@@ -426,7 +426,7 @@ fn fetch_blocking(usage_url: &str, read: CredentialReader) -> Result<UsageOutput
             }
         });
 
-        let client = reqwest::Client::new();
+        let client = tokscale_core::http::client();
         let resp = fetch_usage(&client, usage_url, access_token).await?;
 
         let metrics = usage_metrics(&resp);

--- a/crates/tokscale-cli/src/commands/usage/codex.rs
+++ b/crates/tokscale-cli/src/commands/usage/codex.rs
@@ -1391,7 +1391,7 @@ async fn fetch_with_auth_async(
         .clone()
         .ok_or_else(|| anyhow::anyhow!("No Codex access token."))?;
 
-    let client = reqwest::Client::new();
+    let client = tokscale_core::http::client();
     let mut effective_tokens = tokens.clone();
     let mut effective_access_token = access_token.clone();
     let resp = match fetch_usage(
@@ -1821,7 +1821,7 @@ async fn consume_reset_credit_with_auth_async(
         .access_token
         .clone()
         .ok_or_else(|| anyhow::anyhow!("No Codex access token."))?;
-    let client = reqwest::Client::new();
+    let client = tokscale_core::http::client();
     let redeem_request_id = uuid::Uuid::new_v4().to_string();
 
     match consume_reset_credit(

--- a/crates/tokscale-cli/src/commands/usage/copilot.rs
+++ b/crates/tokscale-cli/src/commands/usage/copilot.rs
@@ -260,7 +260,7 @@ pub fn fetch() -> Result<UsageOutput> {
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let client = reqwest::Client::new();
+        let client = tokscale_core::http::client();
         let resp = fetch_api(&client, &token).await.map_err(|e| {
             if e.to_string().contains("NEEDS_AUTH") {
                 anyhow::anyhow!(

--- a/crates/tokscale-cli/src/commands/usage/grok.rs
+++ b/crates/tokscale-cli/src/commands/usage/grok.rs
@@ -579,7 +579,7 @@ fn fetch_network_usage(credentials: &Credentials) -> Result<UsageOutput> {
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let client = reqwest::Client::builder()
+        let client = tokscale_core::http::client_builder()
             .timeout(Duration::from_secs(12))
             .build()?;
 

--- a/crates/tokscale-cli/src/commands/usage/kimi.rs
+++ b/crates/tokscale-cli/src/commands/usage/kimi.rs
@@ -202,7 +202,7 @@ pub fn fetch() -> Result<UsageOutput> {
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let client = reqwest::Client::new();
+        let client = tokscale_core::http::client();
 
         // Proactive refresh if token is about to expire
         if needs_refresh(expires_at) {

--- a/crates/tokscale-cli/src/commands/usage/minimax.rs
+++ b/crates/tokscale-cli/src/commands/usage/minimax.rs
@@ -149,7 +149,7 @@ pub fn fetch() -> Result<UsageOutput> {
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let client = reqwest::Client::new();
+        let client = tokscale_core::http::client();
         let resp = fetch_api(&client, &api_key).await?;
 
         if is_auth_error(&resp) {

--- a/crates/tokscale-cli/src/commands/usage/minimax_tokenplan.rs
+++ b/crates/tokscale-cli/src/commands/usage/minimax_tokenplan.rs
@@ -159,7 +159,7 @@ pub fn fetch_all() -> Result<Vec<UsageOutput>> {
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let client = reqwest::Client::new();
+        let client = tokscale_core::http::client();
         let mut outputs = Vec::new();
 
         for site in targets {

--- a/crates/tokscale-cli/src/commands/usage/opencode_go.rs
+++ b/crates/tokscale-cli/src/commands/usage/opencode_go.rs
@@ -238,7 +238,7 @@ fn fetch_blocking_with_cap(
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let client = reqwest::Client::builder()
+        let client = tokscale_core::http::client_builder()
             .timeout(std::time::Duration::from_secs(30))
             .build()?;
         let resp = client

--- a/crates/tokscale-cli/src/commands/usage/sakana.rs
+++ b/crates/tokscale-cli/src/commands/usage/sakana.rs
@@ -510,7 +510,7 @@ pub fn fetch() -> Result<UsageOutput> {
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let client = reqwest::Client::builder()
+        let client = tokscale_core::http::client_builder()
             .timeout(std::time::Duration::from_secs(30))
             .redirect(reqwest::redirect::Policy::limited(10))
             .build()?;

--- a/crates/tokscale-cli/src/commands/usage/zai.rs
+++ b/crates/tokscale-cli/src/commands/usage/zai.rs
@@ -81,7 +81,7 @@ pub fn fetch() -> Result<UsageOutput> {
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let client = reqwest::Client::new();
+        let client = tokscale_core::http::client();
         let quota = fetch_quota(&client, &api_key).await?;
         let sub = fetch_sub(&client, &api_key).await.ok();
 

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -423,7 +423,7 @@ fn build_top_agents(parsed: &tokscale_core::ParsedMessages) -> Vec<WrappedAgentE
 }
 
 async fn generate_wrapped_image(data: &WrappedData, options: &RenderOptions) -> Result<RgbaImage> {
-    let client = reqwest::Client::new();
+    let client = tokscale_core::http::client();
     let fonts = ensure_fonts_loaded(&client).await?;
 
     let mut canvas =

--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -48,8 +48,10 @@ pub const CURSOR_AUTO_SYNC_FRESHNESS: Duration = Duration::from_secs(5 * 60);
 
 fn build_cursor_http_client() -> Result<reqwest::Client> {
     // cursor.com sits behind Vercel bot protection that fingerprints TLS
-    // ClientHello. The workspace default is rustls; only Cursor requests need
-    // native TLS (Security.framework / schannel / OpenSSL) to pass (#1250).
+    // ClientHello. Other clients keep the rustls runtime default; only
+    // Cursor requests switch to native TLS (Security.framework / schannel /
+    // OpenSSL) to pass (#1250). linux-gnu links system libssl; musl and
+    // Android vendor OpenSSL via target cfg on the crate manifests.
     reqwest::Client::builder()
         .timeout(CURSOR_HTTP_TIMEOUT)
         .use_native_tls()

--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -46,15 +46,34 @@ const CURSOR_MAX_CSV_BYTES: usize = 64 * 1024 * 1024;
 /// always honored.
 pub const CURSOR_AUTO_SYNC_FRESHNESS: Duration = Duration::from_secs(5 * 60);
 
+/// The Cursor client's builder, split out of `build_cursor_http_client` so a
+/// test can assert which TLS backend it ends up on.
+///
+/// cursor.com sits behind Vercel bot protection that fingerprints the TLS
+/// ClientHello, and rustls' hello is on the block list — since #1138 moved the
+/// workspace to rustls, `cursor login` / `cursor sync` have received a
+/// challenge page instead of the API response (#1250). This is the one client
+/// that asks for the platform's own TLS stack: Security.framework on macOS,
+/// schannel on Windows, OpenSSL on Linux. Every other client stays on rustls
+/// through `tokscale_core::http`.
+fn cursor_http_client_builder() -> reqwest::ClientBuilder {
+    #[allow(clippy::disallowed_methods)]
+    let builder = reqwest::Client::builder().timeout(CURSOR_HTTP_TIMEOUT);
+
+    // Android is excluded from `native-tls` in crates/tokscale-cli/Cargo.toml,
+    // because openssl-src builds Android with `no-stdio` and that leaves
+    // OpenSSL unable to read a CA file at all. Keep this predicate textually
+    // identical to the manifest's; `tests/tls_policy.rs` checks that it is.
+    // The cost is that Cursor login stays broken on Android, where it reports
+    // itself as an expired session (see `sync_cursor_usage`).
+    #[cfg(not(target_os = "android"))]
+    let builder = builder.use_native_tls();
+
+    builder
+}
+
 fn build_cursor_http_client() -> Result<reqwest::Client> {
-    // cursor.com sits behind Vercel bot protection that fingerprints TLS
-    // ClientHello. Other clients keep the rustls runtime default; only
-    // Cursor requests switch to native TLS (Security.framework / schannel /
-    // OpenSSL) to pass (#1250). linux-gnu links system libssl; musl and
-    // Android vendor OpenSSL via target cfg on the crate manifests.
-    reqwest::Client::builder()
-        .timeout(CURSOR_HTTP_TIMEOUT)
-        .use_native_tls()
+    cursor_http_client_builder()
         .build()
         .context("Failed to build Cursor HTTP client")
 }
@@ -1597,6 +1616,26 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
     use tempfile::TempDir;
+
+    /// #1250: cursor.com serves a bot-protection challenge instead of the API
+    /// response when the ClientHello comes from rustls, so this one client has
+    /// to be on the platform TLS stack while everything else stays on rustls
+    /// via `tokscale_core::http`.
+    ///
+    /// reqwest calls its native-tls backend `TlsBackend::Default` and prints
+    /// it as `Default`; `Rustls` is the other value this field can take. The
+    /// field is only printed when both backends are compiled in, which is
+    /// every target except Android — and Android is exactly where
+    /// `.use_native_tls()` is cfg'd out.
+    #[test]
+    #[cfg(not(target_os = "android"))]
+    fn the_cursor_client_is_built_on_the_native_tls_backend() {
+        let rendered = format!("{:?}", cursor_http_client_builder());
+        assert!(
+            rendered.contains("tls_backend: Default"),
+            "the Cursor client must use native TLS, not rustls, got: {rendered}"
+        );
+    }
 
     #[test]
     fn test_extract_user_id_from_session_token_with_url_encoding() {

--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -47,8 +47,12 @@ const CURSOR_MAX_CSV_BYTES: usize = 64 * 1024 * 1024;
 pub const CURSOR_AUTO_SYNC_FRESHNESS: Duration = Duration::from_secs(5 * 60);
 
 fn build_cursor_http_client() -> Result<reqwest::Client> {
+    // cursor.com sits behind Vercel bot protection that fingerprints TLS
+    // ClientHello. The workspace default is rustls; only Cursor requests need
+    // native TLS (Security.framework / schannel / OpenSSL) to pass (#1250).
     reqwest::Client::builder()
         .timeout(CURSOR_HTTP_TIMEOUT)
+        .use_native_tls()
         .build()
         .context("Failed to build Cursor HTTP client")
 }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -4936,7 +4936,7 @@ fn run_delete_data_command() -> Result<()> {
     let rt = Runtime::new()?;
 
     let response = rt.block_on(async {
-        reqwest::Client::new()
+        tokscale_core::http::client()
             .delete(format!("{}/api/settings/submitted-data", api_url))
             .header("Authorization", format!("Bearer {}", auth_token.token))
             .send()
@@ -6015,7 +6015,7 @@ fn run_submit_command(
         to_ts_token_contribution_data(&graph_result, Some(&submit_device), scan_scope);
 
     let response = rt.block_on(async {
-        reqwest::Client::new()
+        tokscale_core::http::client()
             .post(format!("{}/api/submit", api_url))
             .header("Content-Type", "application/json")
             .header("Authorization", format!("Bearer {}", auth_token.token))

--- a/crates/tokscale-cli/src/trae.rs
+++ b/crates/tokscale-cli/src/trae.rs
@@ -434,7 +434,7 @@ pub mod auth {
         refresh_token: &str,
         current_token: &str,
     ) -> Result<TokenPair> {
-        let client = reqwest::Client::new();
+        let client = tokscale_core::http::client();
         let url = format!("{}{}", host, EXCHANGE_TOKEN_PATH);
         let resp = client
             .post(&url)
@@ -1063,7 +1063,7 @@ pub mod sync {
         end_time: i64,
         usage_types: &[i32],
     ) -> Result<Vec<serde_json::Value>> {
-        let client = reqwest::Client::new();
+        let client = tokscale_core::http::client();
         let url = format!("{}/trae/api/v1/pay/query_user_usage_group_by_session", host);
         let mut all = Vec::new();
         let mut page = 1;

--- a/crates/tokscale-cli/src/tui/remote.rs
+++ b/crates/tokscale-cli/src/tui/remote.rs
@@ -96,7 +96,7 @@ pub fn fetch_remote_stats(token: &str, username: &str, api_base_url: &str) -> Re
         .build()?;
 
     let mut stats: RemoteStats = rt.block_on(async {
-        let response = reqwest::Client::new()
+        let response = tokscale_core::http::client()
             .get(url)
             .header("Authorization", format!("Bearer {}", token))
             .send()

--- a/crates/tokscale-cli/src/warp.rs
+++ b/crates/tokscale-cli/src/warp.rs
@@ -304,7 +304,7 @@ async fn sync_warp_cache() -> SyncWarpResult {
 }
 
 async fn fetch_warp_usage(credentials: &WarpCredentials) -> Result<WarpUsageCache> {
-    let client = reqwest::Client::builder()
+    let client = tokscale_core::http::client_builder()
         .timeout(WARP_HTTP_TIMEOUT)
         .build()
         .context("Failed to build Warp HTTP client")?;

--- a/crates/tokscale-cli/tests/tls_policy.rs
+++ b/crates/tokscale-cli/tests/tls_policy.rs
@@ -46,10 +46,62 @@ const MEMBER_MANIFESTS: [&str; 2] = [
 /// `clippy.toml` enforces the same rule at lint time; this test also fails a
 /// plain `cargo test`, and unlike clippy it does not depend on the lint being
 /// run with the right flags.
-const CLIENT_CONSTRUCTION_ALLOWLIST: [&str; 2] = [
+const CLIENT_CONSTRUCTION_ALLOWLIST: [&str; 3] = [
     "crates/tokscale-core/src/http.rs",
     "crates/tokscale-cli/src/cursor.rs",
+    // This file spells the forbidden constructors out as string literals in
+    // order to search for them, so it matches its own scan.
+    "crates/tokscale-cli/tests/tls_policy.rs",
 ];
+
+/// Every directory the client-construction scan walks.
+///
+/// `crates/*/tests` is in here because CI runs clippy without `--all-targets`
+/// (`.github/workflows/test_coverage.yml`), so integration tests are linted by
+/// nothing. A raw client planted in a test would otherwise be caught by neither
+/// this scan nor `clippy::disallowed_methods`.
+const SCANNED_DIRS: [&str; 4] = [
+    "crates/tokscale-cli/src",
+    "crates/tokscale-core/src",
+    "crates/tokscale-cli/tests",
+    "crates/tokscale-core/tests",
+];
+
+/// The five constructors that yield a client on reqwest's *default* backend.
+///
+/// `Client::new`, `Client::builder` and `ClientBuilder::new` are the obvious
+/// three -- and the scan only ever looked for the first two, because
+/// `"ClientBuilder::new("` does not contain `"Client::new("` as a substring.
+/// `Default` is the pair that both lanes missed: reqwest implements it for
+/// both `Client` (`async_impl/client.rs`) and `ClientBuilder`, and both
+/// impls delegate to
+/// `new()`, so they select the same native-tls backend by exactly the same
+/// mechanism. `clippy.toml` lists all five for the same reason.
+const DEFAULT_BACKEND_CONSTRUCTORS: [&str; 5] = [
+    "Client::new(",
+    "Client::builder(",
+    "ClientBuilder::new(",
+    "Client::default(",
+    "ClientBuilder::default(",
+];
+
+/// True when `needle` occurs in `line` as a whole path segment rather than as
+/// the tail of a longer identifier.
+///
+/// Without this, the bare substring `Client::new(` also matches
+/// `FooClient::new(`, and an unrelated type would trip the scan with a
+/// confusing TLS-policy failure.
+fn contains_standalone(line: &str, needle: &str) -> bool {
+    let mut rest = line;
+    while let Some(at) = rest.find(needle) {
+        let preceding = rest[..at].chars().next_back();
+        if !preceding.is_some_and(|c| c.is_alphanumeric() || c == '_') {
+            return true;
+        }
+        rest = &rest[at + needle.len()..];
+    }
+    false
+}
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -58,9 +110,45 @@ fn workspace_root() -> PathBuf {
         .expect("the workspace root must exist two levels above the CLI crate")
 }
 
+/// Read a workspace file with line endings normalised to `\n`.
+///
+/// GitHub's `windows-latest` runner ships Git for Windows with
+/// `core.autocrlf=true`, and this repo carries no `.gitattributes`, so the
+/// checkout on the Windows test leg has CRLF endings. Every assertion below
+/// that spans a line break would then fail on Windows only — a red hard-gated
+/// job that says nothing about the property being guarded.
 fn read(relative: &str) -> String {
     let path = workspace_root().join(relative);
-    std::fs::read_to_string(&path).unwrap_or_else(|error| panic!("{}: {error}", path.display()))
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("{}: {error}", path.display()));
+    normalize_newlines(raw)
+}
+
+fn normalize_newlines(source: String) -> String {
+    source.replace("\r\n", "\n")
+}
+
+/// Without the normalisation in `read`, every assertion here that spans a line
+/// break passes on Linux and macOS and fails on Windows — on a job with no
+/// `continue-on-error`, for a reason that has nothing to do with TLS.
+#[test]
+fn source_is_read_with_line_endings_normalised() {
+    let windows_checkout = "#[cfg(not(target_os = \"android\"))]\r\n    let builder = \
+                            builder.use_native_tls();"
+        .to_string();
+    let expected = "#[cfg(not(target_os = \"android\"))]\n    let builder = \
+                    builder.use_native_tls();";
+
+    assert!(
+        !windows_checkout.contains(expected),
+        "this test is pointless unless a CRLF checkout really does defeat the \
+         substring match it guards"
+    );
+    assert!(
+        normalize_newlines(windows_checkout).contains(expected),
+        "reads must normalise CRLF so the Windows leg checks the same property \
+         as the Linux one"
+    );
 }
 
 fn manifest(relative: &str) -> toml::Value {
@@ -223,6 +311,66 @@ fn the_cursor_call_site_repeats_the_manifest_cfg_verbatim() {
     );
 }
 
+/// `clippy.toml` and the scan above enforce the same rule by two different
+/// mechanisms, and each covers a gap the other has: clippy resolves real paths
+/// (so it is not fooled by a rename) but CI runs it without `--all-targets`,
+/// while the scan is a plain text search that runs under `cargo test` on both
+/// CI platforms. They are only equivalent while they name the same
+/// constructors, and nothing but this test makes that true.
+#[test]
+fn the_lint_config_and_the_source_scan_forbid_the_same_constructors() {
+    let clippy = read("clippy.toml");
+
+    for needle in DEFAULT_BACKEND_CONSTRUCTORS {
+        let method = needle
+            .strip_suffix('(')
+            .expect("every scanned constructor ends in an open paren");
+        let path = format!("reqwest::{method}");
+        assert!(
+            clippy.contains(&format!("path = \"{path}\"")),
+            "clippy.toml must also disallow `{path}`; the source scan already \
+             rejects it, and a rule only one of the two enforces is a rule that \
+             silently lapses whenever the other is skipped"
+        );
+    }
+
+    let disallowed = clippy.matches("path = \"reqwest::").count();
+    assert_eq!(
+        disallowed,
+        DEFAULT_BACKEND_CONSTRUCTORS.len(),
+        "clippy.toml disallows {disallowed} reqwest constructors but the source \
+         scan looks for {}; add the missing one to DEFAULT_BACKEND_CONSTRUCTORS \
+         so both lanes agree",
+        DEFAULT_BACKEND_CONSTRUCTORS.len()
+    );
+}
+
+/// The scan matches raw text, so it has to distinguish `Client::new(` from the
+/// tail of some unrelated `FooClient::new(`. Nothing in the tree trips this
+/// today; the point is that adding such a type later must not produce a
+/// baffling TLS-policy failure.
+#[test]
+fn the_scan_matches_whole_segments_rather_than_identifier_tails() {
+    assert!(contains_standalone(
+        "let c = reqwest::Client::new();",
+        "Client::new("
+    ));
+    assert!(contains_standalone("Client::new()", "Client::new("));
+    assert!(!contains_standalone(
+        "let c = FooClient::new();",
+        "Client::new("
+    ));
+    assert!(!contains_standalone(
+        "let c = my_client::new();",
+        "Client::new("
+    ));
+    // A tail match early in the line must not hide a real one later.
+    assert!(contains_standalone(
+        "FooClient::new(); reqwest::Client::new();",
+        "Client::new("
+    ));
+}
+
 /// Once `default-tls` is in the graph, an unqualified `reqwest::Client::new()`
 /// is a native-tls client. Anything that is not Cursor must therefore say
 /// rustls out loud.
@@ -231,8 +379,12 @@ fn no_client_is_constructed_outside_the_allowlist() {
     let root = workspace_root();
     let mut offenders = Vec::new();
 
-    for crate_dir in ["crates/tokscale-cli/src", "crates/tokscale-core/src"] {
-        let mut stack = vec![root.join(crate_dir)];
+    for crate_dir in SCANNED_DIRS {
+        let dir = root.join(crate_dir);
+        if !dir.exists() {
+            continue;
+        }
+        let mut stack = vec![dir];
         while let Some(dir) = stack.pop() {
             for entry in std::fs::read_dir(&dir).expect("source directory must be readable") {
                 let path = entry.expect("directory entry must be readable").path();
@@ -253,7 +405,10 @@ fn no_client_is_constructed_outside_the_allowlist() {
                 }
                 let source = std::fs::read_to_string(&path).expect("source must be readable");
                 for (number, line) in source.lines().enumerate() {
-                    if line.contains("Client::new(") || line.contains("Client::builder(") {
+                    if DEFAULT_BACKEND_CONSTRUCTORS
+                        .iter()
+                        .any(|needle| contains_standalone(line, needle))
+                    {
                         offenders.push(format!("{relative}:{}: {}", number + 1, line.trim()));
                     }
                 }

--- a/crates/tokscale-cli/tests/tls_policy.rs
+++ b/crates/tokscale-cli/tests/tls_policy.rs
@@ -1,0 +1,270 @@
+//! Guards on which TLS backend each HTTP client in this workspace ends up on.
+//!
+//! reqwest picks its backend from Cargo features, not from code: `native-tls`
+//! implies `default-tls`, and `impl Default for TlsBackend` returns the
+//! *native-tls* backend whenever `default-tls` is enabled and `http3` is not.
+//! Cargo also unifies features across the dependency graph. So a one-word edit
+//! to a shared manifest silently changes the TLS stack of every client in the
+//! repo, and nothing about it fails to compile.
+//!
+//! That is exactly what happened while fixing #1250 (cursor.com blocks rustls'
+//! ClientHello): `native-tls` was added to the workspace `reqwest` entry, which
+//! moved all ~28 clients onto native-tls while the change claimed to touch only
+//! Cursor — and made the `.use_native_tls()` call it added a literal no-op,
+//! since it assigns the value the default already had. A second iteration
+//! gated vendored OpenSSL on `target_env = "musl"`, which left linux-gnu
+//! looking for a system libssl that the cargo-zigbuild cross environment does
+//! not have, and turned both linux-gnu release builds red.
+//!
+//! These tests read the manifests and the source, because the properties they
+//! protect live there rather than in any value a normal unit test can observe.
+//! The complementary runtime check is in `tokscale_core::http`, which asserts
+//! the shared builder really does select rustls.
+
+use std::path::{Path, PathBuf};
+
+/// Cursor's TLS opt-in is excluded on exactly this cfg. Android is the one
+/// target that must keep pure rustls: openssl-src configures Android with
+/// `no-stdio`, which stubs `BIO_new_file`/`BIO_s_file` and so disables
+/// OpenSSL's CA-file loader entirely. A native-tls Android build would run
+/// with an empty trust store and reject every certificate, silently.
+const NATIVE_TLS_TARGET: &str = r#"cfg(not(target_os = "android"))"#;
+
+/// Vendoring must key off the OS, not the libc. `target_os = "linux"` is true
+/// for both -gnu and -musl and false for Android (which reports
+/// `target_os = "android"`), so this covers every Linux release artifact and
+/// no others.
+const VENDORED_TARGET: &str = r#"cfg(target_os = "linux")"#;
+
+const MEMBER_MANIFESTS: [&str; 2] = [
+    "crates/tokscale-cli/Cargo.toml",
+    "crates/tokscale-core/Cargo.toml",
+];
+
+/// The only two places allowed to construct a reqwest client directly. Every
+/// other call site must go through `tokscale_core::http`, which pins rustls.
+/// `clippy.toml` enforces the same rule at lint time; this test also fails a
+/// plain `cargo test`, and unlike clippy it does not depend on the lint being
+/// run with the right flags.
+const CLIENT_CONSTRUCTION_ALLOWLIST: [&str; 2] = [
+    "crates/tokscale-core/src/http.rs",
+    "crates/tokscale-cli/src/cursor.rs",
+];
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("the workspace root must exist two levels above the CLI crate")
+}
+
+fn read(relative: &str) -> String {
+    let path = workspace_root().join(relative);
+    std::fs::read_to_string(&path).unwrap_or_else(|error| panic!("{}: {error}", path.display()))
+}
+
+fn manifest(relative: &str) -> toml::Value {
+    read(relative)
+        .parse::<toml::Value>()
+        .unwrap_or_else(|error| panic!("{relative} is not valid TOML: {error}"))
+}
+
+/// Every `features = [..]` entry for `reqwest` under a `[target.'..']` table,
+/// paired with the cfg it is gated on.
+fn per_target_reqwest_features(relative: &str) -> Vec<(String, Vec<String>)> {
+    let Some(targets) = manifest(relative).get("target").cloned() else {
+        return Vec::new();
+    };
+    let table = targets
+        .as_table()
+        .unwrap_or_else(|| panic!("{relative}: [target] must be a table"))
+        .clone();
+
+    table
+        .into_iter()
+        .filter_map(|(cfg, entry)| {
+            let features = entry
+                .get("dependencies")?
+                .get("reqwest")?
+                .get("features")?
+                .as_array()?
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_owned))
+                .collect();
+            Some((cfg, features))
+        })
+        .collect()
+}
+
+fn workspace_reqwest_features() -> Vec<String> {
+    manifest("Cargo.toml")["workspace"]["dependencies"]["reqwest"]["features"]
+        .as_array()
+        .expect("the workspace reqwest entry must list features")
+        .iter()
+        .filter_map(|value| value.as_str().map(str::to_owned))
+        .collect()
+}
+
+/// The regression that shipped in the first #1250 attempt. `native-tls` on the
+/// shared entry is unified into every crate and every target, so it is not an
+/// opt-in for one client — it is a workspace-wide backend swap.
+#[test]
+fn the_workspace_reqwest_entry_stays_rustls_only() {
+    let features = workspace_reqwest_features();
+
+    for forbidden in [
+        "native-tls",
+        "native-tls-vendored",
+        "native-tls-alpn",
+        "default-tls",
+    ] {
+        assert!(
+            !features.iter().any(|feature| feature == forbidden),
+            "the workspace `reqwest` entry must not enable `{forbidden}`: it implies \
+             `default-tls`, which makes native-tls the default backend for every client \
+             on every target. Opt in per target in the member crates instead. Got: {features:?}"
+        );
+    }
+
+    assert!(
+        features
+            .iter()
+            .any(|feature| feature == "rustls-tls-native-roots"),
+        "rustls must stay available workspace-wide, and with OS roots rather than the \
+         baked-in webpki set. Got: {features:?}"
+    );
+}
+
+/// Both member crates need their own blocks: `use_native_tls()` only exists
+/// when the feature is on for the crate being compiled, so relying on feature
+/// unification from the binary would break a standalone `tokscale-core` build.
+#[test]
+fn both_member_crates_gate_native_tls_on_the_same_non_android_cfg() {
+    for relative in MEMBER_MANIFESTS {
+        let features = per_target_reqwest_features(relative);
+        let gated: Vec<_> = features
+            .iter()
+            .filter(|(_, features)| features.iter().any(|feature| feature == "native-tls"))
+            .collect();
+
+        assert_eq!(
+            gated.len(),
+            1,
+            "{relative} must enable reqwest's `native-tls` under exactly one target cfg, \
+             found {gated:?}"
+        );
+        assert_eq!(
+            gated[0].0, NATIVE_TLS_TARGET,
+            "{relative} must gate `native-tls` on {NATIVE_TLS_TARGET}"
+        );
+    }
+}
+
+/// The second regression: gating vendored OpenSSL on `target_env = "musl"`
+/// left x86_64/aarch64-unknown-linux-gnu hunting for a system libssl that the
+/// cargo-zigbuild cross environment cannot provide, and both release builds
+/// failed in openssl-sys' `build/main.rs` before this test existed.
+#[test]
+fn vendored_openssl_covers_every_linux_target_and_only_linux() {
+    for relative in MEMBER_MANIFESTS {
+        let features = per_target_reqwest_features(relative);
+        let gated: Vec<_> = features
+            .iter()
+            .filter(|(_, features)| {
+                features
+                    .iter()
+                    .any(|feature| feature == "native-tls-vendored")
+            })
+            .collect();
+
+        assert_eq!(
+            gated.len(),
+            1,
+            "{relative} must vendor OpenSSL under exactly one target cfg, found {gated:?}"
+        );
+        assert_eq!(
+            gated[0].0, VENDORED_TARGET,
+            "{relative} must vendor OpenSSL for all of Linux, not a single libc: -gnu and \
+             -musl both cross-compile under cargo-zigbuild with no system OpenSSL available"
+        );
+    }
+}
+
+/// The manifest cfg and the code cfg have to agree. If the manifest excludes
+/// Android but the code does not, Android fails to compile; if the code
+/// excludes Android but the manifest does not, Android silently regains
+/// no-stdio OpenSSL and an empty trust store.
+#[test]
+fn the_cursor_call_site_repeats_the_manifest_cfg_verbatim() {
+    let predicate = NATIVE_TLS_TARGET
+        .strip_prefix("cfg(")
+        .and_then(|rest| rest.strip_suffix(')'))
+        .expect("NATIVE_TLS_TARGET is a cfg(..) expression");
+
+    let cursor = read("crates/tokscale-cli/src/cursor.rs");
+    let expected = format!("#[cfg({predicate})]\n    let builder = builder.use_native_tls();");
+
+    assert!(
+        cursor.contains(&expected),
+        "cursor.rs must gate `.use_native_tls()` on the same cfg its manifest uses. \
+         Expected to find:\n{expected}"
+    );
+    let call_sites: Vec<_> = cursor
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            !trimmed.starts_with("//") && trimmed.contains(".use_native_tls()")
+        })
+        .collect();
+    assert_eq!(
+        call_sites.len(),
+        1,
+        "only one call site may switch TLS backends, found: {call_sites:?}"
+    );
+}
+
+/// Once `default-tls` is in the graph, an unqualified `reqwest::Client::new()`
+/// is a native-tls client. Anything that is not Cursor must therefore say
+/// rustls out loud.
+#[test]
+fn no_client_is_constructed_outside_the_allowlist() {
+    let root = workspace_root();
+    let mut offenders = Vec::new();
+
+    for crate_dir in ["crates/tokscale-cli/src", "crates/tokscale-core/src"] {
+        let mut stack = vec![root.join(crate_dir)];
+        while let Some(dir) = stack.pop() {
+            for entry in std::fs::read_dir(&dir).expect("source directory must be readable") {
+                let path = entry.expect("directory entry must be readable").path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().is_none_or(|ext| ext != "rs") {
+                    continue;
+                }
+                let relative = path
+                    .strip_prefix(&root)
+                    .expect("scanned paths live under the workspace root")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                if CLIENT_CONSTRUCTION_ALLOWLIST.contains(&relative.as_str()) {
+                    continue;
+                }
+                let source = std::fs::read_to_string(&path).expect("source must be readable");
+                for (number, line) in source.lines().enumerate() {
+                    if line.contains("Client::new(") || line.contains("Client::builder(") {
+                        offenders.push(format!("{relative}:{}: {}", number + 1, line.trim()));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "construct HTTP clients through `tokscale_core::http` so the TLS backend is \
+         explicit (#1250). Offending lines:\n{}",
+        offenders.join("\n")
+    );
+}

--- a/crates/tokscale-core/Cargo.toml
+++ b/crates/tokscale-core/Cargo.toml
@@ -32,6 +32,13 @@ sha2 = { workspace = true }
 libc = { workspace = true }
 fs2 = { workspace = true }
 
+# Same vendored-OpenSSL gate as tokscale-cli: musl/Android have nothing to
+# dynamically link. Feature unification from the CLI binary would cover the
+# published artifact, but a standalone `tokscale-core` musl build would
+# otherwise look for system libssl and fail.
+[target.'cfg(any(target_env = "musl", target_os = "android"))'.dependencies]
+reqwest = { workspace = true, features = ["native-tls-vendored"] }
+
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3"

--- a/crates/tokscale-core/Cargo.toml
+++ b/crates/tokscale-core/Cargo.toml
@@ -32,11 +32,15 @@ sha2 = { workspace = true }
 libc = { workspace = true }
 fs2 = { workspace = true }
 
-# Same vendored-OpenSSL gate as tokscale-cli: musl/Android have nothing to
-# dynamically link. Feature unification from the CLI binary would cover the
-# published artifact, but a standalone `tokscale-core` musl build would
-# otherwise look for system libssl and fail.
-[target.'cfg(any(target_env = "musl", target_os = "android"))'.dependencies]
+# Same per-target TLS gates as tokscale-cli; see the long rationale there.
+# Both crates need them: `use_native_tls()` and `use_rustls_tls()` only exist
+# when the corresponding reqwest feature is on for the crate being compiled,
+# and a standalone `tokscale-core` build must resolve the same way the CLI
+# binary does rather than relying on feature unification from the binary.
+[target.'cfg(not(target_os = "android"))'.dependencies]
+reqwest = { workspace = true, features = ["native-tls"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
 reqwest = { workspace = true, features = ["native-tls-vendored"] }
 
 [dev-dependencies]

--- a/crates/tokscale-core/src/http.rs
+++ b/crates/tokscale-core/src/http.rs
@@ -1,0 +1,97 @@
+//! Shared construction of the workspace's HTTP clients.
+//!
+//! Every client except Cursor's goes through here, and every client here is
+//! pinned to rustls with an explicit `use_rustls_tls()` rather than relying on
+//! reqwest's default backend.
+//!
+//! The explicitness is load-bearing, not decoration. reqwest's `native-tls`
+//! feature implies `default-tls`, and `impl Default for TlsBackend`
+//! (reqwest `src/tls.rs`) resolves to the *native-tls* backend whenever
+//! `default-tls` is enabled and `http3` is not. The Cursor client needs
+//! native TLS to get past cursor.com's ClientHello fingerprinting (#1250), so
+//! `default-tls` is compiled in on every target except Android — which means
+//! an unqualified `reqwest::Client::new()` anywhere in this workspace would
+//! silently be a *native-tls* client, not the rustls one its author intended.
+//!
+//! `clippy.toml` forbids `reqwest::Client::new` / `reqwest::Client::builder`
+//! outside this module and `tokscale-cli`'s `cursor.rs` so a new call site
+//! cannot re-open that hole by accident.
+
+/// A `reqwest::ClientBuilder` pinned to the rustls backend.
+///
+/// Behaviourally identical to what an unqualified `reqwest::Client::builder()`
+/// produced before native TLS entered the dependency graph: `use_rustls_tls()`
+/// selects `TlsBackend::Rustls`, and `tls_built_in_certs_native` defaults to
+/// `true`, so roots still come from the OS trust store via the workspace's
+/// `rustls-tls-native-roots` feature.
+#[allow(clippy::disallowed_methods)]
+pub fn client_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder().use_rustls_tls()
+}
+
+/// A rustls-backed `reqwest::Client` with reqwest's default settings.
+///
+/// The drop-in replacement for `reqwest::Client::new()`, including its panic
+/// shape: `Client::new()` is itself `builder().build().expect(..)`, so call
+/// sites keep the error handling they already had.
+pub fn client() -> reqwest::Client {
+    client_builder()
+        .build()
+        .expect("failed to build the shared rustls HTTP client")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression guard for #1250's first attempt, which enabled reqwest's
+    /// `native-tls` feature on the shared workspace dependency. That flipped
+    /// `TlsBackend::default()` to native-tls for all ~28 clients in the
+    /// workspace while the PR claimed only Cursor was affected. Nothing in the
+    /// build caught it, because both backends compile fine either way.
+    ///
+    /// `ClientBuilder`'s `Debug` prints `tls_backend` only when both backends
+    /// are compiled in, which is every target except Android.
+    #[test]
+    #[cfg(not(target_os = "android"))]
+    fn shared_builder_is_pinned_to_rustls() {
+        let rendered = format!("{:?}", client_builder());
+        assert!(
+            rendered.contains("tls_backend: Rustls"),
+            "the shared client builder must select rustls explicitly, got: {rendered}"
+        );
+    }
+
+    /// The reason the assertion above cannot be dropped: with `default-tls` in
+    /// the graph, an unqualified builder is a *native-tls* builder. If this
+    /// ever fails because reqwest stopped printing `Default` here, the pinning
+    /// test above still stands on its own.
+    #[test]
+    #[cfg(not(target_os = "android"))]
+    fn an_unqualified_builder_would_have_been_native_tls() {
+        #[allow(clippy::disallowed_methods)]
+        let rendered = format!("{:?}", reqwest::Client::builder());
+        assert!(
+            rendered.contains("tls_backend: Default"),
+            "reqwest's unqualified default is expected to be the native-tls \
+             backend while `default-tls` is enabled, got: {rendered}"
+        );
+    }
+
+    /// Android is deliberately left without `default-tls`, so there is only
+    /// one backend to choose and reqwest omits the field entirely.
+    #[test]
+    #[cfg(target_os = "android")]
+    fn android_has_no_native_tls_backend_to_choose() {
+        let rendered = format!("{:?}", client_builder());
+        assert!(
+            !rendered.contains("tls_backend"),
+            "Android must compile with rustls only, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn client_builds() {
+        let _ = client();
+    }
+}

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -6,6 +6,7 @@ mod cc_mirror;
 pub mod clients;
 pub mod content_extractor;
 pub mod fs_atomic;
+pub mod http;
 pub mod mcp;
 mod message_cache;
 pub mod model_alias;

--- a/crates/tokscale-core/src/pricing/fetch.rs
+++ b/crates/tokscale-core/src/pricing/fetch.rs
@@ -5,7 +5,7 @@ const MAX_RETRIES: u32 = 3;
 const INITIAL_BACKOFF_MS: u64 = 200;
 
 pub(crate) fn pricing_client() -> Result<Client, String> {
-    Client::builder()
+    crate::http::client_builder()
         .timeout(Duration::from_secs(30))
         .connect_timeout(Duration::from_secs(10))
         .build()
@@ -85,7 +85,7 @@ mod tests {
         // The bare Display, which is what this code used to print. Anchoring on
         // "longer than Display" rather than on the literal cause text keeps a
         // dependency bump from reddening this test for rewording its prose.
-        let displayed = reqwest::Client::new()
+        let displayed = crate::http::client()
             .get(&url)
             .send()
             .await

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -615,7 +615,7 @@ mod tests {
     /// A client that cannot outlive a wedged listener thread: without this the
     /// tests below block forever instead of failing if `accept` never fires.
     fn bounded_client() -> reqwest::Client {
-        reqwest::Client::builder()
+        crate::http::client_builder()
             .timeout(std::time::Duration::from_secs(10))
             .build()
             .unwrap()


### PR DESCRIPTION
## Summary
- Use `native-tls` for the Cursor API HTTP client (`.use_native_tls()` in `build_cursor_http_client`) so requests pass Vercel bot protection that fingerprints rustls TLS ClientHello (#1250).
- Keep rustls as the runtime default for every other HTTP client (`Client::new()` / builder without `.use_native_tls()`). Cargo unifies reqwest features, so this is a runtime default, not a separate crate.
- Enable `native-tls` on the workspace `reqwest`. `native-tls-vendored` is target-gated to musl and Android on the member crates, so linux-gnu dynamically links system `libssl` instead of statically linking the ~25.8MB that #1138 removed.

## Context
Since v4.14.0 (#1138), `tokscale cursor login` and `cursor sync` fail with "Session token expired or invalid" even when the desktop `state.vscdb` token is valid. The token and request headers are correct; `cursor.com` blocks the rustls TLS fingerprint before the app sees the request.

linux-gnu artifacts pick up a runtime `libssl` requirement. musl and Android still vendor OpenSSL because those targets have no system OpenSSL to link.

## Test plan
- [x] `cargo build -p tokscale-cli --release`
- [x] `cargo test -p tokscale-cli cursor::` (39 tests passed)
- [x] `./target/release/tokscale cursor login` — succeeds (was failing on v4.15.0)
- [x] `./target/release/tokscale cursor status` — Session: Valid, Membership: pro
- [x] `cargo tree -p tokscale-cli --target x86_64-unknown-linux-gnu -i openssl-src` — not in the graph
- [x] `cargo tree -p tokscale-cli --target x86_64-unknown-linux-musl -i openssl-src` — present via `native-tls-vendored`
