### PR TITLE
fix(tui): tune widget colors and contribution ramp for light mode

### DIFF
--- a/crates/tokscale-cli/src/tui/themes.rs
+++ b/crates/tokscale-cli/src/tui/themes.rs
@@ -548,6 +548,46 @@ impl Theme {
             Style::default().bg(self.current_row)
         }
     }
+
+    pub(crate) fn hint_key_color(&self) -> Color {
+        let c = if self.light {
+            if self.color_mode == TerminalColorMode::Compatible {
+                Color::DarkGray
+            } else {
+                Color::Rgb(160, 100, 20)
+            }
+        } else {
+            Color::Yellow
+        };
+        self.color(c)
+    }
+
+    pub(crate) fn hint_key_style(&self) -> Style {
+        Style::default().fg(self.hint_key_color())
+    }
+
+    pub(crate) fn count_color(&self) -> Color {
+        let c = if self.light {
+            Color::Rgb(14, 116, 144)
+        } else {
+            Color::Cyan
+        };
+        self.color(c)
+    }
+
+    pub(crate) fn count_style(&self) -> Style {
+        Style::default().fg(self.count_color())
+    }
+
+    pub(crate) fn graph_cell_selected_style(&self, bg: Color) -> Style {
+        let fg = if self.light {
+            self.foreground
+        } else {
+            Color::White
+        };
+        Style::default().fg(fg).bg(bg)
+    }
+
     /// Build a light-background variant of `name` for the current terminal.
     pub(crate) fn from_name_for_current_terminal_light(name: ThemeName) -> Self {
         Self::from_name_with_color_mode_light(name, TerminalColorMode::from_env(std::env::vars()))
@@ -578,7 +618,14 @@ impl Theme {
             self.selection = Color::Gray;
             self.striped_row = Color::White;
             self.current_row = Color::Gray;
-            self.colors[0] = Color::Gray;
+            self.colors = [
+                Color::Gray,
+                Color::Cyan,
+                Color::Blue,
+                Color::DarkGray,
+                Color::Black,
+            ];
+            self.highlight = Color::Blue;
             self.accent = Color::Blue;
             return;
         }
@@ -939,6 +986,48 @@ mod tests {
         // The light surface still inverts: white background, dark text.
         assert_eq!(theme.background, Color::White);
         assert_eq!(theme.foreground, Color::Black);
+
+        // Every contribution grade color is distinct and never blends into the white background.
+        assert!(theme.colors.iter().all(|color| *color != Color::White));
+        let mut unique_colors = theme.colors.to_vec();
+        unique_colors.sort_by_key(|c| format!("{c:?}"));
+        unique_colors.dedup();
+        assert_eq!(unique_colors.len(), 5);
+    }
+
+    #[test]
+    fn theme_hint_and_count_styles_contrast_in_light_and_dark_modes() {
+        let dark = Theme::from_name_with_color_mode(ThemeName::Green, TerminalColorMode::FullColor);
+        let light =
+            Theme::from_name_with_color_mode_light(ThemeName::Green, TerminalColorMode::FullColor);
+
+        assert_eq!(dark.hint_key_style().fg, Some(Color::Yellow));
+        assert_eq!(dark.count_style().fg, Some(Color::Cyan));
+        assert_eq!(
+            dark.graph_cell_selected_style(Color::Black).fg,
+            Some(Color::White)
+        );
+
+        assert_eq!(light.hint_key_style().fg, Some(Color::Rgb(160, 100, 20)));
+        assert_eq!(light.count_style().fg, Some(Color::Rgb(14, 116, 144)));
+        assert_eq!(
+            light.graph_cell_selected_style(Color::White).fg,
+            Some(light.foreground)
+        );
+
+        let compat_dark =
+            Theme::from_name_with_color_mode(ThemeName::Green, TerminalColorMode::Compatible);
+        let compat_light =
+            Theme::from_name_with_color_mode_light(ThemeName::Green, TerminalColorMode::Compatible);
+
+        assert_eq!(compat_dark.hint_key_style().fg, Some(Color::Yellow));
+        assert_eq!(compat_dark.count_style().fg, Some(Color::Cyan));
+        assert_eq!(compat_light.hint_key_style().fg, Some(Color::DarkGray));
+        assert_eq!(compat_light.count_style().fg, Some(Color::Blue));
+        assert_eq!(
+            compat_light.graph_cell_selected_style(Color::White).fg,
+            Some(Color::Black)
+        );
     }
 
     #[test]
@@ -967,6 +1056,8 @@ mod tests {
             theme.subtle_text_style(),
             theme.striped_row_style(),
             theme.current_row_style(),
+            theme.hint_key_style(),
+            theme.count_style(),
         ];
 
         for style in styles {

--- a/crates/tokscale-cli/src/tui/themes.rs
+++ b/crates/tokscale-cli/src/tui/themes.rs
@@ -580,10 +580,29 @@ impl Theme {
     }
 
     pub(crate) fn graph_cell_selected_style(&self, bg: Color) -> Style {
-        let fg = if self.light {
-            self.foreground
-        } else {
-            Color::White
+        let fg = match bg {
+            Color::Black | Color::DarkGray | Color::Blue => Color::White,
+            Color::White | Color::Gray | Color::Cyan => {
+                if self.light {
+                    self.foreground
+                } else {
+                    Color::Black
+                }
+            }
+            Color::Rgb(r, g, b) => {
+                let luminance = 299 * u32::from(r) + 587 * u32::from(g) + 114 * u32::from(b);
+                if luminance > 128_000 {
+                    if self.light {
+                        self.foreground
+                    } else {
+                        Color::Black
+                    }
+                } else {
+                    Color::White
+                }
+            }
+            _ if self.light => self.foreground,
+            _ => Color::White,
         };
         Style::default().fg(fg).bg(bg)
     }
@@ -1007,12 +1026,28 @@ mod tests {
             dark.graph_cell_selected_style(Color::Black).fg,
             Some(Color::White)
         );
+        assert_eq!(
+            dark.graph_cell_selected_style(Color::White).fg,
+            Some(Color::Black)
+        );
+        assert_eq!(
+            dark.graph_cell_selected_style(Color::Rgb(250, 250, 250)).fg,
+            Some(Color::Black)
+        );
+        assert_eq!(
+            dark.graph_cell_selected_style(Color::Rgb(20, 20, 20)).fg,
+            Some(Color::White)
+        );
 
         assert_eq!(light.hint_key_style().fg, Some(Color::Rgb(160, 100, 20)));
         assert_eq!(light.count_style().fg, Some(Color::Rgb(14, 116, 144)));
         assert_eq!(
             light.graph_cell_selected_style(Color::White).fg,
             Some(light.foreground)
+        );
+        assert_eq!(
+            light.graph_cell_selected_style(Color::Black).fg,
+            Some(Color::White)
         );
 
         let compat_dark =
@@ -1022,11 +1057,23 @@ mod tests {
 
         assert_eq!(compat_dark.hint_key_style().fg, Some(Color::Yellow));
         assert_eq!(compat_dark.count_style().fg, Some(Color::Cyan));
+        assert_eq!(
+            compat_dark.graph_cell_selected_style(Color::White).fg,
+            Some(Color::Black)
+        );
+        assert_eq!(
+            compat_dark.graph_cell_selected_style(Color::Black).fg,
+            Some(Color::White)
+        );
         assert_eq!(compat_light.hint_key_style().fg, Some(Color::DarkGray));
         assert_eq!(compat_light.count_style().fg, Some(Color::Blue));
         assert_eq!(
             compat_light.graph_cell_selected_style(Color::White).fg,
             Some(Color::Black)
+        );
+        assert_eq!(
+            compat_light.graph_cell_selected_style(Color::Black).fg,
+            Some(Color::White)
         );
     }
 

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -158,9 +158,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             let cells: Vec<Cell> = if is_very_narrow {
                 vec![
                     Cell::from(day.date.format(date_fmt).to_string()).style(if is_today {
-                        Style::default()
-                            .fg(Color::Yellow)
-                            .add_modifier(Modifier::BOLD)
+                        app.theme.hint_key_style().add_modifier(Modifier::BOLD)
                     } else {
                         Style::default()
                     }),
@@ -170,9 +168,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 let mut cells =
                     vec![
                         Cell::from(day.date.format(date_fmt).to_string()).style(if is_today {
-                            Style::default()
-                                .fg(Color::Yellow)
-                                .add_modifier(Modifier::BOLD)
+                            app.theme.hint_key_style().add_modifier(Modifier::BOLD)
                         } else {
                             Style::default()
                         }),
@@ -195,9 +191,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 let mut cells =
                     vec![
                         Cell::from(day.date.format(date_fmt).to_string()).style(if is_today {
-                            Style::default()
-                                .fg(Color::Yellow)
-                                .add_modifier(Modifier::BOLD)
+                            app.theme.hint_key_style().add_modifier(Modifier::BOLD)
                         } else {
                             Style::default().add_modifier(Modifier::BOLD)
                         }),
@@ -222,7 +216,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         day.tokens.input,
                         day.tokens.cache_write,
                     ))
-                    .style(Style::default().fg(Color::Cyan)),
+                    .style(app.theme.count_style()),
                     total_tokens_cell(day.tokens.total(), &app.theme),
                     Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
                     Cell::from(format_cost_per_million(day.cost, day.tokens.total()))
@@ -471,7 +465,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
                         row.tokens.input,
                         row.tokens.cache_write,
                     ))
-                    .style(Style::default().fg(Color::Cyan)),
+                    .style(app.theme.count_style()),
                     total_tokens_cell(row.tokens.total(), &app.theme),
                     Cell::from(format_cost(row.cost)).style(Style::default().fg(Color::Green)),
                 ]

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -115,7 +115,7 @@ fn render_main_row(frame: &mut Frame, app: &mut App, area: Rect) {
     let total_tokens = app.data.total_tokens;
     right_spans.push(Span::styled(
         format_tokens(total_tokens),
-        Style::default().fg(Color::Cyan),
+        app.theme.count_style(),
     ));
     if !is_very_narrow {
         right_spans.push(Span::styled(
@@ -169,6 +169,8 @@ fn current_count_label(app: &App) -> String {
 
 fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
     let is_very_narrow = app.is_very_narrow();
+    let hint_style = app.theme.hint_key_style();
+    let count_style = app.theme.count_style();
 
     let spans = if is_very_narrow {
         let mut spans = vec![
@@ -178,37 +180,37 @@ fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled("·", Style::default().fg(app.theme.muted)),
             Span::styled("d/t/c", Style::default().fg(Color::Blue)),
             Span::styled("·", Style::default().fg(app.theme.muted)),
-            Span::styled("[s]", Style::default().fg(Color::Cyan)),
+            Span::styled("[s]", count_style),
             Span::styled("·", Style::default().fg(app.theme.muted)),
-            Span::styled("[g]", Style::default().fg(Color::Cyan)),
+            Span::styled("[g]", count_style),
             Span::styled("·", Style::default().fg(app.theme.muted)),
             Span::styled("[p]", Style::default().fg(Color::Magenta)),
             Span::styled("·", Style::default().fg(app.theme.muted)),
-            Span::styled("[r]", Style::default().fg(Color::Yellow)),
+            Span::styled("[r]", hint_style),
             Span::styled("·", Style::default().fg(app.theme.muted)),
             Span::styled("q", Style::default().fg(app.theme.muted)),
         ];
         if app.current_tab == Tab::Daily {
             spans.push(Span::styled("·", Style::default().fg(app.theme.muted)));
             if app.is_daily_detail_active() {
-                spans.push(Span::styled("esc", Style::default().fg(Color::Yellow)));
+                spans.push(Span::styled("esc", hint_style));
             } else {
-                spans.push(Span::styled("↵", Style::default().fg(Color::Yellow)));
+                spans.push(Span::styled("↵", hint_style));
                 spans.push(Span::styled("·", Style::default().fg(app.theme.muted)));
-                spans.push(Span::styled("j", Style::default().fg(Color::Yellow)));
+                spans.push(Span::styled("j", hint_style));
             }
         }
         if app.current_tab == Tab::Monthly {
             spans.push(Span::styled("·", Style::default().fg(app.theme.muted)));
             if app.is_monthly_detail_active() {
-                spans.push(Span::styled("esc", Style::default().fg(Color::Yellow)));
+                spans.push(Span::styled("esc", hint_style));
             } else {
-                spans.push(Span::styled("↵", Style::default().fg(Color::Yellow)));
+                spans.push(Span::styled("↵", hint_style));
             }
         }
         if app.current_tab == Tab::Hourly {
             spans.push(Span::styled("·", Style::default().fg(app.theme.muted)));
-            spans.push(Span::styled("v", Style::default().fg(Color::Yellow)));
+            spans.push(Span::styled("v", hint_style));
         }
         spans
     } else {
@@ -222,52 +224,31 @@ fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
         ];
         if app.current_tab == Tab::Daily {
             if app.is_daily_detail_active() {
-                spans.push(Span::styled(
-                    "[esc:back]",
-                    Style::default().fg(Color::Yellow),
-                ));
+                spans.push(Span::styled("[esc:back]", hint_style));
             } else {
-                spans.push(Span::styled(
-                    "[enter:details]",
-                    Style::default().fg(Color::Yellow),
-                ));
+                spans.push(Span::styled("[enter:details]", hint_style));
                 spans.push(Span::styled(" ", Style::default()));
-                spans.push(Span::styled(
-                    "[j:today]",
-                    Style::default().fg(Color::Yellow),
-                ));
+                spans.push(Span::styled("[j:today]", hint_style));
             }
             spans.push(Span::styled(" • ", Style::default().fg(app.theme.muted)));
         }
         if app.current_tab == Tab::Monthly {
             if app.is_monthly_detail_active() {
-                spans.push(Span::styled(
-                    "[esc:back]",
-                    Style::default().fg(Color::Yellow),
-                ));
+                spans.push(Span::styled("[esc:back]", hint_style));
             } else {
-                spans.push(Span::styled(
-                    "[enter:details]",
-                    Style::default().fg(Color::Yellow),
-                ));
+                spans.push(Span::styled("[enter:details]", hint_style));
             }
             spans.push(Span::styled(" • ", Style::default().fg(app.theme.muted)));
         }
         if app.current_tab == Tab::Hourly {
-            spans.push(Span::styled(
-                "[v:profile]",
-                Style::default().fg(Color::Yellow),
-            ));
+            spans.push(Span::styled("[v:profile]", hint_style));
             spans.push(Span::styled(" • ", Style::default().fg(app.theme.muted)));
         }
-        spans.push(Span::styled(
-            "[s:sources]",
-            Style::default().fg(Color::Cyan),
-        ));
+        spans.push(Span::styled("[s:sources]", count_style));
         spans.push(Span::styled(" ", Style::default()));
         spans.push(Span::styled(
             format!("[g:{}]", app.group_by.borrow()),
-            Style::default().fg(Color::Cyan),
+            count_style,
         ));
         // `w` only does anything under workspace grouping, so only advertise it there.
         if *app.group_by.borrow() == tokscale_core::GroupBy::WorkspaceModel {
@@ -277,7 +258,7 @@ fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
                     tokscale_core::WorktreeRollup::MergeIntoRepo => "[w:repos]",
                     tokscale_core::WorktreeRollup::Separate => "[w:worktrees]",
                 },
-                Style::default().fg(Color::Cyan),
+                count_style,
             ));
         }
         spans.push(Span::styled(" • ", Style::default().fg(app.theme.muted)));
@@ -299,10 +280,7 @@ fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
             }),
         ));
         spans.push(Span::styled(" • ", Style::default().fg(app.theme.muted)));
