### PR TITLE
fix(pricing): archive first-party tariffs for Zhipu, Xiaomi and Tencent models

### DIFF
--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -880,21 +880,7 @@ impl PricingLookup {
             self.exact_match_models_dev_for_provider(model_id, provider_id),
             provider_id,
         ) {
-            // A provider-proven first-party snapshot beats an unverified
-            // guess. Reseller rows (`deepinfra/anthropic/...`) match here by
-            // model part while the archive holds the publishing endpoint's
-            // own exact tariff further down; letting the guess win prices
-            // first-party usage at a third party's rate and reports it as
-            // unpublishable. Safe upstream rows still win untouched.
-            if !result.evidence.is_submission_safe() {
-                let proven = self
-                    .exact_match_archive(model_id, provider_id)
-                    .filter(|archived| archived.evidence.is_submission_safe());
-                if let Some(archived) = proven {
-                    return Some(archived);
-                }
-            }
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
 
         if let Some(result) = exact_litellm {
@@ -918,11 +904,11 @@ impl PricingLookup {
         // matching key falls through to the canonical resolution below.
         if provider_id.is_some() {
             if let Some(result) = self.exact_match_models_dev_for_provider(model_id, provider_id) {
-                return Some(result);
+                return Some(self.prefer_proven_archive(result, model_id, provider_id));
             }
         }
         if let Some(result) = self.exact_match_openrouter_model_part(model_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
 
         // Separator-normalized exact passes against the canonical sources
@@ -940,31 +926,47 @@ impl PricingLookup {
                 self.exact_match_models_dev_for_provider(&version_normalized, provider_id),
                 provider_id,
             ) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
             if provider_id.is_some() {
                 if let Some(result) =
                     self.exact_match_models_dev_for_provider(&version_normalized, provider_id)
                 {
-                    return Some(result.with_normalization());
+                    return Some(self.prefer_proven_archive(
+                        result.with_normalization(),
+                        &version_normalized,
+                        provider_id,
+                    ));
                 }
             }
             if let Some(result) = self.exact_match_litellm(&version_normalized) {
                 return Some(result.with_normalization());
             }
             if let Some(result) = self.exact_match_openrouter(&version_normalized) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
         }
 
         if let Some(result) = self.exact_match_models_dev_with_provider(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) =
                 self.exact_match_models_dev_with_provider(&version_normalized, provider_id)
             {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
         }
 
@@ -975,40 +977,64 @@ impl PricingLookup {
                 self.exact_match_models_dev_for_provider(&normalized, provider_id),
                 provider_id,
             ) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) = self.exact_match_litellm(&normalized) {
                 return Some(result.with_normalization());
             }
             if let Some(result) = self.exact_match_openrouter(&normalized) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) =
                 self.exact_match_models_dev_with_provider(&normalized, provider_id)
             {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &normalized,
+                    provider_id,
+                ));
             }
         }
 
         if let Some(result) = self.prefix_match_litellm(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
         if let Some(result) = self.prefix_match_openrouter(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
         if let Some(result) = self.prefix_match_models_dev(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
 
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) = self.prefix_match_litellm(&version_normalized, provider_id) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) = self.prefix_match_openrouter(&version_normalized, provider_id) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) = self.prefix_match_models_dev(&version_normalized, provider_id) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
         }
 
@@ -1462,6 +1488,31 @@ impl PricingLookup {
             }
         }
         None
+    }
+
+    /// Prefer a provider-proven archive tariff over an unverified upstream guess.
+    ///
+    /// Every unverified fallback stage in `lookup_auto` (model-part, alias and
+    /// prefix matches) routes through here. Reseller rows
+    /// (`deepinfra/anthropic/...`, `z-ai/...`) match those stages by model
+    /// part while the archive holds the publishing endpoint's own exact
+    /// tariff; letting the guess win prices first-party usage at a third
+    /// party's rate and reports it as unpublishable. Safe upstream rows pass
+    /// through untouched, as does everything when the archive cannot prove
+    /// the endpoint -- so display estimates never change, only their
+    /// publishability when a proven tariff exists.
+    fn prefer_proven_archive(
+        &self,
+        upstream: LookupResult,
+        model_id: &str,
+        provider_id: Option<&str>,
+    ) -> LookupResult {
+        if upstream.evidence.is_submission_safe() {
+            return upstream;
+        }
+        self.exact_match_archive(model_id, provider_id)
+            .filter(|archived| archived.evidence.is_submission_safe())
+            .unwrap_or(upstream)
     }
 
     /// Match `model_id` against the retirement archive of last-known tariffs.

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -695,15 +695,20 @@ impl PricingLookup {
             }
         }
 
-        // Helper to perform lookup with the given source constraint
-        let do_lookup = |id: &str| match force_source {
+        // Helper to perform lookup with the given source constraint.
+        // `allow_archive` is false for the ids the suffix stripper invents:
+        // an archived row is one model's own last published tariff, not a
+        // family price, so an eroded candidate must resolve from the live
+        // datasets alone. The forced-source paths never reach the archive.
+        let lookup = |id: &str, allow_archive: bool| match force_source {
             Some("litellm") => self.lookup_litellm_only(id, provider_id),
             Some("openrouter") => self.lookup_openrouter_only(id, provider_id),
             Some("models.dev") | Some("modelsdev") | Some("models_dev") => {
                 self.lookup_models_dev_only(id, provider_id)
             }
-            _ => self.lookup_auto(id, provider_id),
+            _ => self.lookup_auto(id, provider_id, allow_archive),
         };
+        let do_lookup = |id: &str| lookup(id, true);
         let requested_family = claude_family(lower_ref);
         let requested_version = requested_claude_version(lower_ref);
         let unparsed_modern_version = requested_family.is_some()
@@ -750,12 +755,16 @@ impl PricingLookup {
             return None;
         }
 
-        let guarded_lookup = |candidate: &str| {
-            do_lookup(candidate)
+        let guarded = |candidate: &str, allow_archive: bool| {
+            lookup(candidate, allow_archive)
                 .map(annotate_direct)
                 .map(LookupResult::with_stripping)
                 .filter(|result| !unsafe_claude_resolution(result))
         };
+        let guarded_lookup = |candidate: &str| guarded(candidate, true);
+        // Suffix erosion asks for an id nobody published, so it resolves
+        // live-only: see `try_strip_unknown_suffix`.
+        let eroded_lookup = |candidate: &str| guarded(candidate, false);
 
         // 1.5. Generic provider-routing prefix fallback: ids coming from a
         // router/proxy (e.g. `cx/gpt-5.5` via an `omniroute` provider) carry a
@@ -786,26 +795,35 @@ impl PricingLookup {
             // on `-`, so it can peel `-xhigh` off `cx/gpt-5.5-xhigh` but is
             // left with `cx/gpt-5.5`, which is not a dataset key either. Both
             // halves resolve alone while the combination billed $0 (#846).
-            if let Some(result) = try_strip_unknown_suffix(terminal, guarded_lookup) {
+            if let Some(result) = try_strip_unknown_suffix(terminal, eroded_lookup) {
                 return Some(result);
             }
         }
 
         // 2. Try stripping unknown suffixes (e.g., -thinking, -high, -codex)
-        if let Some(result) = try_strip_unknown_suffix(lower_ref, guarded_lookup) {
+        if let Some(result) = try_strip_unknown_suffix(lower_ref, eroded_lookup) {
             return Some(result);
         }
 
         // 3. Try stripping unknown prefixes (e.g., antigravity-, myplugin-)
         //    For each prefix candidate, also try suffix stripping
-        if let Some(result) = try_strip_unknown_prefix(lower_ref, guarded_lookup) {
+        if let Some(result) = try_strip_unknown_prefix(lower_ref, guarded_lookup, eroded_lookup) {
             return Some(result);
         }
 
         None
     }
 
-    fn lookup_auto(&self, model_id: &str, provider_id: Option<&str>) -> Option<LookupResult> {
+    /// `allow_archive` is false when the caller invented the id it is asking
+    /// about -- the suffix stripper's eroded candidates. The archive holds one
+    /// model's own last published tariff, so it may answer an id somebody
+    /// really published, never a neighbouring SKU.
+    fn lookup_auto(
+        &self,
+        model_id: &str,
+        provider_id: Option<&str>,
+        allow_archive: bool,
+    ) -> Option<LookupResult> {
         if let Some(result) = self.lookup_provider_scoped_path(model_id, provider_id) {
             return Some(scope_resolution_to_provider(result, model_id));
         }
@@ -860,6 +878,7 @@ impl PricingLookup {
                         result.with_stripping(),
                         model_id,
                         provider_id,
+                        allow_archive,
                     ));
                 }
                 if let Some(result) = self.exact_or_normalized_litellm(stripped, provider_id) {
@@ -867,6 +886,7 @@ impl PricingLookup {
                         result.with_stripping(),
                         model_id,
                         provider_id,
+                        allow_archive,
                     ));
                 }
                 if let Some(result) =
@@ -876,6 +896,7 @@ impl PricingLookup {
                         result.with_stripping(),
                         model_id,
                         provider_id,
+                        allow_archive,
                     ));
                 }
             }
