### PR TITLE
fix(droid): show transcript-dated usage on the web graph

### DIFF
--- a/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
+++ b/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SUPPORTED_VERSIONED_PARSERS } from "../../src/lib/db/parserHighWater";
@@ -285,6 +288,7 @@ function isDailyBreakdownInsert(text: string): boolean {
 
 function installTx(store: Store) {
   const executedSqlArgs: unknown[] = [];
+  const selectedColumns: Array<Record<string, unknown>> = [];
 
   function applyDailyBreakdownWrite(sqlArg: unknown): void {
     const strings: string[] = [];
@@ -360,9 +364,10 @@ function installTx(store: Store) {
       };
       return builder;
     }),
-    select: vi.fn((columns: Record<string, unknown>) =>
-      makeAwaitableBuilder(selectResult(columns, store)),
-    ),
+    select: vi.fn((columns: Record<string, unknown>) => {
+      selectedColumns.push(columns);
+      return makeAwaitableBuilder(selectResult(columns, store));
+    }),
     insert: vi.fn(() => {
       const builder = {
         values: vi.fn(() => builder),
@@ -392,7 +397,7 @@ function installTx(store: Store) {
     async (callback: (transaction: typeof tx) => Promise<unknown>) =>
       callback(tx),
   );
-  return { executedSqlArgs };
+  return { executedSqlArgs, selectedColumns };
 }
 
 function submissionBody(
@@ -793,5 +798,122 @@ describe("POST /api/submit droid snapshot layout", () => {
       store.days.find((day) => day.date === "2026-08-10")?.sourceBreakdown.droid
         .tokens,
     ).toBe(55_000);
+  });
+});
+
+/**
+ * A Droid day that also carries a client with no versioned parser. The
+ * snapshot layout only ever moves the Droid cell, so the sibling's fate on a
+ * day the snapshot no longer mentions is what the preserve warning describes.
+ */
+function droidAndClaudeBody(
+  days: Array<{ date: string; droid?: number; claude?: number }>,
+) {
+  const dates = days.map((day) => day.date).sort();
+  const entry = (client: string, tokens: number) => ({
+    client,
+    modelId: client === "droid" ? "gemini-3-pro" : "claude-sonnet-4",
+    tokens: { input: tokens, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+    cost: tokens / 1000,
+    messages: 2,
+  });
+  return {
+    device: { id: "dev_1", name: "Device one" },
+    meta: {
+      generatedAt: "2026-08-10T00:00:00Z",
+      version: "4.13.0",
+      dateRange: { start: dates[0], end: dates[dates.length - 1] },
+    },
+    scanScope: { parserVersions: { droid: 1 }, fullHistory: true },
+    summary: { clients: ["droid", "claude"] },
+    years: [],
+    contributions: days.map((day) => ({
+      date: day.date,
+      clients: [
+        ...(day.droid ? [entry("droid", day.droid)] : []),
+        ...(day.claude ? [entry("claude", day.claude)] : []),
+      ],
+    })),
+  };
+}
+
+describe("POST /api/submit droid snapshot layout sibling clients", () => {
+  it("does not report a sibling client as disappeared from a day the snapshot only emptied of Droid", async () => {
+    const store = newStore();
+
+    installTx(store);
+    const first = droidAndClaudeBody([
+      { date: "2026-08-07", droid: 240_000, claude: 10_000 },
+    ]);
+    mockSubmit(first);
+    expect((await post(first)).status).toBe(200);
+
+    installTx(store);
+    const rewritten = droidAndClaudeBody([
+      { date: "2026-08-08", droid: 120_000 },
+      { date: "2026-08-09", droid: 120_000, claude: 10_000 },
+    ]);
+    mockSubmit(rewritten);
+    const response = await post(rewritten);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+
+    // 08-07 is only in the write set because the Droid layout emptied it. The
+    // day never disappeared for Claude -- the submission simply does not cover
+    // it -- so the preserve warning must not fire.
+    const startDay = store.days.find((day) => day.date === "2026-08-07");
+    expect(startDay?.sourceBreakdown.claude?.tokens).toBe(10_000);
+    expect(startDay?.sourceBreakdown.droid).toBeUndefined();
+    expect(
+      json.warnings.filter((warning: string) =>
+        warning.includes("Preserved claude"),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("submission date range aggregate", () => {
+  // This transaction double never enforces NOT NULL, so a green route test
+  // proves nothing about a NULL date range. Pin the SQL expression instead:
+  // `sql` is not mocked, so the fragment the route builds is a real drizzle
+  // object and collectStrings reassembles it verbatim.
+  function renderSql(fragment: unknown): string {
+    const parts: string[] = [];
+    collectStrings(fragment, parts);
+    return parts.join("");
+  }
+
+  it("falls back to the unfiltered bounds, so a history with no token-bearing day is not NULL", async () => {
+    const store = newStore();
+    const { selectedColumns } = installTx(store);
+    const body = submissionBody("droid", SESSION_START_DATING);
+    mockSubmit(body);
+    expect((await post(body)).status).toBe(200);
+
+    const aggregate = selectedColumns.find(
+      (columns) => "totalTokens" in columns && "dateStart" in columns,
+    );
+    expect(aggregate).toBeDefined();
+    // MIN/MAX over the tokens filter alone is NULL for a user whose whole
+    // stored history is legacy tokenless Cursor rows -- a shape validation
+    // explicitly permits -- and both columns are NOT NULL.
+    expect(renderSql(aggregate!.dateStart)).toBe(
+      "COALESCE(MIN(CASE WHEN dailyBreakdown.tokens > 0 THEN dailyBreakdown.date END), MIN(dailyBreakdown.date))",
+    );
+    expect(renderSql(aggregate!.dateEnd)).toBe(
+      "COALESCE(MAX(CASE WHEN dailyBreakdown.tokens > 0 THEN dailyBreakdown.date END), MAX(dailyBreakdown.date))",
+    );
+  });
+
+  it("pins the NOT NULL columns the fallback exists for", () => {
+    const migration = readFileSync(
+      resolve(
+        __dirname,
+        "../../src/lib/db/migrations/0000_add_user_id_unique_constraint.sql",
+      ),
+      "utf8",
+    );
+    expect(migration).toContain('"date_start" date NOT NULL');
+    expect(migration).toContain('"date_end" date NOT NULL');
   });
 });

--- a/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
+++ b/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
@@ -155,7 +155,14 @@ function collectStrings(
   }
 }
 
-type StoredBreakdown = Record<string, { tokens: number }>;
+type StoredBreakdown = Record<
+  string,
+  {
+    tokens: number;
+    cost?: number;
+    provenance?: { costIsComplete?: boolean };
+  }
+>;
 
 type PersistedDay = {
   id: string;

--- a/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
+++ b/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
@@ -204,19 +204,36 @@ function storedTokens(store: Store): number {
   );
 }
 
+function storedCost(store: Store): number {
+  return store.days.reduce(
+    (total, day) =>
+      total +
+      Object.values(day.sourceBreakdown).reduce(
+        (sum, client) => sum + (client.cost ?? 0),
+        0,
+      ),
+    0,
+  );
+}
+
 function aggregatesRow(store: Store) {
   const totalTokens = storedTokens(store);
-  const dates = store.days.map((day) => day.date).sort();
+  const dates = store.days
+    .filter((day) =>
+      Object.values(day.sourceBreakdown).some((client) => client.tokens > 0),
+    )
+    .map((day) => day.date)
+    .sort();
   return {
     totalTokens,
-    totalCost: (totalTokens / 1000).toFixed(4),
+    totalCost: storedCost(store).toFixed(4),
     inputTokens: totalTokens,
     outputTokens: 0,
     dateStart: dates[0] ?? null,
     dateEnd: dates[dates.length - 1] ?? null,
-    activeDays: store.days.length,
-    totalActiveTimeMs: 0,
+    activeDays: dates.length,
     rowCount: store.days.length,
+    totalActiveTimeMs: 0,
   };
 }
 
@@ -274,7 +291,8 @@ function installTx(store: Store) {
     collectStrings(sqlArg, strings);
     const text = strings.join("\n");
     if (text.includes("DELETE FROM daily_breakdown")) {
-      throw new Error("submit route deleted a daily_breakdown row");
+      store.days = store.days.filter((day) => !strings.includes(day.id));
+      return;
     }
     const insert = isDailyBreakdownInsert(text);
     // The batch row update; NOT the legacy-adoption `UPDATE ... AS db`, which
@@ -686,7 +704,7 @@ describe("POST /api/submit droid snapshot layout", () => {
     );
     expect(
       secondJson.warnings.some((warning: string) =>
-        warning.includes("Preserved droid"),
+        warning.includes("Established the Droid parser generation"),
       ),
     ).toBe(false);
     expect(
@@ -722,6 +740,39 @@ describe("POST /api/submit droid snapshot layout", () => {
     expect(startDay?.sourceBreakdown.droid.provenance?.costIsComplete).toBe(
       false,
     );
+  });
+
+  it("carries the stored Droid cost onto new days when an unpriced snapshot moves every token", async () => {
+    const store = newStore();
+
+    installTx(store);
+    const priced = submissionBody("droid", SESSION_START_DATING);
+    mockSubmit(priced);
+    expect((await post(priced)).status).toBe(200);
+
+    installTx(store);
+    const moved = submissionBody("droid", [
+      { date: "2026-08-08", tokens: 120_000, messages: 6 },
+      { date: "2026-08-09", tokens: 120_000, messages: 6 },
+    ]);
+    for (const day of moved.contributions) {
+      day.clients[0].cost = 0;
+      (day as { totals?: { costIsComplete: boolean } }).totals = {
+        costIsComplete: false,
+      };
+    }
+    mockSubmit(moved);
+    const response = await post(moved);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+
+    expect(store.days.map((day) => day.date).sort()).toEqual([
+      "2026-08-08",
+      "2026-08-09",
+    ]);
+    expect(storedCost(store)).toBe(240);
+    expect(json.metrics.dateRange.start).toBe("2026-08-08");
+    expect(json.metrics.dateRange.end).toBe("2026-08-09");
   });
 
   it("still credits genuinely new Droid usage after the layout rewrite", async () => {

--- a/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
+++ b/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
@@ -677,6 +677,44 @@ describe("POST /api/submit droid snapshot layout", () => {
     expect(store.days.find((day) => day.date === "2026-08-09")?.sourceBreakdown.droid.tokens).toBe(
       80_000,
     );
+    expect(
+      secondJson.warnings.some((warning: string) =>
+        warning.includes("Preserved droid"),
+      ),
+    ).toBe(false);
+    expect(
+      secondJson.warnings.some((warning: string) =>
+        warning.includes("Rewrote Droid daily layout"),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps the stored Droid cost floor when a full unpriced snapshot replaces the layout", async () => {
+    const store = newStore();
+
+    installTx(store);
+    const priced = submissionBody("droid", SESSION_START_DATING);
+    mockSubmit(priced);
+    expect((await post(priced)).status).toBe(200);
+
+    installTx(store);
+    const unpriced = submissionBody("droid", PER_GENERATION_DATING);
+    for (const day of unpriced.contributions) {
+      day.clients[0].cost = 0;
+      (day as { totals?: { costIsComplete: boolean } }).totals = {
+        costIsComplete: false,
+      };
+    }
+    mockSubmit(unpriced);
+    const response = await post(unpriced);
+    expect(response.status).toBe(200);
+
+    const startDay = store.days.find((day) => day.date === "2026-08-07");
+    expect(startDay?.sourceBreakdown.droid.tokens).toBe(40_000);
+    expect(Number(startDay?.sourceBreakdown.droid.cost)).toBe(240);
+    expect(startDay?.sourceBreakdown.droid.provenance?.costIsComplete).toBe(
+      false,
+    );
   });
 
   it("still credits genuinely new Droid usage after the layout rewrite", async () => {

--- a/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
+++ b/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
@@ -655,3 +655,47 @@ describe("POST /api/submit antigravity (IDE) re-attribution high-water", () => {
     ).toBe(55_000);
   });
 });
+
+describe("POST /api/submit droid snapshot layout", () => {
+  it("replaces stored Droid days when a full snapshot re-dates the same lifetime", async () => {
+    const { store, firstJson, secondJson } = await submitOldThenNew("droid");
+
+    expect(firstJson.metrics.totalTokens).toBe(240_000);
+    expect(secondJson.metrics.totalTokens).toBe(240_000);
+    expect(storedTokens(store)).toBe(240_000);
+    expect(store.days.map((day) => day.date).sort()).toEqual([
+      "2026-08-07",
+      "2026-08-08",
+      "2026-08-09",
+    ]);
+    expect(store.days.find((day) => day.date === "2026-08-07")?.sourceBreakdown.droid.tokens).toBe(
+      40_000,
+    );
+    expect(store.days.find((day) => day.date === "2026-08-08")?.sourceBreakdown.droid.tokens).toBe(
+      120_000,
+    );
+    expect(store.days.find((day) => day.date === "2026-08-09")?.sourceBreakdown.droid.tokens).toBe(
+      80_000,
+    );
+  });
+
+  it("still credits genuinely new Droid usage after the layout rewrite", async () => {
+    const { store } = await submitOldThenNew("droid");
+
+    installTx(store);
+    const grown = submissionBody("droid", [
+      ...PER_GENERATION_DATING,
+      { date: "2026-08-10", tokens: 55_000, messages: 3 },
+    ]);
+    mockSubmit(grown);
+    const response = await post(grown);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+
+    expect(json.metrics.totalTokens).toBe(295_000);
+    expect(
+      store.days.find((day) => day.date === "2026-08-10")?.sourceBreakdown.droid
+        .tokens,
+    ).toBe(55_000);
+  });
+});

--- a/packages/frontend/__tests__/lib/graphClientFilter.test.ts
+++ b/packages/frontend/__tests__/lib/graphClientFilter.test.ts
@@ -5,6 +5,7 @@ import {
   resolveSelectedDay,
   filterByClient,
   dayHasActivity,
+  findBestDay,
 } from "../../src/lib/utils";
 import type { ClientType, DailyContribution } from "../../src/lib/types";
 
@@ -148,5 +149,33 @@ describe("unpriced Droid days still count as activity", () => {
     const filtered = filterByClient(data, ["droid"]);
     expect(filtered.summary.totalTokens).toBe(150_000_000);
     expect(filtered.summary.activeDays).toBe(1);
+  });
+});
+
+describe("findBestDay", () => {
+  it("ranks by cost first so a free high-token day does not beat a priced day", () => {
+    const free = {
+      ...day("2026-08-01"),
+      totals: { tokens: 9_000, cost: 0, messages: 9 },
+    };
+    const priced = {
+      ...day("2026-08-02"),
+      totals: { tokens: 1_000, cost: 12, messages: 2 },
+    };
+
+    expect(findBestDay([free, priced])).toBe(priced);
+  });
+
+  it("breaks cost ties with tokens so all-free data still picks a real usage day", () => {
+    const quiet = {
+      ...day("2026-08-01"),
+      totals: { tokens: 100, cost: 0, messages: 1 },
+    };
+    const busy = {
+      ...day("2026-08-02"),
+      totals: { tokens: 9_000, cost: 0, messages: 9 },
+    };
+
+    expect(findBestDay([quiet, busy])).toBe(busy);
   });
 });

--- a/packages/frontend/__tests__/lib/graphClientFilter.test.ts
+++ b/packages/frontend/__tests__/lib/graphClientFilter.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { toggleClientFilter, resolveSelectedDay } from "../../src/lib/utils";
+import {
+  toggleClientFilter,
+  resolveSelectedDay,
+  filterByClient,
+  dayHasActivity,
+} from "../../src/lib/utils";
 import type { ClientType, DailyContribution } from "../../src/lib/types";
 
 const availableClients: ClientType[] = ["claude", "codex", "gemini"];
@@ -71,5 +76,77 @@ describe("resolveSelectedDay", () => {
     // Same date, different (filtered) array -> caller gets the new object, never stale.
     expect(resolveSelectedDay("2026-07-11", filtered)).toBe(filtered[0]);
     expect(resolveSelectedDay("2026-07-11", filtered)).not.toBe(contributions[1]);
+  });
+});
+
+describe("unpriced Droid days still count as activity", () => {
+  it("treats token-positive zero-cost days as active", () => {
+    expect(
+      dayHasActivity({
+        ...day("2026-09-01"),
+        totals: { tokens: 150_000_000, cost: 0, messages: 31 },
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps unpriced Droid tokens when the local graph is filtered to that client", () => {
+    const data = {
+      meta: {
+        generatedAt: "2026-09-02T00:00:00.000Z",
+        version: "4.15.0",
+        dateRange: { start: "2026-09-01", end: "2026-09-01" },
+      },
+      summary: {
+        totalTokens: 150_000_000,
+        totalCost: 1,
+        totalDays: 1,
+        activeDays: 1,
+        averagePerDay: 1,
+        maxCostInSingleDay: 1,
+        clients: ["droid", "codex"] as ClientType[],
+        models: ["ox-alpha-(openrouter)-0"],
+      },
+      years: [
+        {
+          year: "2026",
+          totalTokens: 150_000_000,
+          totalCost: 1,
+          range: { start: "2026-09-01", end: "2026-09-01" },
+        },
+      ],
+      contributions: [
+        {
+          date: "2026-09-01",
+          totals: { tokens: 150_000_000, cost: 0, messages: 31 },
+          intensity: 4 as const,
+          tokenBreakdown: {
+            input: 150_000_000,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            reasoning: 0,
+          },
+          clients: [
+            {
+              client: "droid" as const,
+              modelId: "ox-alpha-(openrouter)-0",
+              tokens: {
+                input: 150_000_000,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+              },
+              cost: 0,
+              messages: 31,
+            },
+          ],
+        },
+      ],
+    };
+
+    const filtered = filterByClient(data, ["droid"]);
+    expect(filtered.summary.totalTokens).toBe(150_000_000);
+    expect(filtered.summary.activeDays).toBe(1);
   });
 });

--- a/packages/frontend/__tests__/lib/helpers.test.ts
+++ b/packages/frontend/__tests__/lib/helpers.test.ts
@@ -241,4 +241,21 @@ describe("reapplyReplaceLayoutCostFloors", () => {
     expect(first.provenance?.costIsComplete).toBe(false);
     expect(second.provenance?.costIsComplete).toBe(false);
   });
+
+  it("splits a cell's cost floor across models by token share", () => {
+    const cell = makeClient(100_000, 4, 2) as ClientBreakdownData;
+    cell.models["model-0"].tokens = 75_000;
+    cell.models["model-1"].tokens = 25_000;
+    cell.tokens = 100_000;
+
+    reapplyReplaceLayoutCostFloors(
+      [{ sourceBreakdown: { droid: cell } }],
+      new Map([["droid", 40]]),
+      new Set(["droid"])
+    );
+
+    expect(cell.models["model-0"].cost).toBe(30);
+    expect(cell.models["model-1"].cost).toBe(10);
+    expect(cell.cost).toBe(40);
+  });
 });

--- a/packages/frontend/__tests__/lib/helpers.test.ts
+++ b/packages/frontend/__tests__/lib/helpers.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   applyCostCompleteness,
   mergeClientBreakdownsWithRegressionGuard,
+  reapplyReplaceLayoutCostFloors,
+  type ClientBreakdownData,
 } from "../../src/lib/db/helpers";
 
 // Minimal client breakdown fixture
@@ -220,5 +222,23 @@ describe("applyCostCompleteness", () => {
     expect(next.tokens).toBe(40_000);
     expect(next.cost).toBe(240);
     expect(next.provenance?.costIsComplete).toBe(false);
+  });
+});
+
+describe("reapplyReplaceLayoutCostFloors", () => {
+  it("spreads a pre-rewrite cost floor onto days that had no stored cell", () => {
+    const first = makeClient(120_000, 6, 1) as ClientBreakdownData;
+    const second = makeClient(120_000, 6, 1) as ClientBreakdownData;
+    const rows = [{ sourceBreakdown: { droid: first } }, { sourceBreakdown: { droid: second } }];
+
+    reapplyReplaceLayoutCostFloors(
+      rows,
+      new Map([["droid", 240]]),
+      new Set(["droid"])
+    );
+
+    expect(first.cost + second.cost).toBe(240);
+    expect(first.provenance?.costIsComplete).toBe(false);
+    expect(second.provenance?.costIsComplete).toBe(false);
   });
 });

--- a/packages/frontend/__tests__/lib/helpers.test.ts
+++ b/packages/frontend/__tests__/lib/helpers.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { mergeClientBreakdownsWithRegressionGuard } from "../../src/lib/db/helpers";
+import {
+  applyCostCompleteness,
+  mergeClientBreakdownsWithRegressionGuard,
+} from "../../src/lib/db/helpers";
 
 // Minimal client breakdown fixture
 function makeClient(tokens: number, messages: number, modelCount: number) {
@@ -202,5 +205,20 @@ describe("mergeClientBreakdownsWithRegressionGuard", () => {
       expect(result.warnings[0]).toContain("disappeared");
       expect(result.foldPreservedClients).toEqual(new Set(["kilo"]));
     });
+  });
+});
+
+describe("applyCostCompleteness", () => {
+  it("keeps the stored cost floor and incompleteness tag when incoming pricing is missing", () => {
+    const existing = makeClient(240_000, 12, 1);
+    existing.cost = 240;
+    existing.models["model-0"].cost = 240;
+    const incoming = makeClient(40_000, 2, 1);
+
+    const next = applyCostCompleteness(incoming, existing, false);
+
+    expect(next.tokens).toBe(40_000);
+    expect(next.cost).toBe(240);
+    expect(next.provenance?.costIsComplete).toBe(false);
   });
 });

--- a/packages/frontend/__tests__/lib/parserHighWater.test.ts
+++ b/packages/frontend/__tests__/lib/parserHighWater.test.ts
@@ -1487,7 +1487,7 @@ describe("droid parser high-water", () => {
   it("moves a re-attributed session onto the days the current parser reports", () => {
     const plan = droidPlan(wholeSessionOnOneDay, sessionSplitAcrossDays);
 
-    expect(plan.mode).toBe("baseline-legacy");
+    expect(plan.mode).toBe("replace");
     expect(plan.increments).toEqual({});
     expect(plan.layoutDays?.["2026-08-07"]?.tokens).toBe(21_000);
     expect(plan.layoutDays?.["2026-08-08"]?.tokens).toBe(152_000);
@@ -1506,7 +1506,7 @@ describe("droid parser high-water", () => {
 
     const plan = droidPlan({}, grown, state);
 
-    expect(plan.mode).toBe("incremental");
+    expect(plan.mode).toBe("replace");
     expect(plan.layoutDays?.["2026-08-10"]?.tokens).toBe(79_000);
     expect(plan.nextState?.aggregate.tokens).toBe(400_000);
   });

--- a/packages/frontend/__tests__/lib/parserHighWater.test.ts
+++ b/packages/frontend/__tests__/lib/parserHighWater.test.ts
@@ -1484,27 +1484,15 @@ describe("droid parser high-water", () => {
     expect(stored).toBe(621_000);
   });
 
-  it("credits nothing for a pure re-attribution of the same lifetime total", () => {
+  it("moves a re-attributed session onto the days the current parser reports", () => {
     const plan = droidPlan(wholeSessionOnOneDay, sessionSplitAcrossDays);
 
     expect(plan.mode).toBe("baseline-legacy");
-    const credited = Object.values(plan.increments).reduce(
-      (sum, day) => sum + day.tokens,
-      0
-    );
-    expect(credited).toBe(0);
-
-    // The stored rows are preserved untouched, so the device's total is the
-    // 321,000 it always was rather than the 621,000 the merge alone stores.
-    const stored = Object.keys(sessionSplitAcrossDays).reduce((sum, date) => {
-      const existing = wholeSessionOnOneDay[date];
-      const increment = plan.increments[date];
-      const merged = increment
-        ? addClientBreakdownIncrement(existing, increment)
-        : existing;
-      return sum + (merged?.tokens ?? 0);
-    }, 0);
-    expect(stored).toBe(321_000);
+    expect(plan.increments).toEqual({});
+    expect(plan.layoutDays?.["2026-08-07"]?.tokens).toBe(21_000);
+    expect(plan.layoutDays?.["2026-08-08"]?.tokens).toBe(152_000);
+    expect(plan.layoutDays?.["2026-08-09"]?.tokens).toBe(148_000);
+    expect(plan.nextState?.aggregate.tokens).toBe(321_000);
   });
 
   it("still credits real usage that arrives after the re-attribution", () => {
@@ -1519,10 +1507,8 @@ describe("droid parser high-water", () => {
     const plan = droidPlan({}, grown, state);
 
     expect(plan.mode).toBe("incremental");
-    expect(plan.increments["2026-08-10"]?.tokens).toBe(79_000);
-    expect(
-      Object.values(plan.increments).reduce((sum, day) => sum + day.tokens, 0)
-    ).toBe(79_000);
+    expect(plan.layoutDays?.["2026-08-10"]?.tokens).toBe(79_000);
+    expect(plan.nextState?.aggregate.tokens).toBe(400_000);
   });
 
   it("does not let a date-filtered rescan advance the high-water", () => {

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -63,6 +63,35 @@ const INSERT_CHUNK_SIZE = 1000;
 // (which would double-count the same underlying usage).
 const LEGACY_CLIENT_ALIASES: Record<string, string> = { kilocode: "kilo" };
 
+function emptyLayoutDay(date: string): SubmissionData["contributions"][number] {
+  return {
+    date,
+    clients: [],
+    totals: { tokens: 0, cost: 0, messages: 0 },
+    intensity: 0,
+    tokenBreakdown: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+    },
+  };
+}
+
+function applySnapshotLayoutDays(
+  merged: Record<string, ClientBreakdownData>,
+  date: string,
+  parserPlans: Map<string, ParserHighWaterPlan>
+): void {
+  for (const [client, plan] of parserPlans) {
+    if (!plan.layoutDays) continue;
+    const next = ownValue(plan.layoutDays, date);
+    if (next) merged[client] = next;
+    else delete merged[client];
+  }
+}
+
 function mergeModelBreakdowns(
   target: Record<string, ClientBreakdownData["models"][string]>,
   incoming: Record<string, ClientBreakdownData["models"][string]>
@@ -762,12 +791,38 @@ export async function POST(request: Request) {
       }
       const plannedIncrementClients = [...parserPlans].filter(
         ([, plan]) =>
-          plan.mode === "incremental" || plan.mode === "baseline-legacy"
+          !plan.layoutDays &&
+          (plan.mode === "incremental" || plan.mode === "baseline-legacy")
       );
 
       const existingDaysMap = new Map(
         existingDeviceDays.map((d) => [d.date, d])
       );
+
+      const daysToProcess = new Map(
+        data.contributions.map((day) => [day.date, day] as const)
+      );
+      for (const [client, plan] of parserPlans) {
+        if (!plan.layoutDays) continue;
+        for (const date of Object.keys(plan.layoutDays)) {
+          if (!daysToProcess.has(date)) {
+            daysToProcess.set(date, emptyLayoutDay(date));
+          }
+        }
+        for (const existing of existingDeviceDays) {
+          const breakdown = existing.sourceBreakdown as Record<
+            string,
+            ClientBreakdownData
+          > | null;
+          if (
+            breakdown &&
+            ownValue(breakdown, client) &&
+            !daysToProcess.has(existing.date)
+          ) {
+            daysToProcess.set(existing.date, emptyLayoutDay(existing.date));
+          }
+        }
+      }
 
       // ------------------------------------------
       // STEP 3c: Compute merge results in memory, then batch write
@@ -798,7 +853,7 @@ export async function POST(request: Request) {
         costIsComplete: boolean;
       }> = [];
 
-      for (const incomingDay of data.contributions) {
+      for (const incomingDay of daysToProcess.values()) {
         const incomingClientBreakdown = foldIncomingClientContributions(
           incomingDay.clients
         );
@@ -820,6 +875,13 @@ export async function POST(request: Request) {
         for (const [client, plan] of parserPlans) {
           if (plan.mode === "freeze") {
             delete incomingClientBreakdown[client];
+          } else if (plan.layoutDays) {
+            const layout = ownValue(plan.layoutDays, incomingDay.date);
+            if (layout) {
+              incomingClientBreakdown[client] = layout;
+            } else {
+              delete incomingClientBreakdown[client];
+            }
           } else if (
             plan.mode === "incremental" ||
             plan.mode === "baseline-legacy"
@@ -841,7 +903,11 @@ export async function POST(request: Request) {
             plan.mode === "freeze" ||
             plan.mode === "incremental" ||
             plan.mode === "baseline-legacy";
-          if (planRewroteClient && !incomingClientBreakdown[client]) {
+          if (
+            planRewroteClient &&
+            !plan.layoutDays &&
+            !incomingClientBreakdown[client]
+          ) {
             // A frozen/zero-increment plan is a no-op for that client, not a
             // request to delete its stored row from this day.
             clientsToMerge.delete(client);
@@ -913,6 +979,11 @@ export async function POST(request: Request) {
               }
             }
           }
+          applySnapshotLayoutDays(
+            mergedClientBreakdown,
+            incomingDay.date,
+            parserPlans
+          );
           const dayTotals = recalculateDayTotals(mergedClientBreakdown);
 
           toUpdate.push({
@@ -937,6 +1008,11 @@ export async function POST(request: Request) {
           const insertedClientBreakdown = tagBreakdownCostCompleteness(
             incomingClientBreakdown,
             incomingDay.totals?.costIsComplete ?? true
+          );
+          applySnapshotLayoutDays(
+            insertedClientBreakdown,
+            incomingDay.date,
+            parserPlans
           );
           const dayTotals = recalculateDayTotals(insertedClientBreakdown);
           if (Object.keys(insertedClientBreakdown).length === 0) continue;

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -18,6 +18,8 @@ import {
   breakdownCostIsComplete,
   tagBreakdownCostCompleteness,
   applyCostCompleteness,
+  replaceLayoutCostFloors,
+  reapplyReplaceLayoutCostFloors,
   type ClientBreakdownData,
 } from "@/lib/db/helpers";
 import {
@@ -841,6 +843,14 @@ export async function POST(request: Request) {
         ([, plan]) =>
           plan.mode === "incremental" || plan.mode === "baseline-legacy"
       );
+      const replaceClients = [...parserPlans]
+        .filter(([, plan]) => isReplacePlan(plan))
+        .map(([client]) => client);
+      const replaceCostFloors = replaceLayoutCostFloors(
+        existingDeviceDays,
+        replaceClients
+      );
+      const incompleteReplaceClients = new Set<string>();
 
       const existingDaysMap = new Map(
         existingDeviceDays.map((d) => [d.date, d])
@@ -884,7 +894,12 @@ export async function POST(request: Request) {
         costIsComplete: boolean;
       }> = [];
 
+      const toDelete: string[] = [];
+
       for (const incomingDay of daysToProcess.values()) {
+        if (incomingDay.totals?.costIsComplete === false) {
+          for (const client of replaceClients) incompleteReplaceClients.add(client);
+        }
         const incomingClientBreakdown = foldIncomingClientContributions(
           incomingDay.clients
         );
@@ -1005,6 +1020,10 @@ export async function POST(request: Request) {
             parserPlans,
             incomingDay.totals?.costIsComplete ?? true
           );
+          if (Object.keys(mergedClientBreakdown).length === 0) {
+            toDelete.push(existingDay.id);
+            continue;
+          }
           const dayTotals = recalculateDayTotals(mergedClientBreakdown);
 
           toUpdate.push({
@@ -1053,6 +1072,20 @@ export async function POST(request: Request) {
             costIsComplete: breakdownCostIsComplete(insertedClientBreakdown),
           });
         }
+      }
+
+      reapplyReplaceLayoutCostFloors(
+        [...toInsert, ...toUpdate],
+        replaceCostFloors,
+        incompleteReplaceClients
+      );
+      for (const row of [...toInsert, ...toUpdate]) {
+        const dayTotals = recalculateDayTotals(row.sourceBreakdown);
+        row.tokens = dayTotals.tokens;
+        row.cost = dayTotals.cost.toFixed(4);
+        row.inputTokens = dayTotals.inputTokens;
+        row.outputTokens = dayTotals.outputTokens;
+        row.costIsComplete = breakdownCostIsComplete(row.sourceBreakdown);
       }
 
       const advancedParserStates = [...parserPlans].flatMap(([client, plan]) =>
@@ -1153,6 +1186,17 @@ export async function POST(request: Request) {
         `);
       }
 
+      if (toDelete.length > 0) {
+        const deleteIds = sql.join(
+          toDelete.map((id) => sql`${id}::uuid`),
+          sql`, `
+        );
+        await tx.execute(sql`
+          DELETE FROM daily_breakdown
+          WHERE id IN (${deleteIds})
+        `);
+      }
+
       // Phase 4a observation write — same transaction as the daily rows above,
       // so an explicitly reported cell cannot commit without its guarded
       // daily_breakdown counterpart. Last-write-wins (no GREATEST) for that cell only: omitted
@@ -1181,8 +1225,8 @@ export async function POST(request: Request) {
           totalCost: sql<string>`COALESCE(SUM(CAST(${dailyBreakdown.cost} AS DECIMAL(14,4))), 0)::text`,
           inputTokens: sql<number>`LEAST(COALESCE(SUM(${dailyBreakdown.inputTokens}), 0), 9223372036854775807)::bigint`,
           outputTokens: sql<number>`LEAST(COALESCE(SUM(${dailyBreakdown.outputTokens}), 0), 9223372036854775807)::bigint`,
-          dateStart: sql<string>`MIN(${dailyBreakdown.date})`,
-          dateEnd: sql<string>`MAX(${dailyBreakdown.date})`,
+          dateStart: sql<string>`MIN(CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END)`,
+          dateEnd: sql<string>`MAX(CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END)`,
           activeDays: sql<number>`COUNT(DISTINCT CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END)::int`,
           rowCount: sql<number>`COUNT(*)::int`,
           // One floored day on ONE device makes the summed total a lower bound,

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -107,6 +107,7 @@ function applyReplaceLayouts(
   }
 }
 
+/** Returns the dates added here, i.e. the ones the submission never covered. */
 function expandDaysForReplaceLayouts(
   daysToProcess: Map<string, SubmissionData["contributions"][number]>,
   parserPlans: Map<string, ParserHighWaterPlan>,
@@ -114,12 +115,14 @@ function expandDaysForReplaceLayouts(
     date: string;
     sourceBreakdown: unknown;
   }>
-): void {
+): Set<string> {
+  const layoutOnlyDates = new Set<string>();
   for (const [client, plan] of parserPlans) {
     if (!isReplacePlan(plan) || !plan.layoutDays) continue;
     for (const date of Object.keys(plan.layoutDays)) {
       if (!daysToProcess.has(date)) {
         daysToProcess.set(date, emptyLayoutDay(date));
+        layoutOnlyDates.add(date);
       }
     }
     for (const existing of existingDeviceDays) {
@@ -133,9 +136,11 @@ function expandDaysForReplaceLayouts(
         !daysToProcess.has(existing.date)
       ) {
         daysToProcess.set(existing.date, emptyLayoutDay(existing.date));
+        layoutOnlyDates.add(existing.date);
       }
     }
   }
+  return layoutOnlyDates;
 }
 
 function mergeModelBreakdowns(
@@ -859,7 +864,7 @@ export async function POST(request: Request) {
       const daysToProcess = new Map(
         data.contributions.map((day) => [day.date, day] as const)
       );
-      expandDaysForReplaceLayouts(
+      const layoutOnlyDates = expandDaysForReplaceLayouts(
         daysToProcess,
         parserPlans,
         existingDeviceDays
@@ -935,6 +940,11 @@ export async function POST(request: Request) {
         }
 
         const clientsToMerge = new Set(submittedClients);
+        // A day the submission never covered is in the write set only so a
+        // replace layout can empty its own cell there. The other clients were
+        // not resubmitted for that day at all, so their stored cells did not
+        // disappear -- merging them would preserve them with a false warning.
+        if (layoutOnlyDates.has(incomingDay.date)) clientsToMerge.clear();
         for (const [client, plan] of parserPlans) {
           if (plan.mode === "replace") {
             clientsToMerge.delete(client);
@@ -1225,8 +1235,15 @@ export async function POST(request: Request) {
           totalCost: sql<string>`COALESCE(SUM(CAST(${dailyBreakdown.cost} AS DECIMAL(14,4))), 0)::text`,
           inputTokens: sql<number>`LEAST(COALESCE(SUM(${dailyBreakdown.inputTokens}), 0), 9223372036854775807)::bigint`,
           outputTokens: sql<number>`LEAST(COALESCE(SUM(${dailyBreakdown.outputTokens}), 0), 9223372036854775807)::bigint`,
-          dateStart: sql<string>`MIN(CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END)`,
-          dateEnd: sql<string>`MAX(CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END)`,
+          // The filter keeps an emptied day from stretching the reported range,
+          // but it returns NULL when NO row in scope has tokens -- and
+          // date_start/date_end are NOT NULL, so STEP 3e would abort the whole
+          // submit. A user whose entire stored history is legacy tokenless
+          // Cursor rows is exactly that shape and is explicitly valid. Fall
+          // back to the unfiltered bounds the earlier producers of these
+          // columns used (migrations 0015/0016).
+          dateStart: sql<string>`COALESCE(MIN(CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END), MIN(${dailyBreakdown.date}))`,
+          dateEnd: sql<string>`COALESCE(MAX(CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END), MAX(${dailyBreakdown.date}))`,
           activeDays: sql<number>`COUNT(DISTINCT CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END)::int`,
           rowCount: sql<number>`COUNT(*)::int`,
           // One floored day on ONE device makes the summed total a lower bound,

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -17,6 +17,7 @@ import {
   mergeTimestampMs,
   breakdownCostIsComplete,
   tagBreakdownCostCompleteness,
+  applyCostCompleteness,
   type ClientBreakdownData,
 } from "@/lib/db/helpers";
 import {
@@ -79,16 +80,59 @@ function emptyLayoutDay(date: string): SubmissionData["contributions"][number] {
   };
 }
 
-function applySnapshotLayoutDays(
+function isReplacePlan(plan: ParserHighWaterPlan): boolean {
+  return plan.mode === "replace";
+}
+
+function applyReplaceLayouts(
   merged: Record<string, ClientBreakdownData>,
   date: string,
-  parserPlans: Map<string, ParserHighWaterPlan>
+  parserPlans: Map<string, ParserHighWaterPlan>,
+  incomingCostIsComplete: boolean
 ): void {
   for (const [client, plan] of parserPlans) {
-    if (!plan.layoutDays) continue;
+    if (!isReplacePlan(plan) || !plan.layoutDays) continue;
     const next = ownValue(plan.layoutDays, date);
-    if (next) merged[client] = next;
-    else delete merged[client];
+    if (next) {
+      merged[client] = applyCostCompleteness(
+        next,
+        ownValue(merged, client),
+        incomingCostIsComplete
+      );
+    } else {
+      delete merged[client];
+    }
+  }
+}
+
+function expandDaysForReplaceLayouts(
+  daysToProcess: Map<string, SubmissionData["contributions"][number]>,
+  parserPlans: Map<string, ParserHighWaterPlan>,
+  existingDeviceDays: Array<{
+    date: string;
+    sourceBreakdown: unknown;
+  }>
+): void {
+  for (const [client, plan] of parserPlans) {
+    if (!isReplacePlan(plan) || !plan.layoutDays) continue;
+    for (const date of Object.keys(plan.layoutDays)) {
+      if (!daysToProcess.has(date)) {
+        daysToProcess.set(date, emptyLayoutDay(date));
+      }
+    }
+    for (const existing of existingDeviceDays) {
+      const breakdown = existing.sourceBreakdown as Record<
+        string,
+        ClientBreakdownData
+      > | null;
+      if (
+        breakdown &&
+        ownValue(breakdown, client) &&
+        !daysToProcess.has(existing.date)
+      ) {
+        daysToProcess.set(existing.date, emptyLayoutDay(existing.date));
+      }
+    }
   }
 }
 
@@ -783,6 +827,10 @@ export async function POST(request: Request) {
           warnings.push(
             `Established the ${label} parser generation ${supportedVersion} baseline; existing same-device history was preserved and only bounded lifetime growth was added.`
           );
+        } else if (plan.mode === "replace") {
+          warnings.push(
+            `Rewrote ${label} daily layout from the full parser snapshot without changing the lifetime high-water.`
+          );
         } else if (plan.mode === "freeze") {
           warnings.push(
             `Ignored ${label} changes because this parser generation or partial snapshot cannot safely advance the device high-water.`
@@ -791,8 +839,7 @@ export async function POST(request: Request) {
       }
       const plannedIncrementClients = [...parserPlans].filter(
         ([, plan]) =>
-          !plan.layoutDays &&
-          (plan.mode === "incremental" || plan.mode === "baseline-legacy")
+          plan.mode === "incremental" || plan.mode === "baseline-legacy"
       );
 
       const existingDaysMap = new Map(
@@ -802,27 +849,11 @@ export async function POST(request: Request) {
       const daysToProcess = new Map(
         data.contributions.map((day) => [day.date, day] as const)
       );
-      for (const [client, plan] of parserPlans) {
-        if (!plan.layoutDays) continue;
-        for (const date of Object.keys(plan.layoutDays)) {
-          if (!daysToProcess.has(date)) {
-            daysToProcess.set(date, emptyLayoutDay(date));
-          }
-        }
-        for (const existing of existingDeviceDays) {
-          const breakdown = existing.sourceBreakdown as Record<
-            string,
-            ClientBreakdownData
-          > | null;
-          if (
-            breakdown &&
-            ownValue(breakdown, client) &&
-            !daysToProcess.has(existing.date)
-          ) {
-            daysToProcess.set(existing.date, emptyLayoutDay(existing.date));
-          }
-        }
-      }
+      expandDaysForReplaceLayouts(
+        daysToProcess,
+        parserPlans,
+        existingDeviceDays
+      );
 
       // ------------------------------------------
       // STEP 3c: Compute merge results in memory, then batch write
@@ -873,21 +904,12 @@ export async function POST(request: Request) {
         }
 
         for (const [client, plan] of parserPlans) {
-          if (plan.mode === "freeze") {
+          if (plan.mode === "freeze" || plan.mode === "replace") {
             delete incomingClientBreakdown[client];
-          } else if (plan.layoutDays) {
-            const layout = ownValue(plan.layoutDays, incomingDay.date);
-            if (layout) {
-              incomingClientBreakdown[client] = layout;
-            } else {
-              delete incomingClientBreakdown[client];
-            }
           } else if (
             plan.mode === "incremental" ||
             plan.mode === "baseline-legacy"
           ) {
-            // The full snapshot itself is never merged. Only the bounded growth
-            // calculated against the persisted generation high-water is eligible.
             const increment = ownValue(plan.increments, incomingDay.date);
             if (increment) {
               incomingClientBreakdown[client] = increment;
@@ -899,17 +921,15 @@ export async function POST(request: Request) {
 
         const clientsToMerge = new Set(submittedClients);
         for (const [client, plan] of parserPlans) {
+          if (plan.mode === "replace") {
+            clientsToMerge.delete(client);
+            continue;
+          }
           const planRewroteClient =
             plan.mode === "freeze" ||
             plan.mode === "incremental" ||
             plan.mode === "baseline-legacy";
-          if (
-            planRewroteClient &&
-            !plan.layoutDays &&
-            !incomingClientBreakdown[client]
-          ) {
-            // A frozen/zero-increment plan is a no-op for that client, not a
-            // request to delete its stored row from this day.
+          if (planRewroteClient && !incomingClientBreakdown[client]) {
             clientsToMerge.delete(client);
           }
         }
@@ -979,10 +999,11 @@ export async function POST(request: Request) {
               }
             }
           }
-          applySnapshotLayoutDays(
+          applyReplaceLayouts(
             mergedClientBreakdown,
             incomingDay.date,
-            parserPlans
+            parserPlans,
+            incomingDay.totals?.costIsComplete ?? true
           );
           const dayTotals = recalculateDayTotals(mergedClientBreakdown);
 
@@ -1009,10 +1030,11 @@ export async function POST(request: Request) {
             incomingClientBreakdown,
             incomingDay.totals?.costIsComplete ?? true
           );
-          applySnapshotLayoutDays(
+          applyReplaceLayouts(
             insertedClientBreakdown,
             incomingDay.date,
-            parserPlans
+            parserPlans,
+            incomingDay.totals?.costIsComplete ?? true
           );
           const dayTotals = recalculateDayTotals(insertedClientBreakdown);
           if (Object.keys(insertedClientBreakdown).length === 0) continue;

--- a/packages/frontend/src/components/StatsPanel.tsx
+++ b/packages/frontend/src/components/StatsPanel.tsx
@@ -8,6 +8,7 @@ import {
   calculateCurrentStreak,
   calculateLongestStreak,
   findBestDay,
+  dayHasActivity,
 } from "@/lib/utils";
 import { formatContributionDate } from "@/lib/date-utils";
 import { formatDuration } from "@/lib/format";
@@ -174,7 +175,7 @@ export function StatsPanel({ data, palette, totalActiveTimeMs, sessionCount, mcp
         <StatItem label="Avg / Day" value={formatCurrency(summary.averagePerDay)} />
         <StatItem label="Current Streak" value={`${currentStreak} day${currentStreak !== 1 ? "s" : ""}`} />
         <StatItem label="Longest Streak" value={`${longestStreak} day${longestStreak !== 1 ? "s" : ""}`} />
-        {bestDay && bestDay.totals.cost > 0 && (
+        {bestDay && dayHasActivity(bestDay) && (
           <StatItem label="Best Day" value={formatContributionDate(bestDay)} subValue={formatCurrency(bestDay.totals.cost)} />
         )}
         <StatItem label="Models" value={summary.models.length.toString()} />

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -300,7 +300,7 @@ export function mergeClientBreakdownsWithRegressionGuard(
  * mark a client complete whenever an incomplete rescan happened to report less
  * than the old total for a *larger* token set.
  */
-function applyCostCompleteness(
+export function applyCostCompleteness(
   next: ClientBreakdownData,
   existing: ClientBreakdownData | undefined,
   incomingCostIsComplete: boolean

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -418,11 +418,25 @@ function addClientCostFloor(
   extra: number
 ): void {
   if (extra <= 0) return;
-  cell.cost = quantizeCost((cell.cost || 0) + extra);
-  const modelIds = Object.keys(cell.models ?? {});
-  if (modelIds.length > 0) {
-    const model = cell.models[modelIds[0]];
-    model.cost = quantizeCost((model.cost || 0) + extra);
+  const models = Object.values(cell.models ?? {});
+  if (models.length === 0) {
+    cell.cost = quantizeCost((cell.cost || 0) + extra);
+  } else {
+    const tokenTotal = models.reduce((sum, model) => sum + (model.tokens || 0), 0);
+    let assigned = 0;
+    for (let i = 0; i < models.length; i++) {
+      const share =
+        i === models.length - 1
+          ? quantizeCost(extra - assigned)
+          : tokenTotal > 0
+            ? quantizeCost((extra * (models[i].tokens || 0)) / tokenTotal)
+            : quantizeCost(extra / models.length);
+      models[i].cost = quantizeCost((models[i].cost || 0) + share);
+      assigned = quantizeCost(assigned + share);
+    }
+    cell.cost = quantizeCost(
+      models.reduce((sum, model) => sum + (model.cost || 0), 0)
+    );
   }
   cell.provenance = {
     ...(cell.provenance ?? deriveClientBreakdownProvenance(cell)),

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -388,6 +388,84 @@ export function breakdownCostIsComplete(
   );
 }
 
+export function replaceLayoutCostFloors(
+  existingDays: Array<{ sourceBreakdown: unknown }>,
+  replaceClients: Iterable<string>
+): Map<string, number> {
+  const floors = new Map<string, number>();
+  for (const client of replaceClients) {
+    let cost = 0;
+    for (const day of existingDays) {
+      const breakdown = day.sourceBreakdown as Record<
+        string,
+        ClientBreakdownData
+      > | null;
+      cost += ownValue(breakdown ?? {}, client)?.cost ?? 0;
+    }
+    if (cost > 0) floors.set(client, cost);
+  }
+  return floors;
+}
+
+const COST_SCALE = 10_000;
+
+function quantizeCost(value: number): number {
+  return Math.round((value + Number.EPSILON) * COST_SCALE) / COST_SCALE;
+}
+
+function addClientCostFloor(
+  cell: ClientBreakdownData,
+  extra: number
+): void {
+  if (extra <= 0) return;
+  cell.cost = quantizeCost((cell.cost || 0) + extra);
+  const modelIds = Object.keys(cell.models ?? {});
+  if (modelIds.length > 0) {
+    const model = cell.models[modelIds[0]];
+    model.cost = quantizeCost((model.cost || 0) + extra);
+  }
+  cell.provenance = {
+    ...(cell.provenance ?? deriveClientBreakdownProvenance(cell)),
+    costIsComplete: false,
+  };
+}
+
+/**
+ * Same-day cost floors cannot follow tokens that a snapshot layout moves onto
+ * a day with no previously stored cell. Re-apply the pre-rewrite client total
+ * across the new cells so an unpriced re-date cannot drop lifetime cost.
+ */
+export function reapplyReplaceLayoutCostFloors(
+  rows: Array<{ sourceBreakdown: Record<string, ClientBreakdownData> }>,
+  floors: Map<string, number>,
+  incompleteClients: Set<string>
+): void {
+  for (const [client, floor] of floors) {
+    if (!incompleteClients.has(client)) continue;
+    const cells: ClientBreakdownData[] = [];
+    for (const row of rows) {
+      const cell = ownValue(row.sourceBreakdown, client);
+      if (cell) cells.push(cell);
+    }
+    if (cells.length === 0) continue;
+    const current = cells.reduce((sum, cell) => sum + (cell.cost || 0), 0);
+    const deficit = quantizeCost(floor - current);
+    if (deficit <= 0) continue;
+    const tokenTotal = cells.reduce((sum, cell) => sum + (cell.tokens || 0), 0);
+    let assigned = 0;
+    for (let i = 0; i < cells.length; i++) {
+      const share =
+        i === cells.length - 1
+          ? quantizeCost(deficit - assigned)
+          : tokenTotal > 0
+            ? quantizeCost((deficit * cells[i].tokens) / tokenTotal)
+            : quantizeCost(deficit / cells.length);
+      addClientCostFloor(cells[i], share);
+      assigned = quantizeCost(assigned + share);
+    }
+  }
+}
+
 export function clientContributionToBreakdownData(
   client_contrib: {
     tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; reasoning?: number };

--- a/packages/frontend/src/lib/db/parserHighWater.ts
+++ b/packages/frontend/src/lib/db/parserHighWater.ts
@@ -18,9 +18,9 @@ import { createSafeRecord, ownValue } from "../safeRecord";
  * Copilot is pinned at generation 2 because generation 1 counted differently
  * and must not advance the high-water. Droid is registered at generation 1,
  * the generation every CLI already declares: its shapes differ in *where*
- * tokens land, never in the lifetime total, so no generation needs freezing —
- * bounding every Droid submission by the lifetime high-water is what makes a
- * re-attribution contribute nothing.
+ * tokens land, never in the lifetime total. A full snapshot that still
+ * covers the credited lifetime therefore replaces stored days so the web
+ * graph matches the TUI, without the per-day merge guard inflating totals.
  *
  * Both Antigravity clients are registered at generation 1, the generation every
  * CLI already declares. Their parsers stopped dating usage at the session's
@@ -40,6 +40,13 @@ export const SUPPORTED_VERSIONED_PARSERS: Readonly<Record<string, number>> = {
   "antigravity-cli": 1,
   antigravity: 1,
 };
+
+/**
+ * Parsers whose lifetime total is stable across re-attribution. A full
+ * snapshot that covers the credited aggregate may replace stored days so the
+ * web graph matches the TUI without the per-day merge guard inflating totals.
+ */
+const SNAPSHOT_LAYOUT_CLIENTS: ReadonlySet<string> = new Set(["droid"]);
 
 const TOKEN_FIELDS = [
   "input",
@@ -110,6 +117,14 @@ export type ParserHighWaterMode =
 export interface ParserHighWaterPlan {
   mode: ParserHighWaterMode;
   increments: Record<string, ClientBreakdownData>;
+  /**
+   * Absolute per-day cells for parsers whose snapshot is the day layout
+   * source of truth. When set, the submit route replaces stored client cells
+   * instead of adding bounded increments, so a re-attribution moves tokens
+   * onto the days the current parser reports without changing the lifetime
+   * high-water.
+   */
+  layoutDays?: Record<string, ClientBreakdownData>;
   nextState?: ParserClientHighWaterState;
 }
 
@@ -322,6 +337,52 @@ function applyCreditedIncrements(
     );
   }
   return next;
+}
+
+function snapshotCoversCredited(
+  incoming: ParserAggregateHighWater,
+  credited: ParserAggregateHighWater
+): boolean {
+  return AGGREGATE_FIELDS.every(
+    (field) => incoming[field] >= credited[field]
+  );
+}
+
+function stateFromSnapshot(
+  version: number,
+  incomingDays: Record<string, ClientBreakdownData>
+): ParserClientHighWaterState {
+  const days = normalizeStateDays(incomingDays);
+  return {
+    stateVersion: PARSER_HIGH_WATER_STATE_VERSION,
+    version,
+    baselineEstablished: true,
+    aggregate: aggregateSnapshot(days),
+    days,
+    observedDays: days,
+  };
+}
+
+function layoutFollowsSnapshot(args: {
+  client: string;
+  version: number;
+  incoming: ParserAggregateHighWater;
+  credited: ParserAggregateHighWater;
+  incomingDays: Record<string, ClientBreakdownData>;
+  mode: Extract<ParserHighWaterMode, "baseline-legacy" | "incremental">;
+}): ParserHighWaterPlan | null {
+  if (
+    !SNAPSHOT_LAYOUT_CLIENTS.has(args.client) ||
+    !snapshotCoversCredited(args.incoming, args.credited)
+  ) {
+    return null;
+  }
+  return {
+    mode: args.mode,
+    increments: createSafeRecord<ClientBreakdownData>(),
+    layoutDays: normalizeStateDays(args.incomingDays),
+    nextState: stateFromSnapshot(args.version, args.incomingDays),
+  };
 }
 
 function stateAfterCreditedIncrements(
@@ -649,7 +710,7 @@ export function planParserHighWaterSubmission(args: {
       increments: {},
       nextState: {
         stateVersion: PARSER_HIGH_WATER_STATE_VERSION,
-        version: supportedVersion,
+        version: args.incomingVersion,
         baselineEstablished: false,
         aggregate: emptyAggregate(),
         days: createSafeRecord<ClientBreakdownData>(),
@@ -666,6 +727,17 @@ export function planParserHighWaterSubmission(args: {
     const legacyAggregate = aggregateSnapshot(args.existingLegacyDays);
     const hasLegacy =
       legacyAggregate.tokens > 0 || legacyAggregate.messages > 0;
+    if (hasLegacy) {
+      const followed = layoutFollowsSnapshot({
+        client: args.client,
+        version: args.incomingVersion,
+        incoming: incomingAggregate,
+        credited: legacyAggregate,
+        incomingDays: args.incomingDays,
+        mode: "baseline-legacy",
+      });
+      if (followed) return followed;
+    }
     // At transition, preserving all legacy rows and crediting at most positive
     // lifetime aggregate growth is non-destructive. With deleted old usage D
     // and genuinely new usage N, incoming - legacy = N - D <= N; the existing
@@ -689,7 +761,7 @@ export function planParserHighWaterSubmission(args: {
         )
       : {
           stateVersion: PARSER_HIGH_WATER_STATE_VERSION,
-          version: supportedVersion,
+          version: args.incomingVersion,
           baselineEstablished: true,
           aggregate: incomingAggregate,
           days: normalizeStateDays(args.incomingDays),
@@ -717,6 +789,15 @@ export function planParserHighWaterSubmission(args: {
     args.state.stateVersion === PARSER_HIGH_WATER_STATE_VERSION
       ? args.state.observedDays!
       : previousCreditedDays;
+  const followed = layoutFollowsSnapshot({
+    client: args.client,
+    version: supportedVersion,
+    incoming: incomingAggregate,
+    credited: previousAggregate,
+    incomingDays: args.incomingDays,
+    mode: "incremental",
+  });
+  if (followed) return followed;
   const increments = allocateIncrements(
     previousCreditedDays,
     previousObservedDays,

--- a/packages/frontend/src/lib/db/parserHighWater.ts
+++ b/packages/frontend/src/lib/db/parserHighWater.ts
@@ -112,18 +112,13 @@ export type ParserHighWaterMode =
   | "freeze"
   | "baseline-legacy"
   | "baseline-new"
-  | "incremental";
+  | "incremental"
+  | "replace";
 
 export interface ParserHighWaterPlan {
   mode: ParserHighWaterMode;
   increments: Record<string, ClientBreakdownData>;
-  /**
-   * Absolute per-day cells for parsers whose snapshot is the day layout
-   * source of truth. When set, the submit route replaces stored client cells
-   * instead of adding bounded increments, so a re-attribution moves tokens
-   * onto the days the current parser reports without changing the lifetime
-   * high-water.
-   */
+  /** Absolute cells when `mode` is `replace`; omitted otherwise. */
   layoutDays?: Record<string, ClientBreakdownData>;
   nextState?: ParserClientHighWaterState;
 }
@@ -363,13 +358,12 @@ function stateFromSnapshot(
   };
 }
 
-function layoutFollowsSnapshot(args: {
+function replaceLayoutPlan(args: {
   client: string;
   version: number;
   incoming: ParserAggregateHighWater;
   credited: ParserAggregateHighWater;
   incomingDays: Record<string, ClientBreakdownData>;
-  mode: Extract<ParserHighWaterMode, "baseline-legacy" | "incremental">;
 }): ParserHighWaterPlan | null {
   if (
     !SNAPSHOT_LAYOUT_CLIENTS.has(args.client) ||
@@ -378,7 +372,7 @@ function layoutFollowsSnapshot(args: {
     return null;
   }
   return {
-    mode: args.mode,
+    mode: "replace",
     increments: createSafeRecord<ClientBreakdownData>(),
     layoutDays: normalizeStateDays(args.incomingDays),
     nextState: stateFromSnapshot(args.version, args.incomingDays),
@@ -728,13 +722,12 @@ export function planParserHighWaterSubmission(args: {
     const hasLegacy =
       legacyAggregate.tokens > 0 || legacyAggregate.messages > 0;
     if (hasLegacy) {
-      const followed = layoutFollowsSnapshot({
+      const followed = replaceLayoutPlan({
         client: args.client,
         version: args.incomingVersion,
         incoming: incomingAggregate,
         credited: legacyAggregate,
         incomingDays: args.incomingDays,
-        mode: "baseline-legacy",
       });
       if (followed) return followed;
     }
@@ -789,13 +782,12 @@ export function planParserHighWaterSubmission(args: {
     args.state.stateVersion === PARSER_HIGH_WATER_STATE_VERSION
       ? args.state.observedDays!
       : previousCreditedDays;
-  const followed = layoutFollowsSnapshot({
+  const followed = replaceLayoutPlan({
     client: args.client,
-    version: supportedVersion,
+    version: args.incomingVersion,
     incoming: incomingAggregate,
     credited: previousAggregate,
     incomingDays: args.incomingDays,
-    mode: "incremental",
   });
   if (followed) return followed;
   const increments = allocateIncrements(

--- a/packages/frontend/src/lib/db/parserHighWater.ts
+++ b/packages/frontend/src/lib/db/parserHighWater.ts
@@ -45,6 +45,12 @@ export const SUPPORTED_VERSIONED_PARSERS: Readonly<Record<string, number>> = {
  * Parsers whose lifetime total is stable across re-attribution. A full
  * snapshot that covers the credited aggregate may replace stored days so the
  * web graph matches the TUI without the per-day merge guard inflating totals.
+ *
+ * Replacing is destructive by design: a day the snapshot no longer dates loses
+ * its cell. So local history the user deleted is erased too, as long as the
+ * remaining growth still covers the credited aggregate. Below that cover the
+ * snapshot cannot replace anything and the bounded-growth plan applies, which
+ * keeps every stored row.
  */
 const SNAPSHOT_LAYOUT_CLIENTS: ReadonlySet<string> = new Set(["droid"]);
 
@@ -671,6 +677,12 @@ function validState(
  * with uncredited capacity receives the bounded remainder. Only increments
  * actually written advance the credited ledger, so growth cannot be lost.
  * Date/model reshuffles and deleted local history never erase stored rows.
+ *
+ * SNAPSHOT_LAYOUT_CLIENTS are the deliberate exception to both absolutes
+ * above: once a full snapshot's aggregate covers the credited one, the stored
+ * layout is replaced outright so the web graph matches the TUI, which also
+ * drops the cells of days the snapshot no longer dates. A snapshot that does
+ * not cover it falls back to the bounded-growth plan and keeps every row.
  */
 export function planParserHighWaterSubmission(args: {
   client: string;
@@ -722,6 +734,9 @@ export function planParserHighWaterSubmission(args: {
     const hasLegacy =
       legacyAggregate.tokens > 0 || legacyAggregate.messages > 0;
     if (hasLegacy) {
+      // Tried before the preserving transition below, so a snapshot-layout
+      // client adopts the snapshot's own dating instead of preserving legacy
+      // rows. Everything after this point is the fallback for the rest.
       const followed = replaceLayoutPlan({
         client: args.client,
         version: args.incomingVersion,

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -605,7 +605,12 @@ export async function getPublicProfileResponse(
       }
     }
 
-    // Calculate max tokens for intensity
+    // Calculate max tokens for intensity. Tokens, not cost, because every
+    // embed already shades from tokens -- layoutContributions in
+    // lib/embed/embedShared.ts, getUserEmbedStats and renderIsometric3DSvg all
+    // recompute intensity from totalTokens -- so a cost-scaled profile graph
+    // shaded the same account differently from its own embeds, and a day whose
+    // client reports no pricing read as blank.
     const contributions = Array.from(aggregatedDaily.values());
     const scopedContributions = contributions.filter(
       ({ date }) => date >= chartRange.start && date <= chartRange.end,

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -616,7 +616,10 @@ export async function getPublicProfileResponse(
     const visibleContributions = periodRange
       ? scopedContributions
       : contributions;
-    const maxCost = Math.max(...visibleContributions.map((c) => c.cost), 0);
+    const maxTokens = Math.max(
+      ...visibleContributions.map((c) => c.tokens),
+      0,
+    );
     const periodTotals = scopedContributions.reduce(
       (totals, day) => {
         totals.totalTokens += day.tokens;
@@ -646,15 +649,15 @@ export async function getPublicProfileResponse(
     // Build contribution graph data
     const graphContributions = visibleContributions.map((day) => {
       const intensity =
-        maxCost === 0
+        maxTokens === 0
           ? 0
-          : day.cost === 0
+          : day.tokens === 0
             ? 0
-            : day.cost <= maxCost * 0.25
+            : day.tokens <= maxTokens * 0.25
               ? 1
-              : day.cost <= maxCost * 0.5
+              : day.tokens <= maxTokens * 0.5
                 ? 2
-                : day.cost <= maxCost * 0.75
+                : day.tokens <= maxTokens * 0.75
                   ? 3
                   : 4;
 

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -605,7 +605,7 @@ export async function getPublicProfileResponse(
       }
     }
 
-    // Calculate max cost for intensity
+    // Calculate max tokens for intensity
     const contributions = Array.from(aggregatedDaily.values());
     const scopedContributions = contributions.filter(
       ({ date }) => date >= chartRange.start && date <= chartRange.end,

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -10,6 +10,7 @@ import {
   usernameEqualsIgnoreCase,
 } from "@/lib/db/usernameLookup";
 import { buildSubmissionFreshness } from "@/lib/submissionFreshness";
+import { calculateIntensity } from "@/lib/utils";
 
 const LEGACY_CLIENT_ALIASES: Record<string, string> = { kilocode: "kilo" };
 function normalizeClientId(id: string): string {
@@ -648,18 +649,7 @@ export async function getPublicProfileResponse(
 
     // Build contribution graph data
     const graphContributions = visibleContributions.map((day) => {
-      const intensity =
-        maxTokens === 0
-          ? 0
-          : day.tokens === 0
-            ? 0
-            : day.tokens <= maxTokens * 0.25
-              ? 1
-              : day.tokens <= maxTokens * 0.5
-                ? 2
-                : day.tokens <= maxTokens * 0.75
-                  ? 3
-                  : 4;
+      const intensity = calculateIntensity(day.tokens, maxTokens);
 
       let dayCacheRead = 0;
       let dayCacheWrite = 0;

--- a/packages/frontend/src/lib/utils.ts
+++ b/packages/frontend/src/lib/utils.ts
@@ -187,7 +187,7 @@ export function recalculateIntensity(contributions: DailyContribution[]): DailyC
   }));
 }
 
-function calculateIntensity(tokens: number, maxTokens: number): 0 | 1 | 2 | 3 | 4 {
+export function calculateIntensity(tokens: number, maxTokens: number): 0 | 1 | 2 | 3 | 4 {
   if (tokens === 0 || maxTokens === 0) return 0;
   const ratio = tokens / maxTokens;
   if (ratio >= 0.75) return 4;
@@ -344,10 +344,10 @@ export function calculateLongestStreak(contributions: DailyContribution[]): numb
 export function findBestDay(contributions: DailyContribution[]): DailyContribution | null {
   if (contributions.length === 0) return null;
   return contributions.reduce((best, current) => {
-    if (current.totals.tokens !== best.totals.tokens) {
-      return current.totals.tokens > best.totals.tokens ? current : best;
+    if (current.totals.cost !== best.totals.cost) {
+      return current.totals.cost > best.totals.cost ? current : best;
     }
-    return current.totals.cost > best.totals.cost ? current : best;
+    return current.totals.tokens > best.totals.tokens ? current : best;
   });
 }
 

--- a/packages/frontend/src/lib/utils.ts
+++ b/packages/frontend/src/lib/utils.ts
@@ -196,13 +196,17 @@ function calculateIntensity(tokens: number, maxTokens: number): 0 | 1 | 2 | 3 | 
   return 1;
 }
 
+export function dayHasActivity(day: DailyContribution): boolean {
+  return day.totals.tokens > 0 || day.totals.cost > 0;
+}
+
 function recalculateSummary(
   contributions: DailyContribution[],
   clients: ClientType[]
 ): TokenContributionData["summary"] {
-  const activeDays = contributions.filter((c) => c.totals.cost > 0);
-  const totalCost = activeDays.reduce((sum, c) => sum + c.totals.cost, 0);
-  const totalTokens = activeDays.reduce((sum, c) => sum + c.totals.tokens, 0);
+  const activeDays = contributions.filter(dayHasActivity);
+  const totalCost = contributions.reduce((sum, c) => sum + c.totals.cost, 0);
+  const totalTokens = contributions.reduce((sum, c) => sum + c.totals.tokens, 0);
   const maxCost = Math.max(...contributions.map((c) => c.totals.cost), 0);
 
   const modelSet = new Set<string>();
@@ -287,7 +291,7 @@ export function getDayName(dateStr: string): string {
 
 export function calculateCurrentStreak(contributions: DailyContribution[]): number {
   const sorted = [...contributions]
-    .filter((c) => c.totals.cost > 0)
+    .filter(dayHasActivity)
     .sort((a, b) => b.date.localeCompare(a.date));
 
   if (sorted.length === 0) return 0;
@@ -312,7 +316,7 @@ export function calculateCurrentStreak(contributions: DailyContribution[]): numb
 
 export function calculateLongestStreak(contributions: DailyContribution[]): number {
   const activeDates = contributions
-    .filter((c) => c.totals.cost > 0)
+    .filter(dayHasActivity)
     .map((c) => c.date)
     .sort();
 
@@ -339,7 +343,12 @@ export function calculateLongestStreak(contributions: DailyContribution[]): numb
 
 export function findBestDay(contributions: DailyContribution[]): DailyContribution | null {
   if (contributions.length === 0) return null;
-  return contributions.reduce((best, current) => (current.totals.cost > best.totals.cost ? current : best));
+  return contributions.reduce((best, current) => {
+    if (current.totals.tokens !== best.totals.tokens) {
+      return current.totals.tokens > best.totals.tokens ? current : best;
+    }
+    return current.totals.cost > best.totals.cost ? current : best;
+  });
 }
 
 export function hexToNumber(hex: string): number {


### PR DESCRIPTION
## Summary

Droid already scans in the TUI. Two independent bugs stopped that usage from showing correctly on the profile.

1. **CLI too old (already fixed on `main`).** Tokscale 4.13 **drops** unpriced Factory models (`ox-alpha-(openrouter)-0` and other routing labels) instead of submitting them at $0. A 4.15+ CLI keeps those tokens (`feat(submit): retain unpriced tokens`). That is why a full submit from current `main` can populate Droid days even before this PR ships.

2. **This PR (server + profile).** After Droid is in the lifetime high-water, a transcript re-date used to leave tokens on the old day: the per-day merge refuses decreases, so yesterday stayed empty. A **full** Droid snapshot that still covers the credited lifetime now **replaces stored Droid cells** (lifetime total does not inflate). Token-positive **$0** days also count as active on the contribution graph.

## Reviewer map

- `packages/frontend/src/lib/db/parserHighWater.ts` — Droid `layoutDays` when the incoming snapshot covers the credited aggregate
- `packages/frontend/src/app/api/submit/route.ts` — apply those cells as replacements, including days that left the payload
- `packages/frontend/src/lib/publicProfileData.ts` / `utils.ts` / `StatsPanel.tsx` — intensity and activity from tokens, not cost
- Tests: `parserHighWater.test.ts`, `submitAntigravityCliHighWater.test.ts` (Droid layout), `graphClientFilter.test.ts`

Copilot and Antigravity stay increment-only. Partial/`--today` Droid submits still freeze.

## Test plan

- [x] `bun run --cwd packages/frontend test` (955 passing)
- [x] `bun run --cwd packages/frontend typecheck`
- [ ] After merge: full `tokscale submit` with **4.15+** (no `--today`) so production can rewrite stored Droid days to the transcript layout
