### PR TITLE
fix(openclaw): deduplicate events across transcript archives

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2375,7 +2375,7 @@ fn parse_all_messages_streaming<S: MessageSink>(
         }
     }
 
-    parse_cached_lane(
+    parse_cached_lane_deduped(
         &scan_result,
         &mut source_cache,
         pricing,
@@ -5150,15 +5150,16 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::Droid, droid_count);
     messages.extend(droid_msgs);
 
-    let openclaw_msgs: Vec<ParsedMessage> = scan_result
+    let openclaw_msgs_raw: Vec<UnifiedMessage> = scan_result
         .get(ClientId::OpenClaw)
         .par_iter()
-        .flat_map(|path| {
-            sessions::openclaw::parse_openclaw_transcript(path)
-                .into_iter()
-                .map(|msg| unified_to_parsed(&msg))
-                .collect::<Vec<_>>()
-        })
+        .flat_map(|path| sessions::openclaw::parse_openclaw_transcript(path))
+        .collect();
+    let mut openclaw_seen: HashSet<String> = HashSet::new();
+    let openclaw_msgs: Vec<ParsedMessage> = openclaw_msgs_raw
+        .into_iter()
+        .filter(|message| should_keep_deduped_message(&mut openclaw_seen, message))
+        .map(|message| unified_to_parsed(&message))
         .collect();
     let openclaw_count = openclaw_msgs.len() as i32;
     counts.set(ClientId::OpenClaw, openclaw_count);
@@ -11391,6 +11392,92 @@ mod tests {
                 33
             );
         }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_openclaw_plain_and_compressed_archives_dedup_events_across_aggregate_paths() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let sessions_dir = client_scan_root(source_home.path(), ClientId::OpenClaw)
