### PR TITLE
fix(pricing): archive Zhipu GLM-5.2/5.3 first-party tariffs

### DIFF
--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -880,21 +880,7 @@ impl PricingLookup {
             self.exact_match_models_dev_for_provider(model_id, provider_id),
             provider_id,
         ) {
-            // A provider-proven first-party snapshot beats an unverified
-            // guess. Reseller rows (`deepinfra/anthropic/...`) match here by
-            // model part while the archive holds the publishing endpoint's
-            // own exact tariff further down; letting the guess win prices
-            // first-party usage at a third party's rate and reports it as
-            // unpublishable. Safe upstream rows still win untouched.
-            if !result.evidence.is_submission_safe() {
-                let proven = self
-                    .exact_match_archive(model_id, provider_id)
-                    .filter(|archived| archived.evidence.is_submission_safe());
-                if let Some(archived) = proven {
-                    return Some(archived);
-                }
-            }
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
 
         if let Some(result) = exact_litellm {
@@ -918,11 +904,11 @@ impl PricingLookup {
         // matching key falls through to the canonical resolution below.
         if provider_id.is_some() {
             if let Some(result) = self.exact_match_models_dev_for_provider(model_id, provider_id) {
-                return Some(result);
+                return Some(self.prefer_proven_archive(result, model_id, provider_id));
             }
         }
         if let Some(result) = self.exact_match_openrouter_model_part(model_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
 
         // Separator-normalized exact passes against the canonical sources
@@ -940,31 +926,47 @@ impl PricingLookup {
                 self.exact_match_models_dev_for_provider(&version_normalized, provider_id),
                 provider_id,
             ) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
             if provider_id.is_some() {
                 if let Some(result) =
                     self.exact_match_models_dev_for_provider(&version_normalized, provider_id)
                 {
-                    return Some(result.with_normalization());
+                    return Some(self.prefer_proven_archive(
+                        result.with_normalization(),
+                        &version_normalized,
+                        provider_id,
+                    ));
                 }
             }
             if let Some(result) = self.exact_match_litellm(&version_normalized) {
                 return Some(result.with_normalization());
             }
             if let Some(result) = self.exact_match_openrouter(&version_normalized) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
         }
 
         if let Some(result) = self.exact_match_models_dev_with_provider(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) =
                 self.exact_match_models_dev_with_provider(&version_normalized, provider_id)
             {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
         }
 
@@ -975,40 +977,64 @@ impl PricingLookup {
                 self.exact_match_models_dev_for_provider(&normalized, provider_id),
                 provider_id,
             ) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) = self.exact_match_litellm(&normalized) {
                 return Some(result.with_normalization());
             }
             if let Some(result) = self.exact_match_openrouter(&normalized) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) =
                 self.exact_match_models_dev_with_provider(&normalized, provider_id)
             {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &normalized,
+                    provider_id,
+                ));
             }
         }
 
         if let Some(result) = self.prefix_match_litellm(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
         if let Some(result) = self.prefix_match_openrouter(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
         if let Some(result) = self.prefix_match_models_dev(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
 
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) = self.prefix_match_litellm(&version_normalized, provider_id) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) = self.prefix_match_openrouter(&version_normalized, provider_id) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) = self.prefix_match_models_dev(&version_normalized, provider_id) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
         }
 
@@ -1462,6 +1488,31 @@ impl PricingLookup {
             }
         }
         None
