### PR TITLE
fix(lint): drop the two clippy rules that never fired

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -3,13 +3,19 @@
 # `TlsBackend::default()`, so an unqualified `reqwest::Client::new()` is a
 # *native-tls* client on every target where Cursor's opt-in applies. Route
 # everything else through `tokscale_core::http`, which pins rustls explicitly.
+#
+# `Client::default()` and `ClientBuilder::default()` are a fourth and fifth
+# door into the same room -- reqwest implements `Default` for both types and
+# both impls just call `new()` -- but they cannot be listed here. `default` is
+# a trait-impl item, not an inherent one, so `reqwest::Client::default` does
+# not resolve and clippy answers with `does not refer to a reachable function`
+# and skips the entry; the qualified `<reqwest::Client as Default>::default`
+# form is worse, because clippy 0.1.98 accepts it without resolving it, so it
+# emits no warning and still never fires. Both doors are closed instead by
+# `crates/tokscale-cli/tests/tls_policy.rs`, whose raw-text scan covers all
+# five constructors and fails a plain `cargo test`.
 disallowed-methods = [
     { path = "reqwest::Client::new", reason = "use tokscale_core::http::client() so the TLS backend is explicit (#1250)" },
     { path = "reqwest::Client::builder", reason = "use tokscale_core::http::client_builder() so the TLS backend is explicit (#1250)" },
     { path = "reqwest::ClientBuilder::new", reason = "use tokscale_core::http::client_builder() so the TLS backend is explicit (#1250)" },
-    # `Default` is a fourth door into the same room: reqwest implements it for
-    # both types and both impls just call `new()`, so `Client::default()` is a
-    # native-tls client exactly like `Client::new()` is.
-    { path = "reqwest::Client::default", reason = "use tokscale_core::http::client() so the TLS backend is explicit (#1250)" },
-    { path = "reqwest::ClientBuilder::default", reason = "use tokscale_core::http::client_builder() so the TLS backend is explicit (#1250)" },
 ]

