### PR TITLE
feat(submit): report scan scope and elapsed time with an incremental tip

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -6029,7 +6029,17 @@ fn run_submit_command(
     // client directory, so a slow run should at least say what it is chewing
     // through — and the label advertises the flags that narrow it.
     let scan_scope_label = {
-        let client_count = clients.as_ref().map(Vec::len).unwrap_or_default();
+        let scans_all_clients = clients
+            .as_deref()
+            .is_none_or(|c| c.iter().any(|s| s == "synthetic"));
+        let client_count = if scans_all_clients {
+            tokscale_core::ClientId::COUNT
+        } else {
+            clients
+                .as_ref()
+                .map(Vec::len)
+                .unwrap_or(tokscale_core::ClientId::COUNT)
+        };
         let range_label = match (&since, &until, &year) {
             (None, None, None) => "full history".to_string(),
             _ => {

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5993,11 +5993,9 @@ fn run_submit_command(
     let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
     let explicit_warp_filter = client_filter_explicitly_requests_warp(&clients);
     let explicit_hindsight_filter = client_filter_explicitly_requests_hindsight(&clients);
+    let full_history_scan = since.is_none() && until.is_none() && year.is_none();
     let clients = clients.or_else(|| Some(default_submit_clients()));
-    let scan_scope = submit_scan_scope(
-        clients.as_deref(),
-        since.is_none() && until.is_none() && year.is_none(),
-    );
+    let scan_scope = submit_scan_scope(clients.as_deref(), full_history_scan);
 
     let include_cursor = clients
         .as_ref()
@@ -6027,8 +6025,43 @@ fn run_submit_command(
         emit_cursor_setup_warnings(&cursor_setup_warnings);
     }
 
-    println!("{}", "  Scanning local session data...".bright_black());
+    // Name the effective scope up front: an unbounded `submit` re-scans every
+    // client directory, so a slow run should at least say what it is chewing
+    // through — and the label advertises the flags that narrow it.
+    let scan_scope_label = {
+        let client_count = clients.as_ref().map(Vec::len).unwrap_or_default();
+        let range_label = match (&since, &until, &year) {
+            (None, None, None) => "full history".to_string(),
+            _ => {
+                let mut parts = Vec::new();
+                if let Some(since) = &since {
+                    parts.push(format!("since {since}"));
+                }
+                if let Some(until) = &until {
+                    parts.push(format!("until {until}"));
+                }
+                if let Some(year) = &year {
+                    parts.push(format!("year {year}"));
+                }
+                parts.join(" ")
+            }
+        };
+        format!(
+            "{} {}, {range_label}",
+            client_count,
+            if client_count == 1 {
+                "client"
+            } else {
+                "clients"
+            }
+        )
+    };
+    println!(
+        "{}",
+        format!("  Scanning local session data ({scan_scope_label})...").bright_black()
+    );
 
+    let scan_started = std::time::Instant::now();
     let rt = Runtime::new()?;
     let mut graph_result = rt
         .block_on(async {
@@ -6046,6 +6079,17 @@ fn run_submit_command(
             .await
         })
         .map_err(|e| anyhow::anyhow!(e))?;
+    println!(
+        "{}",
+        format!("  Scanned in {:.1}s.", scan_started.elapsed().as_secs_f64()).bright_black()
+    );
+    if full_history_scan {
+        println!(
+            "{}",
+            "  Tip: narrow the scan with `--since <date>` and `--client <id>` for faster incremental submits."
+                .bright_black()
+        );
+    }
 
     // Preserve local-calendar contributions here. The API validator owns the
     // UTC+ timezone buffer; client-side UTC capping silently drops current-day

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -4952,6 +4952,27 @@ fn submit_scan_scope(clients: Option<&[String]>, full_history: bool) -> Option<T
     })
 }
 
+/// Whether the post-scan tip pointing at `--client` is worth printing.
+///
+/// Only the client filter shortens the scan: `--since`/`--until`/`--year` are
+/// `retain` predicates applied to already-parsed messages, so a date filter
+/// reads and parses exactly the same files. Suggesting one would also cost
+/// data — it clears `full_history` on the scan scope, and
+/// `planParserHighWaterSubmission` freezes a partial snapshot for every client
+/// in `SUPPORTED_VERSIONED_PARSERS` (copilot, droid, antigravity-cli,
+/// antigravity). So the tip names `--client` and nothing else.
+///
+/// It stays quiet once the user has already passed `--client`, and under
+/// autosubmit, whose stdout is the scheduler log file rather than a terminal
+/// anyone is reading advice from.
+fn should_suggest_client_scope_tip(
+    mode: SubmitMode,
+    explicit_client_filter: bool,
+    full_history_scan: bool,
+) -> bool {
+    mode == SubmitMode::Interactive && !explicit_client_filter && full_history_scan
+}
+
 fn run_login_command(token: Option<String>) -> Result<()> {
     use tokio::runtime::Runtime;
 
@@ -5994,6 +6015,7 @@ fn run_submit_command(
     let explicit_warp_filter = client_filter_explicitly_requests_warp(&clients);
     let explicit_hindsight_filter = client_filter_explicitly_requests_hindsight(&clients);
     let full_history_scan = since.is_none() && until.is_none() && year.is_none();
+    let explicit_client_filter = clients.is_some();
     let clients = clients.or_else(|| Some(default_submit_clients()));
     let scan_scope = submit_scan_scope(clients.as_deref(), full_history_scan);
 
@@ -6093,11 +6115,10 @@ fn run_submit_command(
         "{}",
         format!("  Scanned in {:.1}s.", scan_started.elapsed().as_secs_f64()).bright_black()
     );
-    if full_history_scan {
+    if should_suggest_client_scope_tip(mode, explicit_client_filter, full_history_scan) {
         println!(
             "{}",
-            "  Tip: narrow the scan with `--since <date>` and `--client <id>` for faster incremental submits."
-                .bright_black()
+            "  Tip: narrow the scan with `--client <id>` for a faster submit.".bright_black()
         );
     }
 
@@ -8804,6 +8825,39 @@ mod tests {
         let scope = submit_scan_scope(Some(&clients), true).expect("droid scope");
 
         assert_eq!(scope.parser_versions.get("droid"), Some(&1));
+    }
+
+    /// The tip is advice for a person at a prompt. Autosubmit's stdout is the
+    /// scheduler log (`StandardOutPath` in the launchd plist), so printing it
+    /// there is pure noise on every scheduled run.
+    #[test]
+    fn client_scope_tip_is_interactive_only() {
+        assert!(should_suggest_client_scope_tip(
+            SubmitMode::Interactive,
+            false,
+            true
+        ));
+        assert!(!should_suggest_client_scope_tip(
+            SubmitMode::Autosubmit,
+            false,
+            true
+        ));
+    }
+
+    /// Nothing left to suggest once the scan is already narrowed, and the
+    /// bounded runs are not the slow default the tip exists for.
+    #[test]
+    fn client_scope_tip_stays_quiet_once_the_scan_is_narrowed() {
+        assert!(!should_suggest_client_scope_tip(
+            SubmitMode::Interactive,
+            true,
+            true
+        ));
+        assert!(!should_suggest_client_scope_tip(
+            SubmitMode::Interactive,
+            false,
+            false
+        ));
     }
 
     #[test]

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -2949,6 +2949,49 @@ fn test_submit_dry_run_preserves_local_date_ahead_of_utc() {
         .stdout(predicate::str::contains("Total tokens: 1,750"));
 }
 
+/// Regression: an unbounded `submit` re-scans every client directory, and the
+/// silent wait used to give no hint of what was being scanned or how to narrow
+/// it. The scope label, elapsed time, and incremental-submit tip are the
+/// observability for that wait; none of them change what gets submitted.
+#[test]
+fn test_submit_reports_scan_scope_and_elapsed() {
+    let tmp = create_temp_fixture_dir();
+    cmd_with_home(tmp.path())
+        .env("TOKSCALE_API_TOKEN", "test-token")
+        .args([
+            "--no-spinner",
+            "submit",
+            "--client",
+            "opencode",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Scanning local session data (1 client, full history)...",
+        ))
+        .stdout(predicate::str::contains("Scanned in "))
+        .stdout(predicate::str::contains("Tip: narrow the scan"));
+
+    cmd_with_home(tmp.path())
+        .env("TOKSCALE_API_TOKEN", "test-token")
+        .args([
+            "--no-spinner",
+            "submit",
+            "--client",
+            "opencode",
+            "--since",
+            "2026-01-01",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Scanning local session data (1 client, since 2026-01-01)...",
+        ))
+        .stdout(predicate::str::contains("Tip: narrow the scan").not());
+}
+
 #[test]
 fn test_models_with_all_client_flags() {
     let tmp = create_temp_fixture_dir();

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -2950,9 +2950,9 @@ fn test_submit_dry_run_preserves_local_date_ahead_of_utc() {
 }
 
 /// Regression: an unbounded `submit` re-scans every client directory, and the
-/// silent wait used to give no hint of what was being scanned or how to narrow
-/// it. The scope label, elapsed time, and incremental-submit tip are the
-/// observability for that wait; none of them change what gets submitted.
+/// silent wait used to give no hint of what was being scanned or how long it
+/// took. The scope label and the elapsed time are the observability for that
+/// wait; neither changes what gets submitted.
 #[test]
 fn test_submit_reports_scan_scope_and_elapsed() {
     let tmp = create_temp_fixture_dir();
@@ -2971,9 +2971,9 @@ fn test_submit_reports_scan_scope_and_elapsed() {
             "Scanning local session data (1 client, full history)...",
         ))
         .stdout(predicate::str::is_match(r"Scanned in \d+\.\d+s\.").unwrap())
-        .stdout(predicate::str::contains(
-            "Tip: narrow the scan with `--since <date>` and `--client <id>`",
-        ));
+        // The scan is already narrowed to one client, so the tip has nothing
+        // left to suggest.
+        .stdout(predicate::str::contains("Tip:").not());
 
     cmd_with_home(tmp.path())
         .env("TOKSCALE_API_TOKEN", "test-token")
@@ -2991,7 +2991,7 @@ fn test_submit_reports_scan_scope_and_elapsed() {
         .stdout(predicate::str::contains(
             "Scanning local session data (1 client, since 2026-01-01)...",
         ))
-        .stdout(predicate::str::contains("Tip: narrow the scan").not());
+        .stdout(predicate::str::contains("Tip:").not());
 
     cmd_with_home(tmp.path())
         .env("TOKSCALE_API_TOKEN", "test-token")
@@ -3008,6 +3008,51 @@ fn test_submit_reports_scan_scope_and_elapsed() {
             "Scanning local session data ({} clients, full history)...",
             tokscale_core::ClientId::COUNT
         )));
+}
+
+/// The tip may name `--client` and nothing else.
+///
+/// `--since` does not shorten the scan: the date filters are `retain`
+/// predicates run over already-parsed messages, so the same files are read
+/// either way. It also clears `fullHistory` on the scan scope, and
+/// `planParserHighWaterSubmission` (packages/frontend/src/lib/db/parserHighWater.ts)
+/// freezes a partial snapshot for every client in `SUPPORTED_VERSIONED_PARSERS`
+/// — copilot, droid, antigravity-cli and antigravity. Advertising it as a
+/// speedup costs the user data.
+#[test]
+fn test_submit_tip_recommends_only_the_client_filter() {
+    let tmp = create_temp_fixture_dir();
+    cmd_with_home(tmp.path())
+        .env("TOKSCALE_API_TOKEN", "test-token")
+        .args(["--no-spinner", "submit", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Tip: narrow the scan with `--client <id>` for a faster submit.",
+        ))
+        .stdout(predicate::str::is_match(r"Tip:.*--since").unwrap().not());
+}
+
+/// Autosubmit's stdout is the scheduler's log file (`StandardOutPath` in the
+/// launchd plist, the systemd/cron redirect elsewhere), so the tip would be
+/// appended to it on every scheduled run with nobody at a prompt to act on it.
+///
+/// This covers the observable behavior end to end. It does not isolate the mode
+/// gate on its own — `submit_filters` always hands `run_submit_command` a
+/// client list, so the already-narrowed gate would suppress the tip here too.
+/// `client_scope_tip_is_interactive_only` in main.rs is the test that flips
+/// only the mode.
+#[test]
+fn test_autosubmit_run_omits_the_scan_scope_tip() {
+    let tmp = create_temp_fixture_dir();
+    write_settings_json(tmp.path(), r#"{"autosubmit":{"enabled":true}}"#);
+
+    cmd_with_home(tmp.path())
+        .env("TOKSCALE_API_TOKEN", "test-token")
+        .args(["--no-spinner", "autosubmit", "run", "--force"])
+        .assert()
+        .stdout(predicate::str::contains("Scanning local session data ("))
+        .stdout(predicate::str::contains("Tip:").not());
 }
 
 #[test]

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -2970,8 +2970,10 @@ fn test_submit_reports_scan_scope_and_elapsed() {
         .stdout(predicate::str::contains(
             "Scanning local session data (1 client, full history)...",
         ))
-        .stdout(predicate::str::contains("Scanned in "))
-        .stdout(predicate::str::contains("Tip: narrow the scan"));
+        .stdout(predicate::str::is_match(r"Scanned in \d+\.\d+s\.").unwrap())
+        .stdout(predicate::str::contains(
+            "Tip: narrow the scan with `--since <date>` and `--client <id>`",
+        ));
 
     cmd_with_home(tmp.path())
         .env("TOKSCALE_API_TOKEN", "test-token")
@@ -2990,6 +2992,22 @@ fn test_submit_reports_scan_scope_and_elapsed() {
             "Scanning local session data (1 client, since 2026-01-01)...",
         ))
         .stdout(predicate::str::contains("Tip: narrow the scan").not());
+
+    cmd_with_home(tmp.path())
+        .env("TOKSCALE_API_TOKEN", "test-token")
+        .args([
+            "--no-spinner",
+            "submit",
+            "--client",
+            "synthetic",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "Scanning local session data ({} clients, full history)...",
+            tokscale_core::ClientId::COUNT
+        )));
 }
 
 #[test]

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -1000,6 +1000,14 @@ fn cmd_with_home(tmp: &Path) -> Command {
         // `pricing` intentionally bypasses TOKSCALE_PRICING_CACHE_ONLY; the
         // loopback proxies below are the offline guarantee for every command.
         .env("TOKSCALE_PRICING_CACHE_ONLY", "1")
+        // Point every API call at a dead loopback port. `get_api_base_url`
+        // reads TOKSCALE_API_URL and falls back to https://tokscale.ai, and
+        // submit, autosubmit run, login and delete-submitted-data all format
+        // their endpoint onto it. Unpinned, those commands hit production with
+        // whatever token the test set, stopped only by the proxies below — a
+        // guard a `.no_proxy()` on one client would silently remove. Pinning it
+        // here also drops any TOKSCALE_API_URL a developer has exported.
+        .env("TOKSCALE_API_URL", "http://127.0.0.1:9")
         // Keep cache-only fixtures offline even if a future code path ignores
         // the cache-only switch or a developer has proxy variables configured.
         .env("HTTP_PROXY", "http://127.0.0.1:9")
@@ -1052,6 +1060,8 @@ fn offline_cmd_with_home(tmp: &Path) -> Command {
         .env("XDG_DATA_HOME", tmp.join(".local/share"))
         .env("XDG_CACHE_HOME", tmp.join(".cache"))
         .env("TOKSCALE_CONFIG_DIR", sandbox_config_dir(tmp))
+        // Same production-endpoint pin as cmd_with_home.
+        .env("TOKSCALE_API_URL", "http://127.0.0.1:9")
         .env("HTTP_PROXY", "http://127.0.0.1:9")
         .env("HTTPS_PROXY", "http://127.0.0.1:9")
         .env("ALL_PROXY", "http://127.0.0.1:9")
@@ -3049,11 +3059,14 @@ fn test_submit_tip_recommends_only_the_client_filter() {
 /// call site), so any usage at all carries it past the `total_tokens == 0`
 /// short-circuit and into a real `POST {api}/api/submit` with
 /// `Authorization: Bearer test-token`. With `create_temp_fixture_dir` here the
-/// run reached "Submitting to server..." and only the loopback proxies in
-/// `cmd_with_home` stopped the request leaving the machine — a guard that lives
-/// in the harness, not in this test. An empty home ends the run at "No usage
-/// data found to submit." instead, which is what the last assertion pins, and
-/// the scope line and the tip gate are observable either way.
+/// run reached "Submitting to server..." and issued that POST against
+/// `https://tokscale.ai`; the loopback proxies were all that kept the packet on
+/// the machine. `cmd_with_home` now also pins `TOKSCALE_API_URL` to a dead
+/// loopback port, so no test resolves the production endpoint any more — but
+/// an empty home is still what keeps *this* test off the submit path entirely.
+/// It ends the run at "No usage data found to submit." instead, which is what
+/// the last assertion pins, and the scope line and the tip gate are observable
+/// either way.
 ///
 /// `prime_pricing_cache` is still needed: the pricing load runs before the
 /// usage check and ignores `TOKSCALE_PRICING_CACHE_ONLY`.
@@ -3072,6 +3085,38 @@ fn test_autosubmit_run_omits_the_scan_scope_tip() {
         .stdout(predicate::str::is_match(r"Scanned in \d+\.\d+s\.").unwrap())
         .stdout(predicate::str::contains("Tip:").not())
         .stdout(predicate::str::contains("No usage data found to submit."));
+}
+
+/// Every command `cmd_with_home` builds must resolve the API to a dead loopback
+/// port instead of production.
+///
+/// `auth::get_api_base_url` reads `TOKSCALE_API_URL` and falls back to
+/// `https://tokscale.ai`, and `submit`, `autosubmit run`, `login` and
+/// `delete-submitted-data` all format their endpoint onto whatever it returns.
+/// Before the pin the harness neither set nor removed that variable, so a
+/// non-dry-run submit under a fixture with usage sent
+/// `POST https://tokscale.ai/api/submit` carrying the test's bearer token, with
+/// only the loopback proxies stopping it, and a developer with
+/// `TOKSCALE_API_URL` exported silently redirected every test to their own
+/// server.
+///
+/// `login --token` is the cheapest command that reaches the API with no fixture
+/// at all: the `tt_` prefix check passes locally, then it GETs
+/// `{api}/api/auth/token` and prints the request URL when the connection fails.
+/// Asserting on that URL proves the child process resolved the pinned base,
+/// which reading the env map back off the `Command` would not.
+#[test]
+fn test_cmd_with_home_keeps_api_calls_off_production() {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+
+    cmd_with_home(tmp.path())
+        .args(["--no-spinner", "login", "--token", "tt_not_a_real_token"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "url (http://127.0.0.1:9/api/auth/token)",
+        ))
+        .stderr(predicate::str::contains("tokscale.ai").not());
 }
 
 #[test]

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3042,17 +3042,36 @@ fn test_submit_tip_recommends_only_the_client_filter() {
 /// client list, so the already-narrowed gate would suppress the tip here too.
 /// `client_scope_tip_is_interactive_only` in main.rs is the test that flips
 /// only the mode.
+///
+/// The home is deliberately empty of session data, and that is load-bearing.
+/// `autosubmit run` is the one submit path in this file that is not a dry run
+/// (`run_submit_command(.., dry_run = false, ..)` at the `AutosubmitRunDecision`
+/// call site), so any usage at all carries it past the `total_tokens == 0`
+/// short-circuit and into a real `POST {api}/api/submit` with
+/// `Authorization: Bearer test-token`. With `create_temp_fixture_dir` here the
+/// run reached "Submitting to server..." and only the loopback proxies in
+/// `cmd_with_home` stopped the request leaving the machine — a guard that lives
+/// in the harness, not in this test. An empty home ends the run at "No usage
+/// data found to submit." instead, which is what the last assertion pins, and
+/// the scope line and the tip gate are observable either way.
+///
+/// `prime_pricing_cache` is still needed: the pricing load runs before the
+/// usage check and ignores `TOKSCALE_PRICING_CACHE_ONLY`.
 #[test]
 fn test_autosubmit_run_omits_the_scan_scope_tip() {
-    let tmp = create_temp_fixture_dir();
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    prime_pricing_cache(tmp.path());
     write_settings_json(tmp.path(), r#"{"autosubmit":{"enabled":true}}"#);
 
     cmd_with_home(tmp.path())
         .env("TOKSCALE_API_TOKEN", "test-token")
         .args(["--no-spinner", "autosubmit", "run", "--force"])
         .assert()
+        .success()
         .stdout(predicate::str::contains("Scanning local session data ("))
-        .stdout(predicate::str::contains("Tip:").not());
+        .stdout(predicate::str::is_match(r"Scanned in \d+\.\d+s\.").unwrap())
+        .stdout(predicate::str::contains("Tip:").not())
+        .stdout(predicate::str::contains("No usage data found to submit."));
 }
 
 #[test]


### PR DESCRIPTION
An unbounded `submit` re-scans every client directory (the motivating report: 14 months, 17 clients, 48B tokens), and the silent wait between `Scanning local session data...` and `Data to submit:` gave no hint of what was being scanned, how long it took, or how to narrow it. This adds observability only — nothing about what gets scanned or submitted changes.

The scan line now names the effective scope (`Scanning local session data (17 clients, full history)...`, or `(1 client, since 2026-08-01)...` when narrowed), the run reports its wall-clock time (`Scanned in 87.4s.`, covering pricing fetch plus scan plus aggregation), and unbounded scans print one tip line pointing at `--since` and `--client` for faster incremental submits.

## What's Changed
* feat(submit): report scan scope and elapsed time with an incremental tip

## Verification
* `cargo fmt --all -- --check`
* `cargo clippy --locked -p tokscale-cli --all-features -- -D warnings`
* `cargo test -p tokscale-cli --test cli_tests test_submit_` (6 passed, including the new `test_submit_reports_scan_scope_and_elapsed` covering both the full-history label plus tip and the narrowed label without tip)

**Full Changelog**: https://github.com/junhoyeo/tokscale/compare/v4.15.1...feat/submit-scan-progress

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`submit` now reports its scan scope and elapsed time, and tips unbounded interactive runs to narrow with `--client`. Previously the scan stayed silent; this adds observability only and does not change what gets scanned or submitted.

- The scope label shows the effective client count (correct total when scanning all clients via `synthetic`) and active date filters; elapsed time covers pricing fetch, scan, and aggregation.
- The tip names only `--client` — date filters don't shorten the scan and mark submissions as partial snapshots the server freezes — and is suppressed when `--client` is already passed or under autosubmit.
- Test harness now pins `TOKSCALE_API_URL` off production, and the autosubmit tip test uses an empty home so it never reaches the submit endpoint.

<sup>Written for commit d91399f698bdb581a7d221db4295cffc5e835615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

