### PR TITLE
fix(openclaw): read compressed transcript archives

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1066,6 +1066,9 @@ pub fn parser_generation() -> u64 {
 
 fn parser_version(client: ClientId) -> u32 {
     match client {
+        // v1->v2: compressed OpenClaw archives were scanned as plain JSONL and
+        // cached as empty. Their bytes do not change when decoding is fixed.
+        ClientId::OpenClaw => 2,
         // These clients accumulated parser-only invalidations under the old
         // global schema. Their independent counters start from those histories
         // so future changes have an obvious local version to increment.
@@ -3544,6 +3547,49 @@ mod tests {
         // its fingerprint keeps matching and only the version bump discards the
         // v1 lock-timestamp anchor.
         assert_eq!(parser_version(ClientId::Droid), 7);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn openclaw_compressed_archives_discard_cached_empty_v1_results() {
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let source = temp_home.path().join("session.jsonl.deleted.timestamp.zst");
+        let content = br#"{"type":"message","message":{"role":"assistant","model":"example","usage":{"input":100},"timestamp":1700000000000}}"#;
+        fs::write(&source, zstd::encode_all(&content[..], 0).unwrap()).unwrap();
+        let identity = CacheIdentity::for_client(ClientId::OpenClaw);
+        let old_identity = CacheIdentity {
+            parser_version: 1,
+            ..identity
+        };
+        let fingerprint = SourceFingerprint::from_path(&source).unwrap();
+        let entry = CachedSourceEntry::new(
+            old_identity,
+            &source,
+            fingerprint.clone(),
+            Vec::new(),
+            Vec::new(),
+            None,
+        );
+        let shard = cache_shard_path(identity, &source);
+        ensure_cache_dir(shard.parent().unwrap()).unwrap();
+        write_shard_with_limit(&shard, old_identity, &[entry], MAX_CACHE_SHARD_BYTES).unwrap();
+
+        let mut cache = SourceMessageCache::load();
+        assert!(cache.get(identity, &source).is_none());
+        let parsed = crate::sessions::openclaw::parse_openclaw_transcript(&source);
+        assert_eq!(parsed.len(), 1);
+        cache.insert(CachedSourceEntry::new(
+            identity,
+            &source,
+            fingerprint,
+            parsed.clone(),
+            Vec::new(),
+            None,
+        ));
+        cache.save_if_dirty();
+        let warm = SourceMessageCache::load();
+        assert_eq!(warm.get(identity, &source).unwrap().messages, parsed);
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -452,6 +452,7 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 // (<uuid>.jsonl.deleted.<ts>, <uuid>.jsonl.reset.<ts>)
                 "*.jsonl*" => {
                     file_name.ends_with(".jsonl")
+                        || file_name.ends_with(".jsonl.zst")
                         || file_name.contains(".jsonl.deleted.")
                         || file_name.contains(".jsonl.reset.")
                 }
@@ -5621,6 +5622,38 @@ mod tests {
         assert_eq!(result.get(ClientId::OpenClaw).len(), 1);
         assert!(result.get(ClientId::OpenClaw)[0]
             .ends_with("session-archived.jsonl.deleted.1700000000000"));
+    }
+
+    #[test]
+    fn scan_openclaw_compressed_transcripts_reaches_the_parser() {
+        let dir = TempDir::new().unwrap();
+        let sessions = dir.path().join(".openclaw/agents/main/sessions");
+        fs::create_dir_all(&sessions).unwrap();
+        let content = br#"{"type":"message","message":{"role":"assistant","provider":"anthropic","model":"claude-sonnet-4-6","usage":{"input":100,"output":50},"timestamp":1788566869012}}"#;
+        for name in [
+            "plain-archive.jsonl.zst",
+            "deleted.jsonl.deleted.timestamp.nonce.zst",
+            "reset.jsonl.reset.timestamp.nonce.zst",
+        ] {
+            fs::write(
+                sessions.join(name),
+                zstd::encode_all(&content[..], 0).unwrap(),
+            )
+            .unwrap();
+        }
+        fs::write(sessions.join("unrelated.zst"), b"not a session").unwrap();
+
+        let scan = scan_all_clients_with_env_strategy(
+            dir.path().to_str().unwrap(),
+            &["openclaw".to_string()],
+            false,
+        );
+        assert_eq!(scan.get(ClientId::OpenClaw).len(), 3);
+        for path in scan.get(ClientId::OpenClaw) {
+            let messages = crate::sessions::openclaw::parse_openclaw_transcript(path);
+            assert_eq!(messages.len(), 1);
+            assert_eq!(messages[0].tokens.total(), 150);
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/openclaw.rs
+++ b/crates/tokscale-core/src/sessions/openclaw.rs
@@ -3,11 +3,49 @@
 //! Parses OpenClaw transcript JSONL files from agent directories.
 //! Supports legacy sessions.json index parsing for compatibility.
 
-use super::utils::{for_each_json_line, read_file_or_none, CamelUsage};
+use super::utils::{for_each_json_line, lossy_lines, read_file_or_none, CamelUsage};
 use super::UnifiedMessage;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::io::Read;
 use std::path::{Path, PathBuf};
+
+// Archived transcripts are immutable zstd files. Bound expansion before parsing
+// so a corrupt archive cannot allocate its advertised decoded size.
+const MAX_ARCHIVE_BYTES: u64 = 64 * 1024 * 1024;
+
+fn read_archive(path: &Path, max_bytes: u64) -> std::io::Result<Vec<u8>> {
+    let file = std::fs::File::open(path)?;
+    let mut decoder = zstd::stream::read::Decoder::new(file)?;
+    decoder.window_log_max(26)?;
+    let mut bytes = Vec::new();
+    decoder.take(max_bytes + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > max_bytes {
+        return Err(std::io::Error::other(
+            "decoded transcript exceeds archive limit",
+        ));
+    }
+    Ok(bytes)
+}
+
+fn for_each_transcript_line(path: &Path, sink: &mut dyn FnMut(usize, &str)) {
+    if path.extension().is_none_or(|extension| extension != "zst") {
+        for_each_json_line(path, sink);
+        return;
+    }
+
+    match read_archive(path, MAX_ARCHIVE_BYTES) {
+        Ok(bytes) => {
+            for (index, line) in lossy_lines(bytes.as_slice()).enumerate() {
+                let trimmed = line.trim();
+                if !trimmed.is_empty() {
+                    sink(index, trimmed);
+                }
+            }
+        }
+        Err(error) => tracing::warn!(path = %path.display(), %error, "Skipping OpenClaw archive"),
+    }
+}
 
 #[derive(Debug, Deserialize)]
 struct SessionIndex {
@@ -127,7 +165,7 @@ fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedM
     let mut current_provider: Option<String> = None;
     let mut buffer = Vec::with_capacity(4096);
 
-    for_each_json_line(session_path, &mut |_index, trimmed| {
+    for_each_transcript_line(session_path, &mut |_index, trimmed| {
         buffer.clear();
         buffer.extend_from_slice(trimmed.as_bytes());
         let entry: OpenClawEntry = match simd_json::from_slice(&mut buffer) {
@@ -221,6 +259,51 @@ mod tests {
         let mut file = File::create(&path).unwrap();
         file.write_all(content.as_bytes()).unwrap();
         path.to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn compressed_archives_preserve_transcript_usage_and_session_identity() {
+        let dir = TempDir::new().unwrap();
+        let content = concat!(
+            "\u{feff}{\"type\":\"model_change\",\"provider\":\"anthropic\",\"modelId\":\"claude-sonnet-4-6\"}\r\n",
+            "\ninvalid json\n",
+            "{\"type\":\"message\",\"message\":{\"role\":\"assistant\",\"usage\":{\"input\":100,\"output\":50,\"cacheRead\":200,\"cacheWrite\":10,\"cost\":{\"total\":0.05}},\"timestamp\":1788566869012}}\n",
+        );
+        let plain = create_test_session(&dir, "session.jsonl", content);
+        let expected = parse_openclaw_transcript(Path::new(&plain));
+        assert_eq!(expected.len(), 1);
+
+        for filename in [
+            "session.jsonl.zst",
+            "session.jsonl.deleted.2026-09-05T00-00-00.000Z.nonce.zst",
+            "session.jsonl.reset.2026-09-05T00-00-00.000Z.nonce.zst",
+        ] {
+            let path = dir.path().join(filename);
+            std::fs::write(&path, zstd::encode_all(content.as_bytes(), 0).unwrap()).unwrap();
+            assert_eq!(parse_openclaw_transcript(&path), expected, "{filename}");
+        }
+    }
+
+    #[test]
+    fn compressed_archive_enforces_decoded_limit() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("session.jsonl.zst");
+        std::fs::write(&path, zstd::encode_all(&b"12345"[..], 0).unwrap()).unwrap();
+        assert_eq!(read_archive(&path, 5).unwrap(), b"12345");
+        assert!(read_archive(&path, 4).is_err());
+    }
+
+    #[test]
+    fn invalid_or_truncated_compressed_archive_does_not_emit_partial_usage() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("session.jsonl.deleted.timestamp.zst");
+        let content = br#"{"type":"message","message":{"role":"assistant","model":"example","usage":{"input":100},"timestamp":1700000000000}}"#;
+        let mut bytes = zstd::encode_all(&content[..], 0).unwrap();
+        bytes.pop();
+        std::fs::write(&path, bytes).unwrap();
+        assert!(parse_openclaw_transcript(&path).is_empty());
+        std::fs::write(&path, b"not a zstd stream").unwrap();
+        assert!(parse_openclaw_transcript(&path).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
This reporting gap was observed after upgrading OpenClaw: recent OpenClaw usage stopped appearing in Tokscale even though the archived transcripts still contained nonzero token usage. The confirmed incompatibility is Tokscale reading OpenClaw’s zstd-compressed transcript archives as plain JSONL, silently dropping those records.

OpenClaw's archived `.jsonl.deleted.*.zst` and `.jsonl.reset.*.zst` transcripts were discovered but parsed as plain JSONL, silently dropping their token usage. Decode those archives with bounded zstd expansion, discover `.jsonl.zst` files, and bump only OpenClaw's parser cache version so previously empty entries rebuild.

Regression coverage compares plain and compressed usage, exercises discovery through parsing, rejects corrupt/truncated archives and excessive expansion, and proves an old empty cache entry is replaced and stays correct on a warm scan.

Validation: the new parity regression failed before the fix; all 20 OpenClaw-focused tests pass; the full core suite passes (2,058 passed, 2 ignored); `cargo clippy -p tokscale-core --lib -- -D warnings` passes.

Closes #1284.

### OpenClaw upgrade context

The missing usage was reported following an OpenClaw upgrade. Related current release: [OpenClaw v2026.9.2](https://github.com/openclaw/openclaw/releases/tag/v2026.9.2), published September 5, 2026. The upgrade is the reported trigger; compressed archive parsing is the reproduced failure mechanism. We have not yet established the first OpenClaw version that introduced this archive format, so this should not be read as proof that v2026.9.2 introduced compression.
