### PR TITLE
fix(pricing): resolve stealth preview shorthands to canonical upstream keys

### DIFF
--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -5096,6 +5096,101 @@ fn test_submit_includes_unpriced_usage_at_zero_and_keeps_the_rest() {
     );
 }
 
+/// Stealth preview shorthands (`ox-alpha`, `x-preview-f-free`) resolve to
+/// their canonical upstream $0 rows, so they submit with the priced usage:
+/// no per-row warning, no aggregate line, no fix hint.
+#[test]
+fn test_submit_stealth_preview_shorthands_upload_without_warnings() {
+    let tmp = create_temp_fixture_dir();
+    // Mirror the live models.dev rows (both deprecated $0, no cache-write
+    // bucket). The shorthand ids below only resolve through them.
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_secs();
+    let priced_payload = format!(
+        r#"{{"timestamp":{},"data":{{"gpt-4o":{{"input_cost_per_token":0.0000025,"output_cost_per_token":0.00001}}}}}}"#,
+        now
+    );
+    let models_dev_payload = format!(
+        r#"{{"timestamp":{},"data":{{"opencode-go/ox-alpha-free":{{"input_cost_per_token":0.0,"output_cost_per_token":0.0,"cache_read_input_token_cost":0.0}},"opencode/x-preview-f-free":{{"input_cost_per_token":0.0,"output_cost_per_token":0.0,"cache_read_input_token_cost":0.0}}}}}}"#,
+        now
+    );
+    write_canonical_pricing_cache_files(
+        tmp.path(),
+        &priced_payload,
+        &priced_payload,
+        &models_dev_payload,
+    );
+    write_fake_credentials(tmp.path());
+    let preview_dir = tmp
+        .path()
+        .join(".local/share/opencode/storage/message/stealth-preview");
+    fs::create_dir_all(&preview_dir).unwrap();
+    for (file, id, session, provider, model_id) in [
+        (
+            "ox.json",
+            "ox",
+            "stealth-preview-ox",
+            "stealth",
+            "stealth/ox-alpha",
+        ),
+        (
+            "xpreview.json",
+            "xpreview",
+            "stealth-preview-x",
+            "opencode-zen",
+            "x-preview-f-free",
+        ),
+    ] {
+        fs::write(
+            preview_dir.join(file),
+            format!(
+                r#"{{
+            "id": "{id}",
+            "sessionID": "{session}",
+            "role": "assistant",
+            "modelID": "{model_id}",
+            "providerID": "{provider}",
+            "cost": 0,
+            "tokens": {{ "input": 1000, "output": 500, "reasoning": 0, "cache": {{ "read": 0, "write": 0 }} }},
+            "time": {{ "created": 1736510400000.0 }}
+        }}"#,
+            ),
+        )
+        .unwrap();
+    }
+
+    let output = offline_cmd_with_home(tmp.path())
+        .args([
+            "--no-spinner",
+            "submit",
+            "--client",
+            "opencode",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "shorthand preview usage must submit cleanly; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("unpriced"),
+        "upstream-$0 usage must not warn: {stdout}"
+    );
+    assert!(
+        !stdout.contains("custom-pricing.json"),
+        "no fix hint for priced usage: {stdout}"
+    );
+    assert!(
+        stdout.contains("Total tokens: 6,950"),
+        "both preview models (3,000 tokens) must be counted on top of the 3,950-token stock fixture: {stdout}"
+    );
+}
+
 /// Regression: a cold cache with no network must not look like "no usage".
 ///
 /// Every fetchable upstream is unreachable here and nothing is cached, so the

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -177,6 +177,26 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("openai/gpt-daybreak-blue-latest", "gpt-5.6-sol");
     m.insert("openai/daybreak-blue-latest", "gpt-5.6-sol");
 
