### PR TITLE
fix(cursor): stop discarding failed cache moves on account switch

### DIFF
--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -516,12 +516,21 @@ fn upsert_credentials(token: &str, label: Option<&str>) -> Result<String> {
     // reconciliation would treat the previous account's `usage.json` as the new
     // active account's and could drop the new account's only cache.
     let old_active_id = store.active_account_id.clone();
-    if old_active_id != account_id {
-        let _ = reconcile_cache_files(&old_active_id, &account_id);
-    }
+    let reconciled = if old_active_id != account_id {
+        reconcile_cache_files(&old_active_id, &account_id)
+    } else {
+        Ok(())
+    };
 
-    store.active_account_id = account_id.clone();
+    // A freshly read desktop token is worth keeping even when the cache files
+    // could not be moved, so the accounts are saved either way. Only point
+    // `active_account_id` at the new account once its cache really is
+    // `usage.json`.
+    if reconciled.is_ok() {
+        store.active_account_id = account_id.clone();
+    }
     save_credentials_store(&store)?;
+    reconciled?;
     Ok(account_id)
 }
 
@@ -825,7 +834,11 @@ pub fn set_active_account(name_or_id: &str) -> Result<()> {
     let old_active_id = store.active_account_id.clone();
 
     if resolved != old_active_id {
-        let _ = reconcile_cache_files(&old_active_id, &resolved);
+        // Do not record the switch when the caches could not be moved: the active
+        // `usage.*` would then belong to a different account than
+        // `active_account_id` claims, and the next sync would file one account's
+        // usage under the other.
+        reconcile_cache_files(&old_active_id, &resolved)?;
     }
 
     store.active_account_id = resolved;
@@ -836,9 +849,30 @@ pub fn set_active_account(name_or_id: &str) -> Result<()> {
 
 fn reconcile_cache_files(old_account_id: &str, new_account_id: &str) -> Result<()> {
     let cache_dir = get_cursor_cache_dir()?;
+    reconcile_cache_files_in_dir(&cache_dir, old_account_id, new_account_id)
+}
+
+/// Moves `usage.<ext>` back under `old_account_id` and promotes
+/// `usage.<new_account_id>.<ext>` into its place, for every cache extension.
+///
+/// Kept `cache_dir`-relative for the same reason as [`archive_cache_file_in_dir`]:
+/// so tests can point it at a temporary home.
+///
+/// A failure on one extension does not abort the others. Each extension is an
+/// independent pair of caches, so returning early would leave the JSON cache
+/// moved while the legacy CSV cache stays under the wrong account. Every failure
+/// is collected and reported instead, so the caller can decline to record the
+/// switch rather than pointing `active_account_id` at another account's cache.
+fn reconcile_cache_files_in_dir(
+    cache_dir: &Path,
+    old_account_id: &str,
+    new_account_id: &str,
+) -> Result<()> {
     if !cache_dir.exists() {
         return Ok(());
     }
+
+    let mut failures: Vec<String> = Vec::new();
 
     // Move both the current JSON cache and any legacy CSV cache so a switch
     // never strands one format under the wrong account.
@@ -855,20 +889,43 @@ fn reconcile_cache_files(old_account_id: &str, new_account_id: &str) -> Result<(
 
         if active_file.exists() {
             if old_account_file.exists() {
-                let _ = archive_cache_file(&old_account_file, old_account_id);
+                let _ = archive_cache_file_in_dir(cache_dir, &old_account_file, old_account_id);
             }
-            fs::rename(&active_file, &old_account_file)?;
+            if let Err(err) = fs::rename(&active_file, &old_account_file) {
+                failures.push(format!(
+                    "could not move usage.{ext} to {}: {err}",
+                    old_account_file.display()
+                ));
+                // `usage.{ext}` still holds the old account's data. Promoting the
+                // new account's cache over it would destroy the old account's only
+                // copy, so leave this extension untouched.
+                continue;
+            }
         }
 
         if new_account_file.exists() {
             if active_file.exists() {
-                let _ = archive_cache_file(&active_file, "usage.active");
+                let _ = archive_cache_file_in_dir(cache_dir, &active_file, "usage.active");
             }
-            fs::rename(&new_account_file, &active_file)?;
+            if let Err(err) = fs::rename(&new_account_file, &active_file) {
+                failures.push(format!(
+                    "could not promote {} to usage.{ext}: {err}",
+                    new_account_file.display()
+                ));
+            }
         }
     }
 
-    Ok(())
+    if failures.is_empty() {
+        return Ok(());
+    }
+
+    Err(anyhow::anyhow!(
+        "failed to move Cursor cache files while switching from {} to {}: {}",
+        old_account_id,
+        new_account_id,
+        failures.join("; ")
+    ))
 }
 
 pub fn load_active_credentials() -> Option<CursorCredentials> {
@@ -3115,6 +3172,136 @@ mod tests {
         assert!(
             cache_dir.join(CURSOR_SYNC_ATTEMPT_MARKER).exists(),
             "marker must be written even when a secondary account fetch fails"
+        );
+        Ok(())
+    }
+
+    /// A switch has to move the JSON cache and the legacy CSV cache together:
+    /// the previous account's data ends up under its own name and the incoming
+    /// account's cache is promoted to `usage.<ext>`.
+    #[test]
+    fn reconcile_cache_files_moves_both_extensions() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let cache_dir = temp_dir.path().join("cache");
+        fs::create_dir_all(&cache_dir)?;
+
+        let old_id = "old-account";
+        let new_id = "new-account";
+        let old_stem = sanitize_account_id_for_filename(old_id);
+        let new_stem = sanitize_account_id_for_filename(new_id);
+
+        for ext in CURSOR_CACHE_EXTENSIONS {
+            fs::write(cache_dir.join(format!("usage.{ext}")), format!("old-{ext}"))?;
+            fs::write(
+                cache_dir.join(format!("usage.{new_stem}.{ext}")),
+                format!("new-{ext}"),
+            )?;
+        }
+
+        reconcile_cache_files_in_dir(&cache_dir, old_id, new_id)?;
+
+        for ext in CURSOR_CACHE_EXTENSIONS {
+            assert_eq!(
+                fs::read_to_string(cache_dir.join(format!("usage.{ext}")))?,
+                format!("new-{ext}"),
+                "the incoming account's cache must become usage.{ext}"
+            );
+            assert_eq!(
+                fs::read_to_string(cache_dir.join(format!("usage.{old_stem}.{ext}")))?,
+                format!("old-{ext}"),
+                "the previous account's cache must be filed under its own id"
+            );
+            assert!(
+                !cache_dir.join(format!("usage.{new_stem}.{ext}")).exists(),
+                "the promoted cache must not be left behind as a duplicate"
+            );
+        }
+        Ok(())
+    }
+
+    /// #1247 follow-up: a failed cache move used to be discarded with `let _`, so
+    /// the switch was recorded anyway and the next sync filed one account's usage
+    /// under the other. Every extension must be attempted, and every failure must
+    /// reach the caller.
+    #[test]
+    fn reconcile_cache_files_reports_every_failed_extension() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let cache_dir = temp_dir.path().join("cache");
+        fs::create_dir_all(&cache_dir)?;
+
+        let old_id = "old-account";
+        let new_id = "new-account";
+        let old_stem = sanitize_account_id_for_filename(old_id);
+
+        // A regular file named `archive` makes `archive_cache_file_in_dir` fail,
+        // so the blocking entries below are not archived out of the way first.
+        fs::write(cache_dir.join("archive"), b"not a directory")?;
+
+        for ext in CURSOR_CACHE_EXTENSIONS {
+            fs::write(
+                cache_dir.join(format!("usage.{ext}")),
+                b"active-account-data",
+            )?;
+            // Renaming a file onto a non-empty directory fails on every platform.
+            let blocked = cache_dir.join(format!("usage.{old_stem}.{ext}"));
+            fs::create_dir_all(&blocked)?;
+            fs::write(blocked.join("occupied"), b"x")?;
+        }
+
+        let err = reconcile_cache_files_in_dir(&cache_dir, old_id, new_id)
+            .expect_err("a blocked rename must be reported, not discarded");
+        let message = err.to_string();
+
+        for ext in CURSOR_CACHE_EXTENSIONS {
+            assert!(
+                message.contains(&format!("usage.{ext}")),
+                "every extension must be attempted and reported, got: {message}"
+            );
+            assert_eq!(
+                fs::read(cache_dir.join(format!("usage.{ext}")))?,
+                b"active-account-data",
+                "a failed move must leave usage.{ext} in place"
+            );
+        }
+        Ok(())
+    }
+
+    /// Failing to move the active cache out of the way must not fall through to
+    /// promoting the incoming account's cache: `usage.<ext>` still holds the
+    /// previous account's only copy at that point.
+    #[test]
+    fn reconcile_cache_files_does_not_promote_over_a_stuck_active_cache() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let cache_dir = temp_dir.path().join("cache");
+        fs::create_dir_all(&cache_dir)?;
+
+        let old_id = "old-account";
+        let new_id = "new-account";
+        let old_stem = sanitize_account_id_for_filename(old_id);
+        let new_stem = sanitize_account_id_for_filename(new_id);
+
+        fs::write(cache_dir.join("archive"), b"not a directory")?;
+        fs::write(cache_dir.join("usage.json"), b"old-account-data")?;
+
+        let blocked = cache_dir.join(format!("usage.{old_stem}.json"));
+        fs::create_dir_all(&blocked)?;
+        fs::write(blocked.join("occupied"), b"x")?;
+
+        let incoming = cache_dir.join(format!("usage.{new_stem}.json"));
+        fs::write(&incoming, b"new-account-data")?;
+
+        reconcile_cache_files_in_dir(&cache_dir, old_id, new_id)
+            .expect_err("the blocked rename must be reported");
+
+        assert_eq!(
+            fs::read(cache_dir.join("usage.json"))?,
+            b"old-account-data",
+            "the previous account's cache must survive a failed switch"
+        );
+        assert_eq!(
+            fs::read(&incoming)?,
+            b"new-account-data",
+            "the incoming cache must stay under its own account id"
         );
         Ok(())
     }