-        spans.push(Span::styled(
-            "[r:refresh]",
-            Style::default().fg(Color::Yellow),
-        ));
+        spans.push(Span::styled("[r:refresh]", hint_style));
         spans.push(Span::styled(
             " • e • q",
             Style::default().fg(app.theme.muted),

--- a/crates/tokscale-cli/src/tui/ui/hourly.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly.rs
@@ -201,9 +201,7 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
 
         let time_str = hour.datetime.format("%H:00").to_string();
         let time_style = if is_current {
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD)
+            app.theme.hint_key_style().add_modifier(Modifier::BOLD)
         } else if !is_narrow && !is_very_narrow {
             Style::default().add_modifier(Modifier::BOLD)
         } else {
@@ -248,7 +246,7 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
                     hour.tokens.input,
                     hour.tokens.cache_write,
                 ))
-                .style(Style::default().fg(Color::Cyan)),
+                .style(app.theme.count_style()),
                 total_tokens_cell(hour.tokens.total(), &app.theme),
                 Cell::from(format_cost(hour.cost)).style(Style::default().fg(Color::Green)),
                 Cell::from(format_cost_per_million(hour.cost, hour.tokens.total()))

--- a/crates/tokscale-cli/src/tui/ui/hourly_profile.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly_profile.rs
@@ -73,14 +73,11 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 
     // Summary line
     let summary_spans = vec![
-        Span::styled(
-            format!("{} hours", hourly.len()),
-            Style::default().fg(Color::Cyan),
-        ),
+        Span::styled(format!("{} hours", hourly.len()), app.theme.count_style()),
         Span::styled("  |  ", Style::default().fg(app.theme.muted)),
         Span::styled(
             format!("{} total tokens", format_tokens(total_tokens)),
-            Style::default().fg(Color::Cyan),
+            app.theme.count_style(),
         ),
         Span::styled("  |  ", Style::default().fg(app.theme.muted)),
         Span::styled(
@@ -131,10 +128,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             Span::styled("  ", Style::default()),
             Span::styled(bar, Style::default().fg(Color::Green)),
             Span::styled("  ", Style::default()),
-            Span::styled(
-                format!("{:>5.1}%", percentage),
-                Style::default().fg(Color::Yellow),
-            ),
+            Span::styled(format!("{:>5.1}%", percentage), app.theme.hint_key_style()),
         ]));
     }
     lines.push(Line::from(""));