+    // Stealth preview shorthands for the August 2026 Z.AI GLM-5.3-Flash free
+    // preview. Sessions record the bare `ox-alpha` (and the router-qualified
+    // `stealth/ox-alpha` gateways emit), while upstream models.dev tracks the
+    // canonical free incarnations `opencode-go/ox-alpha-free` and
+    // `opencode/x-preview-f-free` at $0.00 (both deprecated). Pin the
+    // shorthand spellings to those canonical keys -- the same "canonical
+    // first-party key" pattern as `minimax-m3` above -- so the live upstream
+    // $0 row prices them instead of an unverified reseller guess. The
+    // qualified `stealth/` form must be explicit because provider-prefix
+    // stripping does not run alias resolution a second time.
+    // Sources (accessed 2026-09-03):
+    // https://openrouter.ai/stealth/ox-alpha ("free to use", ZAI reveal)
+    // https://docs.z.ai/guides/vlm/glm-5.3-flash ("tested anonymously as ox-alpha")
+    // https://models.dev/api.json (providers.opencode.models.x-preview-f-free
+    // and providers.opencode-go.models.ox-alpha-free at input = 0,
+    // output = 0, cache_read = 0, both deprecated)
+    m.insert("ox-alpha", "opencode-go/ox-alpha-free");
+    m.insert("stealth/ox-alpha", "opencode-go/ox-alpha-free");
+    m.insert("x-preview-f-free", "opencode/x-preview-f-free");
+
     // Synthetic model variants (only where resolver needs help)
     m.insert("kimi-k2.5-nvfp4", "kimi-k2.5"); // Quantization variant → base model pricing
     m.insert("kimi-k2-instruct-0905", "kimi-k2.5"); // Specific version → base (avoids reseller)
@@ -365,6 +385,107 @@ mod tests {
             resolve_alias("openai/gpt-daybreak-blue-latest"),
             Some("gpt-5.6-sol")
         );