+    }
+
+    /// Prefer a provider-proven archive tariff over an unverified upstream guess.
+    ///
+    /// Every unverified fallback stage in `lookup_auto` (model-part, alias and
+    /// prefix matches) routes through here. Reseller rows
+    /// (`deepinfra/anthropic/...`, `z-ai/...`) match those stages by model
+    /// part while the archive holds the publishing endpoint's own exact
+    /// tariff; letting the guess win prices first-party usage at a third
+    /// party's rate and reports it as unpublishable. Safe upstream rows pass
+    /// through untouched, as does everything when the archive cannot prove
+    /// the endpoint -- so display estimates never change, only their
+    /// publishability when a proven tariff exists.
+    fn prefer_proven_archive(
+        &self,
+        upstream: LookupResult,
+        model_id: &str,
+        provider_id: Option<&str>,
+    ) -> LookupResult {
+        if upstream.evidence.is_submission_safe() {
+            return upstream;
+        }
+        self.exact_match_archive(model_id, provider_id)
+            .filter(|archived| archived.evidence.is_submission_safe())
+            .unwrap_or(upstream)
     }
 
     /// Match `model_id` against the retirement archive of last-known tariffs.

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -880,6 +880,20 @@ impl PricingLookup {
             self.exact_match_models_dev_for_provider(model_id, provider_id),
             provider_id,
         ) {
+            // A provider-proven first-party snapshot beats an unverified
+            // guess. Reseller rows (`deepinfra/anthropic/...`) match here by
+            // model part while the archive holds the publishing endpoint's
+            // own exact tariff further down; letting the guess win prices
+            // first-party usage at a third party's rate and reports it as
+            // unpublishable. Safe upstream rows still win untouched.
+            if !result.evidence.is_submission_safe() {
+                let proven = self
+                    .exact_match_archive(model_id, provider_id)
+                    .filter(|archived| archived.evidence.is_submission_safe());
+                if let Some(archived) = proven {
+                    return Some(archived);
+                }
+            }
             return Some(result);
         }
 
@@ -1466,17 +1480,21 @@ impl PricingLookup {
             return None;
         }
 
-        // Every archived key is a canonical `claude-{family}-{major}-{minor}`
+        // Every archived key is a canonical `{family}-{major}-{minor}` id
         // under a provider root, so the normalizer the upstream exact passes
-        // already use is the whole matcher. It folds the dated
-        // (`claude-haiku-4-5-20251001`), context-tagged (`claude-opus-4-8[1m]`),
-        // dotted (`claude-haiku-4.5`) and reasoning-tier
-        // (`claude-opus-4-7-thinking-xhigh`) spellings real clients emit, and it
-        // drops any leading provider segment on the way. Comparing the raw id to
-        // the key by equality instead would miss every one of those shapes —
-        // that is, every shape the archive exists to cover.
+        // already use is the whole matcher for the Claude line: it folds the
+        // dated (`claude-haiku-4-5-20251001`), context-tagged
+        // (`claude-opus-4-8[1m]`), dotted (`claude-haiku-4.5`) and
+        // reasoning-tier (`claude-opus-4-7-thinking-xhigh`) spellings real
+        // clients emit, and it drops any leading provider segment on the way.
+        // Comparing the raw id to the key by equality instead would miss
+        // every one of those shapes -- that is, every shape the archive
+        // exists to cover. Ids from other vendors have no normalizer yet and
+        // match verbatim; the provider-qualified gate below still requires
+        // the hint to name the key's publishing endpoint, so a verbatim
+        // match can never elect a neighbouring model.
         let lower = model_id.trim().to_ascii_lowercase();
-        let canonical = normalize_model_name(&lower)?;
+        let canonical = normalize_model_name(&lower).unwrap_or_else(|| lower.clone());
 
         // The id's own leading segment authorises the tariff exactly as a hint
         // does, so `anthropic/claude-opus-4-8` resolves provider-scoped with no

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -801,6 +801,43 @@ mod tests {
         );
     }
 
+    /// A reseller row that only matches by model part must not shadow the
+    /// publishing endpoint's own archived tariff.
+    ///
+    /// Live LiteLLM keys this as `deepinfra/anthropic/claude-opus-4-8` -- a
+    /// nested provider segment, not a first-party root -- so an `anthropic`
+    /// hint resolves it as an unverified ModelPart guess while the archive
+    /// holds `anthropic/claude-opus-4-8` exactly. The guess used to win by
+    /// precedence and the usage submitted at $0.00 with a cost-incomplete
+    /// day; the proven row wins now.
+    #[test]
+    fn unsafe_reseller_row_yields_to_proven_archive() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "deepinfra/anthropic/claude-opus-4-8".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(5e-6),
+                output_cost_per_token: Some(2.5e-5),
+                cache_read_input_token_cost: Some(5e-7),
+                cache_creation_input_token_cost: Some(6.25e-6),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(litellm, HashMap::new());
+        let usage = all_bucket_usage();
+
+        let resolved = service
+            .resolve_for_usage_with_provider("claude-opus-4-8", Some("anthropic"), &usage)
+            .expect("proven archive row must resolve");
+        assert_eq!(resolved.source, "Tokscale Archive");
+        assert_eq!(resolved.matched_key, "anthropic/claude-opus-4-8");
+        assert!(resolved.evidence.is_submission_safe());
+        assert!(service.covers_usage_with_provider("claude-opus-4-8", Some("anthropic"), &usage));
+        let actual =
+            service.calculate_cost_with_provider("claude-opus-4-8", Some("anthropic"), &usage);
+        assert!((actual - 36.75).abs() < 1e-9, "unexpected cost: {actual}");
+    }
+
     /// The shared normalizer folds reasoning-effort suffixes, so the archive
     /// needs no suffix stripper of its own.
     #[test]

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -244,11 +244,16 @@ impl PricingService {
         overrides
     }
 
