### PR TITLE
fix(pricing): prefer proven archive tariff over unverified reseller guess

### DIFF
--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -880,21 +880,7 @@ impl PricingLookup {
             self.exact_match_models_dev_for_provider(model_id, provider_id),
             provider_id,
         ) {
-            // A provider-proven first-party snapshot beats an unverified
-            // guess. Reseller rows (`deepinfra/anthropic/...`) match here by
-            // model part while the archive holds the publishing endpoint's
-            // own exact tariff further down; letting the guess win prices
-            // first-party usage at a third party's rate and reports it as
-            // unpublishable. Safe upstream rows still win untouched.
-            if !result.evidence.is_submission_safe() {
-                let proven = self
-                    .exact_match_archive(model_id, provider_id)
-                    .filter(|archived| archived.evidence.is_submission_safe());
-                if let Some(archived) = proven {
-                    return Some(archived);
-                }
-            }
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
 
         if let Some(result) = exact_litellm {
@@ -918,11 +904,11 @@ impl PricingLookup {
         // matching key falls through to the canonical resolution below.
         if provider_id.is_some() {
             if let Some(result) = self.exact_match_models_dev_for_provider(model_id, provider_id) {
-                return Some(result);
+                return Some(self.prefer_proven_archive(result, model_id, provider_id));
             }
         }
         if let Some(result) = self.exact_match_openrouter_model_part(model_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
 
         // Separator-normalized exact passes against the canonical sources
@@ -940,31 +926,47 @@ impl PricingLookup {
                 self.exact_match_models_dev_for_provider(&version_normalized, provider_id),
                 provider_id,
             ) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
             if provider_id.is_some() {
                 if let Some(result) =
                     self.exact_match_models_dev_for_provider(&version_normalized, provider_id)
                 {
-                    return Some(result.with_normalization());
+                    return Some(self.prefer_proven_archive(
+                        result.with_normalization(),
+                        &version_normalized,
+                        provider_id,
+                    ));
                 }
             }
             if let Some(result) = self.exact_match_litellm(&version_normalized) {
                 return Some(result.with_normalization());
             }
             if let Some(result) = self.exact_match_openrouter(&version_normalized) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
         }
 
         if let Some(result) = self.exact_match_models_dev_with_provider(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) =
                 self.exact_match_models_dev_with_provider(&version_normalized, provider_id)
             {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
         }
 
@@ -975,40 +977,64 @@ impl PricingLookup {
                 self.exact_match_models_dev_for_provider(&normalized, provider_id),
                 provider_id,
             ) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) = self.exact_match_litellm(&normalized) {
                 return Some(result.with_normalization());
             }
             if let Some(result) = self.exact_match_openrouter(&normalized) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) =
                 self.exact_match_models_dev_with_provider(&normalized, provider_id)
             {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &normalized,
+                    provider_id,
+                ));
             }
         }
 
         if let Some(result) = self.prefix_match_litellm(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
         if let Some(result) = self.prefix_match_openrouter(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
         if let Some(result) = self.prefix_match_models_dev(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
 
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) = self.prefix_match_litellm(&version_normalized, provider_id) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) = self.prefix_match_openrouter(&version_normalized, provider_id) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) = self.prefix_match_models_dev(&version_normalized, provider_id) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
         }
 
@@ -1462,6 +1488,31 @@ impl PricingLookup {
             }
         }
         None
