### PR TITLE
chore(ci): pin Rust toolchain to 1.98.0

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -125,7 +125,7 @@ jobs:
           path: .
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.98.0
         with:
           targets: ${{ matrix.settings.target }}
 

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -17,6 +17,7 @@ on:
       - "packages/cli-*/package.json"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
 
 permissions:
   contents: read

--- a/.github/workflows/launcher_validation.yml
+++ b/.github/workflows/launcher_validation.yml
@@ -20,6 +20,7 @@ on:
       - "bun.lock"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
       - "crates/**"
   pull_request:
     branches: [main]

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -62,7 +62,7 @@ jobs:
         run: python3 scripts/check-release-workflow-safety.py
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.98.0
 
       - name: Calculate version
         id: bump

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -8,6 +8,7 @@ on:
       - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'rust-toolchain.toml'
       - '.github/workflows/test_coverage.yml'
   pull_request:
     branches: [main]

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.98.0
         with:
           components: clippy, rustfmt
       - name: Cache cargo registry
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.98.0
 
       - name: Cache cargo registry
         uses: actions/cache@v5
@@ -146,7 +146,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.98.0
 
       - name: Cache cargo registry
         uses: actions/cache@v5

--- a/.github/workflows/workflow_lint.yml
+++ b/.github/workflows/workflow_lint.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
     paths: &workflow_lint_paths
       - ".github/workflows/**"
+      - "rust-toolchain.toml"
+      - "scripts/check-workflow-toolchain-paths.py"
+      - "scripts/test-workflow-toolchain-paths.sh"
   pull_request:
     branches: [main]
     paths: *workflow_lint_paths
@@ -28,3 +31,9 @@ jobs:
       - name: Lint GitHub Actions workflows
         # actionlint 1.7.12; keep the image immutable and review the version when updating this digest.
         uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+
+      - name: Verify Rust workflows re-run on toolchain pin changes
+        run: python3 scripts/check-workflow-toolchain-paths.py
+
+      - name: Run workflow check tests
+        run: bash scripts/test-workflow-toolchain-paths.sh

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.98.0"
+components = ["clippy", "rustfmt"]

