### PR TITLE
fix(openclaw): exclude compaction checkpoint snapshots from usage

### DIFF
--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -749,6 +749,33 @@ fn create_empty_fixture_dir() -> TempDir {
     tmp
 }
 
+fn write_openclaw_checkpoint_fixture(base: &Path) -> std::path::PathBuf {
+    let sessions = base.join(".openclaw/agents/main/sessions");
+    fs::create_dir_all(&sessions).unwrap();
+    let primary = sessions.join("session-original.jsonl");
+    let original = br#"{"type":"message","message":{"role":"assistant","provider":"anthropic","model":"claude-sonnet-4-6","usage":{"input":100,"output":50},"timestamp":1788566869012}}"#;
+    fs::write(&primary, original).unwrap();
+
+    let checkpoint = "11111111-1111-4111-8111-111111111111";
+    let snapshot = br#"{"type":"message","message":{"role":"assistant","provider":"anthropic","model":"claude-sonnet-4-6","usage":{"input":900,"output":450},"timestamp":1788566869012}}"#;
+    fs::write(
+        sessions.join(format!("session-original.checkpoint.{checkpoint}.jsonl")),
+        snapshot,
+    )
+    .unwrap();
+    for reason in ["deleted", "reset"] {
+        fs::write(
+            sessions.join(format!(
+                "session-original.checkpoint.{checkpoint}.jsonl.{reason}.2026-09-05T00-00-00.000Z.zst"
+            )),
+            zstd::encode_all(&snapshot[..], 0).unwrap(),
+        )
+        .unwrap();
+    }
+
+    primary
+}
+
 #[cfg(unix)]
 fn create_timezone_boundary_fixture_dir() -> TempDir {
     let tmp = TempDir::new().expect("failed to create temp dir");
@@ -2398,6 +2425,57 @@ fn test_mcode_headless_stream_counts_identically_cold_and_warm_cache() {
         assert_eq!(entry["cacheWrite"].as_i64(), Some(50), "{pass} cache pass");
         assert_eq!(json["totalMessages"].as_i64(), Some(1), "{pass} cache pass");
     }
+}
+
+#[test]
+fn test_openclaw_checkpoint_snapshots_do_not_inflate_cli_aggregates_or_warm_cache() {
+    let tmp = create_empty_fixture_dir();
+    let primary = write_openclaw_checkpoint_fixture(tmp.path());
+
+    for pass in ["cold", "warm"] {
+        let output = cmd_with_home(tmp.path())
+            .args(["models", "--json", "--client", "openclaw", "--no-spinner"])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{pass} cache pass failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(json["totalMessages"].as_i64(), Some(1), "{pass} cache pass");
+        assert_eq!(json["totalInput"].as_i64(), Some(100), "{pass} cache pass");
+        assert_eq!(json["totalOutput"].as_i64(), Some(50), "{pass} cache pass");
+        assert_eq!(
+            json["entries"].as_array().unwrap().len(),
+            1,
+            "{pass} cache pass"
+        );
+    }
+
+    let source_cache = sandbox_config_dir(tmp.path())
+        .join("cache")
+        .join("source-message-cache-v2");
+    assert!(
+        source_cache.is_dir(),
+        "the checkpoint-only pass must exercise an existing source cache"
+    );
+    fs::remove_file(primary).unwrap();
+
+    let output = cmd_with_home(tmp.path())
+        .args(["models", "--json", "--client", "openclaw", "--no-spinner"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["totalMessages"].as_i64(), Some(0));
+    assert_eq!(json["totalInput"].as_i64(), Some(0));
+    assert_eq!(json["totalOutput"].as_i64(), Some(0));
+    assert!(json["entries"].as_array().unwrap().is_empty());
 }
 
 /// The Windows regression guard for the two tests below.

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1068,7 +1068,13 @@ fn parser_version(client: ClientId) -> u32 {
     match client {
         // v1->v2: compressed OpenClaw archives were scanned as plain JSONL and
         // cached as empty. Their bytes do not change when decoding is fixed.
-        ClientId::OpenClaw => 2,
+        // v2->v3 is reserved for transcript deduplication; merge that change
+        // before this one so each independently shipped behavior has a distinct
+        // identity. v3->v4: compaction checkpoint snapshots are no longer scan
+        // sources. Source-cache entries cannot be reached once discovery omits
+        // them, but parser_generation must change so the source-agnostic TUI
+        // aggregate cache cannot replay totals that included those snapshots.
+        ClientId::OpenClaw => 4,
         // These clients accumulated parser-only invalidations under the old
         // global schema. Their independent counters start from those histories
         // so future changes have an obvious local version to increment.
@@ -3590,6 +3596,11 @@ mod tests {
         cache.save_if_dirty();
         let warm = SourceMessageCache::load();
         assert_eq!(warm.get(identity, &source).unwrap().messages, parsed);
+    }
+
+    #[test]
+    fn openclaw_checkpoint_exclusion_invalidates_v3_derived_caches() {
+        assert_eq!(parser_version(ClientId::OpenClaw), 4);
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -374,6 +374,45 @@ pub fn copilot_exporter_path() -> Option<PathBuf> {
     copilot_exporter_path_with_env_strategy(true)
 }
 
+/// Whether an OpenClaw transcript name is a compaction checkpoint snapshot.
+///
+/// OpenClaw writes these as `<session>.checkpoint.<uuid>.jsonl`; its archive
+/// cleanup can then append a reset/deleted suffix and optionally compress the
+/// result. Keep the UUID checks aligned with OpenClaw's classifier so ordinary
+/// sessions that merely contain `checkpoint` in their names remain visible.
+fn is_openclaw_compaction_checkpoint(file_name: &str) -> bool {
+    fn is_uuid(value: &str) -> bool {
+        if value.len() != 36 {
+            return false;
+        }
+
+        value.bytes().enumerate().all(|(index, byte)| match index {
+            8 | 13 | 18 | 23 => byte == b'-',
+            14 => matches!(byte, b'1'..=b'5'),
+            19 => matches!(byte.to_ascii_lowercase(), b'8' | b'9' | b'a' | b'b'),
+            _ => byte.is_ascii_hexdigit(),
+        })
+    }
+
+    let normalized = file_name.strip_suffix(".zst").unwrap_or(file_name);
+    let stem = normalized.strip_suffix(".jsonl").or_else(|| {
+        [".jsonl.deleted.", ".jsonl.reset."]
+            .into_iter()
+            .filter_map(|marker| normalized.rfind(marker))
+            .max()
+            .map(|index| &normalized[..index])
+    });
+    let Some(stem) = stem else {
+        return false;
+    };
+
+    let lowercase = stem.to_ascii_lowercase();
+    let Some((session_id, checkpoint_id)) = lowercase.rsplit_once(".checkpoint.") else {
+        return false;
+    };
+    !session_id.is_empty() && is_uuid(checkpoint_id)
+}
+
 /// Scan a single directory for session files
 pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
     if !std::path::Path::new(root).exists() {
@@ -451,10 +490,11 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 // OpenClaw: also match archived transcripts
                 // (<uuid>.jsonl.deleted.<ts>, <uuid>.jsonl.reset.<ts>)
                 "*.jsonl*" => {
-                    file_name.ends_with(".jsonl")
-                        || file_name.ends_with(".jsonl.zst")
-                        || file_name.contains(".jsonl.deleted.")
-                        || file_name.contains(".jsonl.reset.")
+                    !is_openclaw_compaction_checkpoint(file_name)
+                        && (file_name.ends_with(".jsonl")
+                            || file_name.ends_with(".jsonl.zst")
+                            || file_name.contains(".jsonl.deleted.")
+                            || file_name.contains(".jsonl.reset."))
                 }
                 "*.csv" => file_name.ends_with(".csv"),
                 "usage*.csv" => {
@@ -5622,6 +5662,58 @@ mod tests {
         assert_eq!(result.get(ClientId::OpenClaw).len(), 1);
         assert!(result.get(ClientId::OpenClaw)[0]
             .ends_with("session-archived.jsonl.deleted.1700000000000"));
+    }
+
+    #[test]
+    fn scan_openclaw_excludes_only_canonical_compaction_checkpoints() {
+        let dir = TempDir::new().unwrap();
+        let sessions = dir.path().join(".openclaw/agents/main/sessions");
+        fs::create_dir_all(&sessions).unwrap();
+        let checkpoint = "11111111-1111-4111-8111-111111111111";
+
+        let kept = [
+            "primary.jsonl",
+            "primary.checkpoint.not-a-uuid.jsonl",
+            "primary.checkpoint.11111111-1111-0111-8111-111111111111.jsonl",
+            "named-checkpoint-session.jsonl.deleted.legacy-timestamp",
+            "primary.checkpoint.not-a-uuid.jsonl.reset.legacy-timestamp.zst",
+        ];
+        for name in kept {
+            fs::write(sessions.join(name), b"{}").unwrap();
+        }
+        for name in [
+            format!("primary.checkpoint.{checkpoint}.jsonl"),
+            format!("primary.checkpoint.{checkpoint}.jsonl.zst"),
+            format!("primary.checkpoint.{checkpoint}.jsonl.deleted.legacy-timestamp"),
+            format!("primary.checkpoint.{checkpoint}.jsonl.reset.legacy-timestamp.zst"),
+        ] {
+            fs::write(sessions.join(name), b"{}").unwrap();
+        }
+
+        let scan = scan_all_clients_with_env_strategy(
+            dir.path().to_str().unwrap(),
+            &["openclaw".to_string()],
+            false,
+        );
+        let names: HashSet<_> = scan
+            .get(ClientId::OpenClaw)
+            .iter()
+            .filter_map(|path| path.file_name().and_then(|name| name.to_str()))
+            .collect();
+        assert_eq!(names, kept.into_iter().collect());
+
+        let checkpoint_only = dir.path().join(".openclaw/agents/checkpoint-only/sessions");
+        fs::create_dir_all(&checkpoint_only).unwrap();
+        fs::write(
+            checkpoint_only.join(format!("only.checkpoint.{checkpoint}.jsonl")),
+            b"{}",
+        )
+        .unwrap();
+        let scan = scan_directory(checkpoint_only.to_str().unwrap(), "*.jsonl*");
+        assert!(
+            scan.is_empty(),
+            "checkpoint-only roots must contribute no sources"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Follow up on #1285 and #1278: exclude OpenClaw compaction checkpoint snapshots from usage discovery, including plain and compressed reset/deleted archives.
- Match OpenClaw's canonical checkpoint UUID grammar while preserving ordinary session names, noncanonical lookalikes, and existing legacy archive spellings.
- Advance OpenClaw's parser generation to version 4 to invalidate TUI aggregates containing previously counted snapshots.

## Verification

- Changed-file diagnostics and formatting passed.
- OpenClaw core tests: 22 passed.
- Workspace clippy with all features and warnings denied passed; core clippy passed again after the version-4 adjustment.
- Independent final-source debug compilation and CLI integration test passed: cold and warm reports contain 1 message, 100 input tokens, and 50 output tokens; a checkpoint-only directory then reports zero despite the existing cache.
- Independent final-source checkpoint test filter: 3 passed.
- Independent requirements, code, security, context, and hands-on QA reviews passed.
- A release build passed before the version-4 constant adjustment. Final-version release relinks timed out; final-version compilation and executable behavior were verified with the debug CLI integration test instead.

## Merge order

Rebased onto `main` at `4664d386` (#1278). #1291 was closed as superseded by #1278, which carries the same dedup and took OpenClaw parser version 3; this branch keeps version 4 and its arm comment now records all three steps (v2 #1285, v3 #1278, v4 here). The checkpoint exclusion is still needed: #1278's scanner accepts every `<id>.jsonl.<suffix>` form and does not exclude checkpoint snapshots, so the matcher here wraps that rule rather than replacing it.
