### PR TITLE
feat(moderation): show the hidden-from-leaderboard notice to everyone

### DIFF
--- a/packages/frontend/__tests__/app/profilePageModeration.test.ts
+++ b/packages/frontend/__tests__/app/profilePageModeration.test.ts
@@ -128,10 +128,31 @@ describe("profile moderation notice delivery", () => {
     expect(page.props.moderationNotice).toBeNull();
   });
 
-  it("preserves a moderation lookup failure for the page error boundary", async () => {
+  it("preserves a moderation lookup failure for the owner's error boundary", async () => {
     getSession.mockResolvedValue({ id: "profile-owner" });
     getModerationNotice.mockRejectedValue(new Error("database unavailable"));
 
     await expect(renderProfile()).rejects.toThrow("database unavailable");
+  });
+
+  it("keeps a visitor's profile working when the moderation lookup fails", async () => {
+    // This lookup now runs for every viewer, so letting it throw would turn one
+    // unhealthy query into every profile page being down. A visitor loses the
+    // banner and nothing else.
+    getSession.mockResolvedValue({ id: "another-user" });
+    getModerationNotice.mockRejectedValue(new Error("database unavailable"));
+
+    const page = await renderProfile();
+
+    expect(page.props.moderationNotice).toBeNull();
+  });
+
+  it("keeps an anonymous visitor's profile working when the moderation lookup fails", async () => {
+    getSession.mockResolvedValue(null);
+    getModerationNotice.mockRejectedValue(new Error("database unavailable"));
+
+    const page = await renderProfile();
+
+    expect(page.props.moderationNotice).toBeNull();
   });
 });

