### PR TITLE
feat(submit): cap unpriced warning rows and report the aggregate total

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5861,7 +5861,17 @@ fn report_excluded_tokenless_rows(excluded: &[ExcludedTokenlessRow]) {
 fn report_unpriced_submission_usage(unpriced: &[tokscale_core::UnpricedSubmissionUsage]) {
     use colored::Colorize;
 
-    for row in unpriced {
+    if unpriced.is_empty() {
+        return;
+    }
+
+    // A long proxy-model history fans out to one row per provider/model pair
+    // (dozens in practice), burying the submittable summary. Cap the per-row
+    // detail exactly like `report_excluded_tokenless_rows` and report the
+    // aggregate instead; every row stays visible via `--dry-run` + JSON logs.
+    const MAX_DETAIL_ROWS: usize = 20;
+
+    for row in unpriced.iter().take(MAX_DETAIL_ROWS) {
         println!(
             "{}",
             format!(
@@ -5876,22 +5886,40 @@ fn report_unpriced_submission_usage(unpriced: &[tokscale_core::UnpricedSubmissio
         );
     }
 
+    if unpriced.len() > MAX_DETAIL_ROWS {
+        println!(
+            "{}",
+            format!("    ... and {} more", unpriced.len() - MAX_DETAIL_ROWS).bright_black()
+        );
+    }
+
+    let total_messages: usize = unpriced.iter().map(|row| row.message_count).sum();
+    let total_tokens: i64 = unpriced.iter().map(|row| row.total_tokens).sum();
+    println!(
+        "{}",
+        format!(
+            "  Unpriced total: {} message(s) ({} tokens) at $0.00 across {} provider/model(s).",
+            total_messages,
+            format_tokens_with_commas(total_tokens),
+            unpriced.len(),
+        )
+        .bright_black()
+    );
+
     // Homebrew-style follow-up: the warnings above name the gap, but nothing
     // told the user the fix is one file away. #1021/#1035 reporters (and the
     // custom-pricing docs added after them) all had to read core sources to
     // discover that an exact-match entry in custom-pricing.json — including
     // explicit 0 rates for free models and routing labels — is the supported fix.
-    if !unpriced.is_empty() {
-        let pricing_path = crate::paths::get_config_dir().join("custom-pricing.json");
-        println!(
-            "{}",
-            format!(
-                "  Hint: unpriced usage is included in token totals with zero cost. Add exact-match entries to\n          {}\n          keyed by the model id alone (the `model` half of the `provider/model` above),\n          where an explicit 0 declares a free model or a known routing-label rate. Re-check\n          with `tokscale submit --dry-run` and `tokscale pricing <model-id>`, then resubmit\n          to replace the temporary cost floor with a complete total.",
-                pricing_path.display(),
-            )
-            .bright_black()
-        );
-    }
+    let pricing_path = crate::paths::get_config_dir().join("custom-pricing.json");
+    println!(
+        "{}",
+        format!(
+            "  Hint: unpriced usage is included in token totals with zero cost. Add exact-match entries to\n          {}\n          keyed by the model id alone (the `model` half of the `provider/model` above),\n          where an explicit 0 declares a free model or a known routing-label rate. Re-check\n          with `tokscale submit --dry-run` and `tokscale pricing <model-id>`, then resubmit\n          to replace the temporary cost floor with a complete total.",
+            pricing_path.display(),
+        )
+        .bright_black()
+    );
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5868,10 +5868,27 @@ fn report_unpriced_submission_usage(unpriced: &[tokscale_core::UnpricedSubmissio
     // A long proxy-model history fans out to one row per provider/model pair
     // (dozens in practice), burying the submittable summary. Cap the per-row
     // detail exactly like `report_excluded_tokenless_rows` and report the
-    // aggregate instead; every row stays visible via `--dry-run` + JSON logs.
+    // aggregate instead. This print is the only place the rows surface at all:
+    // `GraphResult::unpriced_submission_usage` is `#[serde(skip)]` and never
+    // reaches a payload, and `--dry-run` runs this same reporter — so the
+    // capped rows are still named by id below rather than dropped.
     const MAX_DETAIL_ROWS: usize = 20;
 
-    for row in unpriced.iter().take(MAX_DETAIL_ROWS) {
+    // Core keys these rows by `(provider, model)`, which hands the cap the
+    // alphabetically first rows rather than the ones worth pricing. The hint
+    // below asks the user to price the ids printed here, so rank by what
+    // pricing them recovers: tokens first (every row is $0.00 by definition,
+    // so cost cannot rank them), then message count, with the provider/model
+    // key as the tiebreak to keep the output deterministic.
+    let mut ranked: Vec<&tokscale_core::UnpricedSubmissionUsage> = unpriced.iter().collect();
+    ranked.sort_by(|a, b| {
+        b.total_tokens
+            .cmp(&a.total_tokens)
+            .then_with(|| b.message_count.cmp(&a.message_count))
+            .then_with(|| (&a.provider_id, &a.model_id).cmp(&(&b.provider_id, &b.model_id)))
+    });
+
+    for row in ranked.iter().take(MAX_DETAIL_ROWS) {
         println!(
             "{}",
             format!(
@@ -5886,10 +5903,23 @@ fn report_unpriced_submission_usage(unpriced: &[tokscale_core::UnpricedSubmissio
         );
     }
 
-    if unpriced.len() > MAX_DETAIL_ROWS {
+    // Name the capped rows even though their prose is dropped: the hint tells
+    // the user to add pricing keyed by the ids printed above, so an id that
+    // never prints is an unfixable gap.
+    if ranked.len() > MAX_DETAIL_ROWS {
+        let rest = ranked[MAX_DETAIL_ROWS..]
+            .iter()
+            .map(|row| format!("{}/{}", row.provider_id, row.model_id))
+            .collect::<Vec<_>>()
+            .join(", ");
         println!(
             "{}",
-            format!("    ... and {} more", unpriced.len() - MAX_DETAIL_ROWS).bright_black()
+            format!(
+                "    ... and {} more at $0.00: {}",
+                ranked.len() - MAX_DETAIL_ROWS,
+                rest
+            )
+            .bright_black()
         );
     }
 

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5905,22 +5905,24 @@ fn report_unpriced_submission_usage(unpriced: &[tokscale_core::UnpricedSubmissio
 
     // Name the capped rows even though their prose is dropped: the hint tells
     // the user to add pricing keyed by the ids printed above, so an id that
-    // never prints is an unfixable gap.
+    // never prints is an unfixable gap. Wrapped a few per line rather than
+    // truncated -- dropping an id makes it unfixable, whereas one long line is
+    // only unreadable, and a 45-row history put every id on that one line.
     if ranked.len() > MAX_DETAIL_ROWS {
-        let rest = ranked[MAX_DETAIL_ROWS..]
-            .iter()
-            .map(|row| format!("{}/{}", row.provider_id, row.model_id))
-            .collect::<Vec<_>>()
-            .join(", ");
+        const TAIL_IDS_PER_LINE: usize = 4;
+        let capped = &ranked[MAX_DETAIL_ROWS..];
         println!(
             "{}",
-            format!(
-                "    ... and {} more at $0.00: {}",
-                ranked.len() - MAX_DETAIL_ROWS,
-                rest
-            )
-            .bright_black()
+            format!("    ... and {} more at $0.00:", capped.len()).bright_black()
         );
+        for chunk in capped.chunks(TAIL_IDS_PER_LINE) {
+            let ids = chunk
+                .iter()
+                .map(|row| format!("{}/{}", row.provider_id, row.model_id))
+                .collect::<Vec<_>>()
+                .join(", ");
+            println!("{}", format!("      {}", ids).bright_black());
+        }
     }
 
     let total_messages: usize = unpriced

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5893,8 +5893,12 @@ fn report_unpriced_submission_usage(unpriced: &[tokscale_core::UnpricedSubmissio
         );
     }
 
-    let total_messages: usize = unpriced.iter().map(|row| row.message_count).sum();
-    let total_tokens: i64 = unpriced.iter().map(|row| row.total_tokens).sum();
+    let total_messages: usize = unpriced
+        .iter()
+        .fold(0usize, |acc, row| acc.saturating_add(row.message_count));
+    let total_tokens: i64 = unpriced
+        .iter()
+        .fold(0i64, |acc, row| acc.saturating_add(row.total_tokens));
     println!(
         "{}",
         format!(

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -5096,6 +5096,65 @@ fn test_submit_includes_unpriced_usage_at_zero_and_keeps_the_rest() {
     );
 }
 
+/// Regression: a long proxy-model history fans out to one warning row per
+/// provider/model pair and used to bury the submittable summary. Detail rows
+/// are capped (mirroring the tokenless-row reporter) with an aggregate total.
+#[test]
+fn test_submit_caps_unpriced_warning_rows_and_reports_the_total() {
+    let tmp = create_temp_fixture_dir();
+    prime_pricing_cache_with_a_priced_model(tmp.path());
+    write_fake_credentials(tmp.path());
+    let unpriced_dir = tmp
+        .path()
+        .join(".local/share/opencode/storage/message/unpriced-cap");
+    fs::create_dir_all(&unpriced_dir).unwrap();
+    for i in 0..21 {
+        fs::write(
+            unpriced_dir.join(format!("unpriced-{i:02}.json")),
+            format!(
+                r#"{{
+            "id": "unpriced-{i:02}",
+            "sessionID": "unpriced-cap",
+            "role": "assistant",
+            "modelID": "genuinely-unpriced-model-{i:02}",
+            "providerID": "unknown-provider-{i:02}",
+            "cost": 0,
+            "tokens": {{ "input": 1, "output": 0, "reasoning": 0, "cache": {{ "read": 0, "write": 0 }} }},
+            "time": {{ "created": 1736510400000.0 }}
+        }}"#,
+            ),
+        )
+        .unwrap();
+    }
+
+    let output = offline_cmd_with_home(tmp.path())
+        .args([
+            "--no-spinner",
+            "submit",
+            "--client",
+            "opencode",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "capped warnings must not block covered usage; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("... and 1 more"),
+        "rows past the cap must be acknowledged: {stdout}"
+    );
+    assert!(
+        stdout.contains(
+            "Unpriced total: 21 message(s) (21 tokens) at $0.00 across 21 provider/model(s)."
+        ),
+        "the aggregate must account for every row including capped ones: {stdout}"
+    );
+}
+
 /// Regression: a cold cache with no network must not look like "no usage".
 ///
 /// Every fetchable upstream is unreachable here and nothing is cached, so the

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -5155,6 +5155,156 @@ fn test_submit_caps_unpriced_warning_rows_and_reports_the_total() {
     );
 }
 
+/// Regression: the hint tells the user to add custom pricing keyed by the ids
+/// printed above it, so an id the cap swallows is an unfixable gap. Nothing
+/// else surfaces the rows — `unpriced_submission_usage` is `#[serde(skip)]`
+/// and `--dry-run` runs the same reporter — so the capped tail must still be
+/// listed by id.
+#[test]
+fn test_submit_names_the_unpriced_models_past_the_detail_cap() {
+    let tmp = create_temp_fixture_dir();
+    prime_pricing_cache_with_a_priced_model(tmp.path());
+    write_fake_credentials(tmp.path());
+    let unpriced_dir = tmp
+        .path()
+        .join(".local/share/opencode/storage/message/unpriced-tail");
+    fs::create_dir_all(&unpriced_dir).unwrap();
+    for i in 0..22 {
+        fs::write(
+            unpriced_dir.join(format!("unpriced-{i:02}.json")),
+            format!(
+                r#"{{
+            "id": "unpriced-{i:02}",
+            "sessionID": "unpriced-tail",
+            "role": "assistant",
+            "modelID": "genuinely-unpriced-model-{i:02}",
+            "providerID": "unknown-provider-{i:02}",
+            "cost": 0,
+            "tokens": {{ "input": 1, "output": 0, "reasoning": 0, "cache": {{ "read": 0, "write": 0 }} }},
+            "time": {{ "created": 1736510400000.0 }}
+        }}"#,
+            ),
+        )
+        .unwrap();
+    }
+
+    let output = offline_cmd_with_home(tmp.path())
+        .args([
+            "--no-spinner",
+            "submit",
+            "--client",
+            "opencode",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "capped warnings must not block covered usage; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("... and 2 more"),
+        "rows past the cap must be acknowledged: {stdout}"
+    );
+    // Equal tokens and message counts, so the provider/model tiebreak decides:
+    // `...-20` and `...-21` are the two rows that fall past the cap.
+    assert!(
+        stdout.contains("unknown-provider-20/genuinely-unpriced-model-20"),
+        "a capped row must still be nameable for custom-pricing: {stdout}"
+    );
+    assert!(
+        stdout.contains("unknown-provider-21/genuinely-unpriced-model-21"),
+        "a capped row must still be nameable for custom-pricing: {stdout}"
+    );
+}
+
+/// Regression: the cap used to keep the alphabetically first rows, which hid
+/// the heaviest usage behind a provider id starting with `z`. The ids the hint
+/// asks the user to price must be the ones pricing recovers the most tokens
+/// for.
+#[test]
+fn test_submit_orders_unpriced_warning_rows_by_token_impact() {
+    let tmp = create_temp_fixture_dir();
+    prime_pricing_cache_with_a_priced_model(tmp.path());
+    write_fake_credentials(tmp.path());
+    let unpriced_dir = tmp
+        .path()
+        .join(".local/share/opencode/storage/message/unpriced-rank");
+    fs::create_dir_all(&unpriced_dir).unwrap();
+    for i in 0..20 {
+        fs::write(
+            unpriced_dir.join(format!("unpriced-{i:02}.json")),
+            format!(
+                r#"{{
+            "id": "unpriced-{i:02}",
+            "sessionID": "unpriced-rank",
+            "role": "assistant",
+            "modelID": "genuinely-unpriced-model-{i:02}",
+            "providerID": "unknown-provider-{i:02}",
+            "cost": 0,
+            "tokens": {{ "input": 1, "output": 0, "reasoning": 0, "cache": {{ "read": 0, "write": 0 }} }},
+            "time": {{ "created": 1736510400000.0 }}
+        }}"#,
+            ),
+        )
+        .unwrap();
+    }
+    // Sorts last by provider id, so the old alphabetical order pushed the
+    // single row worth pricing past the 20-row cap.
+    fs::write(
+        unpriced_dir.join("unpriced-heavy.json"),
+        r#"{
+            "id": "unpriced-heavy",
+            "sessionID": "unpriced-rank",
+            "role": "assistant",
+            "modelID": "zz-heavy-unpriced-model",
+            "providerID": "zz-provider",
+            "cost": 0,
+            "tokens": { "input": 999, "output": 0, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+            "time": { "created": 1736510400000.0 }
+        }"#,
+    )
+    .unwrap();
+
+    let output = offline_cmd_with_home(tmp.path())
+        .args([
+            "--no-spinner",
+            "submit",
+            "--client",
+            "opencode",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "capped warnings must not block covered usage; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let heaviest =
+        "submitting 1 unpriced zz_provider/zz-heavy-unpriced-model message(s) (999 tokens)";
+    let lightest = "submitting 1 unpriced unknown-provider-00/genuinely-unpriced-model-00";
+    let heaviest_at = stdout
+        .find(heaviest)
+        .unwrap_or_else(|| panic!("the heaviest row must get a detail line: {stdout}"));
+    let lightest_at = stdout
+        .find(lightest)
+        .unwrap_or_else(|| panic!("the lighter rows must still be listed: {stdout}"));
+    assert!(
+        heaviest_at < lightest_at,
+        "detail rows must be ordered by token impact, heaviest first: {stdout}"
+    );
+    assert!(
+        stdout.contains(
+            "Unpriced total: 21 message(s) (1,019 tokens) at $0.00 across 21 provider/model(s)."
+        ),
+        "the aggregate must still cover every row: {stdout}"
+    );
+}
+
 /// Regression: a cold cache with no network must not look like "no usage".
 ///
 /// Every fetchable upstream is unreachable here and nothing is cached, so the

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -5220,6 +5220,77 @@ fn test_submit_names_the_unpriced_models_past_the_detail_cap() {
     );
 }
 
+/// Regression: the capped ids were first printed as one unbroken line, so a
+/// long unpriced history rebuilt the wall of text the cap exists to prevent.
+/// Every capped id still has to appear -- the hint asks the user to price
+/// them -- but wrapped, not on a single line.
+#[test]
+fn test_submit_wraps_the_capped_unpriced_model_names() {
+    let tmp = create_temp_fixture_dir();
+    prime_pricing_cache_with_a_priced_model(tmp.path());
+    write_fake_credentials(tmp.path());
+    let unpriced_dir = tmp
+        .path()
+        .join(".local/share/opencode/storage/message/unpriced-wrap");
+    fs::create_dir_all(&unpriced_dir).unwrap();
+    for i in 0..40 {
+        fs::write(
+            unpriced_dir.join(format!("unpriced-{i:02}.json")),
+            format!(
+                r#"{{
+            "id": "unpriced-{i:02}",
+            "sessionID": "unpriced-wrap",
+            "role": "assistant",
+            "modelID": "genuinely-unpriced-model-{i:02}",
+            "providerID": "unknown-provider-{i:02}",
+            "cost": 0,
+            "tokens": {{ "input": 1, "output": 0, "reasoning": 0, "cache": {{ "read": 0, "write": 0 }} }},
+            "time": {{ "created": 1736510400000.0 }}
+        }}"#,
+            ),
+        )
+        .unwrap();
+    }
+
+    let output = offline_cmd_with_home(tmp.path())
+        .args([
+            "--no-spinner",
+            "submit",
+            "--client",
+            "opencode",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "capped warnings must not block covered usage; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("... and 20 more"),
+        "rows past the cap must be acknowledged: {stdout}"
+    );
+
+    // Every capped id stays reachable: the hint tells the user to price them.
+    for i in 20..40 {
+        let id = format!("unknown-provider-{i:02}/genuinely-unpriced-model-{i:02}");
+        assert!(
+            stdout.contains(&id),
+            "capped row {id} must still be nameable for custom-pricing: {stdout}"
+        );
+    }
+
+    // ... but spread over several lines. Unwrapped, these 20 ids landed on one
+    // ~1000-character line.
+    let longest = stdout.lines().map(str::len).max().unwrap_or(0);
+    assert!(
+        longest < 300,
+        "no output line may bury the screen; longest was {longest} chars: {stdout}"
+    );
+}
+
 /// Regression: the cap used to keep the alphabetically first rows, which hid
 /// the heaviest usage behind a provider id starting with `z`. The ids the hint
 /// asks the user to price must be the ones pricing recovers the most tokens


### PR DESCRIPTION
Long proxy-model histories fan out to one `Warning: submitting … unpriced …` row per provider/model pair (45+ rows in the motivating report), burying the submittable summary (`Date range / Active days / Total tokens / Total cost`) below screens of near-identical yellow lines. The tokenless-row reporter in the same file already solved this exact problem with a 20-row cap plus `... and N more`.

This caps the per-row detail in `report_unpriced_submission_usage` at the same 20 rows with the same `... and N more` acknowledgment, and adds one aggregate line (`Unpriced total: … message(s) (… tokens) at $0.00 across … provider/model(s).`) so capped-off rows are still accounted for. Per-row warning text is byte-identical, so rows under the cap render exactly as before.

## What's Changed
* feat(submit): cap unpriced warning rows and report the aggregate total

## Verification
* `cargo fmt --all -- --check`
* `cargo clippy --locked -p tokscale-cli --all-features -- -D warnings`
* `cargo test -p tokscale-cli --test cli_tests test_submit_` (6 passed, including the new `test_submit_caps_unpriced_warning_rows_and_reports_the_total` with 21 distinct unpriced models and the pre-existing single-row warning test)

**Full Changelog**: https://github.com/junhoyeo/tokscale/compare/v4.15.1...feat/submit-warning-aggregation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the unpriced submission warning at 20 provider/model rows, ranks them by token impact, and adds an aggregate total, so long proxy-model histories no longer bury the submittable summary.

- Rows past the cap are listed by id in the `... and N more` line, wrapped four per line, keeping the custom-pricing hint actionable.
- The 20 visible rows are ordered by token impact (then message count, then provider/model) so the heaviest usage stays visible.
- The aggregate line reports total messages, tokens, and provider/model count at $0.00.
- Rows under the cap render byte-identically to before.

<sup>Written for commit 28ae75035716d023315628ff002319d5e0fccfd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