### PR DESCRIPTION
Follow-up to #1247, where I said I would send this separately.

`reconcile_cache_files` moves `usage.json` back under the outgoing account and promotes the incoming account's per-account cache into its place. Both call sites discarded its error with `let _`, and the function itself aborted on the first `fs::rename` failure with `?`.

## What went wrong

**The switch was recorded even when the caches did not move.** `set_active_account` wrote `active_account_id = new` regardless, so the active `usage.json` still held the outgoing account's data while the store claimed it belonged to the incoming one. The next `cursor sync` then filed one account's usage under the other. `run_cursor_switch` printed `Active Cursor account set to ...` for a switch that had not happened.

**A failure on one extension stranded the other.** `CURSOR_CACHE_EXTENSIONS` is `["json", "csv"]` — current and legacy. Because `?` returned from the whole function, a failure on the JSON cache meant the CSV cache was never attempted and stayed under the wrong account.

## The fix

Failures are collected per extension and reported together, so both caches are always attempted and the caller sees every failure.

A failed "move the active cache out of the way" now `continue`s to the next extension instead of falling through to the promotion. Without that, the promotion would rename the incoming account's cache onto a `usage.json` that still holds the outgoing account's only copy — turning a failed switch into data loss.

`set_active_account` propagates before it mutates anything, so nothing is persisted and no success line is printed for a switch that did not happen.