--- a/crates/tokscale-cli/tests/tls_policy.rs
+++ b/crates/tokscale-cli/tests/tls_policy.rs
@@ -76,7 +76,10 @@ const SCANNED_DIRS: [&str; 4] = [
 /// both `Client` (`async_impl/client.rs`) and `ClientBuilder`, and both
 /// impls delegate to
 /// `new()`, so they select the same native-tls backend by exactly the same
-/// mechanism. `clippy.toml` lists all five for the same reason.
+/// mechanism.
+///
+/// This scan covers all five. `clippy.toml` covers only the first three --
+/// see [`LINTABLE_CONSTRUCTORS`].
 const DEFAULT_BACKEND_CONSTRUCTORS: [&str; 5] = [
     "Client::new(",
     "Client::builder(",
@@ -84,6 +87,23 @@ const DEFAULT_BACKEND_CONSTRUCTORS: [&str; 5] = [
     "Client::default(",
     "ClientBuilder::default(",
 ];
+
+/// The subset of [`DEFAULT_BACKEND_CONSTRUCTORS`] that `clippy.toml` can
+/// actually enforce.
+///
+/// `disallowed-methods` resolves a path to a function, and only these three
+/// are inherent associated functions on reqwest's types. `default` is a
+/// *trait-impl* item, so `reqwest::Client::default` does not resolve: clippy
+/// reports `does not refer to a reachable function` and skips the entry, which
+/// means listing it buys a warning on every build and no enforcement at all.
+/// Writing it qualified as `<reqwest::Client as Default>::default` is worse --
+/// clippy 0.1.98 accepts that form without resolving it, so it warns about
+/// nothing and still never fires.
+///
+/// Hence the asymmetry this file has to encode: the two `Default` doors are
+/// closed by the scan below and by nothing else.
+const LINTABLE_CONSTRUCTORS: [&str; 3] =
+    ["Client::new(", "Client::builder(", "ClientBuilder::new("];
 
 /// True when `needle` occurs in `line` as a whole path segment rather than as
 /// the tail of a longer identifier.
@@ -315,13 +335,25 @@ fn the_cursor_call_site_repeats_the_manifest_cfg_verbatim() {
 /// mechanisms, and each covers a gap the other has: clippy resolves real paths
 /// (so it is not fooled by a rename) but CI runs it without `--all-targets`,
 /// while the scan is a plain text search that runs under `cargo test` on both
-/// CI platforms. They are only equivalent while they name the same
-/// constructors, and nothing but this test makes that true.
+/// CI platforms.
+///
+/// They agree on the three constructors clippy can resolve, and this test
+/// pins that agreement in both directions -- including the direction that is
+/// easy to get wrong. `clippy.toml` used to list all five, and the two
+/// `Default` entries were dead: clippy printed `does not refer to a reachable
+/// function` twice per build and skipped them, so the parity this test
+/// asserted was textual only. Re-adding either one restores that, which is
+/// why the second half asserts their *absence*.
 #[test]
 fn the_lint_config_and_the_source_scan_forbid_the_same_constructors() {
     let clippy = read("clippy.toml");
 
-    for needle in DEFAULT_BACKEND_CONSTRUCTORS {
+    for needle in LINTABLE_CONSTRUCTORS {
+        assert!(
+            DEFAULT_BACKEND_CONSTRUCTORS.contains(&needle),
+            "`{needle}` is listed as lintable but the source scan does not \
+             look for it; the lint config must never be the only lane"
+        );
         let method = needle
             .strip_suffix('(')
             .expect("every scanned constructor ends in an open paren");
@@ -337,12 +369,29 @@ fn the_lint_config_and_the_source_scan_forbid_the_same_constructors() {
     let disallowed = clippy.matches("path = \"reqwest::").count();
     assert_eq!(
         disallowed,
-        DEFAULT_BACKEND_CONSTRUCTORS.len(),
-        "clippy.toml disallows {disallowed} reqwest constructors but the source \
-         scan looks for {}; add the missing one to DEFAULT_BACKEND_CONSTRUCTORS \
-         so both lanes agree",
-        DEFAULT_BACKEND_CONSTRUCTORS.len()
+        LINTABLE_CONSTRUCTORS.len(),
+        "clippy.toml disallows {disallowed} reqwest constructors but only {} \
+         resolve to a function clippy can match; an entry clippy skips is \
+         enforcement the config only appears to have",
+        LINTABLE_CONSTRUCTORS.len()
     );
+
+    for needle in DEFAULT_BACKEND_CONSTRUCTORS {
+        if LINTABLE_CONSTRUCTORS.contains(&needle) {
+            continue;
+        }
+        let method = needle
+            .strip_suffix('(')
+            .expect("every scanned constructor ends in an open paren");
+        let path = format!("reqwest::{method}");
+        assert!(
+            !clippy.contains(&format!("path = \"{path}\"")),
+            "clippy.toml lists `{path}`, but `default` is a trait-impl item \
+             that `disallowed-methods` cannot resolve: clippy warns `does not \
+             refer to a reachable function` and skips it. The scan above is \
+             what closes that door -- leave it there"
+        );
+    }
 }
 
 /// The scan matches raw text, so it has to distinguish `Client::new(` from the


### PR DESCRIPTION
Follow-up to #1252, found while reviewing #1257.

`clippy.toml` listed five reqwest constructors. Two of them never worked.

```
warning: `reqwest::Client::default` does not refer to a reachable function
  --> clippy.toml:13:5
   = help: add `allow-invalid = true` to the entry to suppress this warning

warning: `reqwest::ClientBuilder::default` does not refer to a reachable function
  --> clippy.toml:14:5
```

`disallowed-methods` resolves a path to a function, and `default` is a trait-impl item rather than an inherent associated function, so `reqwest::Client::default` resolves to nothing and clippy skips the entry. Two warnings on every workspace clippy run, and no enforcement behind them.

### Measured, not assumed

Added a probe calling both constructors from a file outside the allowlist, on `3f4fbd73`:

| config | probe | `cargo clippy --workspace --all-features -- -D warnings` |
|---|---|---|
| all five entries | `Client::default()` + `ClientBuilder::default()` | **exit 0**, nothing reported |
| all five entries | `Client::new()` | exit 101, `use of a disallowed method` |
| `<reqwest::Client as NoSuchTrait>::totally_bogus_xyz` | — | **no warning at all** |

The third row is the reason the qualified form is not the fix. Clippy 0.1.98 accepts `<T as Trait>::method` without resolving it, so a completely fictional trait and method produce no complaint — you get silence instead of enforcement, and you lose the warning that was telling you the entry was dead.

One more thing the table shows: exit 0 in row 1 even under `-D warnings`. The "does not refer to a reachable function" message comes from the config loader, not from a lint, so it was never escalated and CI was never at risk. This was noise plus a false claim, not a broken gate.

### The doors are still shut

`crates/tokscale-cli/tests/tls_policy.rs` scans raw source text for all five constructors, so it does not care whether a path resolves. Verified by dropping a `reqwest::Client::default()` call into a non-allowlisted file:

```
test no_client_is_constructed_outside_the_allowlist ... FAILED
crates/tokscale-core/src/zz_probe.rs:3: reqwest::Client::default()
```

That is the same test that caught #1257's `Client::builder()` before it merged.

### What changed

- `clippy.toml`: the two entries are gone, and the comment now says which lane closes those doors instead of implying clippy does.
- `tls_policy.rs`: `LINTABLE_CONSTRUCTORS` names the three clippy can resolve; `DEFAULT_BACKEND_CONSTRUCTORS` still names all five the scan covers.
- `the_lint_config_and_the_source_scan_forbid_the_same_constructors` now checks both directions. It already failed when a lintable entry went missing; it now also fails when a `Default` entry is re-added, so the next person to "fix the gap" gets a test failure explaining why the gap is deliberate rather than a warning nobody reads.

The old parity test could not have caught this: it compared strings in `clippy.toml` against the scan list, which is exactly the comparison that cannot tell an entry clippy enforces from one it skips.

### Gates

Both clippy invocations, because neither is a superset of the other:

```
cargo fmt --all -- --check                                              FMT=0
cargo clippy --locked --workspace --all-features -- -D warnings         CLIPPY=0
cargo clippy --locked --workspace --all-targets --all-features -- -D warnings   CLIPPY_AT=0
cargo test --workspace                                                  TEST=0
```

13 suites `test result: ok`, 0 failed. `does not refer to a reachable` now appears 0 times in both clippy runs.

Negative controls before committing: re-adding `reqwest::Client::default` to `clippy.toml` fails the parity test (exit 101), and removing `reqwest::ClientBuilder::new` from it also fails (exit 101). Both restored and re-verified green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the two `reqwest` `Default` entries that Clippy could not resolve: they produced warnings on every run but never enforced the TLS policy from #1250. The three resolvable constructors remain in Clippy, while the source scan covers all five constructors.

**Lint coverage**

- Separates constructors enforced by Clippy from those covered only by the source scan.
- Makes the parity test reject missing Clippy entries and re-added inert `Default` entries.

<sup>Written for commit 35aac3e83bd4db119f7acf2dfbf8a7b2e6ef1ca4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

