### PR TITLE
fix(antigravity): stop dropping a language server slower than 400ms

### DIFF
--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -2208,15 +2208,15 @@ fn https_rpc_request(
         // context entered (#1264): the TUI usage refresh and `tokscale
         // usage` reach this function while `has_credentials`'s own
         // current-thread runtime is mid-`block_on`, because
-        // `discover_port` probes the IDE's language server
-        // synchronously. A dedicated OS thread never carries a runtime
-        // context, so the nested-runtime panic is structurally
-        // impossible for every caller; the scope (not
-        // `std::thread::spawn`) is what lets the request keep borrowing
-        // `connection`/`method`/`body`. The ~microsecond spawn cost is
-        // irrelevant next to a loopback RPC with a 10s timeout, and a
-        // worker panic now degrades to `Err` instead of unwinding into
-        // whatever thread called us.
+        // `discover_quota` reaches the IDE's language server through
+        // `detect_antigravity_connections`, which is synchronous. A
+        // dedicated OS thread never carries a runtime context, so the
+        // nested-runtime panic is structurally impossible for every
+        // caller; the scope (not `std::thread::spawn`) is what lets the
+        // request keep borrowing `connection`/`method`/`body`. The
+        // ~microsecond spawn cost is irrelevant next to a loopback RPC
+        // with a 10s timeout, and a worker panic now degrades to `Err`
+        // instead of unwinding into whatever thread called us.
         let joined: std::result::Result<Result<Value>, Box<dyn std::any::Any + Send>> =
             std::thread::scope(|scope| {
                 scope

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -73,25 +73,24 @@ const RPC_PATH: &str = "/exa.language_server_pb.LanguageServerService/RetrieveUs
 /// rounds sits well inside the 12s-30s the cloud-backed providers here allow
 /// themselves, and leaves a healthy loopback answer -- milliseconds when idle,
 /// low seconds on a loaded machine -- several times the room it needs.
+///
+/// This is also how long a round waits for a *better-ranked* candidate once it
+/// holds an answer from a worse one. [`ports_from_cli_log`] yields candidates
+/// newest first, because the last port the log names is the current server,
+/// and an older entry can still be answered by a stale `agy` left over from a
+/// restart or an account switch, whose quota is another account's or nobody's
+/// (signed out, which parses fine and reports as "not signed in"). So a round
+/// keeps the best-ranked answer it has seen and returns the moment nothing
+/// better can still arrive. What it is waiting on until then is the current
+/// server -- the server this budget was sized for -- so there is no shorter
+/// grace for that wait. An earlier revision cut it at 2s from the first answer,
+/// which contradicted the premise above: a current server answering in 2-5s on
+/// a loaded machine lost to a stale sibling that answered at once. The cost of
+/// a single bound is confined to a newest logged port that accepts and then
+/// goes quiet while an older one still answers: that round runs to its
+/// deadline before believing the older answer, which is the worst case one
+/// stalled candidate already costs.
 const DISCOVERY_ROUND_TIMEOUT: Duration = Duration::from_secs(5);
-
-/// How long an answer already in hand waits for a better-ranked one.
-///
-/// [`ports_from_cli_log`] yields candidates newest first, because the last
-/// port the log names is the current one. An older entry can still be answered
-/// by a stale `agy` left over from a restart or an account switch, whose quota
-/// is another account's or nobody's (signed out, which parses fine and reports
-/// as "not signed in"). Resolving a round by completion order throws that
-/// preference away, and healthy candidates finish microseconds apart, so which
-/// one lands first is scheduling noise.
-///
-/// So a round keeps the best-ranked answer it has seen and returns as soon as
-/// nothing better can still arrive. This is how long it waits when something
-/// better is merely slow. Only reachable when a preferred candidate has
-/// neither answered nor refused -- it accepted and went quiet -- and it never
-/// costs a summary: what waits is which server is believed, not whether one is
-/// found.
-const PREFERENCE_GRACE: Duration = Duration::from_secs(2);
 
 // ── Wire format ──
 
@@ -289,9 +288,6 @@ const MAX_QUOTA_BODY_BYTES: usize = 1024 * 1024;
 /// Built only once a round has a candidate to send to -- see
 /// [`race_for_quota`], which returns before reaching here on an empty list.
 fn quota_client() -> Result<reqwest::Client> {
-    #[cfg(test)]
-    QUOTA_CLIENTS_BUILT.with(|built| built.set(built.get() + 1));
-
     // `.no_proxy()` because this only ever targets 127.0.0.1: the default
     // builder honours HTTP_PROXY/system proxy settings, which would send a
     // loopback quota request to a remote host unless the user happens to have
@@ -322,24 +318,6 @@ fn quota_client() -> Result<reqwest::Client> {
         // that keeps a `call_rpc` awaited on its own from being unbounded.
         .timeout(DISCOVERY_ROUND_TIMEOUT)
         .build()?)
-}
-
-#[cfg(test)]
-thread_local! {
-    /// Clients built by [`quota_client`] on this thread.
-    ///
-    /// Compiled out of the shipped binary. It exists because "a source with no
-    /// candidates builds no client" has no other observable: the regression it
-    /// guards was a client built before discovery knew whether it had anywhere
-    /// to send, and the only symptom was time.
-    ///
-    /// Per thread rather than process-wide because a sibling test runs its own
-    /// discovery on its own thread at the same time, and a process-wide count
-    /// made this an assertion about the whole test binary's scheduling.
-    /// [`race_for_quota`] calls `quota_client` from the thread that drives it,
-    /// before it spawns anything, so a thread-local sees exactly the builds
-    /// its own test caused.
-    static QUOTA_CLIENTS_BUILT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 async fn call_rpc(client: reqwest::Client, port: u16) -> Result<QuotaSummary> {
@@ -423,18 +401,34 @@ fn detected_ports() -> Vec<u16> {
 ///
 /// "Best" is by position rather than by who finishes first: `ports` arrives
 /// newest first and the newest is the one the log calls current. The round
-/// returns the moment nothing better can still arrive, and waits at most
-/// [`PREFERENCE_GRACE`] for something better that is merely slow.
+/// returns the moment nothing better can still arrive, and until then waits
+/// for a better-ranked candidate exactly as long as it waits for any --
+/// [`DISCOVERY_ROUND_TIMEOUT`] says why that is one bound and not two.
 ///
 /// An empty `ports` returns before building anything, which is what keeps a
 /// machine with no Antigravity from paying for a client it has nothing to
 /// send to.
 async fn race_for_quota(ports: Vec<u16>) -> Option<QuotaSummary> {
+    race_for_quota_with(ports, &quota_client).await
+}
+
+/// [`race_for_quota`] with the client build handed in.
+///
+/// Separate so a test can count the builds one call causes from that call:
+/// whether an empty round builds a client has no other observable -- the
+/// regression it guards was a client built before discovery knew whether it
+/// had anywhere to send, and the only symptom was time. A count kept inside
+/// `quota_client` instead is fed by every round in the process, on every
+/// thread, and puts a `#[cfg(test)]` hook in shipped code.
+async fn race_for_quota_with(
+    ports: Vec<u16>,
+    build_client: &dyn Fn() -> Result<reqwest::Client>,
+) -> Option<QuotaSummary> {
     if ports.is_empty() {
         return None;
     }
 
-    let client = quota_client().ok()?;
+    let client = build_client().ok()?;
     let deadline = tokio::time::Instant::now() + DISCOVERY_ROUND_TIMEOUT;
     let mut settled = vec![false; ports.len()];
     let mut requests = tokio::task::JoinSet::new();
@@ -444,13 +438,12 @@ async fn race_for_quota(ports: Vec<u16>) -> Option<QuotaSummary> {
     }
 
     let mut best: Option<(usize, QuotaSummary)> = None;
-    let mut until = deadline;
 
-    while let Ok(Some(joined)) = tokio::time::timeout_at(until, requests.join_next()).await {
+    while let Ok(Some(joined)) = tokio::time::timeout_at(deadline, requests.join_next()).await {
         // A `JoinError` carries no rank, so a panicked request cannot be
-        // marked settled and the round runs to `until` instead of returning
-        // early. `call_rpc` reports every failure it has as `Err`, so this is
-        // the unreachable arm rather than the failure path.
+        // marked settled and the round runs to its deadline instead of
+        // returning early. `call_rpc` reports every failure it has as `Err`,
+        // so this is the unreachable arm rather than the failure path.
         let Ok((rank, answer)) = joined else { continue };
         settled[rank] = true;
         if let Some(summary) = answer {
@@ -464,9 +457,6 @@ async fn race_for_quota(ports: Vec<u16>) -> Option<QuotaSummary> {
         if settled[..*kept].iter().all(|done| *done) {
             break;
         }
-        // `min` rather than assignment: the grace starts at the first answer
-        // and is never extended by a later one.
-        until = until.min(tokio::time::Instant::now() + PREFERENCE_GRACE);
     }
 
     best.map(|(_, summary)| summary)
@@ -755,11 +745,11 @@ mod tests {
     /// deadline, the two black holes would hold all of it and the language
     /// server listed behind them would never be reached.
     ///
-    /// The server is ranked last on purpose, so each call also pays
-    /// `PREFERENCE_GRACE` waiting to see whether either stalled candidate --
-    /// both of which outrank it -- turns out to be merely slow. That wait is
-    /// the cost of not attributing quota to a stale server, and it is what
-    /// makes this test take seconds rather than milliseconds.
+    /// The server is ranked last on purpose, so each call also pays the whole
+    /// `DISCOVERY_ROUND_TIMEOUT` waiting to see whether either stalled
+    /// candidate -- both of which outrank it -- turns out to be merely slow.
+    /// That wait is the cost of not attributing quota to a stale server, and it
+    /// is what makes this test take seconds rather than milliseconds.
     #[test]
     #[serial]
     fn a_stalled_candidate_does_not_hide_the_language_server_behind_it() {
@@ -805,15 +795,24 @@ mod tests {
     ///
     /// The ordering here is a handshake rather than a delay race: the newer
     /// server does not answer until the older one has been asked, so "the
-    /// older finished first" holds however loaded the machine is. The 250ms
-    /// after that is slack for the older answer to reach the client, and the
-    /// newer then has `PREFERENCE_GRACE` -- eight times as long -- to overtake
-    /// it.
+    /// older finished first" holds however loaded the machine is. What follows
+    /// the handshake is a delay only the round budget covers. An earlier
+    /// revision stopped waiting for a better-ranked candidate 2s after the
+    /// first answer, and with that grace in place this test reports the stale
+    /// server: the current one answered inside the round and still lost.
+    ///
+    /// Two bounds again, as in the #1280 test above: the delay is a floor on
+    /// how late the newer answer is, and load can only make it later, which
+    /// is the direction the assertion wants -- but `DISCOVERY_ROUND_TIMEOUT` is
+    /// the ceiling it has to stay under, with 2s to spare.
     #[test]
     #[serial]
     fn the_newest_logged_port_wins_even_when_an_older_one_answers_first() {
         const OLDER_QUOTA: &str =
             r#"{"response":{"groups":[{"displayName":"Stale Server","buckets":[]}]}}"#;
+        // Past the 2s an earlier revision granted preference, so a grace that
+        // short fails this; a fifth of the round short of its deadline.
+        const NEWER_DELAY: Duration = Duration::from_secs(3);
 
         let (asked_older, older_was_asked) = std::sync::mpsc::channel::<()>();
         let (older_base, _older_seen) = spawn_server(move |_path, _calls| {
@@ -825,7 +824,7 @@ mod tests {
             // was never reached, in which case the test has nothing to say and
             // should fail rather than hang.
             let _ = older_was_asked.recv_timeout(Duration::from_secs(30));
-            std::thread::sleep(Duration::from_millis(250));
+            std::thread::sleep(NEWER_DELAY);
             (200, FIXTURE_QUOTA.to_string())
         });
 
@@ -913,6 +912,11 @@ mod tests {
     /// it on every `tokscale usage`, in the sequential pre-flight loop rather
     /// than the fan-out. The second half of this test is what stops the first
     /// half from passing vacuously.
+    ///
+    /// The count is kept by the builder this test hands in, so it holds exactly
+    /// the builds these two calls caused: no other round, on this thread or
+    /// any other, can reach it. Nothing here is `#[serial]` and nothing needs
+    /// to be.
     #[test]
     fn a_round_with_no_candidates_builds_no_client() {
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -920,21 +924,28 @@ mod tests {
             .build()
             .unwrap();
 
-        let before = QUOTA_CLIENTS_BUILT.with(std::cell::Cell::get);
-        assert!(runtime.block_on(race_for_quota(Vec::new())).is_none());
+        let builds = std::cell::Cell::new(0usize);
+        let counted_client = || {
+            builds.set(builds.get() + 1);
+            quota_client()
+        };
+
+        assert!(runtime
+            .block_on(race_for_quota_with(Vec::new(), &counted_client))
+            .is_none());
         assert_eq!(
-            QUOTA_CLIENTS_BUILT.with(std::cell::Cell::get),
-            before,
+            builds.get(),
+            0,
             "an empty candidate list must return before building anything"
         );
 
         let (base, _seen) = spawn_server(|_path, _calls| (200, FIXTURE_QUOTA.to_string()));
         assert!(runtime
-            .block_on(race_for_quota(vec![port_of(&base)]))
+            .block_on(race_for_quota_with(vec![port_of(&base)], &counted_client))
             .is_some());
         assert_eq!(
-            QUOTA_CLIENTS_BUILT.with(std::cell::Cell::get),
-            before + 1,
+            builds.get(),
+            1,
             "one candidate builds exactly one client, which is what makes the count \
              above meaningful"
         );

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -42,10 +42,56 @@ use super::{UsageAccount, UsageMetric, UsageOutput};
 const PROVIDER: &str = "Antigravity";
 const RPC_PATH: &str = "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary";
 
-/// The loopback call itself answers in a few milliseconds. This bound only
-/// matters when a candidate port belongs to some unrelated process that
-/// accepts the connection and then goes quiet.
-const PROBE_TIMEOUT: Duration = Duration::from_millis(400);
+/// Deadline for one round of candidate requests.
+///
+/// What this replaces was 400ms *per candidate*, applied to a full quota
+/// request. It read as a probe bound, but it was also the only gate on
+/// availability: [`has_credentials`] reports a language server as present
+/// exactly when one answers a quota summary, and `usage/mod.rs` drops a
+/// provider from the report before any fetch runs when it does not. A language
+/// server on a loaded machine pushes a loopback round trip well past 400ms, so
+/// the bound written to abandon *wrong* ports was abandoning the right one
+/// (#1280).
+///
+/// Asking the candidates together is what makes the longer bound affordable. A
+/// port nothing is listening on refuses the connection outright, so a machine
+/// without Antigravity never approaches this, and a port that accepts and then
+/// goes quiet is waited on once for the round rather than once per candidate.
+///
+/// A *round*, not the whole of discovery. [`discover_quota`] has two candidate
+/// sources and each gets its own round, computed when that round starts, so
+/// the requests can cost twice this in total. One instant shared across both
+/// was worse than that arithmetic: a first source that spent it handed the
+/// second an expired deadline, and `tokio::time::timeout_at` resolves an
+/// expired deadline by polling once and dropping the task set, so the second
+/// source's requests were abandoned before a socket was opened. Neither round
+/// covers [`crate::antigravity::detect_antigravity_connections`], which is
+/// synchronous and carries per-socket timeouts of its own.
+///
+/// Bounded at all because usage providers share a fan-out: whatever this
+/// spends is spent by the whole `tokscale usage` report. 10s across both
+/// rounds sits well inside the 12s-30s the cloud-backed providers here allow
+/// themselves, and leaves a healthy loopback answer -- milliseconds when idle,
+/// low seconds on a loaded machine -- several times the room it needs.
+const DISCOVERY_ROUND_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How long an answer already in hand waits for a better-ranked one.
+///
+/// [`ports_from_cli_log`] yields candidates newest first, because the last
+/// port the log names is the current one. An older entry can still be answered
+/// by a stale `agy` left over from a restart or an account switch, whose quota
+/// is another account's or nobody's (signed out, which parses fine and reports
+/// as "not signed in"). Resolving a round by completion order throws that
+/// preference away, and healthy candidates finish microseconds apart, so which
+/// one lands first is scheduling noise.
+///
+/// So a round keeps the best-ranked answer it has seen and returns as soon as
+/// nothing better can still arrive. This is how long it waits when something
+/// better is merely slow. Only reachable when a preferred candidate has
+/// neither answered nor refused -- it accepted and went quiet -- and it never
+/// costs a summary: what waits is which server is believed, not whether one is
+/// found.
+const PREFERENCE_GRACE: Duration = Duration::from_secs(2);
 
 // ── Wire format ──
 
@@ -90,7 +136,14 @@ struct QuotaBucket {
 /// keeps its token inside the running process: "is it installed" and "can we
 /// read quota" are different questions, and only the second one should put a
 /// card on screen. The probe is a loopback request against a port read out of
-/// the CLI log, so it costs a few milliseconds.
+/// the CLI log, so on a machine that has one it costs a few milliseconds. A
+/// machine with neither a logged port nor an Antigravity process sends no
+/// request at all and builds no HTTP client: what it pays is the log read and
+/// the process scan.
+///
+/// This runs the same [`discover_quota`] the fetch runs, so the two cannot
+/// disagree about whether a server is answering: a summary that clears this
+/// gate is a summary the fetch can also obtain.
 pub fn has_credentials() -> bool {
     off_caller_runtime(|| {
         let Ok(rt) = tokio::runtime::Builder::new_current_thread()
@@ -99,7 +152,7 @@ pub fn has_credentials() -> bool {
         else {
             return false;
         };
-        rt.block_on(async { discover_port().await.is_some() })
+        rt.block_on(async { discover_quota().await.is_some() })
     })
     .unwrap_or(false)
 }
@@ -111,10 +164,9 @@ pub fn fetch_all() -> Result<Vec<UsageOutput>> {
             .build()?;
 
         rt.block_on(async {
-            let port = discover_port()
+            let summary = discover_quota()
                 .await
                 .context("Antigravity language server is not running")?;
-            let summary = call_rpc(port).await?;
 
             if summary.groups.is_empty() {
                 anyhow::bail!("Antigravity is running but not signed in");
@@ -138,7 +190,7 @@ pub fn fetch_all() -> Result<Vec<UsageOutput>> {
 /// impossible for whatever entry point is added next. The scope joins before
 /// returning, so both entry points stay as synchronous as they were.
 /// `crate::antigravity::https_rpc_request` isolates its own `block_on` the
-/// same way, and that one is reachable today: `discover_port` walks into it
+/// same way, and that one is reachable today: [`detected_ports`] walks into it
 /// synchronously from inside the runtime `has_credentials` just entered.
 fn off_caller_runtime<T: Send>(work: impl FnOnce() -> T + Send) -> std::thread::Result<T> {
     std::thread::scope(|scope| scope.spawn(work).join())
@@ -215,35 +267,82 @@ fn metric(bucket: QuotaBucket) -> Option<UsageMetric> {
 
 /// Byte ceiling for one quota response.
 ///
-/// `PROBE_TIMEOUT` bounds how long the language server may take, not how much
-/// it may send inside that window, and `Response::json` buffers the whole body
-/// before anything looks at it. Port discovery probes candidate ports, so this
-/// also runs against whatever else happens to be listening on loopback -- a
-/// port that answers with an endless stream would otherwise allocate until the
-/// timeout, and usage providers share a fan-out, so that takes the whole
-/// `tokscale usage` report down rather than one provider.
+/// [`DISCOVERY_ROUND_TIMEOUT`] bounds how long the language server may take,
+/// not how much it may send inside that window, and the body is buffered whole
+/// before anything looks at it. Discovery asks candidate ports, so this runs
+/// against whatever else happens to be listening on loopback -- a port that
+/// answers with an endless stream would otherwise allocate until the timeout,
+/// and usage providers share a fan-out, so that takes the whole `tokscale
+/// usage` report down rather than one provider.
 ///
 /// A real summary is a handful of bucket objects well under a kilobyte; 1 MiB
 /// leaves room for new fields while keeping the worst case bounded.
 const MAX_QUOTA_BODY_BYTES: usize = 1024 * 1024;
 
-async fn call_rpc(port: u16) -> Result<QuotaSummary> {
+/// The client every candidate request in a round shares.
+///
+/// One per round rather than one per request, because `ClientBuilder::build`
+/// is synchronous and would otherwise serialise the requests the round exists
+/// to overlap. `reqwest::Client` is internally reference counted, so handing a
+/// clone to each request is free.
+///
+/// Built only once a round has a candidate to send to -- see
+/// [`race_for_quota`], which returns before reaching here on an empty list.
+fn quota_client() -> Result<reqwest::Client> {
+    #[cfg(test)]
+    QUOTA_CLIENTS_BUILT.with(|built| built.set(built.get() + 1));
+
     // `.no_proxy()` because this only ever targets 127.0.0.1: the default
     // builder honours HTTP_PROXY/system proxy settings, which would send a
     // loopback quota request to a remote host unless the user happens to have
     // a matching NO_PROXY. That both leaks quota metadata and lets the proxy
     // forge the unauthenticated response that port discovery trusts. The IDE
     // RPC client in `crate::antigravity` is built the same way.
-    let client = tokscale_core::http::client_builder()
+    Ok(tokscale_core::http::client_builder()
         .no_proxy()
         // Redirects are refused for the same reason the proxy is: discovery
-        // probes ports that may belong to anything, and reqwest follows up to
-        // ten redirects by default. A stale or hostile local listener answering
-        // 307 with an external URL would carry the request off loopback, and
-        // the remote answer would then be accepted as a quota summary.
+        // asks ports that may belong to anything, and reqwest follows up to ten
+        // redirects by default. A stale or hostile local listener answering 307
+        // with an external URL would carry the request off loopback, and the
+        // remote answer would then be accepted as a quota summary.
         .redirect(reqwest::redirect::Policy::none())
-        .timeout(PROBE_TIMEOUT)
-        .build()?;
+        // No trust store. Every request this client sends is
+        // `http://127.0.0.1:<port>` -- there is no certificate to check, and
+        // the redirect that could carry it to https is refused above. Loading
+        // the platform roots anyway is neither free nor cached: reqwest
+        // 0.12.28 calls `rustls_native_certs::load_native_certs()` inside
+        // every `build()`, measured here at 148-221ms per build with the sixth
+        // costing as much as the first, against 4-19us with this off. That was
+        // latency the whole report paid, because `has_credentials` runs on
+        // `usage/mod.rs`'s sequential pre-flight loop rather than in its
+        // fan-out.
+        .tls_built_in_native_certs(false)
+        // The round is what bounds discovery in practice, since it abandons
+        // every request still in flight at its deadline. This is the backstop
+        // that keeps a `call_rpc` awaited on its own from being unbounded.
+        .timeout(DISCOVERY_ROUND_TIMEOUT)
+        .build()?)
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Clients built by [`quota_client`] on this thread.
+    ///
+    /// Compiled out of the shipped binary. It exists because "a source with no
+    /// candidates builds no client" has no other observable: the regression it
+    /// guards was a client built before discovery knew whether it had anywhere
+    /// to send, and the only symptom was time.
+    ///
+    /// Per thread rather than process-wide because a sibling test runs its own
+    /// discovery on its own thread at the same time, and a process-wide count
+    /// made this an assertion about the whole test binary's scheduling.
+    /// [`race_for_quota`] calls `quota_client` from the thread that drives it,
+    /// before it spawns anything, so a thread-local sees exactly the builds
+    /// its own test caused.
+    static QUOTA_CLIENTS_BUILT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+async fn call_rpc(client: reqwest::Client, port: u16) -> Result<QuotaSummary> {
     let response = client
         .post(format!("http://127.0.0.1:{port}{RPC_PATH}"))
         // Connect-RPC rejects the request without this header.
@@ -260,7 +359,8 @@ async fn call_rpc(port: u16) -> Result<QuotaSummary> {
 
 // ── Port discovery ──
 
-/// Find a language server port that answers `RetrieveUserQuotaSummary`.
+/// Find a language server that answers `RetrieveUserQuotaSummary`, and keep
+/// what it answered.
 ///
 /// Two sources, cheapest first:
 ///
@@ -270,22 +370,106 @@ async fn call_rpc(port: u16) -> Result<QuotaSummary> {
 ///    IDE's language server. That path needs a CSRF token on the process
 ///    command line, which the `agy` CLI does not have — hence source 1.
 ///
-/// Candidates are probed rather than trusted: the process listens on both an
+/// Candidates are asked rather than trusted: the process listens on both an
 /// HTTPS (gRPC) port and an HTTP one, and only the latter speaks plain JSON.
-async fn discover_port() -> Option<u16> {
-    for port in ports_from_cli_log() {
-        if call_rpc(port).await.is_ok() {
-            return Some(port);
+/// The question *is* the quota request, so the summary that proves a port good
+/// is the summary returned. `fetch_all` used to throw it away and ask the same
+/// port the same question again, which is a second round trip for an answer
+/// already in hand.
+async fn discover_quota() -> Option<QuotaSummary> {
+    discover_quota_from(&[&ports_from_cli_log, &detected_ports]).await
+}
+
+/// Ask each source in turn and stop at the first that answers.
+///
+/// Separate from [`discover_quota`] so the sequencing can be tested: source 2
+/// runs `ps` and has no fixture, so the only way to observe that a first
+/// source which spent its whole round still leaves the second one asked is to
+/// hand discovery two sources the test controls.
+async fn discover_quota_from(sources: &[&dyn Fn() -> Vec<u16>]) -> Option<QuotaSummary> {
+    for source in sources {
+        if let Some(summary) = race_for_quota(source()).await {
+            return Some(summary);
         }
     }
-
-    for connection in crate::antigravity::detect_antigravity_connections().ok()? {
-        if call_rpc(connection.port).await.is_ok() {
-            return Some(connection.port);
-        }
-    }
-
     None
+}
+
+/// Ports of the IDE language servers found by scanning processes.
+///
+/// Reached only when the log offered nothing, which keeps `ps` plus a
+/// heartbeat per port off the common path. Unlike source 1 this is
+/// synchronous and brings its own per-socket timeouts, so it sits outside
+/// either round's deadline.
+fn detected_ports() -> Vec<u16> {
+    crate::antigravity::detect_antigravity_connections()
+        .map(|connections| {
+            connections
+                .into_iter()
+                .map(|connection| connection.port)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Ask every candidate at once and keep the best answer.
+///
+/// Asking in sequence made each candidate wait out the one before it, which is
+/// what forced a budget short enough to be paid several times over. Sent
+/// together, a candidate that stalls costs the others nothing, so
+/// [`DISCOVERY_ROUND_TIMEOUT`] -- computed here, when this round starts, never
+/// inherited from a round that already ran -- is the only bound left. Losing
+/// requests are cancelled when the set is dropped.
+///
+/// "Best" is by position rather than by who finishes first: `ports` arrives
+/// newest first and the newest is the one the log calls current. The round
+/// returns the moment nothing better can still arrive, and waits at most
+/// [`PREFERENCE_GRACE`] for something better that is merely slow.
+///
+/// An empty `ports` returns before building anything, which is what keeps a
+/// machine with no Antigravity from paying for a client it has nothing to
+/// send to.
+async fn race_for_quota(ports: Vec<u16>) -> Option<QuotaSummary> {
+    if ports.is_empty() {
+        return None;
+    }
+
+    let client = quota_client().ok()?;
+    let deadline = tokio::time::Instant::now() + DISCOVERY_ROUND_TIMEOUT;
+    let mut settled = vec![false; ports.len()];
+    let mut requests = tokio::task::JoinSet::new();
+    for (rank, port) in ports.into_iter().enumerate() {
+        let client = client.clone();
+        requests.spawn(async move { (rank, call_rpc(client, port).await.ok()) });
+    }
+
+    let mut best: Option<(usize, QuotaSummary)> = None;
+    let mut until = deadline;
+
+    while let Ok(Some(joined)) = tokio::time::timeout_at(until, requests.join_next()).await {
+        // A `JoinError` carries no rank, so a panicked request cannot be
+        // marked settled and the round runs to `until` instead of returning
+        // early. `call_rpc` reports every failure it has as `Err`, so this is
+        // the unreachable arm rather than the failure path.
+        let Ok((rank, answer)) = joined else { continue };
+        settled[rank] = true;
+        if let Some(summary) = answer {
+            if best.as_ref().is_none_or(|(kept, _)| rank < *kept) {
+                best = Some((rank, summary));
+            }
+        }
+        let Some((kept, _)) = best.as_ref() else {
+            continue;
+        };
+        if settled[..*kept].iter().all(|done| *done) {
+            break;
+        }
+        // `min` rather than assignment: the grace starts at the first answer
+        // and is never extended by a later one.
+        until = until.min(tokio::time::Instant::now() + PREFERENCE_GRACE);
+    }
+
+    best.map(|(_, summary)| summary)
 }
 
 fn cli_log_path() -> Option<PathBuf> {
@@ -352,6 +536,409 @@ fn parse_logged_ports(text: &str) -> Vec<u16> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::usage::test_server::{spawn_server, Seen};
+    use crate::commands::usage::{usage_providers, Fetch};
+    use serial_test::serial;
+    use std::sync::{Arc, Mutex};
+    use tempfile::TempDir;
+
+    /// RAII restore of the process-global home redirect, mirroring the copy in
+    /// `super::copilot`'s tests (`tokscale_core::paths::test_env::EnvGuard` is
+    /// `pub(crate)` to the core crate and cannot be imported here). Restoring
+    /// on `Drop` rather than at the end of the body matters because a failing
+    /// assertion panics first, and the next test would then resolve `HOME` to
+    /// a deleted `TempDir`.
+    struct EnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
+
+    impl EnvGuard {
+        fn capture(keys: &[&'static str]) -> Self {
+            Self(
+                keys.iter()
+                    .map(|key| (*key, std::env::var_os(key)))
+                    .collect(),
+            )
+        }
+
+        fn set(&mut self, key: &str, value: impl AsRef<std::ffi::OsStr>) {
+            unsafe { std::env::set_var(key, value) };
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, previous) in self.0.drain(..) {
+                unsafe {
+                    match previous {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
+    /// `dirs::home_dir()` falls back to `USERPROFILE` whenever the `HOME`
+    /// override is rejected, so both have to point at the fixture or the
+    /// Windows leg reads the runner's real `cli.log`.
+    const HOME_ENV_KEYS: [&str; 2] = ["HOME", "USERPROFILE"];
+
+    /// One quota group, named distinctly enough that a real language server
+    /// running on the machine under test cannot be mistaken for the fixture.
+    const FIXTURE_QUOTA: &str = r#"{"response":{"groups":[{"displayName":"Fixture Models","buckets":[{"displayName":"Weekly Limit Remaining","window":"weekly","remainingFraction":0.25}]}]}}"#;
+
+    /// Point the home-rooted `cli.log` lookup at a fixture naming `probe_order`.
+    ///
+    /// Written back to front: the log is appended across runs, so
+    /// [`ports_from_cli_log`] treats the *last* entry as the current port and
+    /// reverses what it parsed. A call site that wants a port tried last has to
+    /// put it first in the file, which is worth hiding here.
+    fn redirect_home_to_logged_ports(env: &mut EnvGuard, home: &TempDir, probe_order: &[u16]) {
+        let log_dir = home.path().join(".gemini").join("antigravity-cli");
+        std::fs::create_dir_all(&log_dir).unwrap();
+        let log: String = probe_order
+            .iter()
+            .rev()
+            .map(|port| {
+                format!(
+                    "I0827 15:07:44 server.go:607] Language server listening on random port at {port} for HTTP\n"
+                )
+            })
+            .collect();
+        std::fs::write(log_dir.join("cli.log"), log).unwrap();
+        for key in HOME_ENV_KEYS {
+            env.set(key, home.path());
+        }
+    }
+
+    /// A listener that accepts and then says nothing.
+    ///
+    /// The case the old per-candidate budget existed for, and the only one
+    /// that can hold a round to `DISCOVERY_ROUND_TIMEOUT`: a port with nothing
+    /// behind it refuses the connection outright and fails in microseconds.
+    fn spawn_black_hole() -> u16 {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind black hole");
+        let port = listener.local_addr().expect("black hole addr").port();
+        std::thread::spawn(move || {
+            // The streams are held rather than dropped: dropping one sends a
+            // FIN, which lets the client fail fast -- the opposite of what this
+            // fixture is for.
+            let mut held = Vec::new();
+            for stream in listener.incoming() {
+                let Ok(stream) = stream else { continue };
+                held.push(stream);
+            }
+        });
+        port
+    }
+
+    fn port_of(base_url: &str) -> u16 {
+        base_url
+            .rsplit(':')
+            .next()
+            .and_then(|port| port.parse().ok())
+            .expect("the test server reports a port")
+    }
+
+    /// The Antigravity entry of the real provider registry.
+    ///
+    /// Taken from the registry rather than hand-assembled because the gate
+    /// under test *is* that tuple's `has`: a provider it rejects never reaches
+    /// a fetch. Driving `fetch_all_report_with_codex` instead would fan out to
+    /// every other provider and read the developer's real credentials, so these
+    /// tests stop at the one entry.
+    fn registered_antigravity_provider() -> (fn() -> bool, Fetch) {
+        let (_, has_credentials, fetch) = usage_providers(Fetch::Multi(fetch_all))
+            .into_iter()
+            .find(|(provider, _, _)| *provider == PROVIDER)
+            .expect("Antigravity is a registered usage provider");
+        (has_credentials, fetch)
+    }
+
+    /// What a failed availability assertion needs in order to be actionable.
+    ///
+    /// The gate is one `bool` and the ways it reaches `false` are far apart:
+    /// the home redirect was lost, the log was not parsed, the request never
+    /// went out, or it went out and was abandoned at the round deadline. A
+    /// bare `assert!` separates none of them, so a CI failure here arrived
+    /// with nothing to act on. `requests` is the sharpest of these -- zero
+    /// means discovery never found the port, one means it asked and did not
+    /// like the answer.
+    fn discovery_state(started: std::time::Instant, seen: &Arc<Mutex<Vec<Seen>>>) -> String {
+        let log = cli_log_path();
+        format!(
+            "elapsed={:?} home={:?} log={:?} log_exists={:?} parsed_ports={:?} requests={:?}",
+            started.elapsed(),
+            std::env::var_os("HOME"),
+            log,
+            log.as_ref().map(|path| path.exists()),
+            ports_from_cli_log(),
+            seen.lock().map(|seen| seen.len()),
+        )
+    }
+
+    /// Regression for #1280.
+    ///
+    /// Antigravity only reaches the report if `has_credentials` says so, and
+    /// that gate ran a whole quota request under a 400ms budget. A language
+    /// server that answers slower than that -- which a loaded machine does
+    /// routinely -- was filtered out of the provider list before any fetch
+    /// ran, so no budget handed to `fetch_all` could have rescued it.
+    ///
+    /// The request count is the other half of the fix: discovery validates a
+    /// port by asking it for quota, and `fetch_all` used to discard that answer
+    /// and ask again.
+    ///
+    /// Two bounds are in play, not one. The fixture's delay is a floor on how
+    /// slow the server is, and load can only push the answer later -- later is
+    /// what the assertion wants. But `DISCOVERY_ROUND_TIMEOUT` is production
+    /// code on this path and is a ceiling the test has to stay under, and the
+    /// delay already spends a fifth of it before anything else happens. The
+    /// diagnostics on the assertion exist so a failure says which of the two
+    /// was hit.
+    #[test]
+    #[serial]
+    fn a_language_server_slower_than_the_old_probe_budget_still_reports() {
+        // Past the old 400ms budget by enough that scheduling noise cannot
+        // close the gap, and a fifth of DISCOVERY_ROUND_TIMEOUT.
+        const SERVER_DELAY: Duration = Duration::from_secs(1);
+
+        let (base, seen) = spawn_server(|_path, _calls| {
+            std::thread::sleep(SERVER_DELAY);
+            (200, FIXTURE_QUOTA.to_string())
+        });
+
+        let home = TempDir::new().unwrap();
+        let mut env = EnvGuard::capture(&HOME_ENV_KEYS);
+        redirect_home_to_logged_ports(&mut env, &home, &[port_of(&base)]);
+
+        let (has_credentials, fetch) = registered_antigravity_provider();
+        let started = std::time::Instant::now();
+        assert!(
+            has_credentials(),
+            "a language server answering in {SERVER_DELAY:?} must not be filtered out of \
+             the report -- {}",
+            discovery_state(started, &seen)
+        );
+
+        let started = std::time::Instant::now();
+        let outputs = fetch.call().unwrap_or_else(|error| {
+            panic!(
+                "the provider the gate admitted must also fetch: {error} -- {}",
+                discovery_state(started, &seen)
+            )
+        });
+        assert_eq!(outputs.len(), 1, "one output per quota group");
+        assert_eq!(outputs[0].provider, PROVIDER);
+        assert_eq!(
+            outputs[0].account.as_ref().unwrap().label.as_deref(),
+            Some("Fixture Models"),
+            "the row must come from the fixture, not from a language server \
+             that happens to be running on this machine"
+        );
+        assert_eq!(outputs[0].metrics.len(), 1);
+        assert!((outputs[0].metrics[0].used_percent - 75.0).abs() < 1e-6);
+
+        assert_eq!(
+            seen.lock().unwrap().len(),
+            2,
+            "one request for the availability gate and one for the fetch: the \
+             fetch must reuse the summary discovery already validated"
+        );
+    }
+
+    /// A candidate that accepts and then goes quiet must not decide the outcome
+    /// for the candidates behind it.
+    ///
+    /// This is what makes one round deadline affordable where a budget per
+    /// candidate was not: the requests are in flight together, so a stalled
+    /// port costs a healthy one nothing. Asked in sequence under the same
+    /// deadline, the two black holes would hold all of it and the language
+    /// server listed behind them would never be reached.
+    ///
+    /// The server is ranked last on purpose, so each call also pays
+    /// `PREFERENCE_GRACE` waiting to see whether either stalled candidate --
+    /// both of which outrank it -- turns out to be merely slow. That wait is
+    /// the cost of not attributing quota to a stale server, and it is what
+    /// makes this test take seconds rather than milliseconds.
+    #[test]
+    #[serial]
+    fn a_stalled_candidate_does_not_hide_the_language_server_behind_it() {
+        let (base, seen) = spawn_server(|_path, _calls| (200, FIXTURE_QUOTA.to_string()));
+
+        let home = TempDir::new().unwrap();
+        let mut env = EnvGuard::capture(&HOME_ENV_KEYS);
+        redirect_home_to_logged_ports(
+            &mut env,
+            &home,
+            &[spawn_black_hole(), spawn_black_hole(), port_of(&base)],
+        );
+
+        let (has_credentials, fetch) = registered_antigravity_provider();
+        let started = std::time::Instant::now();
+        assert!(
+            has_credentials(),
+            "a stalled candidate must not consume the round the others share -- {}",
+            discovery_state(started, &seen)
+        );
+        let started = std::time::Instant::now();
+        let outputs = fetch.call().unwrap_or_else(|error| {
+            panic!(
+                "the fetch must reach the same server: {error} -- {}",
+                discovery_state(started, &seen)
+            )
+        });
+        assert_eq!(
+            outputs[0].account.as_ref().unwrap().label.as_deref(),
+            Some("Fixture Models")
+        );
+    }
+
+    /// The newest logged port wins a round it did not finish first.
+    ///
+    /// [`ports_from_cli_log`] orders candidates newest first on purpose: the
+    /// log is appended across runs, so the last entry is the current server
+    /// and an earlier one can be a stale `agy` from a restart or an account
+    /// switch. Asking them together throws that ordering away if the round
+    /// resolves by completion order, which is how a signed-in user drew an
+    /// "Antigravity is running but not signed in" error from a signed-out
+    /// leftover -- an empty group list parses perfectly well.
+    ///
+    /// The ordering here is a handshake rather than a delay race: the newer
+    /// server does not answer until the older one has been asked, so "the
+    /// older finished first" holds however loaded the machine is. The 250ms
+    /// after that is slack for the older answer to reach the client, and the
+    /// newer then has `PREFERENCE_GRACE` -- eight times as long -- to overtake
+    /// it.
+    #[test]
+    #[serial]
+    fn the_newest_logged_port_wins_even_when_an_older_one_answers_first() {
+        const OLDER_QUOTA: &str =
+            r#"{"response":{"groups":[{"displayName":"Stale Server","buckets":[]}]}}"#;
+
+        let (asked_older, older_was_asked) = std::sync::mpsc::channel::<()>();
+        let (older_base, _older_seen) = spawn_server(move |_path, _calls| {
+            let _ = asked_older.send(());
+            (200, OLDER_QUOTA.to_string())
+        });
+        let (newer_base, newer_seen) = spawn_server(move |_path, _calls| {
+            // A stall guard, not a budget: it only fires if the older server
+            // was never reached, in which case the test has nothing to say and
+            // should fail rather than hang.
+            let _ = older_was_asked.recv_timeout(Duration::from_secs(30));
+            std::thread::sleep(Duration::from_millis(250));
+            (200, FIXTURE_QUOTA.to_string())
+        });
+
+        let home = TempDir::new().unwrap();
+        let mut env = EnvGuard::capture(&HOME_ENV_KEYS);
+        redirect_home_to_logged_ports(
+            &mut env,
+            &home,
+            &[port_of(&newer_base), port_of(&older_base)],
+        );
+
+        let (has_credentials, fetch) = registered_antigravity_provider();
+        let started = std::time::Instant::now();
+        assert!(
+            has_credentials(),
+            "two healthy candidates must still clear the gate -- {}",
+            discovery_state(started, &newer_seen)
+        );
+        let started = std::time::Instant::now();
+        let outputs = fetch.call().unwrap_or_else(|error| {
+            panic!(
+                "the fetch must reach a server: {error} -- {}",
+                discovery_state(started, &newer_seen)
+            )
+        });
+        assert_eq!(
+            outputs[0].account.as_ref().unwrap().label.as_deref(),
+            Some("Fixture Models"),
+            "the round must return the newest logged port, not whichever candidate \
+             answered first"
+        );
+    }
+
+    /// A source that spends its whole round must not silence the next one.
+    ///
+    /// Discovery used to compute one deadline and hand it to both sources. A
+    /// logged port that accepts and then goes quiet held it to expiry, and
+    /// `tokio::time::timeout_at` on an expired deadline polls its inner future
+    /// once and then the delay: the task set is dropped before any of its
+    /// requests opens a socket. So the second source was enumerated, paid for
+    /// and never asked -- another way for Antigravity to vanish from the
+    /// report, which is the failure class this change exists to remove.
+    ///
+    /// The sources are fixtures because the real second source shells out to
+    /// `ps`. What is under test is the sequencing, not what `ps` finds.
+    #[test]
+    fn a_source_that_spends_its_round_still_leaves_the_next_one_asked() {
+        let stalled = spawn_black_hole();
+        let (base, seen) = spawn_server(|_path, _calls| (200, FIXTURE_QUOTA.to_string()));
+        let healthy = port_of(&base);
+        let first: &dyn Fn() -> Vec<u16> = &|| vec![stalled];
+        let second: &dyn Fn() -> Vec<u16> = &|| vec![healthy];
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let started = std::time::Instant::now();
+        let summary = runtime.block_on(discover_quota_from(&[first, second]));
+        let elapsed = started.elapsed();
+
+        assert!(
+            summary.is_some(),
+            "the second source must still be asked after the first spent its round \
+             (elapsed={elapsed:?}, requests={:?})",
+            seen.lock().map(|seen| seen.len())
+        );
+        assert_eq!(
+            seen.lock().unwrap().len(),
+            1,
+            "the healthy server must have been asked exactly once"
+        );
+        assert!(
+            elapsed >= DISCOVERY_ROUND_TIMEOUT,
+            "the first round is meant to have run to its deadline; if it did not, this \
+             test no longer exercises a spent round (elapsed={elapsed:?})"
+        );
+    }
+
+    /// A round with no candidates must not build a client.
+    ///
+    /// The client build is the expensive half of a round -- see
+    /// [`quota_client`] -- and it used to run before discovery knew whether it
+    /// had a single port to send to, so a machine without Antigravity paid for
+    /// it on every `tokscale usage`, in the sequential pre-flight loop rather
+    /// than the fan-out. The second half of this test is what stops the first
+    /// half from passing vacuously.
+    #[test]
+    fn a_round_with_no_candidates_builds_no_client() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let before = QUOTA_CLIENTS_BUILT.with(std::cell::Cell::get);
+        assert!(runtime.block_on(race_for_quota(Vec::new())).is_none());
+        assert_eq!(
+            QUOTA_CLIENTS_BUILT.with(std::cell::Cell::get),
+            before,
+            "an empty candidate list must return before building anything"
+        );
+
+        let (base, _seen) = spawn_server(|_path, _calls| (200, FIXTURE_QUOTA.to_string()));
+        assert!(runtime
+            .block_on(race_for_quota(vec![port_of(&base)]))
+            .is_some());
+        assert_eq!(
+            QUOTA_CLIENTS_BUILT.with(std::cell::Cell::get),
+            before + 1,
+            "one candidate builds exactly one client, which is what makes the count \
+             above meaningful"
+        );
+    }
 
     /// The log is appended across every run and never rotated, so the read has
     /// to be bounded -- and the bound has to keep the *end*, because that is
@@ -584,7 +1171,13 @@ mod tests {
     /// The two calls still carry the other half -- an entry point that stops
     /// using the helper panics on them while the assert stays green -- so keep
     /// both halves.
+    ///
+    /// `#[serial]` because those two calls run the home-rooted discovery, so
+    /// left to overlap they answer the fixture server of whichever test above
+    /// currently has `HOME` redirected, and its request count then counts
+    /// theirs.
     #[test]
+    #[serial]
     fn entry_points_tolerate_an_entered_tokio_runtime_context() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -287,7 +287,13 @@ const MAX_QUOTA_BODY_BYTES: usize = 1024 * 1024;
 ///
 /// Built only once a round has a candidate to send to -- see
 /// [`race_for_quota`], which returns before reaching here on an empty list.
-fn quota_client() -> Result<reqwest::Client> {
+///
+/// `round` is the budget of the round this client serves,
+/// [`DISCOVERY_ROUND_TIMEOUT`] in production. It is handed in rather than read
+/// here so that a round run under a budget of its own -- which is how a test
+/// proves what the round waits for without riding the production deadline --
+/// is not cut short by this client's per-request timeout.
+fn quota_client(round: Duration) -> Result<reqwest::Client> {
     // `.no_proxy()` because this only ever targets 127.0.0.1: the default
     // builder honours HTTP_PROXY/system proxy settings, which would send a
     // loopback quota request to a remote host unless the user happens to have
@@ -316,7 +322,7 @@ fn quota_client() -> Result<reqwest::Client> {
         // The round is what bounds discovery in practice, since it abandons
         // every request still in flight at its deadline. This is the backstop
         // that keeps a `call_rpc` awaited on its own from being unbounded.
-        .timeout(DISCOVERY_ROUND_TIMEOUT)
+        .timeout(round)
         .build()?)
 }
 
@@ -409,27 +415,40 @@ fn detected_ports() -> Vec<u16> {
 /// machine with no Antigravity from paying for a client it has nothing to
 /// send to.
 async fn race_for_quota(ports: Vec<u16>) -> Option<QuotaSummary> {
-    race_for_quota_with(ports, &quota_client).await
+    race_for_quota_with(ports, DISCOVERY_ROUND_TIMEOUT, &quota_client).await
 }
 
-/// [`race_for_quota`] with the client build handed in.
+/// [`race_for_quota`] with the round budget and the client build handed in.
 ///
-/// Separate so a test can count the builds one call causes from that call:
-/// whether an empty round builds a client has no other observable -- the
-/// regression it guards was a client built before discovery knew whether it
-/// had anywhere to send, and the only symptom was time. A count kept inside
-/// `quota_client` instead is fed by every round in the process, on every
-/// thread, and puts a `#[cfg(test)]` hook in shipped code.
+/// Separate so a test can observe two things from its own call.
+///
+/// The builds the call causes: whether an empty round builds a client has no
+/// other observable -- the regression it guards was a client built before
+/// discovery knew whether it had anywhere to send, and the only symptom was
+/// time. A count kept inside `quota_client` instead is fed by every round in
+/// the process, on every thread, and puts a `#[cfg(test)]` hook in shipped
+/// code.
+///
+/// How long the round waits for a better-ranked candidate, which is the whole
+/// of `round`. Proving that takes a fixture that answers seconds late, and
+/// under the production budget that answer landed 2s short of the round's own
+/// deadline, on a machine whose load is the premise of this module: the
+/// margin was a question of scheduling, not of the code. A budget in the tens
+/// of seconds makes the deadline a stall guard again.
+///
+/// `build_client` is given `round` so the client's per-request timeout -- the
+/// backstop for a `call_rpc` awaited outside a round -- cannot undercut it.
 async fn race_for_quota_with(
     ports: Vec<u16>,
-    build_client: &dyn Fn() -> Result<reqwest::Client>,
+    round: Duration,
+    build_client: &dyn Fn(Duration) -> Result<reqwest::Client>,
 ) -> Option<QuotaSummary> {
     if ports.is_empty() {
         return None;
     }
 
-    let client = build_client().ok()?;
-    let deadline = tokio::time::Instant::now() + DISCOVERY_ROUND_TIMEOUT;
+    let client = build_client(round).ok()?;
+    let deadline = tokio::time::Instant::now() + round;
     let mut settled = vec![false; ports.len()];
     let mut requests = tokio::task::JoinSet::new();
     for (rank, port) in ports.into_iter().enumerate() {
@@ -629,6 +648,43 @@ mod tests {
             .expect("the test server reports a port")
     }
 
+    /// The round budget for a test that is not about the deadline.
+    ///
+    /// Long enough that only a fixture which never answers reaches it, so a
+    /// round run under it can be held by a fixture for seconds without the
+    /// test's pass margin becoming a question of scheduling. What it bounds is
+    /// a hang; what it never bounds is how slow this machine is allowed to be.
+    const ROUND_STALL_GUARD: Duration = Duration::from_secs(30);
+
+    /// Two healthy servers whose answers land in a known order.
+    ///
+    /// The older one answers at once. The newer one does not answer until the
+    /// older has been *asked*, and then waits `newer_delay` more -- a
+    /// handshake rather than a delay race, so "the older answered first"
+    /// holds however loaded the machine is, and the delay is a floor on how
+    /// late the newer answer is: load can only push it later. The older's
+    /// group is named `Stale Server` so a round that settled for it says so in
+    /// the failure. Returned as (older, newer, requests seen by the newer).
+    fn spawn_ordered_pair(newer_delay: Duration) -> (String, String, Arc<Mutex<Vec<Seen>>>) {
+        const OLDER_QUOTA: &str =
+            r#"{"response":{"groups":[{"displayName":"Stale Server","buckets":[]}]}}"#;
+
+        let (asked_older, older_was_asked) = std::sync::mpsc::channel::<()>();
+        let (older_base, _older_seen) = spawn_server(move |_path, _calls| {
+            let _ = asked_older.send(());
+            (200, OLDER_QUOTA.to_string())
+        });
+        let (newer_base, newer_seen) = spawn_server(move |_path, _calls| {
+            // A stall guard, not a budget: it only fires if the older server
+            // was never reached, in which case the test has nothing to say and
+            // should fail rather than hang.
+            let _ = older_was_asked.recv_timeout(ROUND_STALL_GUARD);
+            std::thread::sleep(newer_delay);
+            (200, FIXTURE_QUOTA.to_string())
+        });
+        (older_base, newer_base, newer_seen)
+    }
+
     /// The Antigravity entry of the real provider registry.
     ///
     /// Taken from the registry rather than hand-assembled because the gate
@@ -793,40 +849,23 @@ mod tests {
     /// "Antigravity is running but not signed in" error from a signed-out
     /// leftover -- an empty group list parses perfectly well.
     ///
-    /// The ordering here is a handshake rather than a delay race: the newer
-    /// server does not answer until the older one has been asked, so "the
-    /// older finished first" holds however loaded the machine is. What follows
-    /// the handshake is a delay only the round budget covers. An earlier
-    /// revision stopped waiting for a better-ranked candidate 2s after the
-    /// first answer, and with that grace in place this test reports the stale
-    /// server: the current one answered inside the round and still lost.
-    ///
-    /// Two bounds again, as in the #1280 test above: the delay is a floor on
-    /// how late the newer answer is, and load can only make it later, which
-    /// is the direction the assertion wants -- but `DISCOVERY_ROUND_TIMEOUT` is
-    /// the ceiling it has to stay under, with 2s to spare.
+    /// This is the whole path under the production budget: the log parse, the
+    /// newest-first ordering, the round and the fetch. [`spawn_ordered_pair`]
+    /// fixes the answer order by handshake, so the only clock in play is the
+    /// round's own ceiling, and the newer answer sits far inside it. How long
+    /// the round keeps waiting for the newer port is a separate property with
+    /// a budget of its own, proven by
+    /// `a_better_ranked_candidate_is_waited_for_the_whole_round`.
     #[test]
     #[serial]
     fn the_newest_logged_port_wins_even_when_an_older_one_answers_first() {
-        const OLDER_QUOTA: &str =
-            r#"{"response":{"groups":[{"displayName":"Stale Server","buckets":[]}]}}"#;
-        // Past the 2s an earlier revision granted preference, so a grace that
-        // short fails this; a fifth of the round short of its deadline.
-        const NEWER_DELAY: Duration = Duration::from_secs(3);
+        // Room for the older answer to land before the newer one, and no more:
+        // the newer answer must still arrive well inside
+        // DISCOVERY_ROUND_TIMEOUT, which on this path is a ceiling the test
+        // cannot move.
+        const NEWER_DELAY: Duration = Duration::from_millis(250);
 
-        let (asked_older, older_was_asked) = std::sync::mpsc::channel::<()>();
-        let (older_base, _older_seen) = spawn_server(move |_path, _calls| {
-            let _ = asked_older.send(());
-            (200, OLDER_QUOTA.to_string())
-        });
-        let (newer_base, newer_seen) = spawn_server(move |_path, _calls| {
-            // A stall guard, not a budget: it only fires if the older server
-            // was never reached, in which case the test has nothing to say and
-            // should fail rather than hang.
-            let _ = older_was_asked.recv_timeout(Duration::from_secs(30));
-            std::thread::sleep(NEWER_DELAY);
-            (200, FIXTURE_QUOTA.to_string())
-        });
+        let (older_base, newer_base, newer_seen) = spawn_ordered_pair(NEWER_DELAY);
 
         let home = TempDir::new().unwrap();
         let mut env = EnvGuard::capture(&HOME_ENV_KEYS);
@@ -855,6 +894,64 @@ mod tests {
             Some("Fixture Models"),
             "the round must return the newest logged port, not whichever candidate \
              answered first"
+        );
+    }
+
+    /// A round waits for a better-ranked candidate for the whole round, not
+    /// for a grace after the first answer.
+    ///
+    /// [`DISCOVERY_ROUND_TIMEOUT`] exists because the current language server
+    /// can take seconds on a loaded machine, and the current server is the
+    /// best-ranked candidate -- the one a round holding a worse answer is
+    /// waiting on. An earlier revision cut that wait at 2s from the first
+    /// answer, so a current server answering in 2-5s lost to a stale sibling
+    /// that answered at once, and this test reports `Stale Server` against
+    /// that code.
+    ///
+    /// Driven at the round level, under [`ROUND_STALL_GUARD`], because the
+    /// delay has to be seconds to beat the grace it guards against, and under
+    /// the production budget that put the newer answer 2s from the round's
+    /// deadline on a machine whose load is the premise of the whole change.
+    /// Here the delay is only a floor: load can push the newer answer later,
+    /// which is the direction the assertion wants, and the deadline is a
+    /// stall guard 27s away. The provider-path test above covers the same
+    /// ordering end to end with a delay that keeps clear of the ceiling.
+    #[test]
+    fn a_better_ranked_candidate_is_waited_for_the_whole_round() {
+        // Past the 2s the earlier revision granted, by enough that scheduling
+        // noise cannot close the gap.
+        const NEWER_DELAY: Duration = Duration::from_secs(3);
+
+        let (older_base, newer_base, newer_seen) = spawn_ordered_pair(NEWER_DELAY);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let started = std::time::Instant::now();
+        let summary = runtime.block_on(race_for_quota_with(
+            vec![port_of(&newer_base), port_of(&older_base)],
+            ROUND_STALL_GUARD,
+            &quota_client,
+        ));
+        let elapsed = started.elapsed();
+
+        let summary = summary.unwrap_or_else(|| {
+            panic!(
+                "two healthy candidates must yield a summary (elapsed={elapsed:?}, newer \
+                 requests={:?})",
+                newer_seen.lock().map(|seen| seen.len())
+            )
+        });
+        assert_eq!(
+            summary.groups[0].display_name, "Fixture Models",
+            "the round must keep waiting for the better-ranked candidate until it answers, \
+             not settle for the worse one that answered first (elapsed={elapsed:?})"
+        );
+        assert!(
+            elapsed >= NEWER_DELAY,
+            "the newer answer cannot have arrived before its delay (elapsed={elapsed:?}); \
+             the fixture no longer exercises a late better-ranked answer"
         );
     }
 
@@ -916,7 +1013,9 @@ mod tests {
     /// The count is kept by the builder this test hands in, so it holds exactly
     /// the builds these two calls caused: no other round, on this thread or
     /// any other, can reach it. Nothing here is `#[serial]` and nothing needs
-    /// to be.
+    /// to be. The budget is [`ROUND_STALL_GUARD`] because the deadline is not
+    /// what is under test: the one candidate answers at once and the round
+    /// returns on that answer, so the budget only ever bounds a hang.
     #[test]
     fn a_round_with_no_candidates_builds_no_client() {
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -925,13 +1024,17 @@ mod tests {
             .unwrap();
 
         let builds = std::cell::Cell::new(0usize);
-        let counted_client = || {
+        let counted_client = |round| {
             builds.set(builds.get() + 1);
-            quota_client()
+            quota_client(round)
         };
 
         assert!(runtime
-            .block_on(race_for_quota_with(Vec::new(), &counted_client))
+            .block_on(race_for_quota_with(
+                Vec::new(),
+                ROUND_STALL_GUARD,
+                &counted_client
+            ))
             .is_none());
         assert_eq!(
             builds.get(),
@@ -941,7 +1044,11 @@ mod tests {
 
         let (base, _seen) = spawn_server(|_path, _calls| (200, FIXTURE_QUOTA.to_string()));
         assert!(runtime
-            .block_on(race_for_quota_with(vec![port_of(&base)], &counted_client))
+            .block_on(race_for_quota_with(
+                vec![port_of(&base)],
+                ROUND_STALL_GUARD,
+                &counted_client
+            ))
             .is_some());
         assert_eq!(
             builds.get(),

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -914,13 +914,25 @@ mod tests {
     /// deadline on a machine whose load is the premise of the whole change.
     /// Here the delay is only a floor: load can push the newer answer later,
     /// which is the direction the assertion wants, and the deadline is a
-    /// stall guard 27s away. The provider-path test above covers the same
+    /// stall guard 23s away. The provider-path test above covers the same
     /// ordering end to end with a delay that keeps clear of the ceiling.
+    ///
+    /// The delay sits past [`DISCOVERY_ROUND_TIMEOUT`] itself, not merely
+    /// past the old grace. "The whole round" is only proven when the round
+    /// that ran is the one this test handed in: a delay inside the production
+    /// 5s passed against a round that read the production constant instead
+    /// of its `round` parameter, and against any grace between the delay and
+    /// 5s. Past 5s, both of those return `Stale Server` here.
     #[test]
     fn a_better_ranked_candidate_is_waited_for_the_whole_round() {
-        // Past the 2s the earlier revision granted, by enough that scheduling
-        // noise cannot close the gap.
-        const NEWER_DELAY: Duration = Duration::from_secs(3);
+        // Past DISCOVERY_ROUND_TIMEOUT by enough that scheduling noise cannot
+        // close the gap: a round that still ends at the production 5s, by a
+        // grace or by ignoring its budget, has returned the stale answer
+        // before the newer one can land. Checked at compile time because a
+        // shorter delay would not fail this test; it would stop it proving
+        // anything.
+        const NEWER_DELAY: Duration = Duration::from_secs(7);
+        const _: () = assert!(NEWER_DELAY.as_millis() > DISCOVERY_ROUND_TIMEOUT.as_millis());
 
         let (older_base, newer_base, newer_seen) = spawn_ordered_pair(NEWER_DELAY);
 


### PR DESCRIPTION
Discovery probed each candidate port with a full quota request bounded at 400ms, and that bound was never only a probe bound: `has_credentials()` reports Antigravity as present exactly when discovery succeeds, and `usage/mod.rs` drops a provider from the report before any fetch runs when it does not. A language server that answers a loopback round trip in more than 400ms — which a loaded machine does routinely — was missing from `tokscale usage` altogether, against a server that was answering correctly.

### What this replaces

The first version of this branch gave `fetch_all` its own 10s budget and left discovery at 400ms. That was a no-op — `fetch_all` reaches `call_rpc` only through `discover_port`, so the provider never got that far — and the test it shipped called `call_rpc` directly and could not observe the gate. Codex's adversarial review caught it; this is the rewrite.

### Design

- **Discovery keeps what it fetched.** The probe *is* the quota request, so the summary that proves a port good is the summary `fetch_all` needs. It used to discard it and ask the same port the same question again. That removes the second request, and with it the question of what to bound it with.
- **Candidates are asked together under one deadline per source**, not one after another under a budget each. A port with nothing behind it refuses outright, so a machine without Antigravity never approaches the deadline; a port that accepts and then goes quiet is waited on once per round rather than once per candidate. Each source's deadline is computed when its own round starts — a single shared deadline let a stalled logged port consume all of it before process detection was ever asked.
- **A round returns the best-ranked answer, not the first to arrive.** `ports_from_cli_log` orders candidates newest first because the last port the log names is the current one. Resolving by completion order threw that away: a stale `agy` left over from a restart could win on scheduling noise, and a signed-out one (an empty group list parses fine) turned into an intermittent "running but not signed in" for a signed-in user. There is no grace period shorter than the round — a round waits for a better-ranked candidate exactly as long as it waits for any candidate, and returns the moment nothing ranked above its answer can still arrive.
- **No trust store, no eager client.** A round with no candidates returns before building anything, and the client a round does build asks for no trust store (it only posts to `http://127.0.0.1`, refuses redirects, has nothing to verify). `has_credentials()` on a machine without Antigravity: 50–54ms on main, 187–313ms on the previous revision, 52–56ms now.

The runtime isolation from #1269 (`off_caller_runtime`) is kept.

### Tests

Every round-level proof runs under a budget the test owns (30s stall guard), never against the production 5s as a ceiling. `a_better_ranked_candidate_is_waited_for_the_whole_round` delays the newer server 7s — past the production round by 2s, pinned by a compile-time assert so it cannot be lowered back under 5s and silently stop proving anything — and fails with `Stale Server` against both a 4s-grace mutant and a dead-`round`-parameter mutant. Client builds are counted through an injected builder into a `Cell` on the test's own stack, so no `#[cfg(test)]` hook ships in production code and the test needs no `#[serial]`.

An intermittent failure was reported against `a_round_with_no_candidates_builds_no_client` at an earlier revision. Every archived failure came from two short windows in which every run failed and none outside them; the identical panic is produced by an eager-build mutation that was being run in that worktree at the time, and the committed code produces neither signature. Under load: 40/40, 45/45, 51/51 across three revisions at loadavg 100–260.

### Provenance

Found while reviewing #1269. Independent of #1290, which edits `https_rpc_request` in the same file (comment-only overlap).