+    }
+
+    /// Prefer a provider-proven archive tariff over an unverified upstream guess.
+    ///
+    /// Every unverified fallback stage in `lookup_auto` (model-part, alias and
+    /// prefix matches) routes through here. Reseller rows
+    /// (`deepinfra/anthropic/...`, `z-ai/...`) match those stages by model
+    /// part while the archive holds the publishing endpoint's own exact
+    /// tariff; letting the guess win prices first-party usage at a third
+    /// party's rate and reports it as unpublishable. Safe upstream rows pass
+    /// through untouched, as does everything when the archive cannot prove
+    /// the endpoint -- so display estimates never change, only their
+    /// publishability when a proven tariff exists.
+    fn prefer_proven_archive(
+        &self,
+        upstream: LookupResult,
+        model_id: &str,
+        provider_id: Option<&str>,
+    ) -> LookupResult {
+        if upstream.evidence.is_submission_safe() {
+            return upstream;
+        }
+        self.exact_match_archive(model_id, provider_id)
+            .filter(|archived| archived.evidence.is_submission_safe())
+            .unwrap_or(upstream)
     }
 
     /// Match `model_id` against the retirement archive of last-known tariffs.

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -880,6 +880,20 @@ impl PricingLookup {
             self.exact_match_models_dev_for_provider(model_id, provider_id),
             provider_id,
         ) {
+            // A provider-proven first-party snapshot beats an unverified
+            // guess. Reseller rows (`deepinfra/anthropic/...`) match here by
+            // model part while the archive holds the publishing endpoint's
+            // own exact tariff further down; letting the guess win prices
+            // first-party usage at a third party's rate and reports it as
+            // unpublishable. Safe upstream rows still win untouched.
+            if !result.evidence.is_submission_safe() {
+                let proven = self
+                    .exact_match_archive(model_id, provider_id)
+                    .filter(|archived| archived.evidence.is_submission_safe());
+                if let Some(archived) = proven {
+                    return Some(archived);
+                }
+            }
             return Some(result);
         }
 
@@ -1466,17 +1480,21 @@ impl PricingLookup {
             return None;
         }
 
-        // Every archived key is a canonical `claude-{family}-{major}-{minor}`
+        // Every archived key is a canonical `{family}-{major}-{minor}` id
         // under a provider root, so the normalizer the upstream exact passes
-        // already use is the whole matcher. It folds the dated
-        // (`claude-haiku-4-5-20251001`), context-tagged (`claude-opus-4-8[1m]`),
-        // dotted (`claude-haiku-4.5`) and reasoning-tier
-        // (`claude-opus-4-7-thinking-xhigh`) spellings real clients emit, and it
-        // drops any leading provider segment on the way. Comparing the raw id to
-        // the key by equality instead would miss every one of those shapes —
-        // that is, every shape the archive exists to cover.
+        // already use is the whole matcher for the Claude line: it folds the
+        // dated (`claude-haiku-4-5-20251001`), context-tagged
+        // (`claude-opus-4-8[1m]`), dotted (`claude-haiku-4.5`) and
+        // reasoning-tier (`claude-opus-4-7-thinking-xhigh`) spellings real
+        // clients emit, and it drops any leading provider segment on the way.
+        // Comparing the raw id to the key by equality instead would miss
+        // every one of those shapes -- that is, every shape the archive
+        // exists to cover. Ids from other vendors have no normalizer yet and
+        // match verbatim; the provider-qualified gate below still requires
+        // the hint to name the key's publishing endpoint, so a verbatim
+        // match can never elect a neighbouring model.
         let lower = model_id.trim().to_ascii_lowercase();
-        let canonical = normalize_model_name(&lower)?;
+        let canonical = normalize_model_name(&lower).unwrap_or_else(|| lower.clone());
 
         // The id's own leading segment authorises the tariff exactly as a hint
         // does, so `anthropic/claude-opus-4-8` resolves provider-scoped with no

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -801,6 +801,43 @@ mod tests {
         );
     }
 
