### PR TITLE
fix(antigravity): isolate HTTPS RPC block_on from caller runtime contexts

### DIFF
--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -2202,31 +2202,71 @@ fn https_rpc_request(
     }
 
     #[cfg(not(target_os = "windows"))]
-    antigravity_https_runtime().block_on(async {
-        let url = format!(
-            "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/{}",
-            connection.port, method
+    {
+        // `block_on` panics with "Cannot start a runtime from within a
+        // runtime" when the calling thread already has a Tokio runtime
+        // context entered (#1264): the TUI usage refresh and `tokscale
+        // usage` reach this function while `has_credentials`'s own
+        // current-thread runtime is mid-`block_on`, because
+        // `discover_port` probes the IDE's language server
+        // synchronously. A dedicated OS thread never carries a runtime
+        // context, so the nested-runtime panic is structurally
+        // impossible for every caller; the scope (not
+        // `std::thread::spawn`) is what lets the request keep borrowing
+        // `connection`/`method`/`body`. The ~microsecond spawn cost is
+        // irrelevant next to a loopback RPC with a 10s timeout, and a
+        // worker panic now degrades to `Err` instead of unwinding into
+        // whatever thread called us.
+        let joined: std::result::Result<Result<Value>, Box<dyn std::any::Any + Send>> =
+            std::thread::scope(|scope| {
+                scope
+                    .spawn(|| {
+                        antigravity_https_runtime()
+                            .block_on(https_rpc_once(connection, method, body))
+                    })
+                    .join()
+            });
+        joined.unwrap_or_else(|_| {
+            Err(anyhow::anyhow!(
+                "Antigravity HTTPS RPC {method} worker thread panicked"
+            ))
+        })
+    }
+}
+
+/// The HTTPS request future for [`https_rpc_request`], named so the spawned
+/// worker above stays a one-liner: nested four levels deep, the unbreakable
+/// URL literal overflowed rustfmt's max_width and forced a hanging layout
+/// that reads as broken indentation.
+#[cfg(not(target_os = "windows"))]
+async fn https_rpc_once(
+    connection: &AntigravityConnection,
+    method: &str,
+    body: &Value,
+) -> Result<Value> {
+    let url = format!(
+        "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/{}",
+        connection.port, method
+    );
+    let response = antigravity_https_client()
+        .post(url)
+        .header("Content-Type", "application/json")
+        .header("Connect-Protocol-Version", "1")
+        .header("X-Codeium-Csrf-Token", &connection.csrf_token)
+        .json(body)
+        .send()
+        .await?;
+    let status = response.status();
+    let response_body = read_reqwest_response_with_cap(response, MAX_RPC_BODY_BYTES).await?;
+    if !status.is_success() {
+        anyhow::bail!(
+            "Antigravity HTTPS RPC {} failed with status {}: {}",
+            method,
+            status,
+            response_body
         );
-        let response = antigravity_https_client()
-            .post(url)
-            .header("Content-Type", "application/json")
-            .header("Connect-Protocol-Version", "1")
-            .header("X-Codeium-Csrf-Token", &connection.csrf_token)
-            .json(body)
-            .send()
-            .await?;
-        let status = response.status();
-        let response_body = read_reqwest_response_with_cap(response, MAX_RPC_BODY_BYTES).await?;
-        if !status.is_success() {
-            anyhow::bail!(
-                "Antigravity HTTPS RPC {} failed with status {}: {}",
-                method,
-                status,
-                response_body
-            );
-        }
-        Ok(serde_json::from_str(&response_body)?)
-    })
+    }
+    Ok(serde_json::from_str(&response_body)?)
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -4033,6 +4073,40 @@ mod tests {
             cached_rpc_transport(port),
             Some(RpcTransport::PlainHttp),
             "a working plaintext port must be remembered, so the TLS leg is not tried later"
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn https_rpc_request_tolerates_an_entered_tokio_runtime_context() {
+        // Regression for #1264: the TUI usage refresh reaches this function
+        // while `has_credentials`'s own runtime is mid-`block_on`, and the
+        // nested `block_on` used to panic with "Cannot start a runtime from
+        // within a runtime". Entering a runtime here reproduces the caller
+        // side exactly; nothing listens on the port because the point is
+        // that the call returns an error instead of panicking.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let connection = AntigravityConnection {
+            pid: 1,
+            port,
+            csrf_token: "abcdef0123456789abcdef0123456789".to_string(),
+            fingerprint: format!("pid:1:port:{port}"),
+        };
+
+        let error = rt
+            .block_on(async { https_rpc_request(&connection, "GetUsage", &serde_json::json!({})) })
+            .unwrap_err();
+
+        assert!(
+            !error.to_string().contains("runtime"),
+            "nested-runtime panic must be gone, got: {error:#}"
         );
     }
 

--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -4109,13 +4109,21 @@ mod tests {
         // does not contain the word either -- a swallowed panic would keep this
         // test green. Pinning the connection error the request actually
         // produces means only the fixed path can pass.
+        // Matched on reqwest's own predicates rather than its `Display` text:
+        // that wording is an undocumented internal format a version bump can
+        // reword, while a swallowed panic does not downcast to a
+        // `reqwest::Error` at all, so this still separates the two paths.
+        let transport = error
+            .downcast_ref::<reqwest::Error>()
+            .unwrap_or_else(|| panic!("the failure must be the request's own, got: {error:#}"));
+        assert!(
+            transport.is_connect(),
+            "the request must fail connecting to the closed port, got: {error:#}"
+        );
         assert_eq!(
-            error.to_string(),
-            format!(
-                "error sending request for url (https://127.0.0.1:{port}\
-                 /exa.language_server_pb.LanguageServerService/GetUsage)"
-            ),
-            "the request must reach the closed port and fail there, got: {error:#}"
+            transport.url().and_then(|url| url.port()),
+            Some(port),
+            "the failure must name the closed port, got: {error:#}"
         );
     }
 

--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -4104,9 +4104,18 @@ mod tests {
             .block_on(async { https_rpc_request(&connection, "GetUsage", &serde_json::json!({})) })
             .unwrap_err();
 
-        assert!(
-            !error.to_string().contains("runtime"),
-            "nested-runtime panic must be gone, got: {error:#}"
+        // Asserting only the absence of "runtime" would also be satisfied by
+        // the panic-catch path above, whose message ("worker thread panicked")
+        // does not contain the word either -- a swallowed panic would keep this
+        // test green. Pinning the connection error the request actually
+        // produces means only the fixed path can pass.
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "error sending request for url (https://127.0.0.1:{port}\
+                 /exa.language_server_pb.LanguageServerService/GetUsage)"
+            ),
+            "the request must reach the closed port and fail there, got: {error:#}"
         );
     }
 

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -92,32 +92,52 @@ struct QuotaBucket {
 /// card on screen. The probe is a loopback request against a port read out of
 /// the CLI log, so it costs a few milliseconds.
 pub fn has_credentials() -> bool {
-    let Ok(rt) = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    else {
-        return false;
-    };
-    rt.block_on(async { discover_port().await.is_some() })
+    off_caller_runtime(|| {
+        let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        else {
+            return false;
+        };
+        rt.block_on(async { discover_port().await.is_some() })
+    })
+    .unwrap_or(false)
 }
 
 pub fn fetch_all() -> Result<Vec<UsageOutput>> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()?;
+    off_caller_runtime(|| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
 
-    rt.block_on(async {
-        let port = discover_port()
-            .await
-            .context("Antigravity language server is not running")?;
-        let summary = call_rpc(port).await?;
+        rt.block_on(async {
+            let port = discover_port()
+                .await
+                .context("Antigravity language server is not running")?;
+            let summary = call_rpc(port).await?;
 
-        if summary.groups.is_empty() {
-            anyhow::bail!("Antigravity is running but not signed in");
-        }
+            if summary.groups.is_empty() {
+                anyhow::bail!("Antigravity is running but not signed in");
+            }
 
-        Ok(summary.groups.into_iter().map(output_for_group).collect())
+            Ok(summary.groups.into_iter().map(output_for_group).collect())
+        })
     })
+    .unwrap_or_else(|_| Err(anyhow::anyhow!("Antigravity usage worker thread panicked")))
+}
+
+/// Run `work` on a dedicated OS thread, off whatever runtime the caller is on.
+///
+/// Both entry points above drive their own current-thread runtime, and
+/// `block_on` panics with "Cannot start a runtime from within a runtime" when
+/// the calling thread already has a Tokio runtime context entered (#1264) --
+/// the TUI usage refresh does exactly that. A fresh OS thread never carries a
+/// runtime context, so the panic is structurally impossible for every caller,
+/// and the scope joins before returning, which keeps both entry points as
+/// synchronous as they were. `crate::antigravity::https_rpc_request` isolates
+/// its own `block_on` the same way.
+fn off_caller_runtime<T: Send>(work: impl FnOnce() -> T + Send) -> std::thread::Result<T> {
+    std::thread::scope(|scope| scope.spawn(work).join())
 }
 
 fn output_for_group(group: QuotaGroup) -> UsageOutput {
@@ -543,6 +563,25 @@ mod tests {
             third_party.account.as_ref().unwrap().id,
             "claude-and-gpt-models"
         );
+    }
+
+    /// Regression for #1264. Both entry points build their own current-thread
+    /// runtime, and `block_on` panics with "Cannot start a runtime from within
+    /// a runtime" when the calling thread already has a runtime context
+    /// entered -- which the TUI usage refresh does. Neither return value is
+    /// asserted on: whether a language server answers is a property of the
+    /// machine, and the point is that the call returns at all.
+    #[test]
+    fn entry_points_tolerate_an_entered_tokio_runtime_context() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let _ = has_credentials();
+            let _ = fetch_all();
+        });
     }
 
     #[test]

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -568,9 +568,15 @@ mod tests {
     /// Regression for #1264. Both entry points build their own current-thread
     /// runtime, and `block_on` panics with "Cannot start a runtime from within
     /// a runtime" when the calling thread already has a runtime context
-    /// entered -- which the TUI usage refresh does. Neither return value is
-    /// asserted on: whether a language server answers is a property of the
-    /// machine, and the point is that the call returns at all.
+    /// entered -- which the TUI usage refresh does.
+    ///
+    /// Calling them is not the check. Both swallow a worker panic
+    /// (`unwrap_or(false)`, `unwrap_or_else`), so a worker that still panicked
+    /// inside the caller's runtime returns exactly like a working one, and
+    /// neither return value can be asserted on because whether a language
+    /// server answers is a property of the machine. So the isolation itself is
+    /// pinned: work left on the caller's thread sees the entered runtime
+    /// context, and only work moved off that thread does not.
     #[test]
     fn entry_points_tolerate_an_entered_tokio_runtime_context() {
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -579,6 +585,11 @@ mod tests {
             .unwrap();
 
         rt.block_on(async {
+            assert!(
+                off_caller_runtime(|| tokio::runtime::Handle::try_current().is_err())
+                    .expect("the worker must not panic"),
+                "the work must run off the caller's runtime"
+            );
             let _ = has_credentials();
             let _ = fetch_all();
         });

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -130,12 +130,16 @@ pub fn fetch_all() -> Result<Vec<UsageOutput>> {
 ///
 /// Both entry points above drive their own current-thread runtime, and
 /// `block_on` panics with "Cannot start a runtime from within a runtime" when
-/// the calling thread already has a Tokio runtime context entered (#1264) --
-/// the TUI usage refresh does exactly that. A fresh OS thread never carries a
-/// runtime context, so the panic is structurally impossible for every caller,
-/// and the scope joins before returning, which keeps both entry points as
-/// synchronous as they were. `crate::antigravity::https_rpc_request` isolates
-/// its own `block_on` the same way.
+/// the calling thread already has a Tokio runtime context entered (#1264). No
+/// caller does that today -- `tokscale usage` reaches them from a plain sync
+/// `main`, and the TUI usage refresh runs the fetcher on a bare
+/// `std::thread::spawn` -- so this is hardening rather than a live crash path:
+/// a fresh OS thread never carries a runtime context, which keeps the panic
+/// impossible for whatever entry point is added next. The scope joins before
+/// returning, so both entry points stay as synchronous as they were.
+/// `crate::antigravity::https_rpc_request` isolates its own `block_on` the
+/// same way, and that one is reachable today: `discover_port` walks into it
+/// synchronously from inside the runtime `has_credentials` just entered.
 fn off_caller_runtime<T: Send>(work: impl FnOnce() -> T + Send) -> std::thread::Result<T> {
     std::thread::scope(|scope| scope.spawn(work).join())
 }
@@ -568,15 +572,18 @@ mod tests {
     /// Regression for #1264. Both entry points build their own current-thread
     /// runtime, and `block_on` panics with "Cannot start a runtime from within
     /// a runtime" when the calling thread already has a runtime context
-    /// entered -- which the TUI usage refresh does.
+    /// entered. No caller does that today, so what is pinned here is hardening.
     ///
-    /// Calling them is not the check. Both swallow a worker panic
+    /// Calling them is not sufficient on its own. Both swallow a worker panic
     /// (`unwrap_or(false)`, `unwrap_or_else`), so a worker that still panicked
     /// inside the caller's runtime returns exactly like a working one, and
     /// neither return value can be asserted on because whether a language
-    /// server answers is a property of the machine. So the isolation itself is
-    /// pinned: work left on the caller's thread sees the entered runtime
-    /// context, and only work moved off that thread does not.
+    /// server answers is a property of the machine. Hence the assert, which
+    /// pins the isolation itself: work left on the caller's thread sees the
+    /// entered runtime context, and only work moved off that thread does not.
+    /// The two calls still carry the other half -- an entry point that stops
+    /// using the helper panics on them while the assert stays green -- so keep
+    /// both halves.
     #[test]
     fn entry_points_tolerate_an_entered_tokio_runtime_context() {
         let rt = tokio::runtime::Builder::new_current_thread()


### PR DESCRIPTION
Fixes #1264

## The panic

`tokscale` TUI (and `tokscale usage`) panic during Antigravity refresh with:

```
Cannot start a runtime from within a runtime
```

at `crates/tokscale-cli/src/antigravity.rs:2205` — the `block_on` inside `https_rpc_request`.

The chain: the TUI usage tab spawns an OS thread that calls `fetch_all_report_with_intent`, whose provider filtering calls `commands/usage/antigravity::has_credentials`. That function creates its **own** current-thread runtime and blocks on `discover_port()`. When no CLI-log HTTP port answers (the IDE DesktopAgent case), `discover_port` falls through to the synchronous `detect_antigravity_connections`, which probes the language server's HTTPS heartbeat — and `https_rpc_request` calls `antigravity_https_runtime().block_on(...)` on a thread whose Tokio runtime context (`has_credentials`'s runtime) is already entered. Tokio panics.

## The fix

`https_rpc_request` is the single `block_on` choke point in the module, so this patch makes the non-Windows branch run the same request future on a dedicated scoped OS thread instead of the calling thread. A thread spawned fresh never carries an entered runtime context, so the nested-runtime panic is structurally impossible for every caller (`has_credentials`, `fetch_all`, `sync`, `status`, identity probes, tests) — not just the TUI path. The future body is unchanged; only where it is polled moved.

`std::thread::scope` (rather than `std::thread::spawn`) keeps the request borrowing `connection`/`method`/`body` with no extra cloning, and the spawn cost (~microseconds) is noise next to a loopback RPC with a 10s timeout.

Async end-to-end was considered and rejected: it would ripple `async` through `rpc_request`, `list_trajectory_summaries`, `fetch_session_artifact`, `detect_antigravity_connections`, and both sync CLI commands for no behavioral gain.

One deliberate behavior change: if the worker thread panics, the function now returns `Err` instead of unwinding into whatever thread called it — previously such a panic killed the process and left the TUI's fetch thread wedged with its spinner never resolving.

Windows keeps its curl.exe path, which has no runtime involved and is untouched.

## Test

`https_rpc_request_tolerates_an_entered_tokio_runtime_context` reproduces the issue exactly: it enters a real Tokio runtime and calls `https_rpc_request` from inside it. On the old code it aborts with the nested-runtime panic; with the fix it returns the expected connection error. Requires no Antigravity install and no network.

Verified both ways locally: the new test fails on the unfixed code with the exact reported panic (`panicked at crates/tokscale-cli/src/antigravity.rs:2205:33: Cannot start a runtime from within a runtime`) and passes with the fix in place. Full `tokscale-cli` suite (1424 tests), `cargo clippy -p tokscale-cli --all-targets -- -D warnings`, and `cargo fmt --all -- --check` are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1264. Antigravity usage previously panicked with "Cannot start a runtime from within a runtime" because `has_credentials`, `fetch_all`, and the HTTPS RPC path each called `block_on` from a thread with an entered Tokio runtime context. All three now run their work on a dedicated scoped OS thread, which makes the nested-runtime panic impossible for any caller; a panicked worker returns an error instead of unwinding the caller.

- Adds regression tests that reproduce the entered-runtime context without needing an Antigravity install or network access; the `https_rpc_request` test asserts the request's own connection error so a swallowed panic cannot keep it green.
- Leaves the Windows `curl.exe` path unchanged.

<sup>Written for commit 097947344a41d30ca6ff5a39722c52d419ec6d9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