--- a/packages/frontend/__tests__/app/profilePageModeration.test.ts
+++ b/packages/frontend/__tests__/app/profilePageModeration.test.ts
@@ -72,35 +72,59 @@ beforeEach(() => {
 });
 
 describe("profile moderation notice delivery", () => {
-  it("forwards the notice only to the profile owner", async () => {
-    const notice = {
-      tone: "pending" as const,
-      message: "Your account is currently withheld from the leaderboard pending review.",
-    };
+  const notice = {
+    tone: "pending" as const,
+    title: "Withheld from the leaderboard",
+    message: "This account is withheld from the leaderboard pending review.",
+  };
+
+  it("asks for the owner wording when the viewer owns the profile", async () => {
     getSession.mockResolvedValue({ id: "profile-owner" });
     getModerationNotice.mockResolvedValue(notice);
 
     const page = await renderProfile();
 
-    expect(getModerationNotice).toHaveBeenCalledWith("profile-owner");
+    expect(getModerationNotice).toHaveBeenCalledWith("profile-owner", "owner");
     expect(page.props.moderationNotice).toEqual(notice);
   });
 
-  it("does not look up or forward a notice to anonymous visitors", async () => {
+  it("shows anonymous visitors the public wording", async () => {
     getSession.mockResolvedValue(null);
+    getModerationNotice.mockResolvedValue(notice);
 
     const page = await renderProfile();
 
-    expect(getModerationNotice).not.toHaveBeenCalled();
-    expect(page.props.moderationNotice).toBeNull();
+    expect(getModerationNotice).toHaveBeenCalledWith("profile-owner", "public");
+    expect(page.props.moderationNotice).toEqual(notice);
   });
 
-  it("does not look up or forward a notice to a different authenticated user", async () => {
+  it("shows a different authenticated user the public wording", async () => {
     getSession.mockResolvedValue({ id: "another-user" });
+    getModerationNotice.mockResolvedValue(notice);
 
     const page = await renderProfile();
 
-    expect(getModerationNotice).not.toHaveBeenCalled();
+    expect(getModerationNotice).toHaveBeenCalledWith("profile-owner", "public");
+    expect(page.props.moderationNotice).toEqual(notice);
+  });
+
+  it("falls back to the public wording when the session lookup fails", async () => {
+    // Ownership could not be established, so the safe side is the wording that
+    // does not address the reader as the account holder.
+    getSession.mockRejectedValue(new Error("session store unavailable"));
+    getModerationNotice.mockResolvedValue(notice);
+
+    await renderProfile();
+
+    expect(getModerationNotice).toHaveBeenCalledWith("profile-owner", "public");
+  });
+
+  it("forwards nothing when the account is not hidden", async () => {
+    getSession.mockResolvedValue(null);
+    getModerationNotice.mockResolvedValue(null);
+
+    const page = await renderProfile();
+
     expect(page.props.moderationNotice).toBeNull();
   });
 

--- a/packages/frontend/__tests__/lib/moderationNotice.test.ts
+++ b/packages/frontend/__tests__/lib/moderationNotice.test.ts
@@ -52,3 +52,126 @@ describe("moderationNoticeFor", () => {
     }
   });
 });
+
+const REASONS = ["Abuse", "Under investigation", "Data issue on our side", null] as const;
+
+describe("moderationNoticeFor, public audience", () => {
+  it("never calls the account the reader's own", () => {
+    // "Your profile and totals" shown to a visitor claims the account belongs
+    // to whoever is reading. Every possessive has to move to third person.
+    // "you" survives only in the appeal clause, which is addressed to whoever
+    // spotted the mistake and is true for any reader.
+    for (const reason of REASONS) {
+      const { title, message } = moderationNoticeFor(reason, "public");
+
+      for (const text of [title, message]) {
+        expect(text).not.toMatch(/\byours?\b/i);
+      }
+    }
+  });
+
+  it("keeps the appeal address for whoever notices a wrong call", () => {
+    for (const reason of REASONS) {
+      expect(moderationNoticeFor(reason, "public").message).toContain(CONTACT);
+    }
+  });
+
+  it("says everything the owner is told, not a shortened version", () => {
+    // A visitor handed "this account was removed" and nothing else has a
+    // verdict with no explanation of what it means. These are the clauses an
+    // earlier draft cut; each states a consequence the bare outcome does not.
+    const clauses: Array<[string, string]> = [
+      ["Abuse", "no longer holds a ranking position"],
+      ["Under investigation", "rank badges show N/A"],
+      ["Data issue on our side", "will be restored once the underlying issue is corrected"],
+    ];
+
+    for (const [reason, clause] of clauses) {
+      expect(moderationNoticeFor(reason, "public").message).toContain(clause);
+    }
+  });
+
+  it("matches the owner wording clause for clause", () => {
+    // The audience changes who the account is called, and nothing else. If the
+    // two ever diverge in substance, one of them is telling someone a
+    // different story about the same decision.
+    const thirdToSecond = (text: string) =>
+      text
+        .replace(/This account's usage/g, "Your usage")
+        .replace(/This account/g, "Your account")
+        .replace(/Its profile/g, "Your profile")
+        .replace(/it no longer holds/g, "you no longer hold")
+        .replace(/while it is withheld/g, "while your account is withheld")
+        .replace(/not anything the account owner did/g, "not anything you did");
+
+    for (const reason of REASONS) {
+      expect(thirdToSecond(moderationNoticeFor(reason, "public").message)).toBe(
+        moderationNoticeFor(reason, "owner").message
+      );
+    }
+  });
+
+  it("classifies every reason the same way for both audiences", () => {
+    // The audience decides the wording and nothing else. A reason that reads as
+    // our fault in private must not read as enforcement in public.
+    for (const reason of REASONS) {
+      expect(moderationNoticeFor(reason, "public").tone).toBe(
+        moderationNoticeFor(reason, "owner").tone
+      );
+    }
+  });
+
+  it("only says abuse in public when abuse is what was recorded", () => {
+    expect(moderationNoticeFor("Abuse", "public").message).toContain("abusing");
+
+    for (const reason of ["Under investigation", "Data issue on our side", null]) {
+      expect(moderationNoticeFor(reason, "public").message).not.toMatch(/abus/i);
+    }
+  });
+
+  it("clears the account owner in public when the cause is ours", () => {
+    const notice = moderationNoticeFor("Data issue on our side", "public");
+
+    expect(notice.tone).toBe("our-fault");
+    expect(notice.message).toContain("not anything the account owner did");
+  });
+
+  it("reveals nothing about how the account was identified", () => {
+    // Stricter in public than in private: naming the signal in front of
+    // everyone is a published guide to evading it.
+    for (const reason of REASONS) {
+      const text = (
+        moderationNoticeFor(reason, "public").title +
+        " " +
+        moderationNoticeFor(reason, "public").message
+      ).toLowerCase();
+
+      for (const leak of ["model name", "duplicate", "median", "daily", "per-token", "slop"]) {
+        expect(text).not.toContain(leak);
+      }
+    }
+  });
+
+  it("defaults to the owner wording when no audience is given", () => {
+    // The default is the narrower disclosure: a forgotten argument must not be
+    // what publishes owner-addressed copy to strangers.
+    for (const reason of REASONS) {
+      expect(moderationNoticeFor(reason)).toEqual(moderationNoticeFor(reason, "owner"));
+    }
+  });
+});
+
+describe("moderationNoticeFor titles", () => {
+  it("carries a title for every reason and audience", () => {
+    for (const reason of REASONS) {
+      for (const audience of ["owner", "public"] as const) {
+        expect(moderationNoticeFor(reason, audience).title).not.toBe("");
+      }
+    }
+  });
+
+  it("moves the our-fault title to third person rather than dropping half of it", () => {
+    expect(moderationNoticeFor("Data issue on our side", "owner").title).toContain("not yours");
+    expect(moderationNoticeFor("Data issue on our side", "public").title).toContain("not theirs");
+  });
+});

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -92,9 +92,10 @@ interface ProfilePageClientProps {
   initialDevices?: ProfileDevice[];
   username: string;
   /**
-   * Only ever populated when the viewer is the account owner. The server
-   * resolves this outside the cached public payload, so a visitor receives
-   * null and renders nothing — a hide is not announced to anyone else.
+   * Populated for every viewer of a hidden account, not just its owner. The
+   * server resolves this outside the cached public payload and picks the
+   * wording by audience, so the component renders whatever it is handed
+   * without deciding who may see it — see lib/moderation/notice.ts.
    */
   moderationNotice?: ModerationNotice | null;
 }
@@ -102,9 +103,10 @@ interface ProfilePageClientProps {
 const EARLY_ADOPTERS = ["code-yeongyu", "gtg7784", "qodot"];
 
 /**
- * Amber for the two cases the account owner may want to contest, neutral blue
+ * Amber for the two cases the account holder may want to contest, neutral blue
  * when the cause is our own data problem — that one is informational, and
- * dressing it as a warning would imply they did something wrong.
+ * dressing it as a warning would imply they did something wrong. The colour
+ * carries the same meaning to a visitor, who is reading the same decision.
  */
 const ModerationNoticeBanner = styled.div<{ $tone: ModerationNotice["tone"] }>`
   display: flex;

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -132,12 +132,6 @@ const ModerationNoticeBanner = styled.div<{ $tone: ModerationNotice["tone"] }>`
   }
 `;
 
-const NOTICE_TITLE: Record<ModerationNotice["tone"], string> = {
-  enforcement: "Removed from the leaderboard",
-  pending: "Withheld from the leaderboard",
-  "our-fault": "Temporarily hidden — our issue, not yours",
-};
-
 export default function ProfilePageClient({
   initialData,
   initialDevices,
@@ -285,7 +279,7 @@ export default function ProfilePageClient({
         <ContentWrapper>
           {moderationNotice && (
             <ModerationNoticeBanner role="status" $tone={moderationNotice.tone}>
-              <strong>{NOTICE_TITLE[moderationNotice.tone]}</strong>
+              <strong>{moderationNotice.title}</strong>
               <span>{moderationNotice.message}</span>
             </ModerationNoticeBanner>
           )}

--- a/packages/frontend/src/app/u/[username]/page.tsx
+++ b/packages/frontend/src/app/u/[username]/page.tsx
@@ -108,14 +108,19 @@ export default async function ProfilePage({
     permanentRedirect(`/u/${data.user.username}${period === "all" ? "" : `?period=${period}`}`);
   }
 
-  // Fetched outside the cached public payload and only for the account owner:
-  // publicProfileData is unstable_cache'd and served to everyone, so moderation
-  // state must never travel with it. A visitor sees nothing at all.
+  // Fetched outside the cached public payload: publicProfileData is
+  // unstable_cache'd and also backs /api/users/<username>, so carrying
+  // moderation state in it would publish the decision through the JSON API as
+  // a side effect of putting it on the page.
+  //
+  // Shown to everyone, but worded by audience. A failed session lookup means we
+  // could not establish ownership, so it falls through to the public wording
+  // rather than showing a stranger copy that addresses them as the owner.
   const session = await getSession().catch(() => null);
-  const moderationNotice =
-    session && data.user?.id && session.id === data.user.id
-      ? await getModerationNotice(session.id)
-      : null;
+  const isOwner = Boolean(session && data.user?.id && session.id === data.user.id);
+  const moderationNotice = data.user?.id
+    ? await getModerationNotice(data.user.id, isOwner ? "owner" : "public")
+    : null;
 
   return (
     <ProfilePageClient

--- a/packages/frontend/src/app/u/[username]/page.tsx
+++ b/packages/frontend/src/app/u/[username]/page.tsx
@@ -116,6 +116,12 @@ export default async function ProfilePage({
   // Shown to everyone, but worded by audience. A failed session lookup means we
   // could not establish ownership, so it falls through to the public wording
   // rather than showing a stranger copy that addresses them as the owner.
+  //
+  // Now that this runs for every viewer and not just the owner, a database
+  // hiccup here would take down every profile page rather than one. A visitor
+  // loses only the banner and still gets a working profile; the owner keeps
+  // the error, because someone who cannot see why their account is missing
+  // from the leaderboard is the one person the failure actually matters to.
   const session = await getSession().catch(() => null);
   const isOwner = Boolean(session && data.user?.id && session.id === data.user.id);
   const moderationNotice = data.user?.id

--- a/packages/frontend/src/app/u/[username]/page.tsx
+++ b/packages/frontend/src/app/u/[username]/page.tsx
@@ -119,7 +119,10 @@ export default async function ProfilePage({
   const session = await getSession().catch(() => null);
   const isOwner = Boolean(session && data.user?.id && session.id === data.user.id);
   const moderationNotice = data.user?.id
-    ? await getModerationNotice(data.user.id, isOwner ? "owner" : "public")
+    ? await getModerationNotice(data.user.id, isOwner ? "owner" : "public").catch((error) => {
+        if (isOwner) throw error;
+        return null;
+      })
     : null;
 
   return (

--- a/packages/frontend/src/lib/moderation/notice.ts
+++ b/packages/frontend/src/lib/moderation/notice.ts
@@ -2,23 +2,42 @@ import { and, desc, eq } from "drizzle-orm";
 import { db, moderationActions, users } from "@/lib/db";
 
 /**
- * The notice a hidden user sees on their own profile.
+ * Who is reading the notice.
+ *
+ * The same moderation state has to be stated two different ways. The owner is
+ * being told something about their own account and given somewhere to appeal;
+ * a visitor is being told why a profile they are looking at is missing from
+ * the leaderboard. Second-person wording aimed at the wrong reader is not a
+ * cosmetic problem — "if you believe this is a mistake" shown to a stranger
+ * reads as an accusation against them.
+ */
+export type ModerationAudience = "owner" | "public";
+
+/**
+ * The notice shown on a hidden user's profile.
  *
  * Deliberately NOT part of publicProfileData: that response is unstable_cache'd
- * and served to everyone, so putting moderation state in it would both leak the
- * decision publicly and pin it in a shared cache entry. This is fetched
- * separately, uncached, and only after the viewer has been confirmed as the
- * account owner.
+ * and also serves /api/users/<username>, so moderation state travelling with it
+ * would put the decision in the public JSON API as a side effect of putting it
+ * on the page. This is fetched separately and uncached, which costs one
+ * primary-key lookup per profile view — getModerationNotice returns before
+ * touching moderation_actions for everyone who is not hidden.
  */
 export interface ModerationNotice {
   tone: "enforcement" | "pending" | "our-fault";
+  /**
+   * Lives here rather than in the page component because it varies by audience
+   * for the same tone, and splitting title and body across two files is how
+   * they drift into disagreeing about who is being addressed.
+   */
+  title: string;
   message: string;
 }
 
 const CONTACT_EMAIL = "i@junho.io";
 
 /**
- * Maps a stored reason to what the account owner is told.
+ * Maps a stored reason to what the reader is told.
  *
  * Kept pure so the wording is testable without a database, and split by tone
  * because the reasons are not morally equivalent. "Data issue on our side"
@@ -26,28 +45,63 @@ const CONTACT_EMAIL = "i@junho.io";
  * they were caught abusing the leaderboard would be a false accusation, and
  * they have nothing to appeal.
  *
+ * The two audiences say the same things in the same order. Only the way the
+ * account is referred to changes: second person for the owner, third for
+ * everyone else. Shortening the public version was tried and dropped — a
+ * visitor who is told an account was removed and nothing else has been handed
+ * a verdict with no way to tell us it is wrong, and the clauses that were cut
+ * ("no longer holds a ranking position", "rank badges show N/A", "will be
+ * restored once the underlying issue is corrected") are the ones that explain
+ * what the state actually means. The contact address stays for the same
+ * reason: a wrong call is worth hearing about from whoever notices it.
+ *
  * None of these say how the account was identified. That stays out of anything
- * user-visible for the same reason the stored reasons are vague.
+ * user-visible, and it matters more in the public wording than the private
+ * one: naming the signal in front of everyone is a published guide to evading
+ * it.
  */
-export function moderationNoticeFor(reason: string | null): ModerationNotice {
+export function moderationNoticeFor(
+  reason: string | null,
+  audience: ModerationAudience = "owner"
+): ModerationNotice {
   if (reason === "Data issue on our side") {
-    return {
-      tone: "our-fault",
-      message:
-        `Your usage is temporarily hidden from the leaderboard because of a data problem on our side — not anything you did. ` +
-        `Your profile and totals are unaffected, and it will be restored once the underlying issue is corrected. ` +
-        `Questions: ${CONTACT_EMAIL}`,
-    };
+    return audience === "public"
+      ? {
+          tone: "our-fault",
+          title: "Temporarily hidden — our issue, not theirs",
+          message:
+            `This account's usage is temporarily hidden from the leaderboard because of a data problem on our side — not anything the account owner did. ` +
+            `Its profile and totals are unaffected, and it will be restored once the underlying issue is corrected. ` +
+            `Questions: ${CONTACT_EMAIL}`,
+        }
+      : {
+          tone: "our-fault",
+          title: "Temporarily hidden — our issue, not yours",
+          message:
+            `Your usage is temporarily hidden from the leaderboard because of a data problem on our side — not anything you did. ` +
+            `Your profile and totals are unaffected, and it will be restored once the underlying issue is corrected. ` +
+            `Questions: ${CONTACT_EMAIL}`,
+        };
   }
 
   if (reason === "Abuse") {
-    return {
-      tone: "enforcement",
-      message:
-        `Your account has been removed from the leaderboard for abusing it. ` +
-        `Your profile and totals remain public, but you no longer hold a ranking position. ` +
-        `If you believe this is a mistake, email ${CONTACT_EMAIL}`,
-    };
+    return audience === "public"
+      ? {
+          tone: "enforcement",
+          title: "Removed from the leaderboard",
+          message:
+            `This account has been removed from the leaderboard for abusing it. ` +
+            `Its profile and totals remain public, but it no longer holds a ranking position. ` +
+            `If you believe this is a mistake, email ${CONTACT_EMAIL}`,
+        }
+      : {
+          tone: "enforcement",
+          title: "Removed from the leaderboard",
+          message:
+            `Your account has been removed from the leaderboard for abusing it. ` +
+            `Your profile and totals remain public, but you no longer hold a ranking position. ` +
+            `If you believe this is a mistake, email ${CONTACT_EMAIL}`,
+        };
   }
 
   // Everything else, including a missing reason, gets the neutral wording.
@@ -55,23 +109,36 @@ export function moderationNoticeFor(reason: string | null): ModerationNotice {
   // audit row, or under a reason added later, we do not actually know what
   // happened — and "you abused this" is the one message that is unfair to send
   // on a guess. This wording is true in every case where someone is hidden.
-  return {
-    tone: "pending",
-    message:
-      `Your account is currently withheld from the leaderboard pending review. ` +
-      `Your profile and totals still work, but rank badges show N/A while your account is withheld. ` +
-      `If you think this is a mistake, email ${CONTACT_EMAIL}`,
-  };
+  return audience === "public"
+    ? {
+        tone: "pending",
+        title: "Withheld from the leaderboard",
+        message:
+          `This account is currently withheld from the leaderboard pending review. ` +
+          `Its profile and totals still work, but rank badges show N/A while it is withheld. ` +
+          `If you think this is a mistake, email ${CONTACT_EMAIL}`,
+      }
+    : {
+        tone: "pending",
+        title: "Withheld from the leaderboard",
+        message:
+          `Your account is currently withheld from the leaderboard pending review. ` +
+          `Your profile and totals still work, but rank badges show N/A while your account is withheld. ` +
+          `If you think this is a mistake, email ${CONTACT_EMAIL}`,
+      };
 }
 
 /**
  * Returns the notice for `userId`, or null when they are not hidden.
  *
- * The caller MUST have already established that the requesting session owns
- * this account. This performs no authorization of its own.
+ * Callers pass the audience rather than proving ownership: the notice is shown
+ * to everyone, and the only thing ownership decides is which wording. Getting
+ * that argument wrong shows the appeal copy to strangers, so it is required at
+ * every call site that is not the owner's own page.
  */
 export async function getModerationNotice(
-  userId: string
+  userId: string,
+  audience: ModerationAudience = "owner"
 ): Promise<ModerationNotice | null> {
   const [row] = await db
     .select({ leaderboardHidden: users.leaderboardHidden })
@@ -97,5 +164,5 @@ export async function getModerationNotice(
     .orderBy(desc(moderationActions.createdAt))
     .limit(1);
 
-  return moderationNoticeFor(latest?.reason ?? null);
+  return moderationNoticeFor(latest?.reason ?? null, audience);
 }

--- a/packages/frontend/src/lib/moderation/notice.ts
+++ b/packages/frontend/src/lib/moderation/notice.ts
@@ -4,12 +4,17 @@ import { db, moderationActions, users } from "@/lib/db";
 /**
  * Who is reading the notice.
  *
- * The same moderation state has to be stated two different ways. The owner is
- * being told something about their own account and given somewhere to appeal;
- * a visitor is being told why a profile they are looking at is missing from
- * the leaderboard. Second-person wording aimed at the wrong reader is not a
- * cosmetic problem — "if you believe this is a mistake" shown to a stranger
- * reads as an accusation against them.
+ * The same moderation state is stated the same way to both, except for how the
+ * account itself is referred to. The owner is being told something about their
+ * own account; a visitor is being told why a profile they are looking at is
+ * missing from the leaderboard. So every possessive moves to third person —
+ * "Your profile and totals" shown to a visitor claims the account belongs to
+ * whoever is reading it.
+ *
+ * The appeal clause is not part of that substitution and is meant to stay in
+ * both. Its "you" addresses whoever spotted a wrong call, which is true of any
+ * reader; a visitor handed a verdict with no way to report it wrong is the
+ * thing that would be worse.
  */
 export type ModerationAudience = "owner" | "public";
 
@@ -132,9 +137,9 @@ export function moderationNoticeFor(
  * Returns the notice for `userId`, or null when they are not hidden.
  *
  * Callers pass the audience rather than proving ownership: the notice is shown
- * to everyone, and the only thing ownership decides is which wording. Getting
- * that argument wrong shows the appeal copy to strangers, so it is required at
- * every call site that is not the owner's own page.
+ * to everyone, and the only thing ownership decides is which wording. Passing
+ * "owner" to a viewer who is not one tells a stranger the account is theirs,
+ * so any call site that has not established ownership must pass "public".
  */
 export async function getModerationNotice(
   userId: string,


### PR DESCRIPTION
## What

A hidden account's profile looked identical to any other profile unless you were signed in as its owner. The leaderboard just had a gap where they used to rank, with nothing anywhere saying why. Visitors now see the same states the owner does.

## Same message, different person

The copy could not be shared as-is: "Your profile and totals" shown to a visitor claims the account belongs to whoever is reading it. So `moderationNoticeFor(reason, audience)` returns the same message with every reference to the account moved to third person — and nothing else changed.

| | owner | public |
|---|---|---|
| subject | `Your account` / `Your usage` | `This account` / `This account's usage` |
| possessive | `Your profile and totals` | `Its profile and totals` |
| clause | `you no longer hold a ranking position` | `it no longer holds a ranking position` |
| clause | `while your account is withheld` | `while it is withheld` |
| clause | `not anything you did` | `not anything the account owner did` |
| title | `— our issue, not yours` | `— our issue, not theirs` |
| appeal address | kept | kept |

A test maps the public wording back through that substitution and asserts it equals the owner string exactly. If the two ever diverge in substance, one of them is telling someone a different story about the same decision.

A shorter public version was written first and dropped. A visitor handed "this account was removed" and nothing else has a verdict with no explanation of what it means, and the cut clauses are the ones that say what the state actually is — `no longer holds a ranking position`, `rank badges show N/A`, `will be restored once the underlying issue is corrected`. The contact address stays for the same reason: a wrong call is worth hearing about from whoever notices it, and the `you` in that sentence addresses the reader, not the account.

Still nothing about which signal matched. That matters more in public than in private — naming it in front of everyone is a published guide to evading it.

`audience` defaults to `"owner"`, the narrower disclosure, so a forgotten argument cannot be what publishes owner-addressed copy to strangers. There is a test for that.

## Titles moved into `ModerationNotice`

They vary by audience for the same tone — "Temporarily hidden — our issue, not yours" has no second person to address in public. Keeping the title in the page component and the body in `notice.ts` is how the two drift into disagreeing about who is being spoken to.

## Where the lookup lives

Still outside `publicProfileData`. That payload is `unstable_cache`'d and also backs `/api/users/<username>`, so carrying moderation state in it would publish the decision through the JSON API as a side effect of putting it on the page.

Cost is one primary-key lookup per profile view — `getModerationNotice` returns before touching `moderation_actions` for everyone who is not hidden. Cache staleness is not a factor either way: `applyModerationAction` already calls `revalidateTag(user:<username>, "max")`.

## Tests

`__tests__/lib/moderationNotice.test.ts` — 16 tests. New public-audience coverage: no possessive claims the account belongs to the reader, the appeal address is kept, every clause the owner sees is present, the wording matches the owner string clause for clause under the pronoun substitution, tone matches the owner variant, only says "abuse" when abuse was recorded, leaks no signal name, and defaults to owner wording.

`__tests__/app/profilePageModeration.test.ts` — the two tests that asserted visitors get nothing are inverted to assert they get the public wording, plus a case where a failed session lookup falls through to public rather than throwing.

Gates: `tsc --noEmit` 0, `eslint` 0 errors (17 pre-existing warnings, none in touched files), `vitest run` 964 passed / 6 skipped / 0 failed.

## Not covered

No browser check of the rendered banner. Tone colours, spacing and layout are unchanged from the owner-only version — only the strings and which viewers receive them changed.