@@ -180,17 +174,14 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             Span::styled(
                 format!("  {:<10}", weekday.day),
                 Style::default().fg(if is_best {
-                    Color::Yellow
+                    app.theme.hint_key_color()
                 } else {
                     app.theme.foreground
                 }),
             ),
             Span::styled(bar, Style::default().fg(Color::Green)),
             Span::styled("  ", Style::default()),
-            Span::styled(
-                format!("{:>5.1}%", percentage),
-                Style::default().fg(Color::Yellow),
-            ),
+            Span::styled(format!("{:>5.1}%", percentage), app.theme.hint_key_style()),
         ]));
     }
     lines.push(Line::from(""));
@@ -206,10 +197,10 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             ),
             Span::styled(
                 format!("{:02}:00-{:02}:59", hour, hour),
-                Style::default().fg(Color::Yellow),
+                app.theme.hint_key_style(),
             ),
             Span::styled("  (", Style::default().fg(app.theme.muted)),
-            Span::styled(format_tokens(tokens), Style::default().fg(Color::Cyan)),
+            Span::styled(format_tokens(tokens), app.theme.count_style()),
             Span::styled(" tokens, ", Style::default().fg(app.theme.muted)),
             Span::styled(format_cost(cost), Style::default().fg(Color::Green)),
             Span::styled(")", Style::default().fg(app.theme.muted)),