+    }
+
+    #[test]
+    fn resolves_stealth_preview_shorthands_to_canonical_upstream_keys() {
+        assert_eq!(resolve_alias("ox-alpha"), Some("opencode-go/ox-alpha-free"));
+        assert_eq!(resolve_alias("OX-ALPHA"), Some("opencode-go/ox-alpha-free"));
+        // The qualified form must be explicit because provider-prefix
+        // stripping does not run alias resolution a second time.
+        assert_eq!(
+            resolve_alias("stealth/ox-alpha"),
+            Some("opencode-go/ox-alpha-free")
+        );
+        assert_eq!(
+            resolve_alias("x-preview-f-free"),
+            Some("opencode/x-preview-f-free")
+        );
+        assert_eq!(
+            resolve_alias("X-PREVIEW-F-FREE"),
+            Some("opencode/x-preview-f-free")
+        );
+    }
+
+    #[test]
+    fn stealth_preview_shorthands_use_the_upstream_zero_row() {
+        fn zero_row() -> super::super::litellm::ModelPricing {
+            super::super::litellm::ModelPricing {
+                input_cost_per_token: Some(0.0),
+                output_cost_per_token: Some(0.0),
+                cache_read_input_token_cost: Some(0.0),
+                ..Default::default()
+            }
+        }
+
+        // Mirrors the live models.dev rows (both deprecated $0, no
+        // cache-write bucket published).
+        let service = super::super::PricingService::new_with_custom_and_models_dev(
+            super::super::custom::CustomPricing::default(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([
+                ("opencode-go/ox-alpha-free".to_string(), zero_row()),
+                ("opencode/x-preview-f-free".to_string(), zero_row()),
+            ]),
+        );
+        // Cache-write-bearing: the all-zero row covers every shape, so even
+        // usage the upstream row's buckets cannot describe stays priced.
+        let usage = crate::TokenBreakdown {
+            input: 1_000_000,
+            output: 100_000,
+            cache_read: 50_000,
+            cache_write: 10_000,
+            reasoning: 5_000,
+        };
+
+        for (provider, model, expected_key) in [
+            (
+                Some("command-code"),
+                "ox-alpha",
+                "opencode-go/ox-alpha-free",
+            ),
+            (Some("stealth"), "ox-alpha", "opencode-go/ox-alpha-free"),
+            (
+                Some("nous"),
+                "stealth/ox-alpha",
+                "opencode-go/ox-alpha-free",
+            ),
+            (
+                Some("hermes"),
+                "stealth/ox-alpha",
+                "opencode-go/ox-alpha-free",
+            ),
+            (
+                Some("opencode-zen"),
+                "x-preview-f-free",
+                "opencode/x-preview-f-free",
+            ),
+            (
+                Some("opencode_zen"),
+                "x-preview-f-free",
+                "opencode/x-preview-f-free",
+            ),
+        ] {
+            let resolved = service
+                .resolve_for_usage_with_provider(model, provider, &usage)
+                .unwrap_or_else(|| {
+                    panic!("{provider:?}/{model} must resolve the canonical zero row")
+                });
+            assert_eq!(resolved.source, "Models.dev", "id: {model}");
+            assert_eq!(resolved.matched_key, expected_key, "id: {model}");
+            assert!(resolved.evidence.alias_applied, "id: {model}");
+            assert!(resolved.evidence.is_submission_safe(), "id: {model}");
+            assert!(
+                service.covers_usage_with_provider(model, provider, &usage),
+                "id: {model}"
+            );
+            assert_eq!(
+                service.calculate_cost_with_provider(model, provider, &usage),
+                0.0,
+                "id: {model}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Sessions record the August 2026 stealth preview as the bare `ox-alpha` (and the router-qualified `stealth/ox-alpha` gateways emit), while upstream models.dev tracks the canonical free incarnations `opencode-go/ox-alpha-free` and `opencode/x-preview-f-free` at $0.00, both deprecated. The shorthand spellings matched nothing (or an unverified reseller guess), so high-attention free usage submitted at $0.00 with a cost-incomplete day and a warning per provider/model pair.

Pin the shorthand spellings to those canonical keys — the same "canonical first-party key" pattern as the existing `minimax-m3` alias — so the live upstream $0 row prices them: `ox-alpha` and `stealth/ox-alpha` to `opencode-go/ox-alpha-free`, `x-preview-f-free` to `opencode/x-preview-f-free`. The qualified `stealth/` form is explicit because provider-prefix stripping does not run alias resolution a second time. No compiled-in prices, no new lookup tables: the full-key exact upstream hit is submission-safe regardless of which gateway hinted it, the all-zero row covers every usage shape via the existing zero-row rule, and future upstream changes flow through automatically. Verified live that the canonical pairs already resolve exact/Models.dev/safe/covers with cache-write-bearing usage.

## What's Changed
* fix(pricing): resolve stealth preview shorthands to canonical upstream keys

## Verification
* `cargo fmt --all -- --check`
* `cargo clippy --locked --workspace --all-features -- -D warnings`
* `cargo test --locked -p tokscale-core --lib` (2046 passed, including new `resolves_stealth_preview_shorthands_to_canonical_upstream_keys` and `stealth_preview_shorthands_use_the_upstream_zero_row` across every gateway in the motivating report, asserting Models.dev source, alias provenance, safety, full-bucket coverage and $0.00 cost)
* `cargo test -p tokscale-cli --test cli_tests test_submit_stealth_preview_shorthands_upload_without_warnings` (opencode fixtures for both shorthands submit in dry-run with zero `unpriced` output and counted tokens, against a primed models.dev cache mirroring the live rows)

Supersedes #1276, which hardcoded the same $0 in a compiled-in table — withdrawn in favor of consuming the live upstream rows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves stealth preview model shorthands (`ox-alpha`, `x-preview-f-free`) to their canonical upstream $0 rows so free usage submits without warnings or cost-incomplete days.

- Maps `ox-alpha`, `stealth/ox-alpha`, and `openrouter/stealth/ox-alpha` to `opencode-go/ox-alpha-free`, and `x-preview-f-free` to `opencode/x-preview-f-free`.
- Uses the existing live upstream pricing; no compiled-in prices or new lookup tables.
- Adds CLI and core tests covering all gateways from the motivating report.

<sup>Written for commit a0fb31b52bf0fbea7fa8504e66c9b7b5bf922433. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