`upsert_credentials` is the desktop-token refresh path. It still saves the store — dropping a freshly read token would be the worse outcome — but only points `active_account_id` at the new account once its cache really is `usage.json`, then propagates. Its two callers already return `Result`, and `sync_cursor_cache` discards `ensure_credentials_from_local_cursor`'s result, so the sync path is unaffected.

Split out `reconcile_cache_files_in_dir` so tests can drive a temporary cache directory. This mirrors the existing `archive_cache_file` / `archive_cache_file_in_dir` split and its stated reason. The internal archive calls now use the `_in_dir` variant; both resolve to the same directory in production, since `cache_dir` came from `get_cursor_cache_dir()`.

## Tests

Three tests, each checked against the pre-fix behaviour rather than only against the new code:

| Test | Fails without |
| --- | --- |
| `reconcile_cache_files_reports_every_failed_extension` | the per-extension failure collection (old `?` aborts after `json`, so `csv` is never attempted) |
| `reconcile_cache_files_does_not_promote_over_a_stuck_active_cache` | the `continue` (the promotion overwrites `usage.json` with the incoming account's data) |
| `reconcile_cache_files_moves_both_extensions` | nothing — it is the no-regression guard for the happy path |

Failure is forced portably: the destination is an existing non-empty directory, which `fs::rename` refuses on every platform, and a regular file named `archive` blocks `archive_cache_file_in_dir` from clearing the obstacle first.

## Verification

`cargo fmt --all --check`, `cargo clippy --locked --workspace --all-features -- -D warnings`, `cargo clippy --locked --workspace --all-features --all-targets -- -D warnings`, and `cargo test --workspace` all exit 0. 13 suites pass, 0 failures.

Not covered: a rename that fails midway through a real cross-device move.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cursor account switching so a failed cache move no longer records the switch or strands the legacy CSV cache. Previously, `reconcile_cache_files` discarded errors and aborted on the first rename failure; now it attempts every cache extension and reports all failures together.

- A failed move of the active cache skips promotion for that extension, so the incoming account's cache cannot overwrite the outgoing account's only copy.
- `set_active_account` propagates the error before mutating state, so no success line is printed for a switch that did not happen.
- `upsert_credentials` still saves a freshly read desktop token, but only points `active_account_id` at the new account after its cache is in place.
- `sync_cursor_cache` still discards the result from `ensure_credentials_from_local_cursor`, so the sync path is unaffected.
- Splits out `reconcile_cache_files_in_dir` so tests can drive a temporary cache directory; production behavior is unchanged.
- Adds tests covering both extensions moving, every failed extension being reported, and no promotion over a stuck active cache.

<sup>Written for commit 073141790136c862e47ea9e454d053f40b2e7a8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

