### PR TITLE
refactor(core): derive pi-format parser versions from shared base

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1096,9 +1096,10 @@ fn parser_version(client: ClientId) -> u32 {
         // when reconstructing VS Code Copilot Chat requests; v8 aggregates
         // carry those sessions as zero-token.
         ClientId::Copilot => 9,
-        // Pi subagent sessions now derive agent attribution from session_info
-        // names; version-1 caches carry those messages without agent metadata.
-        ClientId::Pi => 2,
+        // Pi delegates to the shared pi-format parser. Pi subagent sessions
+        // now derive agent attribution from session_info names; version-1
+        // caches carry those messages without agent metadata.
+        ClientId::Pi => crate::sessions::pi::PI_FORMAT_PARSER_BASE_VERSION + 1,
         // Devin CLI v1 could stop at a malformed chat_message. v2->v3:
         // message timestamp is now back-calculated to the turn start
         // (created_at - total_time_ms) instead of the recorded (end-anchored)
@@ -1174,9 +1175,10 @@ fn parser_version(client: ClientId) -> u32 {
         // of landing unpriced, and uses a UTC-stable synthetic id for the id-less
         // fallback.
         ClientId::Cursor => 3,
-        // v1->v2: Kimchi's Pi-compatible messages now carry stable namespaced
-        // deduplication keys.
-        ClientId::Kimchi => 2,
+        // Kimchi delegates to the shared pi-format parser. v1->v2: Kimchi's
+        // Pi-compatible messages now carry stable namespaced deduplication
+        // keys.
+        ClientId::Kimchi => crate::sessions::pi::PI_FORMAT_PARSER_BASE_VERSION + 1,
         // v1->v2: Prime Agent now strips a leading BOM and recovers records
         // containing undecodable bytes; its accounting scan also continues past
         // those records instead of truncating and misaligning message indices.
@@ -1282,11 +1284,14 @@ fn parser_version(client: ClientId) -> u32 {
         // byte-identical before and after, so only this bump discards the v1
         // rows still holding a provider-reported zero.
         ClientId::Fx => 2,
-        // omp delegates to the shared pi-format parser, so any pi.rs parse
-        // change that bumps ClientId::Pi must be evaluated for Omp (and Senpi)
-        // too — the shared code path changes what byte-identical omp files
-        // parse to even though omp's own module did not change.
-        ClientId::Omp => 1,
+        // Omp delegates to the shared pi-format parser. Any pi.rs parse change
+        // that bumps PI_FORMAT_PARSER_BASE_VERSION moves Omp together with Pi,
+        // Kimchi, and Senpi (#1195).
+        ClientId::Omp => crate::sessions::pi::PI_FORMAT_PARSER_BASE_VERSION,
+        // Senpi delegates to the shared pi-format parser. Any pi.rs parse
+        // change that bumps PI_FORMAT_PARSER_BASE_VERSION moves Senpi together
+        // with Pi, Kimchi, and Omp (#1195).
+        ClientId::Senpi => crate::sessions::pi::PI_FORMAT_PARSER_BASE_VERSION,
         // v1 -> v2: the OpenCode parser now prefers `session_v2` metadata over
         // the legacy `session` join for workspace and title. A database that
         // carries both tables is byte-identical before and after, so only the
@@ -3723,6 +3728,51 @@ mod tests {
     #[test]
     fn test_junie_parser_version_invalidates_rows_without_cost_provenance() {
         assert_eq!(parser_version(ClientId::Junie), 3);
+    }
+
+    #[test]
+    fn test_pi_format_shared_parser_version_sync() {
+        use crate::sessions::pi::PI_FORMAT_PARSER_BASE_VERSION;
+
+        // All four clients delegate to `sessions/pi.rs`. Their parser versions
+        // must derive from `PI_FORMAT_PARSER_BASE_VERSION` so changes inside pi.rs
+        // invalidate cached messages consistently across all delegating clients (#1195).
+        let delegating_clients = [
+            ClientId::Pi,
+            ClientId::Kimchi,
+            ClientId::Omp,
+            ClientId::Senpi,
+        ];
+
+        for client in delegating_clients {
+            assert!(
+                parser_version(client) >= PI_FORMAT_PARSER_BASE_VERSION,
+                "{:?} must derive from PI_FORMAT_PARSER_BASE_VERSION ({})",
+                client,
+                PI_FORMAT_PARSER_BASE_VERSION
+            );
+        }
+
+        assert_eq!(
+            parser_version(ClientId::Pi),
+            PI_FORMAT_PARSER_BASE_VERSION + 1,
+            "Pi carries +1 for subagent session attribution"
+        );
+        assert_eq!(
+            parser_version(ClientId::Kimchi),
+            PI_FORMAT_PARSER_BASE_VERSION + 1,
+            "Kimchi carries +1 for namespaced dedup keys"
+        );
+        assert_eq!(
+            parser_version(ClientId::Omp),
+            PI_FORMAT_PARSER_BASE_VERSION,
+            "Omp carries base version directly"
+        );
+        assert_eq!(
+            parser_version(ClientId::Senpi),
+            PI_FORMAT_PARSER_BASE_VERSION,
+            "Senpi carries base version directly and has an explicit match arm"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1190,7 +1190,12 @@ fn parser_version(client: ClientId) -> u32 {
         // lineage and usage structural keys before reconciliation bookkeeping.
         // v3->v4 rejects damaged lineage values and matching-critical child
         // timestamps while preserving unrelated damaged usage extensions.
-        ClientId::PrimeAgent => 4,
+        // Prime Agent also delegates to the shared pi-format parser (through
+        // `parse_pi_format_rlm_file_with_observer`), so any pi.rs parse change
+        // that bumps PI_FORMAT_PARSER_BASE_VERSION moves Prime Agent together
+        // with Pi, Kimchi, Omp, and Senpi (#1195); the +3 offset preserves the
+        // v4 history above.
+        ClientId::PrimeAgent => crate::sessions::pi::PI_FORMAT_PARSER_BASE_VERSION + 3,
         // Initial Reasonix implementation. The fingerprint samples the
         // append-only stats JSONL source so appended records are reparsed.
         // v1->v2: strip a leading BOM and recover records containing
@@ -3734,7 +3739,8 @@ mod tests {
     fn test_pi_format_shared_parser_version_sync() {
         use crate::sessions::pi::PI_FORMAT_PARSER_BASE_VERSION;
 
-        // All four clients delegate to `sessions/pi.rs`. Their parser versions
+        // All five clients delegate to `sessions/pi.rs` (Prime Agent through
+        // `parse_pi_format_rlm_file_with_observer`). Their parser versions
         // must derive from `PI_FORMAT_PARSER_BASE_VERSION` so changes inside pi.rs
         // invalidate cached messages consistently across all delegating clients (#1195).
         let delegating_clients = [
@@ -3742,6 +3748,7 @@ mod tests {
             ClientId::Kimchi,
             ClientId::Omp,
             ClientId::Senpi,
+            ClientId::PrimeAgent,
         ];
 
         for client in delegating_clients {
@@ -3772,6 +3779,11 @@ mod tests {
             parser_version(ClientId::Senpi),
             PI_FORMAT_PARSER_BASE_VERSION,
             "Senpi carries base version directly and has an explicit match arm"
+        );
+        assert_eq!(
+            parser_version(ClientId::PrimeAgent),
+            PI_FORMAT_PARSER_BASE_VERSION + 3,
+            "Prime Agent carries +3 for its lossy-decode and lineage-validation history"
         );
     }
 

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -5,8 +5,12 @@
 //! newly-created session files; see [`PRE_SESSION_METADATA_TYPES`].
 //!
 //! Pi descendants reuse this record layout verbatim, so [`parse_pi_format_file`]
-//! is shared: see `sessions::senpi` for Senpi (OmO Native) and `sessions::omp`
-//! for Oh My Pi, which owns the `~/.omp/agent/sessions` root.
+//! is shared: see `sessions::kimchi` for Kimchi, `sessions::senpi` for Senpi (OmO Native),
+//! and `sessions::omp` for Oh My Pi, which owns the `~/.omp/agent/sessions` root.
+//!
+//! [`PI_FORMAT_PARSER_BASE_VERSION`] defines the shared base parser version for these
+//! clients, ensuring format-level changes in `pi.rs` invalidate cached messages
+//! consistently across all four (#1195).
 
 use super::utils::{file_modified_timestamp_ms, for_each_json_line_with_bytes, parse_json_line};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
@@ -17,6 +21,18 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::ops::ControlFlow;
 use std::path::Path;
+
+/// Base parser version for clients sharing the Pi transcript format.
+///
+/// Any parsing change in `sessions/pi.rs` that affects how transcripts are parsed
+/// changes what byte-identical files parse to across all delegating clients:
+/// Pi, Kimchi, Oh My Pi (Omp), and Senpi.
+///
+/// Bumping this base version moves all delegating clients together in
+/// `message_cache::parser_version()`, while allowing each client to keep its
+/// own client-specific version offset for independent historical invalidations
+/// (e.g. dedup key changes, session metadata).
+pub const PI_FORMAT_PARSER_BASE_VERSION: u32 = 1;
 
 /// Pi session header (first line of JSONL)
 #[derive(Debug, Deserialize)]

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -6,11 +6,13 @@
 //!
 //! Pi descendants reuse this record layout verbatim, so [`parse_pi_format_file`]
 //! is shared: see `sessions::kimchi` for Kimchi, `sessions::senpi` for Senpi (OmO Native),
-//! and `sessions::omp` for Oh My Pi, which owns the `~/.omp/agent/sessions` root.
+//! `sessions::omp` for Oh My Pi, which owns the `~/.omp/agent/sessions` root, and
+//! `sessions::prime_agent` for Prime Agent, which enters the same parser through
+//! [`parse_pi_format_rlm_file_with_observer`].
 //!
 //! [`PI_FORMAT_PARSER_BASE_VERSION`] defines the shared base parser version for these
 //! clients, ensuring format-level changes in `pi.rs` invalidate cached messages
-//! consistently across all four (#1195).
+//! consistently across all five (#1195).
 
 use super::utils::{file_modified_timestamp_ms, for_each_json_line_with_bytes, parse_json_line};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
@@ -26,7 +28,7 @@ use std::path::Path;
 ///
 /// Any parsing change in `sessions/pi.rs` that affects how transcripts are parsed
 /// changes what byte-identical files parse to across all delegating clients:
-/// Pi, Kimchi, Oh My Pi (Omp), and Senpi.
+/// Pi, Kimchi, Oh My Pi (Omp), Senpi, and Prime Agent.
 ///
 /// Bumping this base version moves all delegating clients together in
 /// `message_cache::parser_version()`, while allowing each client to keep its


### PR DESCRIPTION
## Problem

Four clients (`Pi`, `Kimchi`, `Omp`, and `Senpi`) parse the same transcript format through `sessions/pi.rs`, but previously maintained separate `parser_version()` branches in `message_cache.rs`, while `Senpi` was missing an explicit arm entirely and fell through to the wildcard `_ => 1`. A format change inside `pi.rs` therefore only invalidated caches for client IDs someone remembered to bump manually, risking silent cache desynchronization (#1195).

## Solution

1. Define `PI_FORMAT_PARSER_BASE_VERSION = 1` in `crates/tokscale-core/src/sessions/pi.rs` as the authoritative format version for the shared Pi layout.
2. In `crates/tokscale-core/src/message_cache.rs`, derive each delegating client's parser version from `PI_FORMAT_PARSER_BASE_VERSION` while preserving existing effective versions and client-specific historical offsets:
   - `ClientId::Pi`: `PI_FORMAT_PARSER_BASE_VERSION + 1` (= 2, preserving agent attribution offset)
   - `ClientId::Kimchi`: `PI_FORMAT_PARSER_BASE_VERSION + 1` (= 2, preserving namespaced dedup key offset)
   - `ClientId::Omp`: `PI_FORMAT_PARSER_BASE_VERSION` (= 1)
   - `ClientId::Senpi`: `PI_FORMAT_PARSER_BASE_VERSION` (= 1, now explicitly matched instead of falling through to wildcard)
3. Since effective parser versions for all clients remain identical, `parser_generation()` is unchanged and no existing valid caches are prematurely evicted.
4. Add unit test `test_pi_format_shared_parser_version_sync` in `message_cache.rs` verifying that all delegating clients derive from `PI_FORMAT_PARSER_BASE_VERSION`.

Resolves #1195

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a shared parser version base for the five clients that parse the Pi transcript format, so a format change in `sessions/pi.rs` invalidates caches for all of them at once. Previously each client had its own `parser_version()` arm (and `Senpi` fell through to the wildcard); effective versions are unchanged, so no caches are evicted.

- Derives Pi, Kimchi, Omp, Senpi, and Prime Agent from `PI_FORMAT_PARSER_BASE_VERSION`, preserving each client's effective version (Pi 2, Kimchi 2, Omp 1, Senpi 1, Prime Agent 4).
- Adds a regression test covering all five delegating clients and resolves #1195.

<sup>Written for commit a1e0b00fc551ca9a40985f1053776a0c9793f34b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