--- a/scripts/check-workflow-toolchain-paths.py
+++ b/scripts/check-workflow-toolchain-paths.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Require every path-filtered Rust workflow to re-run when the toolchain pin changes.
+
+`rust-toolchain.toml` selects the compiler for every bare `cargo` call in the
+checkout: rustup ranks it above the `rustup default` that
+`dtolnay/rust-toolchain` sets, so bumping the pin changes what CI builds with.
+A workflow whose `paths:` filter omits the file would skip exactly the run
+that should exercise the new compiler.
+"""
+import pathlib
+import re
+import sys
+
+
+ROOT = pathlib.Path.cwd()
+WORKFLOWS_DIR = ROOT / ".github/workflows"
+TOOLCHAIN_FILE = "rust-toolchain.toml"
+RUST_MARKERS = re.compile(r"dtolnay/rust-toolchain|\bcargo\b")
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def strip_yaml_comment(value: str) -> str:
+    quote: str | None = None
+    for index, char in enumerate(value):
+        if quote:
+            if char == quote:
+                quote = None
+            continue
+        if char in {'"', "'"}:
+            quote = char
+            continue
+        if char == "#" and (index == 0 or value[index - 1].isspace()):
+            return value[:index].rstrip()
+    return value.rstrip()
+
+
+def indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def unquote(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
+def trigger_block(lines: list[str]) -> tuple[int, int]:
+    """Return the [start, end) line range of the top-level `on:` mapping."""
+    start = None
+    for index, line in enumerate(lines):
+        if re.match(r"""(?:on|"on"|'on'):\s*$""", line):
+            start = index + 1
+            break
+    if start is None:
+        return 0, 0
+    for index in range(start, len(lines)):
+        if lines[index].strip() and indent_of(lines[index]) == 0:
+            return start, index
+    return start, len(lines)
+
+
+def list_entries(lines: list[str], start: int, indent: int) -> list[str]:
+    entries: list[str] = []
+    for line in lines[start:]:
+        if not line.strip():
+            continue
+        if indent_of(line) <= indent:
+            break
+        item = re.match(r"\s*-\s*(.+?)\s*$", line)
+        if item:
+            entries.append(unquote(item.group(1)))
+    return entries
+
+
+def path_filters(label: str, lines: list[str]) -> list[tuple[int, str, list[str]]]:
+    """Return (line_number, key, entries) for each paths/paths-ignore filter under `on:`."""
+    start, end = trigger_block(lines)
+    anchors: dict[str, list[str]] = {}
+    filters: list[tuple[int, str, list[str]]] = []
+    for index in range(start, end):
+        match = re.match(r"(\s*)(paths|paths-ignore):\s*(.*)$", lines[index])
+        if not match:
+            continue
+        line_number = index + 1
+        indent = len(match.group(1))
+        key = match.group(2)
+        rest = match.group(3).strip()
+
+        if rest.startswith("*"):
+            alias = rest[1:].strip()
+            if alias not in anchors:
+                fail(f"{label}:{line_number}: `{key}: *{alias}` has no earlier anchor")
+            filters.append((line_number, key, anchors[alias]))
+            continue
+
+        anchor = None
+        if rest.startswith("&"):
+            anchor, _, rest = rest[1:].partition(" ")
+            rest = rest.strip()
+        if rest.startswith("[") and rest.endswith("]"):
+            entries = [unquote(item) for item in rest[1:-1].split(",") if item.strip()]
+        elif rest:
+            fail(f"{label}:{line_number}: unsupported `{key}:` value: {rest}")
+        else:
+            entries = list_entries(lines, index + 1, indent)
+        if anchor:
+            anchors[anchor] = entries
+        filters.append((line_number, key, entries))
+    return filters
+
+
+def workflow_problems(path: pathlib.Path) -> list[str] | None:
+    """Return the filter problems for a Rust workflow, or None if it is not one."""
+    label = path.relative_to(ROOT).as_posix()
+    lines = [
+        strip_yaml_comment(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+    ]
+    if not any(RUST_MARKERS.search(line) for line in lines):
+        return None
+
+    problems: list[str] = []
+    for line_number, key, entries in path_filters(label, lines):
+        if key == "paths" and TOOLCHAIN_FILE not in entries:
+            problems.append(f"{label}:{line_number}: `paths:` filter omits {TOOLCHAIN_FILE}")
+        if key == "paths-ignore" and TOOLCHAIN_FILE in entries:
+            problems.append(f"{label}:{line_number}: `paths-ignore:` filter lists {TOOLCHAIN_FILE}")
+    return problems
+
+
+def main() -> None:
+    if not (ROOT / TOOLCHAIN_FILE).exists():
+        fail(f"Missing {TOOLCHAIN_FILE}; the Rust workflows pin their compiler through it")
+    if not WORKFLOWS_DIR.is_dir():
+        fail(f"Missing workflows directory: {WORKFLOWS_DIR}")
+
+    checked: list[str] = []
+    problems: list[str] = []
+    for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        found = workflow_problems(path)
+        if found is None:
+            continue
+        checked.append(path.name)
+        problems.extend(found)
+
+    if not checked:
+        fail(f"No Rust workflows found under {WORKFLOWS_DIR}")
+    if problems:
+        for problem in problems:
+            print(f"ERROR: {problem}", file=sys.stderr)
+        fail(f"a {TOOLCHAIN_FILE}-only bump would skip the workflows above")
+    print(
+        f"Workflow toolchain paths OK: {len(checked)} Rust workflows checked "
+        f"({', '.join(checked)})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-workflow-toolchain-paths.py
+++ b/scripts/check-workflow-toolchain-paths.py
@@ -15,7 +15,11 @@ import sys
 ROOT = pathlib.Path.cwd()
 WORKFLOWS_DIR = ROOT / ".github/workflows"
 TOOLCHAIN_FILE = "rust-toolchain.toml"
+WORKFLOW_GLOBS = ("*.yml", "*.yaml")
 RUST_MARKERS = re.compile(r"dtolnay/rust-toolchain|\bcargo\b")
+# `on: push` or `on: [push, pull_request]`: event names alone, so no `paths:`
+# can hide in them. Any other inline value (a flow mapping, an anchor) can.
+INLINE_TRIGGER_WITHOUT_FILTERS = re.compile(r"[A-Za-z_]+|\[[^\[\]{}:]*\]")
 
 
 def fail(message: str) -> None:
@@ -49,13 +53,25 @@ def unquote(value: str) -> str:
     return value
 
 
-def trigger_block(lines: list[str]) -> tuple[int, int]:
-    """Return the [start, end) line range of the top-level `on:` mapping."""
+def trigger_block(label: str, lines: list[str]) -> tuple[int, int]:
+    """Return the [start, end) line range of the top-level `on:` mapping.
+
+    An inline `on:` value is either a bare event list, which cannot carry a
+    filter and yields an empty range, or unsupported, which fails loudly
+    rather than exempting the workflow.
+    """
     start = None
     for index, line in enumerate(lines):
-        if re.match(r"""(?:on|"on"|'on'):\s*$""", line):
+        match = re.match(r"""(?:on|"on"|'on'):\s*(.*)$""", line)
+        if not match:
+            continue
+        inline = match.group(1).strip()
+        if not inline:
             start = index + 1
             break
+        if INLINE_TRIGGER_WITHOUT_FILTERS.fullmatch(inline):
+            return 0, 0
+        fail(f"{label}:{index + 1}: unsupported inline `on:` value: {inline}")
     if start is None:
         return 0, 0
     for index in range(start, len(lines)):
@@ -79,7 +95,7 @@ def list_entries(lines: list[str], start: int, indent: int) -> list[str]:
 
 def path_filters(label: str, lines: list[str]) -> list[tuple[int, str, list[str]]]:
     """Return (line_number, key, entries) for each paths/paths-ignore filter under `on:`."""
-    start, end = trigger_block(lines)
+    start, end = trigger_block(label, lines)
     anchors: dict[str, list[str]] = {}
     filters: list[tuple[int, str, list[str]]] = []
     for index in range(start, end):
@@ -141,7 +157,10 @@ def main() -> None:
 
     checked: list[str] = []
     problems: list[str] = []
-    for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+    workflows = sorted(
+        path for pattern in WORKFLOW_GLOBS for path in WORKFLOWS_DIR.glob(pattern)
+    )
+    for path in workflows:
         found = workflow_problems(path)
         if found is None:
             continue

--- a/scripts/test-workflow-toolchain-paths.sh
+++ b/scripts/test-workflow-toolchain-paths.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_UNDER_TEST="${ROOT_DIR}/scripts/check-workflow-toolchain-paths.py"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+write_good_tree() {
+  local work="$1"
+  mkdir -p "${work}/.github/workflows"
+  cat > "${work}/rust-toolchain.toml" <<'EOF_TOML'
+[toolchain]
+channel = "1.98.0"
+EOF_TOML
+  cat > "${work}/.github/workflows/rust_anchored.yml" <<'EOF_YAML'
+name: Rust Anchored
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths: &rust_paths
+      - 'crates/**'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+  pull_request:
+    branches: [main]
+    paths: *rust_paths
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@1.98.0
+      - run: cargo test --workspace
+EOF_YAML
+  cat > "${work}/.github/workflows/rust_unfiltered.yml" <<'EOF_YAML'
+name: Rust Unfiltered
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@1.98.0
+      - run: cargo build --release
+EOF_YAML
+  cat > "${work}/.github/workflows/frontend.yml" <<'EOF_YAML'
+name: Frontend
+
+on:
+  pull_request:
+    paths:
+      # cargo is only mentioned in this comment, so the filter is exempt
+      - "packages/frontend/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: bun test
+EOF_YAML
+}
+
+run_check() {
+  local work="$1"
+  local output="$2"
+  (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1)
+}
+
+test_accepts_rust_workflows_that_watch_the_pin() {
+  local work="${TMP_DIR}/good"
+  write_good_tree "${work}"
+
+  local output="${TMP_DIR}/good-output.txt"
+  run_check "${work}" "${output}"
+
+  grep -q "Workflow toolchain paths OK: 2 Rust workflows checked (rust_anchored.yml, rust_unfiltered.yml)" "${output}"
+}
+
+test_rejects_rust_workflow_whose_filter_omits_the_pin() {
+  local work="${TMP_DIR}/omitted"
+  write_good_tree "${work}"
+  sed -i.bak "/rust-toolchain.toml/d" "${work}/.github/workflows/rust_anchored.yml"
+  rm "${work}/.github/workflows/rust_anchored.yml.bak"
+
+  local output="${TMP_DIR}/omitted-output.txt"
+  if run_check "${work}" "${output}"; then
+    echo "Expected toolchain path check to reject a filter that omits rust-toolchain.toml" >&2
+    return 1
+  fi
+
+  grep -q "rust_anchored.yml:7: \`paths:\` filter omits rust-toolchain.toml" "${output}"
+  # Deleting the entry shifts the alias line up by one.
+  grep -q "rust_anchored.yml:12: \`paths:\` filter omits rust-toolchain.toml" "${output}"
+}
+
+test_rejects_pin_missing_from_one_trigger_only() {
+  local work="${TMP_DIR}/one-trigger"
+  write_good_tree "${work}"
+  python3 - "${work}/.github/workflows/rust_anchored.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "    paths: *rust_paths\n",
+    "    paths:\n      - 'crates/**'\n",
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/one-trigger-output.txt"
+  if run_check "${work}" "${output}"; then
+    echo "Expected toolchain path check to reject a pull_request filter that omits rust-toolchain.toml" >&2
+    return 1
+  fi
+
+  grep -q "rust_anchored.yml:13: \`paths:\` filter omits rust-toolchain.toml" "${output}"
+  if grep -q "rust_anchored.yml:7:" "${output}"; then
+    echo "Expected the push filter, which lists rust-toolchain.toml, to pass" >&2
+    return 1
+  fi
+}
+
+test_rejects_pin_listed_in_paths_ignore() {
+  local work="${TMP_DIR}/paths-ignore"
+  write_good_tree "${work}"
+  python3 - "${work}/.github/workflows/rust_unfiltered.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "  workflow_dispatch:\n",
+    "  pull_request:\n    paths-ignore: [\"docs/**\", \"rust-toolchain.toml\"]\n",
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/paths-ignore-output.txt"
+  if run_check "${work}" "${output}"; then
+    echo "Expected toolchain path check to reject a paths-ignore that lists rust-toolchain.toml" >&2
+    return 1
+  fi
+
+  grep -q "rust_unfiltered.yml:5: \`paths-ignore:\` filter lists rust-toolchain.toml" "${output}"
+}
+
+test_rejects_missing_toolchain_pin() {
+  local work="${TMP_DIR}/no-pin"
+  write_good_tree "${work}"
+  rm "${work}/rust-toolchain.toml"
+
+  local output="${TMP_DIR}/no-pin-output.txt"
+  if run_check "${work}" "${output}"; then
+    echo "Expected toolchain path check to reject a tree without rust-toolchain.toml" >&2
+    return 1
+  fi
+
+  grep -q "Missing rust-toolchain.toml" "${output}"
+}
+
+test_rejects_tree_without_rust_workflows() {
+  local work="${TMP_DIR}/no-rust"
+  write_good_tree "${work}"
+  rm "${work}/.github/workflows/rust_anchored.yml" "${work}/.github/workflows/rust_unfiltered.yml"
+
+  local output="${TMP_DIR}/no-rust-output.txt"
+  if run_check "${work}" "${output}"; then
+    echo "Expected toolchain path check to reject a tree with no Rust workflows" >&2
+    return 1
+  fi
+
+  grep -q "No Rust workflows found" "${output}"
+}
+
+test_accepts_rust_workflows_that_watch_the_pin
+test_rejects_rust_workflow_whose_filter_omits_the_pin
+test_rejects_pin_missing_from_one_trigger_only
+test_rejects_pin_listed_in_paths_ignore
+test_rejects_missing_toolchain_pin
+test_rejects_tree_without_rust_workflows
+
+echo "workflow toolchain path tests passed"

--- a/scripts/test-workflow-toolchain-paths.sh
+++ b/scripts/test-workflow-toolchain-paths.sh
@@ -36,6 +36,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.98.0
       - run: cargo test --workspace
 EOF_YAML
+  # No dtolnay/rust-toolchain step: this workflow runs cargo on the runner's
+  # preinstalled toolchain, so only the bare `cargo` marker classifies it.
   cat > "${work}/.github/workflows/rust_unfiltered.yml" <<'EOF_YAML'
 name: Rust Unfiltered
 
@@ -47,7 +49,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@1.98.0
       - run: cargo build --release
 EOF_YAML
   cat > "${work}/.github/workflows/frontend.yml" <<'EOF_YAML'
@@ -169,6 +170,106 @@ test_rejects_missing_toolchain_pin() {
   grep -q "Missing rust-toolchain.toml" "${output}"
 }
 
+test_rejects_cargo_only_workflow_whose_filter_omits_the_pin() {
+  local work="${TMP_DIR}/cargo-only"
+  write_good_tree "${work}"
+  python3 - "${work}/.github/workflows/rust_unfiltered.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "  workflow_dispatch:\n",
+    "  pull_request:\n    paths: [\"crates/**\", \"Cargo.lock\"]\n",
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/cargo-only-output.txt"
+  if run_check "${work}" "${output}"; then
+    echo "Expected toolchain path check to classify a workflow by its cargo call alone" >&2
+    return 1
+  fi
+
+  grep -q "rust_unfiltered.yml:5: \`paths:\` filter omits rust-toolchain.toml" "${output}"
+}
+
+test_rejects_yaml_extension_workflow_whose_filter_omits_the_pin() {
+  local work="${TMP_DIR}/yaml-ext"
+  write_good_tree "${work}"
+  cat > "${work}/.github/workflows/rust_yaml_ext.yaml" <<'EOF_YAML'
+name: Rust Yaml Extension
+on:
+  pull_request:
+    paths:
+      - 'crates/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@1.98.0
+      - run: cargo test --workspace
+EOF_YAML
+
+  local output="${TMP_DIR}/yaml-ext-output.txt"
+  if run_check "${work}" "${output}"; then
+    echo "Expected toolchain path check to scan .yaml workflows too" >&2
+    return 1
+  fi
+
+  grep -q "rust_yaml_ext.yaml:4: \`paths:\` filter omits rust-toolchain.toml" "${output}"
+}
+
+test_rejects_inline_flow_mapping_trigger() {
+  local work="${TMP_DIR}/flow-mapping"
+  write_good_tree "${work}"
+  python3 - "${work}/.github/workflows/rust_unfiltered.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "on:\n  workflow_dispatch:\n",
+    'on: {pull_request: {paths: ["crates/**", "Cargo.lock"]}}\n',
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/flow-mapping-output.txt"
+  if run_check "${work}" "${output}"; then
+    echo "Expected toolchain path check to reject an inline flow mapping under on:" >&2
+    return 1
+  fi
+
+  grep -q "rust_unfiltered.yml:3: unsupported inline \`on:\` value" "${output}"
+}
+
+test_accepts_inline_event_list_trigger() {
+  local work="${TMP_DIR}/event-list"
+  write_good_tree "${work}"
+  python3 - "${work}/.github/workflows/rust_unfiltered.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "on:\n  workflow_dispatch:\n",
+    "on: [push, pull_request]\n",
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/event-list-output.txt"
+  run_check "${work}" "${output}"
+
+  grep -q "Workflow toolchain paths OK: 2 Rust workflows checked (rust_anchored.yml, rust_unfiltered.yml)" "${output}"
+}
+
 test_rejects_tree_without_rust_workflows() {
   local work="${TMP_DIR}/no-rust"
   write_good_tree "${work}"
@@ -187,6 +288,10 @@ test_accepts_rust_workflows_that_watch_the_pin
 test_rejects_rust_workflow_whose_filter_omits_the_pin
 test_rejects_pin_missing_from_one_trigger_only
 test_rejects_pin_listed_in_paths_ignore
+test_rejects_cargo_only_workflow_whose_filter_omits_the_pin
+test_rejects_yaml_extension_workflow_whose_filter_omits_the_pin
+test_rejects_inline_flow_mapping_trigger
+test_accepts_inline_event_list_trigger
 test_rejects_missing_toolchain_pin
 test_rejects_tree_without_rust_workflows
 


### PR DESCRIPTION
## Summary
Pins the Rust toolchain version to `1.98.0` in a new `rust-toolchain.toml` at the repository root and updates all CI workflows (`build-native.yml`, `publish-cli.yml`, `test_coverage.yml`) from `dtolnay/rust-toolchain@stable` to `@1.98.0`.

Resolves #1237

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the Rust toolchain to 1.98.0 via a new `rust-toolchain.toml` at the repo root and switches all CI workflows from `dtolnay/rust-toolchain@stable` to `@1.98.0`. This resolves #1237 and makes local and CI builds use the same compiler.

**Workflow path filters**
- Rust workflows now list `rust-toolchain.toml` in their `paths:` filters so a toolchain-only bump re-runs builds, lint, and tests.
- `workflow_lint.yml` runs a new checker that fails if a Rust workflow's `paths:` omits the pin or `paths-ignore:` lists it, backed by a test suite.

<sup>Written for commit 2f71c05ecc8d36304aaf164ae8c4ace2f5a740c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