@@ -230,7 +221,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     lines.push(Line::from(""));
     lines.push(Line::from(vec![
         Span::styled("Press ", Style::default().fg(app.theme.muted)),
-        Span::styled("[v]", Style::default().fg(Color::Yellow)),
+        Span::styled("[v]", app.theme.hint_key_style()),
         Span::styled(
             " to switch to table view",
             Style::default().fg(app.theme.muted),

--- a/crates/tokscale-cli/src/tui/ui/minutely.rs
+++ b/crates/tokscale-cli/src/tui/ui/minutely.rs
@@ -144,9 +144,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 vec![
                     Cell::from(minute.datetime.format("%m/%d %H:%M").to_string()).style(
                         if is_current {
-                            Style::default()
-                                .fg(Color::Yellow)
-                                .add_modifier(Modifier::BOLD)
+                            app.theme.hint_key_style().add_modifier(Modifier::BOLD)
                         } else {
                             Style::default()
                         },
@@ -157,9 +155,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 let mut cells = vec![
                     Cell::from(minute.datetime.format("%m-%d %H:%M").to_string()).style(
                         if is_current {
-                            Style::default()
-                                .fg(Color::Yellow)
-                                .add_modifier(Modifier::BOLD)
+                            app.theme.hint_key_style().add_modifier(Modifier::BOLD)
                         } else {
                             Style::default()
                         },
@@ -184,9 +180,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 let mut cells = vec![
                     Cell::from(minute.datetime.format("%Y-%m-%d %H:%M").to_string()).style(
                         if is_current {
-                            Style::default()
-                                .fg(Color::Yellow)
-                                .add_modifier(Modifier::BOLD)
+                            app.theme.hint_key_style().add_modifier(Modifier::BOLD)
                         } else {
                             Style::default().add_modifier(Modifier::BOLD)
                         },
@@ -214,7 +208,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         minute.tokens.input,
                         minute.tokens.cache_write,
                     ))
-                    .style(Style::default().fg(Color::Cyan)),
+                    .style(app.theme.count_style()),
                     total_tokens_cell(minute.tokens.total(), &app.theme),
                     Cell::from(format_cost(minute.cost)).style(Style::default().fg(Color::Green)),
                 ]);

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -302,7 +302,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         .style(metric_cache_write_style),
                     total_tokens_cell(model.tokens.total(), &app.theme),
                     Cell::from(format_ms_per_1k(model.performance.ms_per_1k_tokens))
-                        .style(Style::default().fg(Color::Yellow)),
+                        .style(app.theme.hint_key_style()),
                     Cell::from(format_cost(model.cost)).style(Style::default().fg(Color::Green)),
                     Cell::from(format_cost_per_million(model.cost, model.tokens.total()))
                         .style(Style::default().fg(Color::Rgb(150, 200, 150))),
@@ -329,10 +329,10 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         model.tokens.input,
                         model.tokens.cache_write,
                     ))
-                    .style(Style::default().fg(Color::Cyan)),
+                    .style(app.theme.count_style()),
                     total_tokens_cell(model.tokens.total(), &app.theme),
                     Cell::from(format_ms_per_1k(model.performance.ms_per_1k_tokens))
-                        .style(Style::default().fg(Color::Yellow)),
+                        .style(app.theme.hint_key_style()),
                     Cell::from(format_cost(model.cost)).style(Style::default().fg(Color::Green)),
                     Cell::from(format_cost_per_million(model.cost, model.tokens.total()))
                         .style(Style::default().fg(Color::Rgb(150, 200, 150))),

--- a/crates/tokscale-cli/src/tui/ui/monthly.rs
+++ b/crates/tokscale-cli/src/tui/ui/monthly.rs
@@ -180,7 +180,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         month.tokens.input,
                         month.tokens.cache_write,
                     ))
-                    .style(Style::default().fg(Color::Cyan)),
+                    .style(app.theme.count_style()),
                     total_tokens_cell(month.tokens.total(), &app.theme),
                     Cell::from(format_cost(month.cost)).style(Style::default().fg(Color::Green)),
                     Cell::from(format_cost_per_million(month.cost, month.tokens.total()))
@@ -449,7 +449,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
                         day.tokens.input,
                         day.tokens.cache_write,
                     ))
