### PR TITLE
fix(zai): parse quota reset times and subscription renewal

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/zai.rs
+++ b/crates/tokscale-cli/src/commands/usage/zai.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use chrono::{TimeZone, Utc};
 use serde::Deserialize;
 
 use super::helpers::capitalize;
@@ -16,6 +17,7 @@ struct QuotaData {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct Limit {
     #[serde(rename = "type")]
     limit_type: Option<String>,
@@ -27,17 +29,72 @@ struct Limit {
     current_value: Option<f64>,
     number: Option<i64>,
     unit: Option<i64>,
+    #[serde(alias = "next_reset_time", alias = "nextResetTime")]
+    next_reset_time: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct SubResp {
     data: Option<Vec<Sub>>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct Sub {
+    #[serde(alias = "product_name", alias = "productName")]
     product_name: Option<String>,
+    #[serde(alias = "next_renew_time", alias = "nextRenewTime")]
     next_renew_time: Option<String>,
+}
+
+fn parse_reset_time_str(s: &str) -> Option<String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    if chrono::DateTime::parse_from_rfc3339(s).is_ok() {
+        return Some(s.to_string());
+    }
+    if let Ok(ts) = s.parse::<i64>() {
+        let ms = if ts.abs() > 10_000_000_000 {
+            ts
+        } else {
+            ts * 1000
+        };
+        return Utc
+            .timestamp_millis_opt(ms)
+            .single()
+            .map(|dt| dt.to_rfc3339());
+    }
+    if let Ok(d) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        if let Some(dt) = d.and_hms_opt(0, 0, 0) {
+            return Some(chrono::DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc).to_rfc3339());
+        }
+    }
+    if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
+        return Some(chrono::DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc).to_rfc3339());
+    }
+    Some(s.to_string())
+}
+
+fn parse_reset_time(val: Option<&serde_json::Value>) -> Option<String> {
+    let val = val?;
+    match val {
+        serde_json::Value::Number(n) => {
+            let ts = n.as_i64()?;
+            let ms = if ts.abs() > 10_000_000_000 {
+                ts
+            } else {
+                ts * 1000
+            };
+            Utc.timestamp_millis_opt(ms)
+                .single()
+                .map(|dt| dt.to_rfc3339())
+        }
+        serde_json::Value::String(s) => parse_reset_time_str(s),
+        _ => None,
+    }
 }
 
 async fn fetch_quota(client: &reqwest::Client, key: &str) -> Result<QuotaResp> {
@@ -105,24 +162,32 @@ fn build_metrics(
                     (Some(6), Some(1)) => (&mut *weekly_metric, "Weekly"),
                     _ => continue,
                 };
+                let resets_at = parse_reset_time(limit.next_reset_time.as_ref());
                 if target.is_none() || prefer {
+                    let existing_resets_at = target.as_ref().and_then(|m| m.resets_at.clone());
                     *target = Some(UsageMetric {
                         label: label.to_string(),
                         used_percent: pct,
                         remaining_percent: 100.0 - pct,
                         remaining_label: None,
-                        resets_at: None,
+                        resets_at: resets_at.or(existing_resets_at),
                     });
+                } else if let Some(ref mut metric) = target {
+                    if metric.resets_at.is_none() && resets_at.is_some() {
+                        metric.resets_at = resets_at;
+                    }
                 }
             }
             Some("TIME_LIMIT") => {
                 let remaining_label = limit.remaining.map(|r| format!("{:.0} left", r));
+                let resets_at = parse_reset_time(limit.next_reset_time.as_ref())
+                    .or_else(|| search_reset.clone());
                 *search_metric = Some(UsageMetric {
                     label: "Web Search".into(),
                     used_percent: pct,
                     remaining_percent: 100.0 - pct,
                     remaining_label,
-                    resets_at: search_reset.clone(),
+                    resets_at,
                 });
             }
             _ => {}