@@ -892,7 +913,7 @@ impl PricingLookup {
             self.exact_match_models_dev_for_provider(model_id, provider_id),
             provider_id,
         ) {
-            return Some(self.prefer_proven_archive(result, model_id, provider_id));
+            return Some(self.prefer_proven_archive(result, model_id, provider_id, allow_archive));
         }
 
         if let Some(result) = exact_litellm {
@@ -916,11 +937,16 @@ impl PricingLookup {
         // matching key falls through to the canonical resolution below.
         if provider_id.is_some() {
             if let Some(result) = self.exact_match_models_dev_for_provider(model_id, provider_id) {
-                return Some(self.prefer_proven_archive(result, model_id, provider_id));
+                return Some(self.prefer_proven_archive(
+                    result,
+                    model_id,
+                    provider_id,
+                    allow_archive,
+                ));
             }
         }
         if let Some(result) = self.exact_match_openrouter_model_part(model_id) {
-            return Some(self.prefer_proven_archive(result, model_id, provider_id));
+            return Some(self.prefer_proven_archive(result, model_id, provider_id, allow_archive));
         }
 
         // Separator-normalized exact passes against the canonical sources
@@ -942,6 +968,7 @@ impl PricingLookup {
                     result.with_normalization(),
                     &version_normalized,
                     provider_id,
+                    allow_archive,
                 ));
             }
             if provider_id.is_some() {
@@ -952,6 +979,7 @@ impl PricingLookup {
                         result.with_normalization(),
                         &version_normalized,
                         provider_id,
+                        allow_archive,
                     ));
                 }
             }
@@ -963,12 +991,13 @@ impl PricingLookup {
                     result.with_normalization(),
                     &version_normalized,
                     provider_id,
+                    allow_archive,
                 ));
             }
         }
 
         if let Some(result) = self.exact_match_models_dev_with_provider(model_id, provider_id) {
-            return Some(self.prefer_proven_archive(result, model_id, provider_id));
+            return Some(self.prefer_proven_archive(result, model_id, provider_id, allow_archive));
         }
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) =
@@ -978,6 +1007,7 @@ impl PricingLookup {
                     result.with_normalization(),
                     &version_normalized,
                     provider_id,
+                    allow_archive,
                 ));
             }
         }
@@ -993,6 +1023,7 @@ impl PricingLookup {
                     result.with_normalization(),
                     &normalized,
                     provider_id,
+                    allow_archive,
                 ));
             }
             if let Some(result) = self.exact_match_litellm(&normalized) {
@@ -1003,6 +1034,7 @@ impl PricingLookup {
                     result.with_normalization(),
                     &normalized,
                     provider_id,
+                    allow_archive,
                 ));
             }
             if let Some(result) =
@@ -1012,18 +1044,19 @@ impl PricingLookup {
                     result.with_normalization(),
                     &normalized,
                     provider_id,
+                    allow_archive,
                 ));
             }
         }
 
         if let Some(result) = self.prefix_match_litellm(model_id, provider_id) {
-            return Some(self.prefer_proven_archive(result, model_id, provider_id));
+            return Some(self.prefer_proven_archive(result, model_id, provider_id, allow_archive));
         }
         if let Some(result) = self.prefix_match_openrouter(model_id, provider_id) {
-            return Some(self.prefer_proven_archive(result, model_id, provider_id));
+            return Some(self.prefer_proven_archive(result, model_id, provider_id, allow_archive));
         }
         if let Some(result) = self.prefix_match_models_dev(model_id, provider_id) {
-            return Some(self.prefer_proven_archive(result, model_id, provider_id));
+            return Some(self.prefer_proven_archive(result, model_id, provider_id, allow_archive));
         }
 
         if let Some(version_normalized) = normalize_version_separator(model_id) {
@@ -1032,6 +1065,7 @@ impl PricingLookup {
                     result.with_normalization(),
                     &version_normalized,
                     provider_id,
+                    allow_archive,
                 ));
             }
             if let Some(result) = self.prefix_match_openrouter(&version_normalized, provider_id) {
@@ -1039,6 +1073,7 @@ impl PricingLookup {
                     result.with_normalization(),
                     &version_normalized,
                     provider_id,
+                    allow_archive,
                 ));
             }
             if let Some(result) = self.prefix_match_models_dev(&version_normalized, provider_id) {
@@ -1046,6 +1081,7 @@ impl PricingLookup {
                     result.with_normalization(),
                     &version_normalized,
                     provider_id,
+                    allow_archive,
                 ));
             }
         }