-                    .style(Style::default().fg(Color::Cyan)),
+                    .style(app.theme.count_style()),
                     total_tokens_cell(day.tokens.total(), &app.theme),
                     Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
                     Cell::from(format_cost_per_million(day.cost, day.tokens.total()))

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -324,7 +324,7 @@ impl SessionColumn {
                 format_cache_hit_rate(s.tokens.cache_read, s.tokens.input, s.tokens.cache_write),
                 ctx,
             ))
-            .style(Style::default().fg(Color::Cyan)),
+            .style(app.theme.count_style()),
             // Spelled out rather than `total_tokens_cell` — same style, but the
             // helper has no width to clamp against.
             Self::Total => Cell::from(self.fit(format_tokens(s.tokens.total()), ctx))
@@ -337,7 +337,7 @@ impl SessionColumn {
             }
             Self::Duration => {
                 Cell::from(self.fit(format_duration(s.first_active_ms, s.last_active_ms), ctx))
-                    .style(Style::default().fg(Color::Yellow))
+                    .style(app.theme.hint_key_style())
             }
             Self::LastActive => Cell::from(
                 self.fit(

--- a/crates/tokscale-cli/src/tui/ui/stats.rs
+++ b/crates/tokscale-cli/src/tui/ui/stats.rs
@@ -142,14 +142,14 @@ fn render_graph(frame: &mut Frame, app: &mut App, area: Rect) {
                 Some(day) => {
                     let color = intensity_color(day.intensity);
                     if is_selected {
-                        ("▓▓", Style::default().fg(Color::White).bg(color))
+                        ("▓▓", app.theme.graph_cell_selected_style(color))
                     } else {
                         ("██", Style::default().fg(color))
                     }
                 }
                 None => {
                     if is_selected {
-                        ("▓▓", Style::default().fg(Color::White).bg(theme_colors[0]))
+                        ("▓▓", app.theme.graph_cell_selected_style(theme_colors[0]))
                     } else {
                         ("· ", subtle_text_style)
                     }
@@ -305,10 +305,7 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
     let row1_col2 = Line::from(vec![
         Span::styled(tokens_label, Style::default().fg(app.theme.muted)),
         Span::raw(" "),
-        Span::styled(
-            format_tokens(total_tokens),
-            Style::default().fg(Color::Cyan),
-        ),
+        Span::styled(format_tokens(total_tokens), app.theme.count_style()),
     ]);
     frame.render_widget(
         Paragraph::new(row1_col2),
@@ -323,7 +320,7 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
     let row2 = Line::from(vec![
         Span::styled("Sessions:", Style::default().fg(app.theme.muted)),
         Span::raw(" "),
-        Span::styled(sessions.to_string(), Style::default().fg(Color::Cyan)),
+        Span::styled(sessions.to_string(), app.theme.count_style()),
     ]);
     frame.render_widget(Paragraph::new(row2), Rect::new(inner.x, y, col1_width, 1));
 
@@ -354,7 +351,7 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
         Span::raw(" "),
         Span::styled(
             format!("{} days", app.data.current_streak),
-            Style::default().fg(Color::Cyan),
+            app.theme.count_style(),
         ),
     ]);
     frame.render_widget(Paragraph::new(row3), Rect::new(inner.x, y, col1_width, 1));
@@ -369,7 +366,7 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
         Span::raw(" "),
         Span::styled(
             format!("{} days", app.data.longest_streak),
-            Style::default().fg(Color::Cyan),
+            app.theme.count_style(),
         ),
     ]);
     frame.render_widget(
@@ -388,7 +385,7 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
         Span::raw(" "),
         Span::styled(
             format!("{}/{}", active_days, total_days),
-            Style::default().fg(Color::Cyan),
+            app.theme.count_style(),
         ),
     ]);
     frame.render_widget(
@@ -431,7 +428,7 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
                 total_cost
             ),
             Style::default()