+            .join("main")
+            .join("sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+
+        let model_change =
+            r#"{"type":"model_change","provider":"anthropic","modelId":"claude-sonnet-4-6"}"#;
+        let shared = r#"{"type":"message","id":"shared-event","message":{"role":"assistant","content":[{"type":"text","text":"shared"}],"usage":{"input":100,"output":10},"timestamp":1788566869000}}"#;
+        let distinct = r#"{"type":"message","id":"distinct-event","message":{"role":"assistant","content":[{"type":"text","text":"distinct"}],"usage":{"input":100,"output":10},"timestamp":1788566869000}}"#;
+        let plain_idless = r#"{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"plain idless"}],"usage":{"input":7,"output":1},"timestamp":1788566870000}}"#;
+        let archive_only = r#"{"type":"message","id":"archive-only","message":{"role":"assistant","content":[{"type":"text","text":"older history"}],"usage":{"input":40,"output":4},"timestamp":1788566800000}}"#;
+        let archive_idless = r#"{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"archive idless"}],"usage":{"input":7,"output":1},"timestamp":1788566870000}}"#;
+
+        std::fs::write(
+            sessions_dir.join("session.jsonl"),
+            [model_change, shared, distinct, plain_idless].join("\n"),
+        )
+        .unwrap();
+        let archive = [model_change, archive_only, shared, archive_idless].join("\n");
+        std::fs::write(
+            sessions_dir.join("session.jsonl.deleted.2026-09-05T00-00-00.000Z.zst"),
+            zstd::encode_all(archive.as_bytes(), 0).unwrap(),
+        )
+        .unwrap();
+
+        let clients = vec!["openclaw".to_string()];
+        let home = source_home.path().to_str().unwrap();
+        let cold = parse_all_messages_with_pricing(home, &clients, None);
+        let warm = parse_all_messages_with_pricing(home, &clients, None);
+        let direct = parse_local_clients(LocalParseOptions {
+            home_dir: Some(home.to_string()),
+            use_env_roots: false,
+            clients: Some(clients),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+
+        for (path, messages) in [("cold", &cold), ("warm", &warm)] {
+            assert_eq!(messages.len(), 5, "{path}");
+            assert_eq!(
+                messages
+                    .iter()
+                    .map(|message| message.tokens.input)
+                    .sum::<i64>(),
+                254,
+                "{path}",
+            );
+        }
+        assert_eq!(warm, cold);
+        assert_eq!(
+            cold.iter()
+                .filter(|message| {
+                    message.dedup_key.as_deref()
+                        == Some("openclaw:shared-event:1788566869000:100:10")
+                })
+                .count(),
+            1,
+        );
+        assert_eq!(
+            cold.iter()
+                .filter(|message| message.dedup_key.is_none())
+                .count(),
+            2,
+            "events without IDs must remain distinct rather than collapsing by usage",
+        );
+        assert_eq!(direct.counts.get(ClientId::OpenClaw), 5);
+        assert_eq!(direct.messages.len(), 5);
+        assert_eq!(
+            direct
+                .messages
+                .iter()
+                .map(|message| message.input)
+                .sum::<i64>(),
+            254,
+        );
     }
 
     /// `/fork` copies the transcript into a new session file, so the same

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1068,7 +1068,9 @@ fn parser_version(client: ClientId) -> u32 {
     match client {
         // v1->v2: compressed OpenClaw archives were scanned as plain JSONL and
         // cached as empty. Their bytes do not change when decoding is fixed.
-        ClientId::OpenClaw => 2,
+        // v2->v3: assistant events carry stable cross-transcript dedup keys;
+        // v2 cache rows have no keys and would keep counting archive copies.
+        ClientId::OpenClaw => 3,
         // These clients accumulated parser-only invalidations under the old
         // global schema. Their independent counters start from those histories
         // so future changes have an obvious local version to increment.
@@ -3294,6 +3296,11 @@ mod tests {
     fn test_devin_parser_versions_invalidate_v1_entries() {
         assert_eq!(parser_version(ClientId::DevinCli), 3);
         assert_eq!(parser_version(ClientId::DevinDesktop), 2);
+    }
+
+    #[test]
+    fn test_openclaw_dedup_parser_version_invalidates_v2_entries() {
+        assert_eq!(parser_version(ClientId::OpenClaw), 3);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/openclaw.rs
+++ b/crates/tokscale-core/src/sessions/openclaw.rs
@@ -65,6 +65,7 @@ struct SessionEntry {
 struct OpenClawEntry {
     #[serde(rename = "type")]
     entry_type: String,
+    id: Option<String>,
     message: Option<OpenClawMessage>,
     #[serde(rename = "customType")]
     custom_type: Option<String>,
@@ -88,6 +89,23 @@ struct OpenClawModelData {
     provider: Option<String>,
     #[serde(rename = "modelId")]
     model_id: Option<String>,
+}
+
+/// Stable identity for one assistant event across live, archived, and forked
+/// transcript copies. OpenClaw preserves event IDs when copying transcript
+/// history; timestamp and usage make short IDs safe across unrelated sessions.
+fn openclaw_dedup_key(
+    event_id: &str,
+    timestamp: Option<i64>,
+    tokens: &crate::TokenBreakdown,
+) -> String {
+    match timestamp {
+        Some(timestamp) => format!(
+            "openclaw:{event_id}:{timestamp}:{}:{}",
+            tokens.input, tokens.output
+        ),
+        None => format!("openclaw:{event_id}:{}:{}", tokens.input, tokens.output),
+    }
 }
 
 pub fn parse_openclaw_index(index_path: &Path) -> Vec<UnifiedMessage> {
@@ -226,17 +244,24 @@ fn parse_openclaw_session(session_path: &Path, session_id: &str) -> Vec<UnifiedM
 
                     current_model = Some(model.clone());
                     current_provider = Some(provider.clone());
-                    let timestamp = msg.timestamp.unwrap_or(file_mtime_ms);
+                    let message_timestamp = msg.timestamp;
+                    let timestamp = message_timestamp.unwrap_or(file_mtime_ms);
                     let cost = usage.cost.as_ref().and_then(|c| c.total).unwrap_or(0.0);
+                    let tokens = usage.to_breakdown();
+                    let dedup_key = entry
+                        .id
+                        .filter(|id| !id.is_empty())
+                        .map(|id| openclaw_dedup_key(&id, message_timestamp, &tokens));
 
-                    messages.push(UnifiedMessage::new(
+                    messages.push(UnifiedMessage::new_with_dedup(
                         "openclaw",
                         model,
                         provider,
                         session_id.to_string(),
                         timestamp,
-                        usage.to_breakdown(),
+                        tokens,
                         cost.max(0.0),
+                        dedup_key,
                     ));
                 }
             }


### PR DESCRIPTION
## Summary

- Follow up on #1285: count an OpenClaw assistant event once when its plain transcript and compressed archive coexist, while preserving archive-only history and distinct events.
- Apply stable event-ID-based deduplication to cached cold/warm scans and direct aggregation. Events without usable IDs remain separate rather than being collapsed by matching usage alone.
- Advance the OpenClaw parser version from 2 to 3 so previously cached messages without dedup keys are reparsed.

## Verification

- Regression failed before the fix: 6 messages instead of 5.
- OpenClaw tests: 22 passed.
- Independent cache tests: 73 passed.
- Changed-file diagnostics, formatting, strict clippy for core/CLI including all targets, and workspace build passed.
- Independent real CLI fixture: both cold and warm scans report 3 messages, 240 input tokens, and 24 output tokens, preserving the archive-only event.
- Independent requirements, code, security, context, and hands-on QA reviews passed.

## Integration

This is separate from the checkpoint-artifact exclusion follow-up. Merge this parser-version-3 change before that follow-up's version-4 change. Pending #1278 must preserve this decoder/dedup behavior and advance the parser version again if its rebase changes cached message interpretation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates OpenClaw assistant events across plain transcripts and compressed archives, so the same event is counted once instead of once per copy. Uses stable event IDs when available; events without IDs remain separate, and archive-only history is preserved. Bumps the OpenClaw parser version to 3 to invalidate cached messages that lack dedup keys.

<sup>Written for commit 3be6ed48abd2a22dc6e9bc5db2fb64441e9df8e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