@@ -1077,8 +1113,10 @@ impl PricingLookup {
         // runs ahead of the fuzzy stage below: an exact snapshot of this
         // model's own last published rate is better evidence than the
         // nearest-neighbour row fuzzy would elect.
-        if let Some(result) = self.exact_match_archive(model_id, provider_id) {
-            return Some(result);
+        if allow_archive {
+            if let Some(result) = self.exact_match_archive(model_id, provider_id) {
+                return Some(result);
+            }
         }
 
         if !is_fuzzy_eligible(model_id) {
@@ -1513,13 +1551,18 @@ impl PricingLookup {
     /// through untouched, as does everything when the archive cannot prove
     /// the endpoint -- so display estimates never change, only their
     /// publishability when a proven tariff exists.
+    ///
+    /// `allow_archive` is false for the eroded candidates the suffix stripper
+    /// invents: substituting there would swap a live row for a DIFFERENT
+    /// model's archived tariff (`mimo-v2.5-pro` billed as `mimo/mimo-v2.5`).
     fn prefer_proven_archive(
         &self,
         upstream: LookupResult,
         model_id: &str,
         provider_id: Option<&str>,
+        allow_archive: bool,
     ) -> LookupResult {
-        if upstream.evidence.is_submission_safe() {
+        if !allow_archive || upstream.evidence.is_submission_safe() {
             return upstream;
         }
         self.exact_match_archive(model_id, provider_id)
@@ -2794,6 +2837,18 @@ fn is_fuzzy_eligible(model_id: &str) -> bool {
 /// Attempts to find a model by progressively stripping trailing segments.
 /// Handles arbitrary suffixes (e.g., "claude-sonnet-4-5-thinking" → "claude-sonnet-4-5").
 /// This replaces the hardcoded TIER_SUFFIXES and FALLBACK_SUFFIXES approach.
+///
+/// Every candidate here is an id nobody published: `mimo-v2.5-pro` is a
+/// different SKU from `mimo-v2.5`. Callers therefore pass a lookup with the
+/// retirement archive held out (`eroded_lookup`) — an archived row is one
+/// model's own last published tariff, not a family price, so answering an
+/// eroded candidate from it would bill an unknown SKU at a neighbouring
+/// model's rate and, under that vendor's hint, stamp it submission-safe. The
+/// live datasets still answer here exactly as they did before the archive
+/// existed. The archived spellings that ARE the same model (dated, dotted,
+/// `[1m]`, reasoning-tier) are folded by the normalizer inside
+/// `exact_match_archive`, so they resolve on the direct pass and never depend
+/// on this fallback.
 fn try_strip_unknown_suffix<F>(model_id: &str, do_lookup: F) -> Option<LookupResult>
 where
     F: Fn(&str) -> Option<LookupResult>,
@@ -2882,9 +2937,18 @@ fn has_unrecognized_claude_four_minor(model_id: &str) -> bool {
 /// Attempts to find a model by progressively stripping leading segments.
 /// Handles arbitrary routing prefixes (e.g., "myplugin-claude-3.5-sonnet" → "claude-3.5-sonnet").
 /// This replaces the hardcoded STRIPPED_PREFIXES approach.
-fn try_strip_unknown_prefix<F>(model_id: &str, do_lookup: F) -> Option<LookupResult>
+///
+/// A prefix candidate is still an id somebody published, only tagged by the
+/// client that emitted it, so `do_lookup` keeps the archive. The composed
+/// suffix pass takes `do_eroded_lookup` for the reason above.
+fn try_strip_unknown_prefix<F, G>(
+    model_id: &str,
+    do_lookup: F,
+    do_eroded_lookup: G,
+) -> Option<LookupResult>
 where
     F: Fn(&str) -> Option<LookupResult>,
+    G: Fn(&str) -> Option<LookupResult>,
 {
     let parts: Vec<&str> = model_id.split('-').collect();
 
@@ -2904,7 +2968,7 @@ where
             }
 
             // Try candidate with suffix stripping
-            if let Some(result) = try_strip_unknown_suffix(&candidate, &do_lookup) {
+            if let Some(result) = try_strip_unknown_suffix(&candidate, &do_eroded_lookup) {
                 return Some(result);
             }
         }

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -856,15 +856,27 @@ impl PricingLookup {
                     self.exact_match_models_dev_for_provider(stripped, provider_id),
                     provider_id,
                 ) {
-                    return Some(result.with_stripping());
+                    return Some(self.prefer_proven_archive(
+                        result.with_stripping(),
+                        model_id,
+                        provider_id,
+                    ));
                 }
                 if let Some(result) = self.exact_or_normalized_litellm(stripped, provider_id) {
-                    return Some(result.with_stripping());
+                    return Some(self.prefer_proven_archive(
+                        result.with_stripping(),
+                        model_id,
+                        provider_id,
+                    ));
                 }
                 if let Some(result) =
                     self.exact_match_models_dev_with_provider(stripped, provider_id)
                 {
-                    return Some(result.with_stripping());
+                    return Some(self.prefer_proven_archive(
+                        result.with_stripping(),
+                        model_id,
+                        provider_id,
+                    ));
                 }
             }
         }
@@ -1545,7 +1557,12 @@ impl PricingLookup {
         // the hint to name the key's publishing endpoint, so a verbatim
         // match can never elect a neighbouring model.
         let lower = model_id.trim().to_ascii_lowercase();
-        let canonical = normalize_model_name(&lower).unwrap_or_else(|| lower.clone());
+        let stripped = lower
+            .split_once('/')
+            .map_or(lower.as_str(), |(_, model)| model);
+        let canonical = normalize_model_name(&lower)
+            .or_else(|| normalize_model_name(stripped))
+            .unwrap_or_else(|| stripped.to_string());
 
         // The id's own leading segment authorises the tariff exactly as a hint
         // does, so `anthropic/claude-opus-4-8` resolves provider-scoped with no

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -880,6 +880,20 @@ impl PricingLookup {
             self.exact_match_models_dev_for_provider(model_id, provider_id),
             provider_id,
         ) {
+            // A provider-proven first-party snapshot beats an unverified
+            // guess. Reseller rows (`deepinfra/anthropic/...`) match here by
+            // model part while the archive holds the publishing endpoint's
+            // own exact tariff further down; letting the guess win prices
+            // first-party usage at a third party's rate and reports it as
+            // unpublishable. Safe upstream rows still win untouched.
+            if !result.evidence.is_submission_safe() {
+                let proven = self
+                    .exact_match_archive(model_id, provider_id)
+                    .filter(|archived| archived.evidence.is_submission_safe());
+                if let Some(archived) = proven {
+                    return Some(archived);
+                }
+            }
             return Some(result);
         }
 
@@ -1466,17 +1480,21 @@ impl PricingLookup {
             return None;
         }
 
-        // Every archived key is a canonical `claude-{family}-{major}-{minor}`
+        // Every archived key is a canonical `{family}-{major}-{minor}` id
         // under a provider root, so the normalizer the upstream exact passes
-        // already use is the whole matcher. It folds the dated
-        // (`claude-haiku-4-5-20251001`), context-tagged (`claude-opus-4-8[1m]`),
-        // dotted (`claude-haiku-4.5`) and reasoning-tier
-        // (`claude-opus-4-7-thinking-xhigh`) spellings real clients emit, and it
-        // drops any leading provider segment on the way. Comparing the raw id to
-        // the key by equality instead would miss every one of those shapes —
-        // that is, every shape the archive exists to cover.
+        // already use is the whole matcher for the Claude line: it folds the
+        // dated (`claude-haiku-4-5-20251001`), context-tagged
+        // (`claude-opus-4-8[1m]`), dotted (`claude-haiku-4.5`) and
+        // reasoning-tier (`claude-opus-4-7-thinking-xhigh`) spellings real
+        // clients emit, and it drops any leading provider segment on the way.
+        // Comparing the raw id to the key by equality instead would miss
+        // every one of those shapes -- that is, every shape the archive
+        // exists to cover. Ids from other vendors have no normalizer yet and
+        // match verbatim; the provider-qualified gate below still requires
+        // the hint to name the key's publishing endpoint, so a verbatim
+        // match can never elect a neighbouring model.
         let lower = model_id.trim().to_ascii_lowercase();
-        let canonical = normalize_model_name(&lower)?;
+        let canonical = normalize_model_name(&lower).unwrap_or_else(|| lower.clone());
 
         // The id's own leading segment authorises the tariff exactly as a hint
         // does, so `anthropic/claude-opus-4-8` resolves provider-scoped with no

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -368,6 +368,8 @@ impl PricingService {
             // cache-hit per M tokens, flat 1M context, no tiers).
             ("zhipu/glm-5.2", 1.4e-6, 4.4e-6, 0.26e-6, None),
             ("zhipu/glm-5.3", 1.4e-6, 4.4e-6, 0.26e-6, None),
+            ("zai/glm-5.2", 1.4e-6, 4.4e-6, 0.26e-6, None),
+            ("zai/glm-5.3", 1.4e-6, 4.4e-6, 0.26e-6, None),
             // Xiaomi MiMo-V2.5: $0.14/$0.28 per 1M, $0.0028 cached input,
             // no published cache-write tariff (only cache-hit vs cache-miss
             // input). No live dataset carries a first-party row -- only the
@@ -377,6 +379,7 @@ impl PricingService {
             // cache-hit / $0.14 cache-miss input / $0.28 output per MTok,
             // flat to 1M context since the 2026-05-27 permanent cut).
             ("xiaomi/mimo-v2.5", 0.14e-6, 0.28e-6, 0.0028e-6, None),
+            ("mimo/mimo-v2.5", 0.14e-6, 0.28e-6, 0.0028e-6, None),
             // Tencent Hunyuan HY3: $0.132/$0.528 per 1M, $0.033 cache-hit;
             // HY4-Preview: $0.834/$2.501 per 1M, $0.042 cache-hit. Neither
             // publishes a separate cache-write tariff. No live dataset
@@ -390,6 +393,8 @@ impl PricingService {
             // (USD numbers archived here, matching the datasets' currency).
             ("tencent/hy3", 0.132e-6, 0.528e-6, 0.033e-6, None),
             ("tencent/hy4-preview", 0.834e-6, 2.501e-6, 0.042e-6, None),
+            ("hunyuan/hy3", 0.132e-6, 0.528e-6, 0.033e-6, None),
+            ("hunyuan/hy4-preview", 0.834e-6, 2.501e-6, 0.042e-6, None),
         ];
 
         let mut overrides = HashMap::with_capacity(entries.len());
@@ -809,25 +814,34 @@ mod tests {
                 reasoning: 0,
             };
 
-            let resolved = service
-                .resolve_for_usage_with_provider(model, Some("zhipu"), &usage)
-                .unwrap_or_else(|| panic!("{model} must resolve first-party"));
-            assert_eq!(resolved.source, "Tokscale Archive", "model: {model}");
-            assert_eq!(
-                resolved.matched_key,
-                format!("zhipu/{model}"),
-                "model: {model}"
-            );
-            assert!(resolved.evidence.is_submission_safe(), "model: {model}");
-            assert!(
-                service.covers_usage_with_provider(model, Some("zhipu"), &usage),
-                "model: {model}"
-            );
-            let actual = service.calculate_cost_with_provider(model, Some("zhipu"), &usage);
-            assert!(
-                (actual - 6.06).abs() < 1e-9,
-                "model: {model}, unexpected cost: {actual}"
-            );
+            for (provider, test_model) in [
+                (Some("zhipu"), model.to_string()),
+                (None, format!("zhipu/{model}")),
+            ] {
+                let resolved = service
+                    .resolve_for_usage_with_provider(&test_model, provider, &usage)
+                    .unwrap_or_else(|| panic!("{test_model} must resolve first-party"));
+                assert_eq!(resolved.source, "Tokscale Archive", "model: {test_model}");
+                assert!(
+                    resolved.matched_key == format!("zhipu/{model}")
+                        || resolved.matched_key == format!("zai/{model}"),
+                    "unexpected matched_key: {}",
+                    resolved.matched_key
+                );
+                assert!(
+                    resolved.evidence.is_submission_safe(),
+                    "model: {test_model}"
+                );
+                assert!(
+                    service.covers_usage_with_provider(&test_model, provider, &usage),
+                    "model: {test_model}"
+                );
+                let actual = service.calculate_cost_with_provider(&test_model, provider, &usage);
+                assert!(
+                    (actual - 6.06).abs() < 1e-9,
+                    "model: {test_model}, unexpected cost: {actual}"
+                );
+            }
         }
     }
 
@@ -873,19 +887,31 @@ mod tests {
             reasoning: 0,
         };
 
-        let resolved = service
-            .resolve_for_usage_with_provider("mimo-v2.5", Some("xiaomi"), &usage)
-            .expect("mimo-v2.5 must resolve first-party");
-        assert_eq!(resolved.source, "Tokscale Archive");
-        assert_eq!(resolved.matched_key, "xiaomi/mimo-v2.5");
-        assert!(resolved.evidence.is_submission_safe());
-        assert!(service.covers_usage_with_provider("mimo-v2.5", Some("xiaomi"), &usage));
-        let actual = service.calculate_cost_with_provider("mimo-v2.5", Some("xiaomi"), &usage);
-        assert!((actual - 0.4228).abs() < 1e-9, "unexpected cost: {actual}");
-        assert!(
-            !service.covers_usage_with_provider("mimo-v2.5", Some("xiaomi"), &all_bucket_usage()),
-            "cache-write-bearing usage must stay unpriced: no published tariff"
-        );
+        for (provider, model_id) in [
+            (Some("xiaomi"), "mimo-v2.5"),
+            (Some("mimo"), "mimo-v2.5"),
+            (None, "xiaomi/mimo-v2.5"),
+            (None, "mimo/mimo-v2.5"),
+        ] {
+            let resolved = service
+                .resolve_for_usage_with_provider(model_id, provider, &usage)
+                .expect("mimo-v2.5 must resolve first-party");
+            assert_eq!(resolved.source, "Tokscale Archive");
+            assert!(
+                resolved.matched_key == "xiaomi/mimo-v2.5"
+                    || resolved.matched_key == "mimo/mimo-v2.5",
+                "unexpected matched key: {}",
+                resolved.matched_key
+            );
+            assert!(resolved.evidence.is_submission_safe());
+            assert!(service.covers_usage_with_provider(model_id, provider, &usage));
+            let actual = service.calculate_cost_with_provider(model_id, provider, &usage);
+            assert!((actual - 0.4228).abs() < 1e-9, "unexpected cost: {actual}");
+            assert!(
+                !service.covers_usage_with_provider(model_id, provider, &all_bucket_usage()),
+                "cache-write-bearing usage must stay unpriced: no published tariff"
+            );
+        }
     }
 
     /// Tencent publishes no first-party row to any live dataset -- only
@@ -934,30 +960,40 @@ mod tests {
             models_dev,
         );
 
-        for (model, expected_key, expected_cost) in [
-            ("hy3", "tencent/hy3", 0.693),
-            ("hy4-preview", "tencent/hy4-preview", 3.377),
-        ] {
-            let usage = usage_without_cache_write();
-            let resolved = service
-                .resolve_for_usage_with_provider(model, Some("tencent"), &usage)
-                .unwrap_or_else(|| panic!("{model} must resolve first-party"));
-            assert_eq!(resolved.source, "Tokscale Archive", "model: {model}");
-            assert_eq!(resolved.matched_key, expected_key, "model: {model}");
-            assert!(resolved.evidence.is_submission_safe(), "model: {model}");
-            assert!(
-                service.covers_usage_with_provider(model, Some("tencent"), &usage),
-                "model: {model}"
-            );
-            let actual = service.calculate_cost_with_provider(model, Some("tencent"), &usage);
-            assert!(
-                (actual - expected_cost).abs() < 1e-9,
-                "model: {model}, unexpected cost: {actual}"
-            );
-            assert!(
-                !service.covers_usage_with_provider(model, Some("tencent"), &all_bucket_usage()),
-                "model: {model}, cache-write-bearing usage must stay unpriced"
-            );
+        for (model, expected_cost) in [("hy3", 0.693), ("hy4-preview", 3.377)] {
+            for (test_model, provider) in [
+                (model.to_string(), Some("tencent")),
+                (format!("tencent/{model}"), None),
+            ] {
+                let usage = usage_without_cache_write();
+                let resolved = service
+                    .resolve_for_usage_with_provider(&test_model, provider, &usage)
+                    .unwrap_or_else(|| panic!("{test_model} must resolve first-party"));
+                assert_eq!(resolved.source, "Tokscale Archive", "model: {test_model}");
+                assert!(
+                    resolved.matched_key == format!("tencent/{model}")
+                        || resolved.matched_key == format!("hunyuan/{model}"),
+                    "model: {test_model}, unexpected matched_key: {}",
+                    resolved.matched_key
+                );
+                assert!(
+                    resolved.evidence.is_submission_safe(),
+                    "model: {test_model}"
+                );
+                assert!(
+                    service.covers_usage_with_provider(&test_model, provider, &usage),
+                    "model: {test_model}"
+                );
+                let actual = service.calculate_cost_with_provider(&test_model, provider, &usage);
+                assert!(
+                    (actual - expected_cost).abs() < 1e-9,
+                    "model: {test_model}, unexpected cost: {actual}"
+                );
+                assert!(
+                    !service.covers_usage_with_provider(&test_model, provider, &all_bucket_usage()),
+                    "model: {test_model}, cache-write-bearing usage must stay unpriced"
+                );
+            }
         }
     }
 

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -801,6 +801,43 @@ mod tests {
         );
     }
 
+    /// A reseller row that only matches by model part must not shadow the
+    /// publishing endpoint's own archived tariff.
+    ///
+    /// Live LiteLLM keys this as `deepinfra/anthropic/claude-opus-4-8` -- a
+    /// nested provider segment, not a first-party root -- so an `anthropic`
+    /// hint resolves it as an unverified ModelPart guess while the archive
+    /// holds `anthropic/claude-opus-4-8` exactly. The guess used to win by
+    /// precedence and the usage submitted at $0.00 with a cost-incomplete
+    /// day; the proven row wins now.
+    #[test]
+    fn unsafe_reseller_row_yields_to_proven_archive() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "deepinfra/anthropic/claude-opus-4-8".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(5e-6),
+                output_cost_per_token: Some(2.5e-5),
+                cache_read_input_token_cost: Some(5e-7),
+                cache_creation_input_token_cost: Some(6.25e-6),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(litellm, HashMap::new());
+        let usage = all_bucket_usage();
+
+        let resolved = service
+            .resolve_for_usage_with_provider("claude-opus-4-8", Some("anthropic"), &usage)
+            .expect("proven archive row must resolve");
+        assert_eq!(resolved.source, "Tokscale Archive");
+        assert_eq!(resolved.matched_key, "anthropic/claude-opus-4-8");
+        assert!(resolved.evidence.is_submission_safe());
+        assert!(service.covers_usage_with_provider("claude-opus-4-8", Some("anthropic"), &usage));
+        let actual =
+            service.calculate_cost_with_provider("claude-opus-4-8", Some("anthropic"), &usage);
+        assert!((actual - 36.75).abs() < 1e-9, "unexpected cost: {actual}");
+    }
+
     /// The shared normalizer folds reasoning-effort suffixes, so the archive
     /// needs no suffix stripper of its own.
     #[test]

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -2770,4 +2770,107 @@ mod tests {
         assert!(service.calculate_cost_with_provider("atlas-chat", None, &usage) > 0.0);
         assert!(!service.covers_usage_with_provider("atlas-chat", None, &usage));
     }
+
+    /// Regression: an archived row is one model's own last published tariff,
+    /// not a family price, so the generic suffix stripper must not reach it.
+    ///
+    /// `mimo-v2.5-pro` (the id the MiMo Code fixture records), `glm-5.3-flash`
+    /// and `hy3-instruct` are SKUs no vendor page prices. Peeling the trailing
+    /// segment and answering from the base model's archived row billed them at
+    /// a neighbouring model's rate and -- under that vendor's own hint --
+    /// stamped the result submission-safe, which would publish a made-up
+    /// price. With no dataset row of their own they stay unpriced, exactly as
+    /// they were before the archive carried these vendors.
+    #[test]
+    fn unknown_sku_suffix_never_reaches_the_archive() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let usage = TokenBreakdown {
+            input: 1_000_000,
+            output: 1_000_000,
+            cache_read: 1_000_000,
+            cache_write: 0,
+            reasoning: 0,
+        };
+
+        for (model, provider) in [
+            ("mimo-v2.5-pro", Some("xiaomi")),
+            ("mimo-v2.5-pro", Some("mimo")),
+            ("glm-5.2-air", Some("zhipu")),
+            ("glm-5.2-flash", Some("zhipu")),
+            ("glm-5.2-x", Some("zhipu")),
+            ("glm-5.2-thinking", Some("zhipu")),
+            ("glm-5.3-air", Some("zhipu")),
+            ("glm-5.3-flash", Some("zhipu")),
+            ("hy3-instruct", Some("tencent")),
+            ("hy3-instruct", Some("hunyuan")),
+        ] {
+            assert!(
+                service
+                    .resolve_for_usage_with_provider(model, provider, &usage)
+                    .is_none(),
+                "model: {model}, an unknown SKU has no archived rate of its own"
+            );
+            assert!(
+                !service.covers_usage_with_provider(model, provider, &usage),
+                "model: {model}, a suffix-eroded price must never become submission-safe"
+            );
+        }
+
+        // The base SKUs the archive does carry keep resolving: the guard
+        // refuses eroded candidates, not the archive.
+        for (model, provider) in [
+            ("mimo-v2.5", Some("xiaomi")),
+            ("glm-5.2", Some("zhipu")),
+            ("hy3", Some("tencent")),
+        ] {
+            let resolved = service
+                .resolve_for_usage_with_provider(model, provider, &usage)
+                .unwrap_or_else(|| panic!("{model} must keep its archived price"));
+            assert_eq!(resolved.source, "Tokscale Archive", "model: {model}");
+            assert!(resolved.evidence.is_submission_safe(), "model: {model}");
+        }
+    }
+
+    /// Regression: the guard declines the ARCHIVE for an eroded candidate, not
+    /// the whole lookup. Filtering the composed result instead threw the live
+    /// row away with it: inside `lookup_auto` the archive substitutes itself
+    /// for an unverified upstream hit, so the marketplace row that prices
+    /// `mimo-v2.5-pro` was already gone by the time the filter saw the source,
+    /// and merely ADDING an archive row dropped every MiMo Code session to $0.
+    #[test]
+    fn suffix_eroded_sku_keeps_its_live_dataset_price() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "openrouter/xiaomi/mimo-v2.5".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.14e-6),
+                output_cost_per_token: Some(0.28e-6),
+                cache_read_input_token_cost: Some(0.0028e-6),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(litellm, HashMap::new());
+        let usage = TokenBreakdown {
+            input: 1_000_000,
+            output: 1_000_000,
+            cache_read: 1_000_000,
+            cache_write: 0,
+            reasoning: 0,
+        };
+
+        // `mimo-v2.5-pro` under a `mimo` hint is verbatim what the MiMo Code
+        // parser records, and the marketplace row is the only live key for it.
+        let resolved = service
+            .resolve_for_usage_with_provider("mimo-v2.5-pro", Some("mimo"), &usage)
+            .expect("the marketplace row must keep pricing the unknown -pro SKU");
+        assert_eq!(resolved.source, "LiteLLM");
+        assert_eq!(resolved.matched_key, "openrouter/xiaomi/mimo-v2.5");
+        assert!(service.calculate_cost_with_provider("mimo-v2.5-pro", Some("mimo"), &usage) > 0.0);
+
+        // The id the archive does carry still takes the first-party tariff.
+        let base = service
+            .resolve_for_usage_with_provider("mimo-v2.5", Some("mimo"), &usage)
+            .expect("mimo-v2.5 must resolve first-party");
+        assert_eq!(base.source, "Tokscale Archive");
+    }
 }

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -368,6 +368,15 @@ impl PricingService {
             // cache-hit per M tokens, flat 1M context, no tiers).
             ("zhipu/glm-5.2", 1.4e-6, 4.4e-6, 0.26e-6, None),
             ("zhipu/glm-5.3", 1.4e-6, 4.4e-6, 0.26e-6, None),
+            // Xiaomi MiMo-V2.5: $0.14/$0.28 per 1M, $0.0028 cached input,
+            // no published cache-write tariff (only cache-hit vs cache-miss
+            // input). No live dataset carries a first-party row -- only the
+            // `openrouter/xiaomi/*` marketplace key -- so a `xiaomi` hint
+            // resolved as an unverified guess. Verified 2026-09-03 against
+            // https://mimo.mi.com/docs/en-US/pricing (MiMo-V2.5: $0.0028
+            // cache-hit / $0.14 cache-miss input / $0.28 output per MTok,
+            // flat to 1M context since the 2026-05-27 permanent cut).
+            ("xiaomi/mimo-v2.5", 0.14e-6, 0.28e-6, 0.0028e-6, None),
         ];
 
         let mut overrides = HashMap::with_capacity(entries.len());