+    /// A reseller row that only matches by model part must not shadow the
+    /// publishing endpoint's own archived tariff.
+    ///
+    /// Live LiteLLM keys this as `deepinfra/anthropic/claude-opus-4-8` -- a
+    /// nested provider segment, not a first-party root -- so an `anthropic`
+    /// hint resolves it as an unverified ModelPart guess while the archive
+    /// holds `anthropic/claude-opus-4-8` exactly. The guess used to win by
+    /// precedence and the usage submitted at $0.00 with a cost-incomplete
+    /// day; the proven row wins now.
+    #[test]
+    fn unsafe_reseller_row_yields_to_proven_archive() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "deepinfra/anthropic/claude-opus-4-8".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(5e-6),
+                output_cost_per_token: Some(2.5e-5),
+                cache_read_input_token_cost: Some(5e-7),
+                cache_creation_input_token_cost: Some(6.25e-6),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(litellm, HashMap::new());
+        let usage = all_bucket_usage();
+
+        let resolved = service
+            .resolve_for_usage_with_provider("claude-opus-4-8", Some("anthropic"), &usage)
+            .expect("proven archive row must resolve");
+        assert_eq!(resolved.source, "Tokscale Archive");
+        assert_eq!(resolved.matched_key, "anthropic/claude-opus-4-8");
+        assert!(resolved.evidence.is_submission_safe());
+        assert!(service.covers_usage_with_provider("claude-opus-4-8", Some("anthropic"), &usage));
+        let actual =
+            service.calculate_cost_with_provider("claude-opus-4-8", Some("anthropic"), &usage);
+        assert!((actual - 36.75).abs() < 1e-9, "unexpected cost: {actual}");
+    }
+
     /// The shared normalizer folds reasoning-effort suffixes, so the archive
     /// needs no suffix stripper of its own.
     #[test]


### PR DESCRIPTION
Live datasets key some first-party models only under reseller roots (`deepinfra/anthropic/claude-opus-4-8`, `z-ai/glm-5.2` — nested provider segments, not first-party roots), so a first-party hint resolves there as an unverified ModelPart guess. Those guesses won by precedence even though the retirement archive holds (or, in follow-ups, will hold) the publishing endpoint's own exact tariff, and the usage submitted at $0.00 with a cost-incomplete day. Verified against the live datasets: before this change `anthropic/claude-opus-4-8` resolved `model_part`/`LiteLLM`/`covers=false`; after, `provider_scoped`/`Tokscale Archive`/`covers=true`.

Every unverified fallback stage in `lookup_auto` (model-part, alias and prefix matches) now routes through a `prefer_proven_archive` guard: when the upstream winner is not submission-safe and the archive holds a submission-safe row for the hinted endpoint, the proven tariff wins. Safe upstream rows (including a live first-party exact key) still win untouched, and anything the archive cannot prove stays exactly as before — display estimates never change, only their publishability when a proven tariff exists. Normalization provenance (`with_normalization`) is preserved on passthrough. `exact_match_archive` additionally accepts non-Claude ids verbatim (previously only Claude ids canonicalized, everything else returned None), still gated on the hint naming the key's publishing endpoint, in preparation for first-party archive rows from other vendors. Two fallback stages are proven necessary by failing-then-passing tests (the provider-pinned chooser for opus-4-8, the model-part fallback for glm-5.2); the rest is uniform application of the same guard, which is an identity function wherever no proven archive row exists.

## What's Changed
* fix(pricing): prefer proven archive tariff over unverified reseller guess
* fix(pricing): apply proven-archive preference at every unverified fallback

## Verification
* `cargo fmt --all -- --check`
* `cargo clippy --locked --workspace --all-features -- -D warnings`
* `cargo test --locked -p tokscale-core --lib` (2045 passed on this branch, including the new `unsafe_reseller_row_yields_to_proven_archive` fixture shaped exactly like the live LiteLLM row, plus all pre-existing archive precedence pins such as `live_upstream_price_wins_over_the_retired_model_archive` and `codex_auto_review_is_never_served_from_the_archive`)
* Live-dataset probe before/after for `anthropic/claude-opus-4-8` and six other first-party pairs (probe script removed after use; the other six stay unpriced here and are covered by follow-up archive-row PRs per vendor, stacked on this one)

**Full Changelog**: https://github.com/junhoyeo/tokscale/compare/v4.15.1...fix/pricing-prefer-proven-archive
