### PR TITLE
feat(pricing): price dead free-preview models at published zero

### DIFF
--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -5096,6 +5096,82 @@ fn test_submit_includes_unpriced_usage_at_zero_and_keeps_the_rest() {
     );
 }
 
+/// Dead free-preview incarnations (`ox-alpha`, `x-preview-f-free`) carry a
+/// published $0, so they submit with the priced usage: no per-row warning,
+/// no aggregate line, no fix hint.
+#[test]
+fn test_submit_free_preview_models_upload_without_warnings() {
+    let tmp = create_temp_fixture_dir();
+    prime_pricing_cache_with_a_priced_model(tmp.path());
+    write_fake_credentials(tmp.path());
+    let preview_dir = tmp
+        .path()
+        .join(".local/share/opencode/storage/message/free-preview");
+    fs::create_dir_all(&preview_dir).unwrap();
+    for (file, id, session, provider, input, output) in [
+        ("ox.json", "ox", "free-preview-ox", "stealth", 1000, 500),
+        (
+            "xpreview.json",
+            "xpreview",
+            "free-preview-x",
+            "opencode-zen",
+            2000,
+            100,
+        ),
+    ] {
+        let model_id = if id == "ox" {
+            "stealth/ox-alpha".to_string()
+        } else {
+            "x-preview-f-free".to_string()
+        };
+        fs::write(
+preview_dir.join(file),
+format!(
+r#"{{
+"id": "{id}",
+"sessionID": "{session}",
+"role": "assistant",
+"modelID": "{model_id}",
+"providerID": "{provider}",
+"cost": 0,
+"tokens": {{ "input": {input}, "output": {output}, "reasoning": 0, "cache": {{ "read": 0, "write": 0 }} }},
+"time": {{ "created": 1736510400000.0 }}
+}}"#,
+),
+)
+.unwrap();
+    }
+
+    let output = offline_cmd_with_home(tmp.path())
+        .args([
+            "--no-spinner",
+            "submit",
+            "--client",
+            "opencode",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "free preview usage must submit cleanly; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("unpriced"),
+        "published-$0 usage must not warn: {stdout}"
+    );
+    assert!(
+        !stdout.contains("custom-pricing.json"),
+        "no fix hint for priced usage: {stdout}"
+    );
+    assert!(
+        stdout.contains("Total tokens: 7,550"),
+        "both preview models (3,600 tokens) must be counted on top of the 3,950-token stock fixture: {stdout}"
+    );
+}
+
 /// Regression: a cold cache with no network must not look like "no usage".
 ///
 /// Every fetchable upstream is unreachable here and nothing is cached, so the

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -136,6 +136,16 @@ pub struct PricingLookup {
     /// provider-qualified path instead and can only be submission-safe when the
     /// lookup actually proves the publishing endpoint.
     archive: HashMap<String, ModelPricing>,
+    /// Published $0 tariffs for dead free-preview incarnations (`ox-alpha`,
+    /// `x-preview-f-free`).
+    ///
+    /// Deliberately not folded into `archive`: archived rows are snapshots
+    /// that may since have moved, so they match provider-qualified and are
+    /// only safe when the endpoint is proven. A dead preview's $0 is final --
+    /// the id can never be billed again -- so these match bare like
+    /// `cursor`/`sakana` and answer with `BuiltIn` evidence regardless of
+    /// which gateway routed the request.
+    free_preview: HashMap<String, ModelPricing>,
     litellm_keys: Vec<String>,
     openrouter_keys: Vec<String>,
     litellm_key_parts: Vec<KeyModelPart>,
@@ -149,6 +159,7 @@ pub struct PricingLookup {
     models_dev_model_part: HashMap<String, String>,
     cursor_lower: HashMap<String, String>,
     sakana_lower: HashMap<String, String>,
+    free_preview_lower: HashMap<String, String>,
     lookup_cache: RwLock<HashMap<String, Option<CachedResult>>>,
 }
 
@@ -368,13 +379,14 @@ impl PricingLookup {
         Self::new_with_models_dev(litellm, openrouter, cursor, HashMap::new(), HashMap::new())
     }
 
-    // @keep: the omission of cursor/sakana is the whole point and reads like a bug otherwise.
+    // @keep: the omission of cursor/sakana/free_preview is the whole point and reads like a bug otherwise.
     /// True when at least one *fetchable* upstream dataset loaded.
     ///
-    /// The `cursor`, `sakana` and `archive` tables are compiled-in constants
-    /// that are present on every run, so they are deliberately not consulted:
-    /// counting them would report healthy pricing during a total upstream
-    /// outage, which is exactly the condition callers use this to detect.
+    /// The `cursor`, `sakana`, `free_preview` and `archive` tables are
+    /// compiled-in constants that are present on every run, so they are
+    /// deliberately not consulted: counting them would report healthy pricing
+    /// during a total upstream outage, which is exactly the condition callers
+    /// use this to detect.
     pub fn has_upstream_dataset(&self) -> bool {
         !self.litellm.is_empty() || !self.openrouter.is_empty() || !self.models_dev.is_empty()
     }
@@ -392,6 +404,7 @@ impl PricingLookup {
             cursor,
             sakana,
             models_dev,
+            HashMap::new(),
             HashMap::new(),
         )
     }