@@ -822,6 +831,48 @@ mod tests {
                 "model: {model}"
             );
         }
+    }
+
+    /// Xiaomi publishes no first-party row to any live dataset -- only the
+    /// `openrouter/xiaomi/*` marketplace key -- so a `xiaomi` hint for
+    /// `mimo-v2.5` resolved as an unverified guess. The archived first-party
+    /// tariff ($0.14/$0.28 per 1M, $0.0028 cached input, verified 2026-09-03)
+    /// wins for the publishing endpoint.
+    #[test]
+    fn xiaomi_mimo_rate_resolves_first_party_over_marketplace_row() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "openrouter/xiaomi/mimo-v2.5".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.14e-6),
+                output_cost_per_token: Some(0.28e-6),
+                cache_read_input_token_cost: Some(0.0028e-6),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(litellm, HashMap::new());
+        // No published cache-write tariff, so the covered usage carries none.
+        let usage = TokenBreakdown {
+            input: 1_000_000,
+            output: 1_000_000,
+            cache_read: 1_000_000,
+            cache_write: 0,
+            reasoning: 0,
+        };
+
+        let resolved = service
+            .resolve_for_usage_with_provider("mimo-v2.5", Some("xiaomi"), &usage)
+            .expect("mimo-v2.5 must resolve first-party");
+        assert_eq!(resolved.source, "Tokscale Archive");
+        assert_eq!(resolved.matched_key, "xiaomi/mimo-v2.5");
+        assert!(resolved.evidence.is_submission_safe());
+        assert!(service.covers_usage_with_provider("mimo-v2.5", Some("xiaomi"), &usage));
+        let actual = service.calculate_cost_with_provider("mimo-v2.5", Some("xiaomi"), &usage);
+        assert!((actual - 0.4228).abs() < 1e-9, "unexpected cost: {actual}");
+        assert!(
+            !service.covers_usage_with_provider("mimo-v2.5", Some("xiaomi"), &all_bucket_usage()),
+            "cache-write-bearing usage must stay unpriced: no published tariff"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -244,11 +244,16 @@ impl PricingService {
         overrides
     }
 
-    // @keep: a snapshot of last-known published rates for Anthropic models that
-    // upstream will eventually stop carrying. LiteLLM, OpenRouter and models.dev
-    // all describe the CURRENT catalogue: once a provider retires a model those
-    // rows are dropped, and every historical session that used it silently loses
-    // its price. This archive is the only place that memory lives.
+    // @keep: a snapshot of published first-party rates for models no live
+    // dataset carries first-party. LiteLLM, OpenRouter and models.dev all
+    // describe the CURRENT catalogue from resellers as well as vendors: once
+    // a provider retires a model those rows are dropped, and some current
+    // models were never listed first-party at all (only `deepinfra/*`,
+    // `z-ai/*`, `openrouter/*` reseller keys exist). In both cases every
+    // historical session that used the model at the publishing endpoint
+    // silently loses its price without this memory, and a reseller row that
+    // merely shares the model name wins by precedence as an unverified
+    // guess. This archive is the only place that memory lives.
     //
     // Precedence is the same slot as the Cursor/Sakana overrides in
     // PricingLookup - after every upstream exact/normalized/prefix match, before
@@ -256,11 +261,11 @@ impl PricingService {
     // answers, and once upstream drops it the archive answers with that model's
     // own last rate instead of letting fuzzy elect a neighbouring row.
     //
-    // Keys are provider-qualified on purpose. Anthropic bills these rates on its
-    // own API; a request routed through Vertex or Bedrock is a different tariff.
-    // With an `anthropic/` root, an anthropic hint resolves ProviderScoped with
-    // matching provider identity (submission-safe), and a `vertex`/`vertex_ai`
-    // hint is recognised as a cross-provider alias and stays an estimate.
+    // Keys are provider-qualified on purpose. Each vendor bills these rates
+    // on its own API; a request routed through another endpoint is a
+    // different tariff. With a matching root, a same-vendor hint resolves
+    // ProviderScoped with matching provider identity (submission-safe), and
+    // any other hint stays an estimate.
     //
     // Rates verified 2026-09-02 against both live datasets: models.dev keys them
     // exactly as written here, LiteLLM keys them bare (`claude-haiku-4-5`, ...)
@@ -279,7 +284,11 @@ impl PricingService {
     // cost is preserved.
     fn build_archive_overrides() -> HashMap<String, ModelPricing> {
         /// `(model id, input, output, cache read, cache creation)`, per token.
-        type ArchivedRateRow = (&'static str, f64, f64, f64, f64);
+        /// Cache creation is `None` where the vendor publishes no such bucket
+        /// (Zhipu, Xiaomi and Tencent document cached-input reads but no
+        /// cache-write tariff): usage populating that bucket then stays
+        /// unpriced rather than billed at an invented rate.
+        type ArchivedRateRow = (&'static str, f64, f64, f64, Option<f64>);
 
         // Every first-party Claude row the narrowest dataset still carries, so
         // whichever one is retired next already has its last published rate
@@ -290,22 +299,75 @@ impl PricingService {
         // nothing retires the model that is shipping.
         let entries: &[ArchivedRateRow] = &[
             // Claude Haiku 4.5: $1.00/$5.00 per 1M, $0.10 cache read, $1.25 cache write.
-            ("anthropic/claude-haiku-4-5", 1e-6, 5e-6, 1e-7, 1.25e-6),
+            (
+                "anthropic/claude-haiku-4-5",
+                1e-6,
+                5e-6,
+                1e-7,
+                Some(1.25e-6),
+            ),
             // Claude Sonnet 4.5 / 4.6: $3.00/$15.00 per 1M, $0.30 cache read,
             // $3.75 cache write. 4.5 is the oldest Sonnet any of the three
             // still carries.
-            ("anthropic/claude-sonnet-4-5", 3e-6, 1.5e-5, 3e-7, 3.75e-6),
-            ("anthropic/claude-sonnet-4-6", 3e-6, 1.5e-5, 3e-7, 3.75e-6),
+            (
+                "anthropic/claude-sonnet-4-5",
+                3e-6,
+                1.5e-5,
+                3e-7,
+                Some(3.75e-6),
+            ),
+            (
+                "anthropic/claude-sonnet-4-6",
+                3e-6,
+                1.5e-5,
+                3e-7,
+                Some(3.75e-6),
+            ),
             // Claude Opus 4.5 / 4.6 / 4.7 / 4.8: $5.00/$25.00 per 1M, $0.50
             // cache read, $6.25 cache write. 4.5 is the oldest Opus carried by
             // all three, so it is the next one due to fall off -- LiteLLM and
             // OpenRouter still list opus-4 and opus-4-1 (and LiteLLM
             // claude-3-opus), but models.dev has already dropped them, so
             // their rates cannot be cross-checked and they are not archived.
-            ("anthropic/claude-opus-4-5", 5e-6, 2.5e-5, 5e-7, 6.25e-6),
-            ("anthropic/claude-opus-4-6", 5e-6, 2.5e-5, 5e-7, 6.25e-6),
-            ("anthropic/claude-opus-4-7", 5e-6, 2.5e-5, 5e-7, 6.25e-6),
-            ("anthropic/claude-opus-4-8", 5e-6, 2.5e-5, 5e-7, 6.25e-6),
+            (
+                "anthropic/claude-opus-4-5",
+                5e-6,
+                2.5e-5,
+                5e-7,
+                Some(6.25e-6),
+            ),
+            (
+                "anthropic/claude-opus-4-6",
+                5e-6,
+                2.5e-5,
+                5e-7,
+                Some(6.25e-6),
+            ),
+            (
+                "anthropic/claude-opus-4-7",
+                5e-6,
+                2.5e-5,
+                5e-7,
+                Some(6.25e-6),
+            ),
+            (
+                "anthropic/claude-opus-4-8",
+                5e-6,
+                2.5e-5,
+                5e-7,
+                Some(6.25e-6),
+            ),
+            // Zhipu GLM-5.2 / GLM-5.3: $1.40/$4.40 per 1M, $0.26 cached
+            // input, no published cache-write tariff (cached-input storage
+            // is "Limited-time Free"). No live dataset carries a first-party
+            // row -- only the `z-ai/*` reseller keys -- so a `zhipu` hint
+            // resolved as an unverified guess. Verified 2026-09-03 against
+            // https://docs.z.ai/guides/overview/pricing ("Latest Models":
+            // GLM-5.3 and GLM-5.2 at $1.4 in / $0.26 cached / $4.4 out) and
+            // https://bigmodel.cn/pricing (8元 in / 28元 out / 2元
+            // cache-hit per M tokens, flat 1M context, no tiers).
+            ("zhipu/glm-5.2", 1.4e-6, 4.4e-6, 0.26e-6, None),
+            ("zhipu/glm-5.3", 1.4e-6, 4.4e-6, 0.26e-6, None),
         ];
 
         let mut overrides = HashMap::with_capacity(entries.len());
@@ -316,7 +378,7 @@ impl PricingService {
                     input_cost_per_token: Some(*input),
                     output_cost_per_token: Some(*output),
                     cache_read_input_token_cost: Some(*cache_read),
-                    cache_creation_input_token_cost: Some(*cache_creation),
+                    cache_creation_input_token_cost: *cache_creation,
                     ..Default::default()
                 },
             );
@@ -694,6 +756,72 @@ mod tests {
     #[test]
     fn retired_claude_opus_4_8_keeps_its_last_known_price() {
         assert_retired_anthropic_price("claude-opus-4-8", 5.0, 25.0, 0.5, 6.25);
+    }
+
+    /// Zhipu publishes no first-party row to any live dataset -- only the
+    /// `z-ai/*` reseller keys -- so a `zhipu` hint resolved as an unverified
+    /// guess. The archived first-party tariff ($1.40/$4.40 per 1M, $0.26
+    /// cached input, verified 2026-09-03) wins for the publishing endpoint.
+    #[test]
+    fn zhipu_glm_rates_resolve_first_party_over_reseller_row() {
+        fn reseller_row() -> ModelPricing {
+            ModelPricing {
+                input_cost_per_token: Some(1.4e-6),
+                output_cost_per_token: Some(4.4e-6),
+                cache_read_input_token_cost: Some(0.26e-6),
+                ..Default::default()
+            }
+        }
+
+        for model in ["glm-5.2", "glm-5.3"] {
+            let mut openrouter = HashMap::new();
+            openrouter.insert(format!("z-ai/{model}"), reseller_row());
+            let service = PricingService::new(HashMap::new(), openrouter);
+            // No published cache-write tariff, so the covered usage carries
+            // none; cache-write-bearing usage stays unpriced (pinned below).
+            let usage = TokenBreakdown {
+                input: 1_000_000,
+                output: 1_000_000,
+                cache_read: 1_000_000,
+                cache_write: 0,
+                reasoning: 0,
+            };
+
+            let resolved = service
+                .resolve_for_usage_with_provider(model, Some("zhipu"), &usage)
+                .unwrap_or_else(|| panic!("{model} must resolve first-party"));
+            assert_eq!(resolved.source, "Tokscale Archive", "model: {model}");
+            assert_eq!(
+                resolved.matched_key,
+                format!("zhipu/{model}"),
+                "model: {model}"
+            );
+            assert!(resolved.evidence.is_submission_safe(), "model: {model}");
+            assert!(
+                service.covers_usage_with_provider(model, Some("zhipu"), &usage),
+                "model: {model}"
+            );
+            let actual = service.calculate_cost_with_provider(model, Some("zhipu"), &usage);
+            assert!(
+                (actual - 6.06).abs() < 1e-9,
+                "model: {model}, unexpected cost: {actual}"
+            );
+        }
+    }
+
+    /// Zhipu documents cached-input reads but no cache-write tariff, so
+    /// cache-write-bearing usage must stay unpriced rather than billed at an
+    /// invented rate.
+    #[test]
+    fn zhipu_cache_write_usage_stays_unpriced() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+
+        for model in ["glm-5.2", "glm-5.3"] {
+            assert!(
+                !service.covers_usage_with_provider(model, Some("zhipu"), &all_bucket_usage()),
+                "model: {model}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -377,6 +377,19 @@ impl PricingService {
             // cache-hit / $0.14 cache-miss input / $0.28 output per MTok,
             // flat to 1M context since the 2026-05-27 permanent cut).
             ("xiaomi/mimo-v2.5", 0.14e-6, 0.28e-6, 0.0028e-6, None),
+            // Tencent Hunyuan HY3: $0.132/$0.528 per 1M, $0.033 cache-hit;
+            // HY4-Preview: $0.834/$2.501 per 1M, $0.042 cache-hit. Neither
+            // publishes a separate cache-write tariff. No live dataset
+            // carries a first-party row -- only `deepinfra/tencent/*` and
+            // `crossmodel/tencent/*` reseller keys -- so a `tencent` hint
+            // resolved as an unverified guess. Verified 2026-09-03 against
+            // https://cloud.tencent.com/document/product/1823/130055
+            // (Hy3: 1元 in / 4元 out / 0.25元 cache-hit; Hy4 preview: 6元
+            // in / 18元 out / 0.3元 cache-hit per M tokens, flat) and the
+            // Intl sheet https://intl.cloud.tencent.com/document/product/1300/78937
+            // (USD numbers archived here, matching the datasets' currency).
+            ("tencent/hy3", 0.132e-6, 0.528e-6, 0.033e-6, None),
+            ("tencent/hy4-preview", 0.834e-6, 2.501e-6, 0.042e-6, None),
         ];
 
         let mut overrides = HashMap::with_capacity(entries.len());
@@ -873,6 +886,79 @@ mod tests {
             !service.covers_usage_with_provider("mimo-v2.5", Some("xiaomi"), &all_bucket_usage()),
             "cache-write-bearing usage must stay unpriced: no published tariff"
         );
+    }
+
+    /// Tencent publishes no first-party row to any live dataset -- only
+    /// `deepinfra/tencent/*` and `crossmodel/tencent/*` reseller keys -- so a
+    /// `tencent` hint for `hy3` / `hy4-preview` resolved as an unverified
+    /// guess. The archived first-party tariffs (Intl USD sheet, verified
+    /// 2026-09-03) win for the publishing endpoint. Each case mirrors the
+    /// live reseller shape, exercising the LiteLLM path (hy3) and the
+    /// models.dev path (hy4-preview).
+    #[test]
+    fn tencent_hunyuan_rates_resolve_first_party_over_reseller_rows() {
+        fn usage_without_cache_write() -> TokenBreakdown {
+            TokenBreakdown {
+                input: 1_000_000,
+                output: 1_000_000,
+                cache_read: 1_000_000,
+                cache_write: 0,
+                reasoning: 0,
+            }
+        }
+
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "deepinfra/tencent/Hy3".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.132e-6),
+                output_cost_per_token: Some(0.528e-6),
+                cache_read_input_token_cost: Some(0.033e-6),
+                ..Default::default()
+            },
+        );
+        let mut models_dev = HashMap::new();
+        models_dev.insert(
+            "crossmodel/tencent/hy4-preview".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.834e-6),
+                output_cost_per_token: Some(2.501e-6),
+                cache_read_input_token_cost: Some(0.042e-6),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new_with_custom_and_models_dev(
+            CustomPricing::default(),
+            litellm,
+            HashMap::new(),
+            models_dev,
+        );
+
+        for (model, expected_key, expected_cost) in [
+            ("hy3", "tencent/hy3", 0.693),
+            ("hy4-preview", "tencent/hy4-preview", 3.377),
+        ] {
+            let usage = usage_without_cache_write();
+            let resolved = service
+                .resolve_for_usage_with_provider(model, Some("tencent"), &usage)
+                .unwrap_or_else(|| panic!("{model} must resolve first-party"));
+            assert_eq!(resolved.source, "Tokscale Archive", "model: {model}");
+            assert_eq!(resolved.matched_key, expected_key, "model: {model}");
+            assert!(resolved.evidence.is_submission_safe(), "model: {model}");
+            assert!(
+                service.covers_usage_with_provider(model, Some("tencent"), &usage),
+                "model: {model}"
+            );
+            let actual = service.calculate_cost_with_provider(model, Some("tencent"), &usage);
+            assert!(
+                (actual - expected_cost).abs() < 1e-9,
+                "model: {model}, unexpected cost: {actual}"
+            );
+            assert!(
+                !service.covers_usage_with_provider(model, Some("tencent"), &all_bucket_usage()),
+                "model: {model}, cache-write-bearing usage must stay unpriced"
+            );
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -801,9 +801,9 @@ mod tests {
         }
 
         for model in ["glm-5.2", "glm-5.3"] {
-            let mut openrouter = HashMap::new();
-            openrouter.insert(format!("z-ai/{model}"), reseller_row());
-            let service = PricingService::new(HashMap::new(), openrouter);
+            let mut litellm = HashMap::new();
+            litellm.insert(format!("openrouter/z-ai/{model}"), reseller_row());
+            let service = PricingService::new(litellm, HashMap::new());
             // No published cache-write tariff, so the covered usage carries
             // none; cache-write-bearing usage stays unpriced (pinned below).
             let usage = TokenBreakdown {
@@ -814,19 +814,19 @@ mod tests {
                 reasoning: 0,
             };
 
-            for (provider, test_model) in [
-                (Some("zhipu"), model.to_string()),
-                (None, format!("zhipu/{model}")),
+            for (provider, test_model, expected_key) in [
+                (Some("zhipu"), model.to_string(), format!("zhipu/{model}")),
+                (None, format!("zhipu/{model}"), format!("zhipu/{model}")),
+                (Some("zai"), model.to_string(), format!("zai/{model}")),
+                (None, format!("zai/{model}"), format!("zai/{model}")),
             ] {
                 let resolved = service
                     .resolve_for_usage_with_provider(&test_model, provider, &usage)
                     .unwrap_or_else(|| panic!("{test_model} must resolve first-party"));
                 assert_eq!(resolved.source, "Tokscale Archive", "model: {test_model}");
-                assert!(
-                    resolved.matched_key == format!("zhipu/{model}")
-                        || resolved.matched_key == format!("zai/{model}"),
-                    "unexpected matched_key: {}",
-                    resolved.matched_key
+                assert_eq!(
+                    resolved.matched_key, expected_key,
+                    "model: {test_model}, unexpected matched_key"
                 );
                 assert!(
                     resolved.evidence.is_submission_safe(),
@@ -887,22 +887,17 @@ mod tests {
             reasoning: 0,
         };
 
-        for (provider, model_id) in [
-            (Some("xiaomi"), "mimo-v2.5"),
-            (Some("mimo"), "mimo-v2.5"),
-            (None, "xiaomi/mimo-v2.5"),
-            (None, "mimo/mimo-v2.5"),
+        for (provider, model_id, expected_key) in [
+            (Some("xiaomi"), "mimo-v2.5", "xiaomi/mimo-v2.5"),
+            (Some("mimo"), "mimo-v2.5", "mimo/mimo-v2.5"),
+            (None, "xiaomi/mimo-v2.5", "xiaomi/mimo-v2.5"),
+            (None, "mimo/mimo-v2.5", "mimo/mimo-v2.5"),
         ] {
             let resolved = service
                 .resolve_for_usage_with_provider(model_id, provider, &usage)
                 .expect("mimo-v2.5 must resolve first-party");
             assert_eq!(resolved.source, "Tokscale Archive");
-            assert!(
-                resolved.matched_key == "xiaomi/mimo-v2.5"
-                    || resolved.matched_key == "mimo/mimo-v2.5",
-                "unexpected matched key: {}",
-                resolved.matched_key
-            );
+            assert_eq!(resolved.matched_key, expected_key, "unexpected matched key");
             assert!(resolved.evidence.is_submission_safe());
             assert!(service.covers_usage_with_provider(model_id, provider, &usage));
             let actual = service.calculate_cost_with_provider(model_id, provider, &usage);
@@ -961,20 +956,28 @@ mod tests {
         );
 
         for (model, expected_cost) in [("hy3", 0.693), ("hy4-preview", 3.377)] {
-            for (test_model, provider) in [
-                (model.to_string(), Some("tencent")),
-                (format!("tencent/{model}"), None),
+            for (test_model, provider, expected_key) in [
+                (
+                    model.to_string(),
+                    Some("tencent"),
+                    format!("tencent/{model}"),
+                ),
+                (
+                    model.to_string(),
+                    Some("hunyuan"),
+                    format!("hunyuan/{model}"),
+                ),
+                (format!("tencent/{model}"), None, format!("tencent/{model}")),
+                (format!("hunyuan/{model}"), None, format!("hunyuan/{model}")),
             ] {
                 let usage = usage_without_cache_write();
                 let resolved = service
                     .resolve_for_usage_with_provider(&test_model, provider, &usage)
                     .unwrap_or_else(|| panic!("{test_model} must resolve first-party"));
                 assert_eq!(resolved.source, "Tokscale Archive", "model: {test_model}");
-                assert!(
-                    resolved.matched_key == format!("tencent/{model}")
-                        || resolved.matched_key == format!("hunyuan/{model}"),
-                    "model: {test_model}, unexpected matched_key: {}",
-                    resolved.matched_key
+                assert_eq!(
+                    resolved.matched_key, expected_key,
+                    "model: {test_model}, unexpected matched_key"
                 );
                 assert!(
                     resolved.evidence.is_submission_safe(),


### PR DESCRIPTION
Live datasets key many first-party models only under reseller roots (`deepinfra/anthropic/claude-opus-4-8`, `deepinfra/tencent/Hy3`, `openrouter/xiaomi/mimo-v2.5`, `z-ai/glm-5.2`), so a first-party hint resolves as an unverified ModelPart guess. Those guesses won by precedence even though the retirement archive holds the publishing endpoint's exact tariff, and the usage submitted at $0.00 with a cost-incomplete day.

This consolidates first-party tariff archives for Chinese LLM providers (Zhipu GLM-5.2/5.3, Xiaomi MiMo-V2.5, Tencent Hunyuan HY3/HY4-Preview) and makes proven archive rows win over unverified reseller guesses at every fallback stage:

- **Provenance precedence**: Every unverified fallback stage in `lookup_auto` routes through `prefer_proven_archive`. When an upstream winner is not submission-safe and the archive holds a submission-safe row for the hinted endpoint, the proven tariff wins.
- **Provider-qualified model IDs**: Strip leading provider prefixes before archive matching non-Claude models so qualified IDs like `tencent/hy3`, `zhipu/glm-5.2`, and `xiaomi/mimo-v2.5` match directly as submission-safe.
- **Zhipu GLM-5.2/5.3**: Archive at $1.40/$4.40 per 1M with $0.26 cached input, verified 2026-09-03 against Zhipu and BigModel pricing.
- **Xiaomi MiMo-V2.5**: Archive at $0.14/$0.28 per 1M with $0.0028 cached input, verified 2026-09-03 against Xiaomi MiMo docs. Supports both `xiaomi` and `mimo` endpoint roots.
- **Tencent Hunyuan HY3/HY4-Preview**: Archive at $0.132/$0.528 (HY3) and $0.834/$2.501 (HY4-Preview) per 1M with verified cache-hit rates from Tencent Cloud international USD sheet. Supports both `tencent` and `hunyuan` endpoint roots.
- **Unpublished cache-write handling**: Models without published cache-write tariffs leave that bucket unpriced rather than billing an invented rate.

Supersedes and consolidates #1271, #1272, and #1273 into a single cohesive PR.

## What's Changed
* fix(pricing): prefer proven archive tariff over unverified reseller guess
* fix(pricing): apply proven-archive preference at every unverified fallback
* fix(pricing): archive Zhipu GLM-5.2/5.3 first-party tariffs
* fix(pricing): archive Xiaomi MiMo-V2.5 first-party tariff
* fix(pricing): archive Tencent Hunyuan HY3/HY4-Preview first-party tariffs
* fix(pricing): preserve archive resolution for provider-qualified model ids

## Verification
* `cargo fmt --all -- --check`
* `cargo clippy --locked -p tokscale-core --all-features -- -D warnings`
* `cargo test --locked -p tokscale-core --lib` (2049 passed, covering all provider hints, qualified IDs, shadow reseller fixtures, and unpublished-bucket behavior)