@@ -143,7 +208,7 @@ pub fn fetch() -> Result<UsageOutput> {
         let quota = fetch_quota(&client, &api_key).await?;
         let sub = fetch_sub(&client, &api_key).await.ok();
 
-        let plan = sub
+        let base_plan = sub
             .as_ref()
             .and_then(|s| s.data.as_ref())
             .and_then(|d| d.first())
@@ -156,15 +221,28 @@ pub fn fetch() -> Result<UsageOutput> {
                     .map(|l| capitalize(&l))
             });
 
-        let mut session_metric = None;
-        let mut weekly_metric = None;
-        let mut search_metric = None;
-
-        let search_reset = sub
+        let next_renew = sub
             .as_ref()
             .and_then(|s| s.data.as_ref())
             .and_then(|d| d.first())
             .and_then(|s| s.next_renew_time.clone());
+
+        let plan = match (base_plan, next_renew.as_deref()) {
+            (Some(tier), Some(renew)) if !renew.trim().is_empty() => {
+                Some(format!("{tier} (renews {})", renew.trim()))
+            }
+            (Some(tier), _) => Some(tier),
+            (None, Some(renew)) if !renew.trim().is_empty() => {
+                Some(format!("Renews {}", renew.trim()))
+            }
+            (None, _) => None,
+        };
+
+        let mut session_metric = None;
+        let mut weekly_metric = None;
+        let mut search_metric = None;
+
+        let search_reset = next_renew.as_deref().and_then(parse_reset_time_str);
 
         if let Some(limits) = quota.data.as_ref().and_then(|d| d.limits.as_ref()) {
             build_metrics(
@@ -272,5 +350,89 @@ mod tests {
         assert!(session.is_none());
         assert!(weekly.is_none());
         assert!(search.is_none());
+    }
+
+    #[test]
+    fn credit_limit_with_next_reset_time_sets_resets_at() {
+        let lim: Limit = serde_json::from_value(serde_json::json!({
+            "type": "CREDIT_LIMIT",
+            "unit": 6,
+            "number": 1,
+            "percentage": 100.0,
+            "nextResetTime": 1788701854998i64,
+        }))
+        .expect("valid limit with nextResetTime");
+
+        let (_, weekly, _) = run(&[lim]);
+        let weekly = weekly.expect("weekly metric present");
+        assert_eq!(weekly.used_percent, 100.0);
+        assert_eq!(weekly.remaining_percent, 0.0);
+        assert_eq!(
+            weekly.resets_at.as_deref(),
+            Some("2026-09-06T13:37:34.998+00:00")
+        );
+    }
+
+    #[test]
+    fn credit_limit_preserves_resets_at_from_tokens_limit_fallback() {
+        let tokens_lim: Limit = serde_json::from_value(serde_json::json!({
+            "type": "TOKENS_LIMIT",
+            "unit": 3,
+            "number": 5,
+            "percentage": 20.0,
+            "nextResetTime": 1788701854998i64,
+        }))
+        .expect("tokens limit");
+        let credit_lim: Limit = serde_json::from_value(serde_json::json!({
+            "type": "CREDIT_LIMIT",
+            "unit": 3,
+            "number": 5,
+            "percentage": 80.0,
+        }))
+        .expect("credit limit without reset");
+
+        let (session, _, _) = run(&[tokens_lim, credit_lim]);
+        let session = session.expect("session metric present");
+        assert_eq!(session.used_percent, 80.0);
+        assert_eq!(
+            session.resets_at.as_deref(),
+            Some("2026-09-06T13:37:34.998+00:00")
+        );
+    }
+
+    #[test]
+    fn sub_resp_deserializes_camel_case_fields() {
+        let json = serde_json::json!({
+            "data": [{
+                "id": "845544",
+                "productName": "GLM Coding Max",
+                "nextRenewTime": "2026-11-30"
+            }]
+        });
+        let sub_resp: SubResp = serde_json::from_value(json).expect("valid SubResp");
+        let sub = sub_resp.data.as_ref().unwrap().first().unwrap();
+        assert_eq!(sub.product_name.as_deref(), Some("GLM Coding Max"));
+        assert_eq!(sub.next_renew_time.as_deref(), Some("2026-11-30"));
+    }
+
+    #[test]
+    fn parse_reset_time_handles_dates_and_epoch() {
+        let val_num = serde_json::json!(1788701854998i64);
+        assert_eq!(
+            parse_reset_time(Some(&val_num)).as_deref(),
+            Some("2026-09-06T13:37:34.998+00:00")
+        );
+
+        let val_str = serde_json::json!("1788701854998");
+        assert_eq!(
+            parse_reset_time(Some(&val_str)).as_deref(),
+            Some("2026-09-06T13:37:34.998+00:00")
+        );
+
+        let val_date = serde_json::json!("2026-11-30");
+        assert_eq!(
+            parse_reset_time(Some(&val_date)).as_deref(),
+            Some("2026-11-30T00:00:00+00:00")
+        );
     }
 }

--- a/crates/tokscale-cli/src/commands/usage/zai.rs
+++ b/crates/tokscale-cli/src/commands/usage/zai.rs
@@ -53,15 +53,24 @@ struct Sub {
 /// already being milliseconds. Shared by both entry points below: when only one
 /// of them carried the heuristic, a numeric string and a JSON number could
 /// resolve to different instants.
+///
+/// A non-positive epoch is absent, not 1970. `null` is one way to say "no reset
+/// scheduled" and a zero epoch is the other, because a serializer whose field
+/// is not nullable emits the type's default. Left alone, 0 resolves to
+/// `1970-01-01T00:00:00+00:00`, which is a perfectly truthy `Some` everywhere
+/// `resets_at` is consumed: it outranks a real reset time carried by a sibling
+/// quota entry in `build_metrics`, it blocks the subscription-renewal fallback
+/// on the `TIME_LIMIT` path, and `helpers::format_reset_time` renders any past
+/// instant as "resets now", so the screen would say that forever.
 fn epoch_to_rfc3339(ts: i64) -> Option<String> {
-    // `unsigned_abs`, not `abs`: the float spelling below saturates on cast, so
-    // a large negative value lands on i64::MIN, where `abs` overflows and
-    // panics in a debug build.
-    let ms = if ts.unsigned_abs() > 10_000_000_000 {
-        ts
-    } else {
-        ts * 1000
-    };
+    if ts <= 0 {
+        return None;
+    }
+    // The guard above is load-bearing beyond the sentinel: it is what makes the
+    // arithmetic here total. `ts` is positive, so the `* 1000` branch tops out
+    // at 10_000_000_000_000, and the negative saturation of the float spelling
+    // below can no longer reach an overflowing `abs`.
+    let ms = if ts > 10_000_000_000 { ts } else { ts * 1000 };
     Utc.timestamp_millis_opt(ms)
         .single()
         .map(|dt| dt.to_rfc3339())
@@ -526,8 +535,11 @@ mod tests {
 
     #[test]
     fn out_of_range_epochs_are_rejected_without_panicking() {
-        // Floats saturate on cast, so these reach the i64 bounds rather than
-        // wrapping; the numeric-string spelling reaches i64::MIN directly.
+        // Floats saturate on cast rather than wrapping, so these land on the
+        // i64 bounds; the numeric-string spelling reaches i64::MIN directly.
+        // The two negatives are now turned away by the sign guard and the
+        // positive one by chrono's range check, so this stays a regression
+        // test against either half being relaxed.
         assert_eq!(parse_reset_time(Some(&serde_json::json!(-1e300f64))), None);
         assert_eq!(parse_reset_time(Some(&serde_json::json!(1e300f64))), None);
         assert_eq!(
@@ -592,6 +604,77 @@ mod tests {
     #[test]
     fn time_limit_falls_back_to_renewal_when_its_own_reset_is_unparseable() {
         let lim = limit_with_reset("TIME_LIMIT", 0, 0, 10.0, serde_json::json!("unknown"));
+        let (_, _, search) =
+            run_with_search_reset(&[lim], Some("2026-11-30T00:00:00+00:00".to_string()));
+        let search = search.expect("web search metric present");
+        assert_eq!(
+            search.resets_at.as_deref(),
+            Some("2026-11-30T00:00:00+00:00")
+        );
+    }
+
+    #[test]
+    fn non_positive_epochs_are_rejected_in_every_spelling() {
+        // Epoch 0 is a sentinel, not a reset time. Left alone it resolves to
+        // 1970-01-01, which is truthy everywhere `resets_at` is consumed.
+        for zero in [
+            serde_json::json!(0i64),
+            serde_json::json!(0.0f64),
+            serde_json::json!("0"),
+        ] {
+            assert_eq!(parse_reset_time(Some(&zero)), None, "spelling: {zero}");
+        }
+        // A reset time before the epoch is nonsense for a *next* reset.
+        for negative in [
+            serde_json::json!(-1i64),
+            serde_json::json!(-1.0f64),
+            serde_json::json!("-1"),
+        ] {
+            assert_eq!(
+                parse_reset_time(Some(&negative)),
+                None,
+                "spelling: {negative}"
+            );
+        }
+    }
+
+    #[test]
+    fn zero_epoch_never_suppresses_a_valid_reset_time() {
+        // Same defect class as the unparseable-string case above, reached
+        // through the numeric path: as 1970-01-01 the sentinel wins both the
+        // CREDIT_LIMIT overwrite and the `resets_at.is_none()` fill-in, and
+        // `helpers::format_reset_time` then renders "resets now" forever.
+        let valid = || {
+            limit_with_reset(
+                "TOKENS_LIMIT",
+                3,
+                5,
+                20.0,
+                serde_json::json!(1788701854998i64),
+            )
+        };
+        let sentinel = || limit_with_reset("CREDIT_LIMIT", 3, 5, 80.0, serde_json::json!(0i64));
+
+        let (session, _, _) = run(&[valid(), sentinel()]);
+        let session = session.expect("session metric present");
+        assert_eq!(session.used_percent, 80.0);
+        assert_eq!(
+            session.resets_at.as_deref(),
+            Some("2026-09-06T13:37:34.998+00:00")
+        );
+
+        let (session, _, _) = run(&[sentinel(), valid()]);
+        let session = session.expect("session metric present");
+        assert_eq!(session.used_percent, 80.0);
+        assert_eq!(
+            session.resets_at.as_deref(),
+            Some("2026-09-06T13:37:34.998+00:00")
+        );
+    }
+
+    #[test]
+    fn time_limit_falls_back_to_renewal_when_its_own_reset_is_zero() {
+        let lim = limit_with_reset("TIME_LIMIT", 0, 0, 10.0, serde_json::json!(0i64));
         let (_, _, search) =
             run_with_search_reset(&[lim], Some("2026-11-30T00:00:00+00:00".to_string()));
         let search = search.expect("web search metric present");

--- a/crates/tokscale-cli/src/commands/usage/zai.rs
+++ b/crates/tokscale-cli/src/commands/usage/zai.rs
@@ -48,6 +48,33 @@ struct Sub {
     next_renew_time: Option<String>,
 }
 
+/// Z.ai does not document whether its epoch fields are seconds or
+/// milliseconds, so treat anything past the year-2286 second boundary as
+/// already being milliseconds. Shared by both entry points below: when only one
+/// of them carried the heuristic, a numeric string and a JSON number could
+/// resolve to different instants.
+fn epoch_to_rfc3339(ts: i64) -> Option<String> {
+    // `unsigned_abs`, not `abs`: the float spelling below saturates on cast, so
+    // a large negative value lands on i64::MIN, where `abs` overflows and
+    // panics in a debug build.
+    let ms = if ts.unsigned_abs() > 10_000_000_000 {
+        ts
+    } else {
+        ts * 1000
+    };
+    Utc.timestamp_millis_opt(ms)
+        .single()
+        .map(|dt| dt.to_rfc3339())
+}
+
+/// Parse one of the timestamp shapes Z.ai sends, or `None`.
+///
+/// Unrecognized input must not be passed through as if it were a timestamp.
+/// `resets_at` is consumed as one: a raw string like `"unknown"` outranks a
+/// real reset time carried by a sibling quota entry in `build_metrics`, and it
+/// blocks the subscription-renewal fallback on the `TIME_LIMIT` path. It would
+/// then reach the screen verbatim, because `helpers::format_reset_time` echoes
+/// whatever it cannot parse as RFC 3339.
 fn parse_reset_time_str(s: &str) -> Option<String> {
     let s = s.trim();
     if s.is_empty() {
@@ -57,40 +84,38 @@ fn parse_reset_time_str(s: &str) -> Option<String> {
         return Some(s.to_string());
     }
     if let Ok(ts) = s.parse::<i64>() {
-        let ms = if ts.abs() > 10_000_000_000 {
-            ts
-        } else {
-            ts * 1000
-        };
-        return Utc
-            .timestamp_millis_opt(ms)
-            .single()
-            .map(|dt| dt.to_rfc3339());
+        return epoch_to_rfc3339(ts);
     }
     if let Ok(d) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
         if let Some(dt) = d.and_hms_opt(0, 0, 0) {
             return Some(chrono::DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc).to_rfc3339());
         }
     }
-    if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
-        return Some(chrono::DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc).to_rfc3339());
+    // Offsetless date-time, with either separator. The `T` spelling is the near
+    // miss most likely to arrive from an API that almost emits RFC 3339, and
+    // dropping unrecognized input above means it would otherwise be lost.
+    for fmt in ["%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"] {
+        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, fmt) {
+            return Some(chrono::DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc).to_rfc3339());
+        }
     }
-    Some(s.to_string())
+    None
 }
 
 fn parse_reset_time(val: Option<&serde_json::Value>) -> Option<String> {
     let val = val?;
     match val {
         serde_json::Value::Number(n) => {
-            let ts = n.as_i64()?;
-            let ms = if ts.abs() > 10_000_000_000 {
-                ts
-            } else {
-                ts * 1000
-            };
-            Utc.timestamp_millis_opt(ms)
-                .single()
-                .map(|dt| dt.to_rfc3339())
+            // JSON draws no int/float distinction, so whether a millisecond
+            // epoch arrives as 1788701854998 or 1788701854998.0 is a detail of
+            // Z.ai's serializer. `as_i64` returns None for the float spelling,
+            // which would discard the reset time entirely. The cast saturates
+            // rather than wrapping, so a float too large to be an epoch lands
+            // on an i64 bound and is rejected as out of range.
+            let ts = n
+                .as_i64()
+                .or_else(|| n.as_f64().map(|f| f.round() as i64))?;
+            epoch_to_rfc3339(ts)
         }
         serde_json::Value::String(s) => parse_reset_time_str(s),
         _ => None,
@@ -293,8 +318,36 @@ mod tests {
         .expect("valid Limit fixture")
     }
 
+    fn limit_with_reset(
+        kind: &str,
+        unit: i64,
+        number: i64,
+        percentage: f64,
+        reset: serde_json::Value,
+    ) -> Limit {
+        serde_json::from_value(serde_json::json!({
+            "type": kind,
+            "unit": unit,
+            "number": number,
+            "percentage": percentage,
+            "nextResetTime": reset,
+        }))
+        .expect("valid Limit fixture")
+    }
+
     fn run(
         limits: &[Limit],
+    ) -> (
+        Option<UsageMetric>,
+        Option<UsageMetric>,
+        Option<UsageMetric>,
+    ) {
+        run_with_search_reset(limits, None)
+    }
+
+    fn run_with_search_reset(
+        limits: &[Limit],
+        search_reset: Option<String>,
     ) -> (
         Option<UsageMetric>,
         Option<UsageMetric>,
@@ -303,7 +356,7 @@ mod tests {
         let mut session = None;
         let mut weekly = None;
         let mut search = None;
-        build_metrics(limits, None, &mut session, &mut weekly, &mut search);
+        build_metrics(limits, search_reset, &mut session, &mut weekly, &mut search);
         (session, weekly, search)
     }
 
@@ -432,6 +485,118 @@ mod tests {
         let val_date = serde_json::json!("2026-11-30");
         assert_eq!(
             parse_reset_time(Some(&val_date)).as_deref(),
+            Some("2026-11-30T00:00:00+00:00")
+        );
+    }
+
+    #[test]
+    fn float_epoch_is_not_dropped() {
+        // JSON draws no int/float distinction, so the same millisecond epoch
+        // can arrive either way depending on Z.ai's serializer.
+        let as_int = serde_json::json!(1788701854998i64);
+        let as_float = serde_json::json!(1788701854998.0f64);
+        assert_eq!(
+            parse_reset_time(Some(&as_float)).as_deref(),
+            Some("2026-09-06T13:37:34.998+00:00")
+        );
+        assert_eq!(
+            parse_reset_time(Some(&as_float)),
+            parse_reset_time(Some(&as_int))
+        );
+    }
+
+    #[test]
+    fn second_and_millisecond_epochs_agree_across_json_types() {
+        let secs = serde_json::json!(1788701854i64);
+        let secs_float = serde_json::json!(1788701854.0f64);
+        let secs_str = serde_json::json!("1788701854");
+        assert_eq!(
+            parse_reset_time(Some(&secs)).as_deref(),
+            Some("2026-09-06T13:37:34+00:00")
+        );
+        assert_eq!(
+            parse_reset_time(Some(&secs_str)),
+            parse_reset_time(Some(&secs))
+        );
+        assert_eq!(
+            parse_reset_time(Some(&secs_float)),
+            parse_reset_time(Some(&secs))
+        );
+    }
+
+    #[test]
+    fn out_of_range_epochs_are_rejected_without_panicking() {
+        // Floats saturate on cast, so these reach the i64 bounds rather than
+        // wrapping; the numeric-string spelling reaches i64::MIN directly.
+        assert_eq!(parse_reset_time(Some(&serde_json::json!(-1e300f64))), None);
+        assert_eq!(parse_reset_time(Some(&serde_json::json!(1e300f64))), None);
+        assert_eq!(
+            parse_reset_time(Some(&serde_json::json!("-9223372036854775808"))),
+            None
+        );
+    }
+
+    #[test]
+    fn offsetless_date_time_is_accepted_with_either_separator() {
+        // Rejecting unrecognized input means a near-miss RFC 3339 value would
+        // otherwise be dropped instead of merely rendering badly.
+        assert_eq!(
+            parse_reset_time(Some(&serde_json::json!("2026-11-30T04:05:06"))).as_deref(),
+            Some("2026-11-30T04:05:06+00:00")
+        );
+        assert_eq!(
+            parse_reset_time(Some(&serde_json::json!("2026-11-30 04:05:06"))).as_deref(),
+            Some("2026-11-30T04:05:06+00:00")
+        );
+    }
+
+    #[test]
+    fn unrecognized_reset_time_is_rejected() {
+        let bogus = serde_json::json!("unknown");
+        assert_eq!(parse_reset_time(Some(&bogus)), None);
+    }
+
+    #[test]
+    fn unparseable_reset_time_never_suppresses_a_valid_one() {
+        // An unparseable value must not be treated as a timestamp, in either
+        // arrival order: as a raw string it would win both the CREDIT_LIMIT
+        // overwrite and the `resets_at.is_none()` fill-in below.
+        let valid = || {
+            limit_with_reset(
+                "TOKENS_LIMIT",
+                3,
+                5,
+                20.0,
+                serde_json::json!(1788701854998i64),
+            )
+        };
+        let bogus = || limit_with_reset("CREDIT_LIMIT", 3, 5, 80.0, serde_json::json!("unknown"));
+
+        let (session, _, _) = run(&[valid(), bogus()]);
+        let session = session.expect("session metric present");
+        assert_eq!(session.used_percent, 80.0);
+        assert_eq!(
+            session.resets_at.as_deref(),
+            Some("2026-09-06T13:37:34.998+00:00")
+        );
+
+        let (session, _, _) = run(&[bogus(), valid()]);
+        let session = session.expect("session metric present");
+        assert_eq!(session.used_percent, 80.0);
+        assert_eq!(
+            session.resets_at.as_deref(),
+            Some("2026-09-06T13:37:34.998+00:00")
+        );
+    }
+
+    #[test]
+    fn time_limit_falls_back_to_renewal_when_its_own_reset_is_unparseable() {
+        let lim = limit_with_reset("TIME_LIMIT", 0, 0, 10.0, serde_json::json!("unknown"));
+        let (_, _, search) =
+            run_with_search_reset(&[lim], Some("2026-11-30T00:00:00+00:00".to_string()));
+        let search = search.expect("web search metric present");
+        assert_eq!(
+            search.resets_at.as_deref(),
             Some("2026-11-30T00:00:00+00:00")
         );
     }

--- a/crates/tokscale-cli/src/commands/usage/zai.rs
+++ b/crates/tokscale-cli/src/commands/usage/zai.rs
@@ -95,6 +95,18 @@ fn parse_reset_time_str(s: &str) -> Option<String> {
     if let Ok(ts) = s.parse::<i64>() {
         return epoch_to_rfc3339(ts);
     }
+    // The float spelling, so a string and a JSON number carrying the same
+    // value resolve the same way: `"1788701854998.0"` must agree with
+    // `1788701854998.0`, which `parse_reset_time` already accepts. Same
+    // rounding, same saturating cast, same range check downstream.
+    if let Some(ts) = s
+        .parse::<f64>()
+        .ok()
+        .filter(|f| f.is_finite())
+        .map(|f| f.round() as i64)
+    {
+        return epoch_to_rfc3339(ts);
+    }
     if let Ok(d) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
         if let Some(dt) = d.and_hms_opt(0, 0, 0) {
             return Some(chrono::DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc).to_rfc3339());
@@ -496,6 +508,28 @@ mod tests {
             parse_reset_time(Some(&val_date)).as_deref(),
             Some("2026-11-30T00:00:00+00:00")
         );
+    }
+
+    /// cubic on e5ca8b5b: the numeric-string path accepted only an integer
+    /// spelling, so `"1788701854998.0"` resolved to `None` while the same
+    /// value as a JSON number resolved to a reset time. Both entry points
+    /// must agree, or the unification `epoch_to_rfc3339` exists for is
+    /// only half true.
+    #[test]
+    fn float_epoch_string_agrees_with_float_epoch_number() {
+        let as_number = parse_reset_time(Some(&serde_json::json!(1788701854998.0)));
+        let as_string = parse_reset_time(Some(&serde_json::json!("1788701854998.0")));
+        assert_eq!(as_number.as_deref(), Some("2026-09-06T13:37:34.998+00:00"));
+        assert_eq!(as_string, as_number);
+        // seconds-precision float too, and the integer spellings still agree
+        let secs_num = parse_reset_time(Some(&serde_json::json!(1788701854.0)));
+        let secs_str = parse_reset_time(Some(&serde_json::json!("1788701854.0")));
+        assert_eq!(secs_str, secs_num);
+        assert_eq!(secs_num.as_deref(), Some("2026-09-06T13:37:34+00:00"));
+        // non-finite spellings are not epochs
+        for bad in ["inf", "-inf", "nan", "NaN"] {
+            assert_eq!(parse_reset_time_str(bad), None, "{bad}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Z.ai quota limits from `/api/monitor/usage/quota/limit` return `nextResetTime` epoch millisecond timestamps, but tokscale previously dropped them from the `Limit` struct and hardcoded `resets_at: None` for session and weekly metrics. Consequently, users with exhausted or active quota windows saw no reset countdown or timestamp in `tokscale usage` or the TUI.

Additionally, subscription responses from `/api/biz/subscription/list` use camelCase fields (`productName`, `nextRenewTime`) which failed to deserialize without camelCase mapping, causing `product_name` and `next_renew_time` to always resolve to `None`.

### Changes
- **Parsed Quota Reset Timestamps**: Added `next_reset_time` (`nextResetTime`) to `Limit` and implemented `parse_reset_time` to convert epoch millisecond (and second/ISO string) timestamps into RFC 3339 for `UsageMetric.resets_at`.
- **Preserved Reset Timestamps across Limit Types**: When `CREDIT_LIMIT` and `TOKENS_LIMIT` are both present, any valid `resets_at` timestamp is preserved.
- **Deserialized Subscription Data**: Added `#[serde(rename_all = "camelCase")]` (with aliases) on `Sub` so `productName` and `nextRenewTime` are properly deserialized.
- **Surfaced Subscription Renewal**: Included subscription renewal date in `plan` metadata (e.g. `GLM Coding Max (renews 2026-11-30)`), consistent with providers like Sakana.
- **Normalized Web Search Reset**: Converted `next_renew_time` to RFC 3339 for `TIME_LIMIT` (`Web Search`) metrics.

## What's Changed
- `crates/tokscale-cli/src/commands/usage/zai.rs`:
  - Support `nextResetTime` on `Limit` and map to `resets_at`
  - Support camelCase `productName` and `nextRenewTime` on `Sub`
  - Surface renewal date in `UsageOutput.plan`
  - Added unit tests for `nextResetTime` parsing, fallback preservation, camelCase subscription deserialization, and date/epoch parsing

## Verification
- `cargo fmt --check` (passes cleanly)
- `cargo clippy -p tokscale-cli -- -D warnings` (zero warnings)
- `cargo test --bin tokscale commands::usage::zai` (8 passed, 0 failed)
- Verified live against `api.z.ai`:
  ```text
  ╭────────────────────────────────────────────────────────────────╮
  │ Z.ai                                                           │
  │ Session       100% left  [============]                        │
  │ Weekly        0% left    [------------]resets in 18h 8m        │
  │ Plan      GLM Coding Max (renews 2026-11-30)                   │
  ╰────────────────────────────────────────────────────────────────╯
  ```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Z.ai quota reset timestamps and subscription renewal dates being dropped when parsing API responses. Reset countdowns now display correctly in `tokscale usage` and the TUI, and the plan line shows renewal info like `GLM Coding Max (renews 2026-11-30)` instead of omitting it.

- Parses `nextResetTime` into `resets_at`, accepting epoch seconds or milliseconds (integers or floats, as JSON numbers or strings), RFC 3339, and date strings.
- Deserializes camelCase subscription fields (`productName`, `nextRenewTime`).
- Unparseable or non-positive reset times are treated as absent so they can't suppress a valid reset time from a sibling quota entry or the subscription renewal fallback.
- Preserves a valid `resets_at` across `CREDIT_LIMIT` and `TOKENS_LIMIT` entries, and uses `nextRenewTime` as the Web Search reset fallback.

<sup>Written for commit c0cd0adb58bf4597bace893a800ce17e1b28b7e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