@@ -413,6 +426,10 @@ impl PricingLookup {
         sakana: HashMap<String, ModelPricing>,
         models_dev: HashMap<String, ModelPricing>,
         archive: HashMap<String, ModelPricing>,
+        // @keep: separate table rather than archive rows because the match
+        // semantics differ (bare BuiltIn match, not provider-qualified); see
+        // the field docs.
+        free_preview: HashMap<String, ModelPricing>,
     ) -> Self {
         // Longest key first, then alphabetical. The alphabetical leg only pins
         // equal-length ties so a run is reproducible; it carries no pricing
@@ -490,6 +507,11 @@ impl PricingLookup {
             sakana_lower.insert(key.to_lowercase(), key.clone());
         }
 
+        let mut free_preview_lower = HashMap::with_capacity(free_preview.len());
+        for key in free_preview.keys() {
+            free_preview_lower.insert(key.to_lowercase(), key.clone());
+        }
+
         let build_key_parts = |keys: &[String]| -> Vec<KeyModelPart> {
             keys.iter()
                 .map(|key| {
@@ -515,6 +537,7 @@ impl PricingLookup {
             sakana,
             models_dev,
             archive,
+            free_preview,
             litellm_keys,
             openrouter_keys,
             litellm_key_parts,
@@ -528,6 +551,7 @@ impl PricingLookup {
             models_dev_model_part,
             cursor_lower,
             sakana_lower,
+            free_preview_lower,
             lookup_cache: RwLock::new(HashMap::with_capacity(64)),
         }
     }
@@ -880,7 +904,7 @@ impl PricingLookup {
             self.exact_match_models_dev_for_provider(model_id, provider_id),
             provider_id,
         ) {
-            return Some(self.prefer_proven_archive(result, model_id, provider_id));
+            return Some(self.prefer_proven_rate(result, model_id, provider_id));
         }
 
         if let Some(result) = exact_litellm {
@@ -904,11 +928,11 @@ impl PricingLookup {
         // matching key falls through to the canonical resolution below.
         if provider_id.is_some() {
             if let Some(result) = self.exact_match_models_dev_for_provider(model_id, provider_id) {
-                return Some(self.prefer_proven_archive(result, model_id, provider_id));
+                return Some(self.prefer_proven_rate(result, model_id, provider_id));
             }
         }
         if let Some(result) = self.exact_match_openrouter_model_part(model_id) {
-            return Some(self.prefer_proven_archive(result, model_id, provider_id));
+            return Some(self.prefer_proven_rate(result, model_id, provider_id));
         }
 
         // Separator-normalized exact passes against the canonical sources
@@ -926,7 +950,7 @@ impl PricingLookup {
                 self.exact_match_models_dev_for_provider(&version_normalized, provider_id),
                 provider_id,
             ) {
-                return Some(self.prefer_proven_archive(
+                return Some(self.prefer_proven_rate(
                     result.with_normalization(),
                     &version_normalized,
                     provider_id,
@@ -936,7 +960,7 @@ impl PricingLookup {
                 if let Some(result) =
                     self.exact_match_models_dev_for_provider(&version_normalized, provider_id)
                 {
-                    return Some(self.prefer_proven_archive(
+                    return Some(self.prefer_proven_rate(
                         result.with_normalization(),
                         &version_normalized,
                         provider_id,
@@ -947,7 +971,7 @@ impl PricingLookup {
                 return Some(result.with_normalization());
             }
             if let Some(result) = self.exact_match_openrouter(&version_normalized) {
-                return Some(self.prefer_proven_archive(
+                return Some(self.prefer_proven_rate(
                     result.with_normalization(),
                     &version_normalized,
                     provider_id,
@@ -956,13 +980,13 @@ impl PricingLookup {
         }
 
         if let Some(result) = self.exact_match_models_dev_with_provider(model_id, provider_id) {
-            return Some(self.prefer_proven_archive(result, model_id, provider_id));
+            return Some(self.prefer_proven_rate(result, model_id, provider_id));
         }
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) =
                 self.exact_match_models_dev_with_provider(&version_normalized, provider_id)
             {
-                return Some(self.prefer_proven_archive(
+                return Some(self.prefer_proven_rate(
                     result.with_normalization(),
                     &version_normalized,
                     provider_id,
@@ -977,7 +1001,7 @@ impl PricingLookup {
                 self.exact_match_models_dev_for_provider(&normalized, provider_id),
                 provider_id,
             ) {
-                return Some(self.prefer_proven_archive(
+                return Some(self.prefer_proven_rate(
                     result.with_normalization(),
                     &normalized,
                     provider_id,
@@ -987,7 +1011,7 @@ impl PricingLookup {
                 return Some(result.with_normalization());
             }
             if let Some(result) = self.exact_match_openrouter(&normalized) {
-                return Some(self.prefer_proven_archive(
+                return Some(self.prefer_proven_rate(
                     result.with_normalization(),
                     &normalized,
                     provider_id,
@@ -996,7 +1020,7 @@ impl PricingLookup {
             if let Some(result) =
                 self.exact_match_models_dev_with_provider(&normalized, provider_id)
             {
-                return Some(self.prefer_proven_archive(
+                return Some(self.prefer_proven_rate(
                     result.with_normalization(),
                     &normalized,
                     provider_id,
@@ -1005,32 +1029,32 @@ impl PricingLookup {
         }
 
         if let Some(result) = self.prefix_match_litellm(model_id, provider_id) {
-            return Some(self.prefer_proven_archive(result, model_id, provider_id));
+            return Some(self.prefer_proven_rate(result, model_id, provider_id));
         }
         if let Some(result) = self.prefix_match_openrouter(model_id, provider_id) {
-            return Some(self.prefer_proven_archive(result, model_id, provider_id));
+            return Some(self.prefer_proven_rate(result, model_id, provider_id));
         }
         if let Some(result) = self.prefix_match_models_dev(model_id, provider_id) {
-            return Some(self.prefer_proven_archive(result, model_id, provider_id));
+            return Some(self.prefer_proven_rate(result, model_id, provider_id));
         }
 
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) = self.prefix_match_litellm(&version_normalized, provider_id) {
-                return Some(self.prefer_proven_archive(
+                return Some(self.prefer_proven_rate(
                     result.with_normalization(),
                     &version_normalized,
                     provider_id,
                 ));
             }
             if let Some(result) = self.prefix_match_openrouter(&version_normalized, provider_id) {
-                return Some(self.prefer_proven_archive(
+                return Some(self.prefer_proven_rate(
                     result.with_normalization(),
                     &version_normalized,
                     provider_id,
                 ));
             }
             if let Some(result) = self.prefix_match_models_dev(&version_normalized, provider_id) {
-                return Some(self.prefer_proven_archive(
+                return Some(self.prefer_proven_rate(
                     result.with_normalization(),
                     &version_normalized,
                     provider_id,
@@ -1056,6 +1080,20 @@ impl PricingLookup {
         }
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) = self.exact_match_sakana(&version_normalized) {
+                return Some(result.with_normalization());
+            }
+        }
+
+        // Dead free-preview ids (`ox-alpha`, `x-preview-f-free`) sit at the
+        // same precedence: a live upstream exact row still wins above, while
+        // an unverified reseller guess is displaced by `prefer_proven_rate`
+        // at its own stage. This slot only answers when upstream has nothing
+        // at all (the bare-`ox-alpha` shape).
+        if let Some(result) = self.exact_match_free_preview(model_id) {
+            return Some(result);
+        }
+        if let Some(version_normalized) = normalize_version_separator(model_id) {
+            if let Some(result) = self.exact_match_free_preview(&version_normalized) {
                 return Some(result.with_normalization());
             }
         }
@@ -1490,18 +1528,51 @@ impl PricingLookup {
         None
     }
 
-    /// Prefer a provider-proven archive tariff over an unverified upstream guess.
+    /// Match `model_id` against the free-preview table of published $0
+    /// tariffs, ignoring which gateway routed the request.
+    ///
+    /// Same shape as the Cursor/Sakana built-ins above: an exact hit, plus
+    /// the terminal segment for router-qualified ids real clients emit
+    /// (`stealth/ox-alpha`). Both answer `BuiltIn`, which is submission-safe
+    /// by construction -- the freeness is a property of the preview id, and
+    /// a dead preview's $0 is final.
+    fn exact_match_free_preview(&self, model_id: &str) -> Option<LookupResult> {
+        if let Some(key) = self.free_preview_lower.get(model_id) {
+            return lookup_result_if_usable(
+                self.free_preview.get(key).unwrap(),
+                FREE_PREVIEW_SOURCE,
+                key,
+            )
+            .map(|result| result.with_kind(ResolutionKind::BuiltIn));
+        }
+        if let Some(model_part) = model_id.split('/').next_back() {
+            if model_part != model_id {
+                if let Some(key) = self.free_preview_lower.get(model_part) {
+                    return lookup_result_if_usable(
+                        self.free_preview.get(key).unwrap(),
+                        FREE_PREVIEW_SOURCE,
+                        key,
+                    )
+                    .map(|result| result.with_kind(ResolutionKind::BuiltIn));
+                }
+            }
+        }
+        None
+    }
+
+    /// Prefer a proven first-party rate over an unverified upstream guess.
     ///
     /// Every unverified fallback stage in `lookup_auto` (model-part, alias and
     /// prefix matches) routes through here. Reseller rows
-    /// (`deepinfra/anthropic/...`, `z-ai/...`) match those stages by model
-    /// part while the archive holds the publishing endpoint's own exact
-    /// tariff; letting the guess win prices first-party usage at a third
-    /// party's rate and reports it as unpublishable. Safe upstream rows pass
-    /// through untouched, as does everything when the archive cannot prove
-    /// the endpoint -- so display estimates never change, only their
-    /// publishability when a proven tariff exists.
-    fn prefer_proven_archive(
+    /// (`deepinfra/anthropic/...`, `z-ai/...`, `opencode/x-preview-f-free`)
+    /// match those stages by model part while a compiled-in table holds the
+    /// publishing endpoint's own exact tariff (the archive) or the preview
+    /// id's published $0 (the free-preview table); letting the guess win
+    /// misprices first-party usage and reports it as unpublishable. Safe
+    /// upstream rows pass through untouched, as does everything when neither
+    /// table can prove a rate -- so display estimates never change, only
+    /// their publishability when a proven rate exists.
+    fn prefer_proven_rate(
         &self,
         upstream: LookupResult,
         model_id: &str,
@@ -1510,9 +1581,19 @@ impl PricingLookup {
         if upstream.evidence.is_submission_safe() {
             return upstream;
         }
-        self.exact_match_archive(model_id, provider_id)
+        if let Some(proven) = self
+            .exact_match_archive(model_id, provider_id)
             .filter(|archived| archived.evidence.is_submission_safe())
-            .unwrap_or(upstream)
+        {
+            return proven;
+        }
+        // A free-preview $0 is final for its id rather than endpoint-proven,
+        // so it needs no safety filter: `exact_match_free_preview` only
+        // answers `BuiltIn`, which is submission-safe by construction.
+        if let Some(free) = self.exact_match_free_preview(model_id) {
+            return free;
+        }
+        upstream
     }
 
     /// Match `model_id` against the retirement archive of last-known tariffs.
@@ -2959,6 +3040,15 @@ const ROUTING_LABELS: &[&str] = &["auto", "agent_review"];
 /// to tell "this rate is a snapshot of a model upstream no longer carries" from
 /// "LiteLLM says so today".
 pub(super) const ARCHIVE_SOURCE: &str = "Tokscale Archive";
+
+/// Source label reported for a price served from the free-preview table.
+///
+/// Deliberately distinct from the live dataset labels and from the archive:
+/// `tokscale pricing` and the submission diagnostics print this verbatim, and
+/// a reader has to be able to tell "this id was a published $0 preview" from
+/// "LiteLLM says so today" and from "this rate is a snapshot of a model
+/// upstream no longer carries".
+pub(super) const FREE_PREVIEW_SOURCE: &str = "FreePreview";
 
 pub(crate) fn is_routing_label(model_id: &str) -> bool {
     let lower = model_id.trim().to_lowercase();

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -880,21 +880,7 @@ impl PricingLookup {
             self.exact_match_models_dev_for_provider(model_id, provider_id),
             provider_id,
         ) {
-            // A provider-proven first-party snapshot beats an unverified
-            // guess. Reseller rows (`deepinfra/anthropic/...`) match here by
-            // model part while the archive holds the publishing endpoint's
-            // own exact tariff further down; letting the guess win prices
-            // first-party usage at a third party's rate and reports it as
-            // unpublishable. Safe upstream rows still win untouched.
-            if !result.evidence.is_submission_safe() {
-                let proven = self
-                    .exact_match_archive(model_id, provider_id)
-                    .filter(|archived| archived.evidence.is_submission_safe());
-                if let Some(archived) = proven {
-                    return Some(archived);
-                }
-            }
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
 
         if let Some(result) = exact_litellm {
@@ -918,11 +904,11 @@ impl PricingLookup {
         // matching key falls through to the canonical resolution below.
         if provider_id.is_some() {
             if let Some(result) = self.exact_match_models_dev_for_provider(model_id, provider_id) {
-                return Some(result);
+                return Some(self.prefer_proven_archive(result, model_id, provider_id));
             }
         }
         if let Some(result) = self.exact_match_openrouter_model_part(model_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
 
         // Separator-normalized exact passes against the canonical sources
@@ -940,31 +926,47 @@ impl PricingLookup {
                 self.exact_match_models_dev_for_provider(&version_normalized, provider_id),
                 provider_id,
             ) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
             if provider_id.is_some() {
                 if let Some(result) =
                     self.exact_match_models_dev_for_provider(&version_normalized, provider_id)
                 {
-                    return Some(result.with_normalization());
+                    return Some(self.prefer_proven_archive(
+                        result.with_normalization(),
+                        &version_normalized,
+                        provider_id,
+                    ));
                 }
             }
             if let Some(result) = self.exact_match_litellm(&version_normalized) {
                 return Some(result.with_normalization());
             }
             if let Some(result) = self.exact_match_openrouter(&version_normalized) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
         }
 
         if let Some(result) = self.exact_match_models_dev_with_provider(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) =
                 self.exact_match_models_dev_with_provider(&version_normalized, provider_id)
             {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
         }
 
@@ -975,40 +977,64 @@ impl PricingLookup {
                 self.exact_match_models_dev_for_provider(&normalized, provider_id),
                 provider_id,
             ) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) = self.exact_match_litellm(&normalized) {
                 return Some(result.with_normalization());
             }
             if let Some(result) = self.exact_match_openrouter(&normalized) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) =
                 self.exact_match_models_dev_with_provider(&normalized, provider_id)
             {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &normalized,
+                    provider_id,
+                ));
             }
         }
 
         if let Some(result) = self.prefix_match_litellm(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
         if let Some(result) = self.prefix_match_openrouter(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
         if let Some(result) = self.prefix_match_models_dev(model_id, provider_id) {
-            return Some(result);
+            return Some(self.prefer_proven_archive(result, model_id, provider_id));
         }
 
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) = self.prefix_match_litellm(&version_normalized, provider_id) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) = self.prefix_match_openrouter(&version_normalized, provider_id) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
             if let Some(result) = self.prefix_match_models_dev(&version_normalized, provider_id) {
-                return Some(result.with_normalization());
+                return Some(self.prefer_proven_archive(
+                    result.with_normalization(),
+                    &version_normalized,
+                    provider_id,
+                ));
             }
         }
 
@@ -1462,6 +1488,31 @@ impl PricingLookup {
             }
         }
         None
+    }
+
+    /// Prefer a provider-proven archive tariff over an unverified upstream guess.
+    ///
+    /// Every unverified fallback stage in `lookup_auto` (model-part, alias and
+    /// prefix matches) routes through here. Reseller rows
+    /// (`deepinfra/anthropic/...`, `z-ai/...`) match those stages by model
+    /// part while the archive holds the publishing endpoint's own exact
+    /// tariff; letting the guess win prices first-party usage at a third
+    /// party's rate and reports it as unpublishable. Safe upstream rows pass
+    /// through untouched, as does everything when the archive cannot prove
+    /// the endpoint -- so display estimates never change, only their
+    /// publishability when a proven tariff exists.
+    fn prefer_proven_archive(
+        &self,
+        upstream: LookupResult,
+        model_id: &str,
+        provider_id: Option<&str>,
+    ) -> LookupResult {
+        if upstream.evidence.is_submission_safe() {
+            return upstream;
+        }
+        self.exact_match_archive(model_id, provider_id)
+            .filter(|archived| archived.evidence.is_submission_safe())
+            .unwrap_or(upstream)
     }
 
     /// Match `model_id` against the retirement archive of last-known tariffs.

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -880,6 +880,20 @@ impl PricingLookup {
             self.exact_match_models_dev_for_provider(model_id, provider_id),
             provider_id,
         ) {
+            // A provider-proven first-party snapshot beats an unverified
+            // guess. Reseller rows (`deepinfra/anthropic/...`) match here by
+            // model part while the archive holds the publishing endpoint's
+            // own exact tariff further down; letting the guess win prices
+            // first-party usage at a third party's rate and reports it as
+            // unpublishable. Safe upstream rows still win untouched.
+            if !result.evidence.is_submission_safe() {
+                let proven = self
+                    .exact_match_archive(model_id, provider_id)
+                    .filter(|archived| archived.evidence.is_submission_safe());
+                if let Some(archived) = proven {
+                    return Some(archived);
+                }
+            }
             return Some(result);
         }
 
@@ -1466,17 +1480,21 @@ impl PricingLookup {
             return None;
         }
 
-        // Every archived key is a canonical `claude-{family}-{major}-{minor}`
+        // Every archived key is a canonical `{family}-{major}-{minor}` id
         // under a provider root, so the normalizer the upstream exact passes
-        // already use is the whole matcher. It folds the dated
-        // (`claude-haiku-4-5-20251001`), context-tagged (`claude-opus-4-8[1m]`),
-        // dotted (`claude-haiku-4.5`) and reasoning-tier
-        // (`claude-opus-4-7-thinking-xhigh`) spellings real clients emit, and it
-        // drops any leading provider segment on the way. Comparing the raw id to
-        // the key by equality instead would miss every one of those shapes —
-        // that is, every shape the archive exists to cover.
+        // already use is the whole matcher for the Claude line: it folds the
+        // dated (`claude-haiku-4-5-20251001`), context-tagged
+        // (`claude-opus-4-8[1m]`), dotted (`claude-haiku-4.5`) and
+        // reasoning-tier (`claude-opus-4-7-thinking-xhigh`) spellings real
+        // clients emit, and it drops any leading provider segment on the way.
+        // Comparing the raw id to the key by equality instead would miss
+        // every one of those shapes -- that is, every shape the archive
+        // exists to cover. Ids from other vendors have no normalizer yet and
+        // match verbatim; the provider-qualified gate below still requires
+        // the hint to name the key's publishing endpoint, so a verbatim
+        // match can never elect a neighbouring model.
         let lower = model_id.trim().to_ascii_lowercase();
-        let canonical = normalize_model_name(&lower)?;
+        let canonical = normalize_model_name(&lower).unwrap_or_else(|| lower.clone());
 
         // The id's own leading segment authorises the tariff exactly as a hint
         // does, so `anthropic/claude-opus-4-8` resolves provider-scoped with no

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -94,6 +94,7 @@ impl PricingService {
                 Self::build_sakana_overrides(),
                 models_dev_data,
                 Self::build_archive_overrides(),
+                Self::build_free_preview_overrides(),
             ),
         }
     }
@@ -241,6 +242,52 @@ impl PricingService {
                 ..Default::default()
             },
         );
+        overrides
+    }
+
+    // @keep: published $0 for dead free-preview incarnations. Both ids below
+    // are the August 2026 stealth preview of Z.AI's GLM-5.3-Flash, served free
+    // for a week and then retired: OpenRouter's page states "This model is
+    // free to use" (https://openrouter.ai/stealth/ox-alpha, accessed
+    // 2026-09-03), Z.AI confirms it "tested GLM-5.3-Flash anonymously as
+    // ox-alpha on OpenCode and OpenRouter"
+    // (https://docs.z.ai/guides/vlm/glm-5.3-flash, accessed 2026-09-03), the
+    // Stealth EULA provides access "free of charge"
+    // (https://openrouter.ai/terms/stealth, accessed 2026-09-03), and the Zen
+    // catalog lists `Ox Alpha Free (Unlimited)` at input = 0, output = 0,
+    // cache_read = 0 with status "deprecated". This is a published tariff,
+    // not a guess -- contrast `openai/codex-auto-review`, which has no
+    // published rate anywhere and is deliberately left unpriced.
+    //
+    // Every bucket is an explicit zero (tiers: none exist), so
+    // `quotes_zero_for_every_published_rate` covers any usage shape -- the
+    // same treatment as the documented-free `opencode/nemotron-3-ultra-free`
+    // row. A dead preview's $0 is final: the id can never be billed again,
+    // so these match bare with `BuiltIn` evidence regardless of which
+    // gateway (`command-code`, `hermes`, `nous`, `stealth`, `opencode-zen`)
+    // routed the historical request.
+    //
+    // Non-goals, deliberately: no generic `:free`-suffix rule (a naming
+    // convention is weaker evidence than a per-id published $0; those ids
+    // stay on the `custom-pricing.json` path) and no `ox-alpha-free` row
+    // (seen in the wild but without a citable published tariff).
+    fn build_free_preview_overrides() -> HashMap<String, ModelPricing> {
+        const ZERO: f64 = 0.0;
+        let entries: &[&str] = &["ox-alpha", "x-preview-f-free"];
+
+        let mut overrides = HashMap::with_capacity(entries.len());
+        for model_id in entries {
+            overrides.insert(
+                model_id.to_string(),
+                ModelPricing {
+                    input_cost_per_token: Some(ZERO),
+                    output_cost_per_token: Some(ZERO),
+                    cache_read_input_token_cost: Some(ZERO),
+                    cache_creation_input_token_cost: Some(ZERO),
+                    ..Default::default()
+                },
+            );
+        }
         overrides
     }
 
@@ -836,6 +883,116 @@ mod tests {
         let actual =
             service.calculate_cost_with_provider("claude-opus-4-8", Some("anthropic"), &usage);
         assert!((actual - 36.75).abs() < 1e-9, "unexpected cost: {actual}");
+    }
+
+    /// Dead free-preview incarnations submit at their published $0 from any
+    /// gateway, with no warning: the freeness is a property of the preview
+    /// id, and every usage shape (including cache-write and reasoning) is
+    /// covered by the all-zero row.
+    #[test]
+    fn free_preview_ids_resolve_at_zero_from_any_gateway() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+
+        for (provider, model, expected_key) in [
+            (Some("command-code"), "ox-alpha", "ox-alpha"),
+            (Some("stealth"), "ox-alpha", "ox-alpha"),
+            (Some("nous"), "ox-alpha", "ox-alpha"),
+            (Some("hermes"), "ox-alpha", "ox-alpha"),
+            // Router-qualified ids real clients emit resolve by terminal segment.
+            (Some("stealth"), "stealth/ox-alpha", "ox-alpha"),
+            (Some("nous"), "stealth/ox-alpha", "ox-alpha"),
+            (Some("opencode-zen"), "x-preview-f-free", "x-preview-f-free"),
+            (Some("opencode_zen"), "x-preview-f-free", "x-preview-f-free"),
+            (None, "ox-alpha", "ox-alpha"),
+            (None, "x-preview-f-free", "x-preview-f-free"),
+        ] {
+            let resolved = service
+                .resolve_for_usage_with_provider(model, provider, &all_bucket_usage())
+                .unwrap_or_else(|| panic!("{provider:?}/{model} must resolve the free preview"));
+            assert_eq!(resolved.source, "FreePreview", "id: {model}");
+            assert_eq!(resolved.matched_key, expected_key, "id: {model}");
+            assert!(resolved.evidence.is_submission_safe(), "id: {model}");
+            assert!(
+                service.covers_usage_with_provider(model, provider, &all_bucket_usage()),
+                "id: {model}"
+            );
+            let actual = service.calculate_cost_with_provider(model, provider, &all_bucket_usage());
+            assert_eq!(actual, 0.0, "id: {model}");
+        }
+
+        // Reasoning tokens bill at the output rate, which is an explicit zero.
+        let reasoning_usage = TokenBreakdown {
+            input: 1_000_000,
+            output: 0,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 100_000,
+        };
+        assert!(service.covers_usage_with_provider("ox-alpha", Some("stealth"), &reasoning_usage));
+        assert_eq!(
+            service.calculate_cost_with_provider("ox-alpha", Some("stealth"), &reasoning_usage),
+            0.0
+        );
+    }
+
+    /// An unverified reseller guess for a free-preview id must not shadow its
+    /// published $0: live models.dev keys `opencode/x-preview-f-free`, which
+    /// an `opencode-zen` hint can only match by model part.
+    #[test]
+    fn free_preview_zero_beats_unverified_reseller_guess() {
+        let mut models_dev = HashMap::new();
+        models_dev.insert(
+            "opencode/x-preview-f-free".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(2e-6),
+                output_cost_per_token: Some(8e-6),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new_with_custom_and_models_dev(
+            CustomPricing::default(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        let resolved = service
+            .resolve_for_usage_with_provider(
+                "x-preview-f-free",
+                Some("opencode-zen"),
+                &all_bucket_usage(),
+            )
+            .expect("free preview must resolve");
+        assert_eq!(resolved.source, "FreePreview");
+        assert_eq!(resolved.matched_key, "x-preview-f-free");
+        assert!(resolved.evidence.is_submission_safe());
+        assert!(service.covers_usage_with_provider(
+            "x-preview-f-free",
+            Some("opencode-zen"),
+            &all_bucket_usage()
+        ));
+    }
+
+    /// A live first-party exact row still beats the $0 snapshot: the table
+    /// covers dead previews, never a live tariff dispute.
+    #[test]
+    fn live_upstream_exact_wins_over_free_preview_zero() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "ox-alpha".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(1e-6),
+                output_cost_per_token: Some(2e-6),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(litellm, HashMap::new());
+
+        let resolved = service
+            .resolve_for_usage_with_provider("ox-alpha", Some("stealth"), &all_bucket_usage())
+            .expect("live upstream row must resolve");
+        assert_eq!(resolved.source, "LiteLLM");
+        assert!(resolved.evidence.is_submission_safe());
     }
 
     /// The shared normalizer folds reasoning-effort suffixes, so the archive

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -801,6 +801,43 @@ mod tests {
         );
     }
 
+    /// A reseller row that only matches by model part must not shadow the
+    /// publishing endpoint's own archived tariff.
+    ///
+    /// Live LiteLLM keys this as `deepinfra/anthropic/claude-opus-4-8` -- a
+    /// nested provider segment, not a first-party root -- so an `anthropic`
+    /// hint resolves it as an unverified ModelPart guess while the archive
+    /// holds `anthropic/claude-opus-4-8` exactly. The guess used to win by
+    /// precedence and the usage submitted at $0.00 with a cost-incomplete
+    /// day; the proven row wins now.
+    #[test]
+    fn unsafe_reseller_row_yields_to_proven_archive() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "deepinfra/anthropic/claude-opus-4-8".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(5e-6),
+                output_cost_per_token: Some(2.5e-5),
+                cache_read_input_token_cost: Some(5e-7),
+                cache_creation_input_token_cost: Some(6.25e-6),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(litellm, HashMap::new());
+        let usage = all_bucket_usage();
+
+        let resolved = service
+            .resolve_for_usage_with_provider("claude-opus-4-8", Some("anthropic"), &usage)
+            .expect("proven archive row must resolve");
+        assert_eq!(resolved.source, "Tokscale Archive");
+        assert_eq!(resolved.matched_key, "anthropic/claude-opus-4-8");
+        assert!(resolved.evidence.is_submission_safe());
+        assert!(service.covers_usage_with_provider("claude-opus-4-8", Some("anthropic"), &usage));
+        let actual =
+            service.calculate_cost_with_provider("claude-opus-4-8", Some("anthropic"), &usage);
+        assert!((actual - 36.75).abs() < 1e-9, "unexpected cost: {actual}");
+    }
+
     /// The shared normalizer folds reasoning-effort suffixes, so the archive
     /// needs no suffix stripper of its own.
     #[test]

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -255,7 +255,15 @@ impl PricingService {
     // Stealth EULA provides access "free of charge"
     // (https://openrouter.ai/terms/stealth, accessed 2026-09-03), and the Zen
     // catalog lists `Ox Alpha Free (Unlimited)` at input = 0, output = 0,
-    // cache_read = 0 with status "deprecated". This is a published tariff,
+    // cache_read = 0 with status "deprecated". Upstream models.dev agrees --
+    // its live api.json carries `opencode/x-preview-f-free` and
+    // `opencode-go/ox-alpha-free` at input = 0, output = 0, cache_read = 0,
+    // both deprecated (checked 2026-09-03) -- but neither row is consumable
+    // as-is: sessions spell the gateway `opencode-zen`/`opencode_zen`
+    // against the `opencode` root (an identity gap no alias can prove safe
+    // for paid rows), both rows omit the cache-write bucket (so
+    // cache-write-bearing usage would stay uncovered), and no `ox-alpha` row
+    // exists under any provider at all. This is still a published tariff,
     // not a guess -- contrast `openai/codex-auto-review`, which has no
     // published rate anywhere and is deliberately left unpriced.
     //


### PR DESCRIPTION
`ox-alpha` and `x-preview-f-free` are the August 2026 stealth preview of Z.AI's GLM-5.3-Flash, served free for a week and then retired — high-attention usage that submitted at $0.00 with a cost-incomplete day and a warning per provider/model pair. Both ids carry a published $0 (OpenRouter: "This model is free to use", Z.AI: "tested GLM-5.3-Flash anonymously as ox-alpha on OpenCode and OpenRouter", Stealth EULA: access "free of charge", Zen catalog: `Ox Alpha Free (Unlimited)` at input = 0, output = 0, cache_read = 0, now deprecated), so they submit at $0 with no warning. Depends on #1271 (proven-rate precedence + verbatim archive fallback); merge that first and this shrinks to the free-preview commits. The diff currently also renames #1271's `prefer_proven_archive` helper to `prefer_proven_rate` as it gains the second table — flagging since it touches unmerged code.

Why a compiled-in table when upstream models.dev tracks these (it does — live api.json carries `opencode/x-preview-f-free` and `opencode-go/ox-alpha-free` at $0, both deprecated; tokscale fetches upstream `https://models.dev/api.json` directly, no mirror needed)? Two gaps verified live: sessions spell the gateway `opencode-zen`/`opencode_zen` against the `opencode` root, so the row only ever matches as an unverified cross-provider guess — and proving that identity by folding would widen blast radius to every zen-hinted paid resolution, which needs endpoint-billing equivalence this PR does not claim. And both upstream rows omit the cache-write bucket while the opencode parser always populates it, so write-bearing usage would stay uncovered. No `ox-alpha` row exists under any provider at all (only the `-free`-suffixed sibling), so for that id compiled-in data or `custom-pricing.json` are the only paths. The $0 here is final (deprecated ids), not a guess — contrast `openai/codex-auto-review`, which stays unpriced.

Adds a `free_preview` built-in table (`ox-alpha`, `x-preview-f-free`, every bucket an explicit zero, no tiers) matching bare with `BuiltIn` evidence regardless of gateway, at the Cursor/Sakana precedence slot plus consultation from the proven-rate guard so the live models.dev `opencode/x-preview-f-free` model-part guess cannot shadow it. All-zero rows cover every usage shape via the existing `quotes_zero_for_every_published_rate` rule (same treatment as the documented-free `opencode/nemotron-3-ultra-free` row). A live first-party exact row still beats the $0 snapshot, and `has_upstream_dataset` keeps excluding compiled-in tables. Deliberate non-goals: no generic `:free`-suffix rule (convention is weaker evidence than a per-id published $0; those ids stay on `custom-pricing.json`) and no `ox-alpha-free` row (seen in the wild, no citable tariff).

## What's Changed
* feat(pricing): price dead free-preview models at published zero

## Verification
* `cargo fmt --all -- --check`
* `cargo clippy --locked --workspace --all-features -- -D warnings`
* `cargo test --locked -p tokscale-core --lib` (2048 passed, including `free_preview_ids_resolve_at_zero_from_any_gateway` across all gateways in the motivating report plus router-qualified `stealth/ox-alpha`, `free_preview_zero_beats_unverified_reseller_guess` against a paid reseller fixture, and `live_upstream_exact_wins_over_free_preview_zero` pinning live-beats-snapshot)
* `cargo test -p tokscale-cli --test cli_tests test_submit_free_preview_models_upload_without_warnings` (opencode fixtures for both ids submit in dry-run with zero `unpriced` output and counted tokens)
* Live-dataset probe before the change (`ox-alpha` unresolvable, `x-preview-f-free` unverified model-part guess; probe script removed after use)