-    // @keep: a snapshot of last-known published rates for Anthropic models that
-    // upstream will eventually stop carrying. LiteLLM, OpenRouter and models.dev
-    // all describe the CURRENT catalogue: once a provider retires a model those
-    // rows are dropped, and every historical session that used it silently loses
-    // its price. This archive is the only place that memory lives.
+    // @keep: a snapshot of published first-party rates for models no live
+    // dataset carries first-party. LiteLLM, OpenRouter and models.dev all
+    // describe the CURRENT catalogue from resellers as well as vendors: once
+    // a provider retires a model those rows are dropped, and some current
+    // models were never listed first-party at all (only `deepinfra/*`,
+    // `z-ai/*`, `openrouter/*` reseller keys exist). In both cases every
+    // historical session that used the model at the publishing endpoint
+    // silently loses its price without this memory, and a reseller row that
+    // merely shares the model name wins by precedence as an unverified
+    // guess. This archive is the only place that memory lives.
     //
     // Precedence is the same slot as the Cursor/Sakana overrides in
     // PricingLookup - after every upstream exact/normalized/prefix match, before
@@ -256,11 +261,11 @@ impl PricingService {
     // answers, and once upstream drops it the archive answers with that model's
     // own last rate instead of letting fuzzy elect a neighbouring row.
     //
-    // Keys are provider-qualified on purpose. Anthropic bills these rates on its
-    // own API; a request routed through Vertex or Bedrock is a different tariff.
-    // With an `anthropic/` root, an anthropic hint resolves ProviderScoped with
-    // matching provider identity (submission-safe), and a `vertex`/`vertex_ai`
-    // hint is recognised as a cross-provider alias and stays an estimate.
+    // Keys are provider-qualified on purpose. Each vendor bills these rates
+    // on its own API; a request routed through another endpoint is a
+    // different tariff. With a matching root, a same-vendor hint resolves
+    // ProviderScoped with matching provider identity (submission-safe), and
+    // any other hint stays an estimate.
     //
     // Rates verified 2026-09-02 against both live datasets: models.dev keys them
     // exactly as written here, LiteLLM keys them bare (`claude-haiku-4-5`, ...)
@@ -279,7 +284,11 @@ impl PricingService {
     // cost is preserved.
     fn build_archive_overrides() -> HashMap<String, ModelPricing> {
         /// `(model id, input, output, cache read, cache creation)`, per token.
-        type ArchivedRateRow = (&'static str, f64, f64, f64, f64);
+        /// Cache creation is `None` where the vendor publishes no such bucket
+        /// (Zhipu, Xiaomi and Tencent document cached-input reads but no
+        /// cache-write tariff): usage populating that bucket then stays
+        /// unpriced rather than billed at an invented rate.
+        type ArchivedRateRow = (&'static str, f64, f64, f64, Option<f64>);
 
         // Every first-party Claude row the narrowest dataset still carries, so
         // whichever one is retired next already has its last published rate
@@ -290,22 +299,75 @@ impl PricingService {
         // nothing retires the model that is shipping.
         let entries: &[ArchivedRateRow] = &[
             // Claude Haiku 4.5: $1.00/$5.00 per 1M, $0.10 cache read, $1.25 cache write.
-            ("anthropic/claude-haiku-4-5", 1e-6, 5e-6, 1e-7, 1.25e-6),
+            (
+                "anthropic/claude-haiku-4-5",
+                1e-6,
+                5e-6,
+                1e-7,
+                Some(1.25e-6),
+            ),
             // Claude Sonnet 4.5 / 4.6: $3.00/$15.00 per 1M, $0.30 cache read,
             // $3.75 cache write. 4.5 is the oldest Sonnet any of the three
             // still carries.
-            ("anthropic/claude-sonnet-4-5", 3e-6, 1.5e-5, 3e-7, 3.75e-6),
-            ("anthropic/claude-sonnet-4-6", 3e-6, 1.5e-5, 3e-7, 3.75e-6),
+            (
+                "anthropic/claude-sonnet-4-5",
+                3e-6,
+                1.5e-5,
+                3e-7,
+                Some(3.75e-6),
+            ),
+            (
+                "anthropic/claude-sonnet-4-6",
+                3e-6,
+                1.5e-5,
+                3e-7,
+                Some(3.75e-6),
+            ),
             // Claude Opus 4.5 / 4.6 / 4.7 / 4.8: $5.00/$25.00 per 1M, $0.50
             // cache read, $6.25 cache write. 4.5 is the oldest Opus carried by
             // all three, so it is the next one due to fall off -- LiteLLM and
             // OpenRouter still list opus-4 and opus-4-1 (and LiteLLM
             // claude-3-opus), but models.dev has already dropped them, so
             // their rates cannot be cross-checked and they are not archived.
-            ("anthropic/claude-opus-4-5", 5e-6, 2.5e-5, 5e-7, 6.25e-6),
-            ("anthropic/claude-opus-4-6", 5e-6, 2.5e-5, 5e-7, 6.25e-6),
-            ("anthropic/claude-opus-4-7", 5e-6, 2.5e-5, 5e-7, 6.25e-6),
-            ("anthropic/claude-opus-4-8", 5e-6, 2.5e-5, 5e-7, 6.25e-6),
+            (
+                "anthropic/claude-opus-4-5",
+                5e-6,
+                2.5e-5,
+                5e-7,
+                Some(6.25e-6),
+            ),
+            (
+                "anthropic/claude-opus-4-6",
+                5e-6,
+                2.5e-5,
+                5e-7,
+                Some(6.25e-6),
+            ),
+            (
+                "anthropic/claude-opus-4-7",
+                5e-6,
+                2.5e-5,
+                5e-7,
+                Some(6.25e-6),
+            ),
+            (
+                "anthropic/claude-opus-4-8",
+                5e-6,
+                2.5e-5,
+                5e-7,
+                Some(6.25e-6),
+            ),
+            // Zhipu GLM-5.2 / GLM-5.3: $1.40/$4.40 per 1M, $0.26 cached
+            // input, no published cache-write tariff (cached-input storage
+            // is "Limited-time Free"). No live dataset carries a first-party
+            // row -- only the `z-ai/*` reseller keys -- so a `zhipu` hint
+            // resolved as an unverified guess. Verified 2026-09-03 against
+            // https://docs.z.ai/guides/overview/pricing ("Latest Models":
+            // GLM-5.3 and GLM-5.2 at $1.4 in / $0.26 cached / $4.4 out) and
+            // https://bigmodel.cn/pricing (8元 in / 28元 out / 2元
+            // cache-hit per M tokens, flat 1M context, no tiers).
+            ("zhipu/glm-5.2", 1.4e-6, 4.4e-6, 0.26e-6, None),
+            ("zhipu/glm-5.3", 1.4e-6, 4.4e-6, 0.26e-6, None),
         ];
 
         let mut overrides = HashMap::with_capacity(entries.len());
@@ -316,7 +378,7 @@ impl PricingService {
                     input_cost_per_token: Some(*input),
                     output_cost_per_token: Some(*output),
                     cache_read_input_token_cost: Some(*cache_read),
-                    cache_creation_input_token_cost: Some(*cache_creation),
+                    cache_creation_input_token_cost: *cache_creation,
                     ..Default::default()
                 },
             );
@@ -694,6 +756,72 @@ mod tests {
     #[test]
     fn retired_claude_opus_4_8_keeps_its_last_known_price() {
         assert_retired_anthropic_price("claude-opus-4-8", 5.0, 25.0, 0.5, 6.25);
+    }
+
+    /// Zhipu publishes no first-party row to any live dataset -- only the
+    /// `z-ai/*` reseller keys -- so a `zhipu` hint resolved as an unverified
+    /// guess. The archived first-party tariff ($1.40/$4.40 per 1M, $0.26
+    /// cached input, verified 2026-09-03) wins for the publishing endpoint.
+    #[test]
+    fn zhipu_glm_rates_resolve_first_party_over_reseller_row() {
+        fn reseller_row() -> ModelPricing {
+            ModelPricing {
+                input_cost_per_token: Some(1.4e-6),
+                output_cost_per_token: Some(4.4e-6),
+                cache_read_input_token_cost: Some(0.26e-6),
+                ..Default::default()
+            }
+        }
+
+        for model in ["glm-5.2", "glm-5.3"] {
+            let mut openrouter = HashMap::new();
+            openrouter.insert(format!("z-ai/{model}"), reseller_row());
+            let service = PricingService::new(HashMap::new(), openrouter);
+            // No published cache-write tariff, so the covered usage carries
+            // none; cache-write-bearing usage stays unpriced (pinned below).
+            let usage = TokenBreakdown {
+                input: 1_000_000,
+                output: 1_000_000,
+                cache_read: 1_000_000,
+                cache_write: 0,
+                reasoning: 0,
+            };
+
+            let resolved = service
+                .resolve_for_usage_with_provider(model, Some("zhipu"), &usage)
+                .unwrap_or_else(|| panic!("{model} must resolve first-party"));
+            assert_eq!(resolved.source, "Tokscale Archive", "model: {model}");
+            assert_eq!(
+                resolved.matched_key,
+                format!("zhipu/{model}"),
+                "model: {model}"
+            );
+            assert!(resolved.evidence.is_submission_safe(), "model: {model}");
+            assert!(
+                service.covers_usage_with_provider(model, Some("zhipu"), &usage),
+                "model: {model}"
+            );
+            let actual = service.calculate_cost_with_provider(model, Some("zhipu"), &usage);
+            assert!(
+                (actual - 6.06).abs() < 1e-9,
+                "model: {model}, unexpected cost: {actual}"
+            );
+        }
+    }
+
+    /// Zhipu documents cached-input reads but no cache-write tariff, so
+    /// cache-write-bearing usage must stay unpriced rather than billed at an
+    /// invented rate.
+    #[test]
+    fn zhipu_cache_write_usage_stays_unpriced() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+
+        for model in ["glm-5.2", "glm-5.3"] {
+            assert!(
+                !service.covers_usage_with_provider(model, Some("zhipu"), &all_bucket_usage()),
+                "model: {model}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
No live dataset carries a first-party Zhipu row — only the `z-ai/*` reseller keys — so a `zhipu` hint for `glm-5.2`/`glm-5.3` resolved as an unverified guess and submitted at $0.00. Stacked on #1271 (which lets a proven archive tariff win over such guesses); without it these rows would stay shadowed.

Adds `zhipu/glm-5.2` and `zhipu/glm-5.3` to the archive at $1.40/$4.40 per 1M with $0.26 cached input, verified 2026-09-03 against https://docs.z.ai/guides/overview/pricing and https://bigmodel.cn/pricing (flat 1M context, no tiers). Zhipu publishes no cache-write tariff, so the rows carry none: cache-write-bearing usage stays unpriced rather than billed at an invented rate (pinned by test). Same-provider proxy spellings (`babeltown/`, `owo_ollama/`, `custom/` prefixes) intentionally still resolve as estimates — only the publishing endpoint's own hint is submission-safe.

## What's Changed
* fix(pricing): archive Zhipu GLM-5.2/5.3 first-party tariffs

## Verification
* `cargo fmt --all -- --check`
* `cargo clippy --locked -p tokscale-core --all-features -- -D warnings`
* `cargo test --locked -p tokscale-core --lib` (2047 passed, including new `zhipu_glm_rates_resolve_first_party_over_reseller_row` with a `z-ai/` reseller shadow fixture and `zhipu_cache_write_usage_stays_unpriced` for the unpublished bucket)

Depends on #1271 — the diff currently includes its two commits; merge that first and this shrinks to the single Zhipu commit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `zhipu` hints for `glm-5.2`/`glm-5.3` resolving as unverified guesses billed at $0.00 by archiving first-party tariffs ($1.40/$4.40 per 1M, $0.26 cached input), and makes proven archive tariffs win over unverified reseller matches at every fallback stage.

**Bug Fixes**
- Zhipu publishes no cache-write tariff, so cache-write-bearing usage stays unpriced rather than billed at an invented rate.
- Reseller rows (`z-ai/*`, `deepinfra/*`) that match only by model part no longer shadow the publishing endpoint's archived tariff; same-provider proxy spellings still resolve as estimates.

Depends on #1271 — merge that first; this diff includes those changes.

<sup>Written for commit c9b388ccc582822613c60fd0b4d7df772d731857. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