-                .fg(Color::Yellow)
+                .fg(app.theme.hint_key_color())
                 .add_modifier(Modifier::ITALIC),
         ));
         frame.render_widget(
@@ -497,7 +494,7 @@ fn render_breakdown_panel(frame: &mut Frame, app: &mut App, area: Rect) {
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw("  "),
-            Span::styled(format_tokens(day.tokens), Style::default().fg(Color::Cyan)),
+            Span::styled(format_tokens(day.tokens), app.theme.count_style()),
             Span::raw("  "),
             Span::styled(
                 format_cost(day.cost),


### PR DESCRIPTION
## Summary
Fixes #1193 by routing hardcoded widget colors through theme helpers tuned for light mode, fixing white-on-white contribution graph cell selection, and establishing a distinct contribution ramp for compatible color mode on light surfaces.

## Changes
- `crates/tokscale-cli/src/tui/themes.rs`:
  - Added `hint_key_style()` / `hint_key_color()` to provide dark amber/gold (`#a06414` in full color, `Color::DarkGray` in compatible mode) in light mode instead of washed-out `Color::Yellow`.
  - Added `count_style()` / `count_color()` to provide deep cyan (`#0e7490` in full color, `Color::Blue` in compatible mode) in light mode instead of bright ANSI `Color::Cyan`.
  - Added `graph_cell_selected_style(bg)` to use `self.foreground` in light mode for `▓▓` stippled cells, eliminating white-on-white selection highlights.
  - In `apply_light()`, assigned a full 5-grade ramp (`[Gray, Cyan, Blue, DarkGray, Black]`) for `TerminalColorMode::Compatible` so no contribution grade blends into the white surface.
  - Added unit tests covering light vs. dark mode contrast for hint/count styles, graph cell selection styles, and compatible light contribution ramp uniqueness.
- `crates/tokscale-cli/src/tui/ui/stats.rs`:
  - Replaced hardcoded `Color::White` on `▓▓` selected contribution cells with `theme.graph_cell_selected_style()`.
  - Routed token count, session count, streak, active days, and spending footer spans through `theme.count_style()` and `theme.hint_key_color()`.
- `crates/tokscale-cli/src/tui/ui/footer.rs`:
  - Replaced hardcoded `Color::Cyan` token counts and label brackets (`[s]`, `[g]`, `[w]`) with `theme.count_style()`.
  - Replaced hardcoded `Color::Yellow` key hints (`[r]`, `esc`, `enter`, `j`, `v`, `[r:refresh]`) with `theme.hint_key_style()`.
- `crates/tokscale-cli/src/tui/ui/{daily, hourly, minutely, monthly, models, sessions, hourly_profile}.rs`:
  - Routed cache hit rate, time/best indicators, duration, and performance metrics through `theme.count_style()` and `theme.hint_key_style()`.

## Verification
- `cargo test -p tokscale-cli` (all 183 unit tests + 8 integration tests pass)
- `cargo test -p tokscale-core` (all 2058 unit + integration tests pass)
- `cargo fmt --all -- --check` (clean formatting)
- `cargo clippy --locked --workspace --all-features -- -D warnings` (clean clippy)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1193 by routing hardcoded widget colors through light-mode-aware theme helpers and making selected graph cell foreground contrast adaptively with its background.

- Adds `hint_key_style()`/`count_style()` helpers that keep yellow/cyan in dark mode but switch to dark amber/deep cyan in light mode.
- Fixes selected contribution graph cell contrast by choosing foreground per background luminance, preventing white-on-white and black-on-black in both light and dark ramps.
- Gives compatible color mode a distinct 5-grade contribution ramp in light mode so no grade blends into the white background.
- Routes key hints, token counts, and metric spans across footer, stats, models, sessions, and all time-granularity views through the new helpers.

<sup>Written for commit 491029e637b0c0af14b77ff7e89e1640155ea698. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

