### PR TITLE
feat(tui): add a Projects tab with cross-client usage rollups

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ tokscale models --json > report.json   # Save to file
 
 The interactive TUI mode provides:
 
-- **10 Views**: Overview (chart + top models), Usage (subscription quotas), Models, Daily, Hourly, Monthly, Sessions, Projects (per-workspace rollups), Stats (contribution graph), Agents. A per-minute view (Minutely) is hidden by default and can be enabled with `minutelyTabEnabled` in `settings.json` — see [Configuration](#configuration)
+- **10 Views**: Overview (chart + top models), Usage (subscription quotas), Models, Daily, Hourly, Monthly, Sessions, Projects (per-workspace rollups), Stats (contribution graph), Agents. In Projects, Codex Desktop's ordinary chat directories (`Documents/Codex/YYYY-MM-DD/<chat>`) are combined into **Codex Chat**, preserving their session count, tokens, and cost; directories containing a Git repository remain separate. A per-minute view (Minutely) is hidden by default and can be enabled with `minutelyTabEnabled` in `settings.json` — see [Configuration](#configuration)
 - **Keyboard Navigation**:
   - `←/→/Tab/BackTab`: Switch views
   - `↑/↓` or `Home/End`: Navigate lists

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
 ## Features
 
 - **Interactive TUI Mode** - Beautiful terminal UI powered by Ratatui (default mode)
-  - 6 interactive views: Overview, Models, Daily, Hourly, Stats, Agents (plus an optional Minutely view, opt-in via `minutelyTabEnabled`)
+  - 10 interactive views: Overview, Usage, Models, Daily, Hourly, Monthly, Sessions, Projects, Stats, Agents (plus an optional Minutely view, opt-in via `minutelyTabEnabled`)
   - Keyboard & mouse navigation
   - GitHub-style contribution graph with configurable color themes
   - Real-time filtering and sorting
@@ -285,7 +285,7 @@ tokscale models --json > report.json   # Save to file
 
 The interactive TUI mode provides:
 
-- **8 Views**: Overview (chart + top models), Usage (subscription quotas), Models, Daily, Hourly, Stats (contribution graph), Agents. A per-minute view (Minutely) is hidden by default and can be enabled with `minutelyTabEnabled` in `settings.json` — see [Configuration](#configuration)
+- **10 Views**: Overview (chart + top models), Usage (subscription quotas), Models, Daily, Hourly, Monthly, Sessions, Projects (per-workspace rollups), Stats (contribution graph), Agents. A per-minute view (Minutely) is hidden by default and can be enabled with `minutelyTabEnabled` in `settings.json` — see [Configuration](#configuration)
 - **Keyboard Navigation**:
   - `←/→/Tab/BackTab`: Switch views
   - `↑/↓` or `Home/End`: Navigate lists

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -20,7 +20,7 @@ use super::codex_login::{
 };
 use super::data::{
     AgentUsage, DailyUsage, DataLoader, HourlyUsage, MinutelyUsage, ModelUsage, MonthlyUsage,
-    SessionUsage, TokenBreakdown, UsageData,
+    ProjectUsage, SessionUsage, TokenBreakdown, UsageData,
 };
 use super::privacy::looks_like_email;
 use super::settings::Settings;
@@ -66,6 +66,7 @@ pub enum Tab {
     Minutely,
     Monthly,
     Sessions,
+    Projects,
     Stats,
     Agents,
 }
@@ -81,6 +82,7 @@ impl Tab {
             Tab::Minutely,
             Tab::Monthly,
             Tab::Sessions,
+            Tab::Projects,
             Tab::Stats,
             Tab::Agents,
         ]
@@ -96,6 +98,7 @@ impl Tab {
             Tab::Minutely => "Minutely",
             Tab::Monthly => "Monthly",
             Tab::Sessions => "Sessions",
+            Tab::Projects => "Projects",
             Tab::Stats => "Stats",
             Tab::Agents => "Agents",
         }
@@ -111,6 +114,7 @@ impl Tab {
             Tab::Minutely => "Min",
             Tab::Monthly => "Mon",
             Tab::Sessions => "Ses",
+            Tab::Projects => "Prj",
             Tab::Stats => "Sta",
             Tab::Agents => "Agt",
         }
@@ -125,7 +129,8 @@ impl Tab {
             Tab::Hourly => Tab::Minutely,
             Tab::Minutely => Tab::Monthly,
             Tab::Monthly => Tab::Sessions,
-            Tab::Sessions => Tab::Stats,
+            Tab::Sessions => Tab::Projects,
+            Tab::Projects => Tab::Stats,
             Tab::Stats => Tab::Agents,
             Tab::Agents => Tab::Overview,
         }
@@ -141,7 +146,8 @@ impl Tab {
             Tab::Minutely => Tab::Hourly,
             Tab::Monthly => Tab::Minutely,
             Tab::Sessions => Tab::Monthly,
-            Tab::Stats => Tab::Sessions,
+            Tab::Projects => Tab::Sessions,
+            Tab::Stats => Tab::Projects,
             Tab::Agents => Tab::Stats,
         }
     }
@@ -1808,6 +1814,7 @@ impl App {
             }
             Tab::Monthly => self.data.monthly.len(),
             Tab::Sessions => self.data.sessions.len(),
+            Tab::Projects => self.data.projects.len(),
             Tab::Stats => {
                 if self.selected_graph_cell.is_some() {
                     self.stats_breakdown_total_lines
@@ -2186,6 +2193,10 @@ impl App {
                     )
                 }),
             Tab::Stats | Tab::Usage => None,
+            Tab::Projects => self
+                .get_sorted_projects()
+                .get(self.selected_index)
+                .map(|p| format!("{}: {} tokens, ${:.4}", p.label, p.tokens.total(), p.cost)),
         };
 
         if let Some(text) = text {
@@ -2635,6 +2646,60 @@ impl App {
 
         sessions
     }
+
+    pub fn get_sorted_projects(&self) -> Vec<&ProjectUsage> {
+        let mut projects: Vec<&ProjectUsage> = self.data.projects.iter().collect();
+
+        let tie_breaker = |a: &&ProjectUsage, b: &&ProjectUsage| {
+            a.label
+                .cmp(&b.label)
+                .then_with(|| a.workspace_key.cmp(&b.workspace_key))
+                .then_with(|| a.group_key.cmp(&b.group_key))
+        };
+
+        match (self.sort_field, self.sort_direction) {
+            (SortField::Cost, SortDirection::Descending) => projects.sort_by(|a, b| {
+                b.cost
+                    .total_cmp(&a.cost)
+                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
+                    .then_with(|| tie_breaker(a, b))
+            }),
+            (SortField::Cost, SortDirection::Ascending) => projects.sort_by(|a, b| {
+                a.cost
+                    .total_cmp(&b.cost)
+                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
+                    .then_with(|| tie_breaker(a, b))
+            }),
+            (SortField::Tokens, SortDirection::Descending) => projects.sort_by(|a, b| {
+                b.tokens
+                    .total()
+                    .cmp(&a.tokens.total())
+                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
+                    .then_with(|| tie_breaker(a, b))
+            }),
+            (SortField::Tokens, SortDirection::Ascending) => projects.sort_by(|a, b| {
+                a.tokens
+                    .total()
+                    .cmp(&b.tokens.total())
+                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
+                    .then_with(|| tie_breaker(a, b))
+            }),
+            // "Date" maps to last_active for projects: most recently active
+            // project first when descending, oldest active first when ascending.
+            (SortField::Date, SortDirection::Descending) => projects.sort_by(|a, b| {
+                b.last_active_ms
+                    .cmp(&a.last_active_ms)
+                    .then_with(|| tie_breaker(a, b))
+            }),
+            (SortField::Date, SortDirection::Ascending) => projects.sort_by(|a, b| {
+                a.last_active_ms
+                    .cmp(&b.last_active_ms)
+                    .then_with(|| tie_breaker(a, b))
+            }),
+        }
+
+        projects
+    }
 }
 
 #[cfg(test)]
@@ -2652,7 +2717,7 @@ mod tests {
     #[test]
     fn test_tab_all() {
         let tabs = Tab::all();
-        assert_eq!(tabs.len(), 10);
+        assert_eq!(tabs.len(), 11);
         assert_eq!(tabs[0], Tab::Overview);
         assert_eq!(tabs[1], Tab::Usage);
         assert_eq!(tabs[2], Tab::Models);
@@ -2661,8 +2726,9 @@ mod tests {
         assert_eq!(tabs[5], Tab::Minutely);
         assert_eq!(tabs[6], Tab::Monthly);
         assert_eq!(tabs[7], Tab::Sessions);
-        assert_eq!(tabs[8], Tab::Stats);
-        assert_eq!(tabs[9], Tab::Agents);
+        assert_eq!(tabs[8], Tab::Projects);
+        assert_eq!(tabs[9], Tab::Stats);
+        assert_eq!(tabs[10], Tab::Agents);
     }
 
     #[test]
@@ -2674,7 +2740,8 @@ mod tests {
         assert_eq!(Tab::Hourly.next(), Tab::Minutely);
         assert_eq!(Tab::Minutely.next(), Tab::Monthly);
         assert_eq!(Tab::Monthly.next(), Tab::Sessions);
-        assert_eq!(Tab::Sessions.next(), Tab::Stats);
+        assert_eq!(Tab::Sessions.next(), Tab::Projects);
+        assert_eq!(Tab::Projects.next(), Tab::Stats);
         assert_eq!(Tab::Stats.next(), Tab::Agents);
         assert_eq!(Tab::Agents.next(), Tab::Overview);
     }
@@ -2689,7 +2756,8 @@ mod tests {
         assert_eq!(Tab::Minutely.prev(), Tab::Hourly);
         assert_eq!(Tab::Monthly.prev(), Tab::Minutely);
         assert_eq!(Tab::Sessions.prev(), Tab::Monthly);
-        assert_eq!(Tab::Stats.prev(), Tab::Sessions);
+        assert_eq!(Tab::Projects.prev(), Tab::Sessions);
+        assert_eq!(Tab::Stats.prev(), Tab::Projects);
         assert_eq!(Tab::Agents.prev(), Tab::Stats);
     }
 
@@ -2703,6 +2771,7 @@ mod tests {
         assert_eq!(Tab::Minutely.as_str(), "Minutely");
         assert_eq!(Tab::Monthly.as_str(), "Monthly");
         assert_eq!(Tab::Sessions.as_str(), "Sessions");
+        assert_eq!(Tab::Projects.as_str(), "Projects");
         assert_eq!(Tab::Stats.as_str(), "Stats");
     }
 
@@ -2716,6 +2785,7 @@ mod tests {
         assert_eq!(Tab::Minutely.short_name(), "Min");
         assert_eq!(Tab::Monthly.short_name(), "Mon");
         assert_eq!(Tab::Sessions.short_name(), "Ses");
+        assert_eq!(Tab::Projects.short_name(), "Prj");
         assert_eq!(Tab::Stats.short_name(), "Sta");
     }
 
@@ -3642,6 +3712,9 @@ mod tests {
         assert_eq!(app.current_tab, Tab::Sessions);
 
         app.handle_key_event(key(KeyCode::Tab));
+        assert_eq!(app.current_tab, Tab::Projects);
+
+        app.handle_key_event(key(KeyCode::Tab));
         assert_eq!(app.current_tab, Tab::Stats);
 
         app.handle_key_event(key(KeyCode::Tab));
@@ -3661,6 +3734,9 @@ mod tests {
 
         app.handle_key_event(key(KeyCode::BackTab));
         assert_eq!(app.current_tab, Tab::Stats);
+
+        app.handle_key_event(key(KeyCode::BackTab));
+        assert_eq!(app.current_tab, Tab::Projects);
 
         app.handle_key_event(key(KeyCode::BackTab));
         assert_eq!(app.current_tab, Tab::Sessions);
@@ -3698,6 +3774,7 @@ mod tests {
             Tab::Minutely,
             Tab::Monthly,
             Tab::Sessions,
+            Tab::Projects,
             Tab::Stats,
             Tab::Agents,
             Tab::Overview,

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -2596,110 +2596,93 @@ impl App {
 
     pub fn get_sorted_sessions(&self) -> Vec<&SessionUsage> {
         let mut sessions: Vec<&SessionUsage> = self.data.sessions.iter().collect();
-
-        let tie_breaker = |a: &&SessionUsage, b: &&SessionUsage| {
-            a.client
-                .cmp(&b.client)
-                .then_with(|| a.session_id.cmp(&b.session_id))
-        };
-
-        match (self.sort_field, self.sort_direction) {
-            (SortField::Cost, SortDirection::Descending) => sessions.sort_by(|a, b| {
-                b.cost
-                    .total_cmp(&a.cost)
-                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
-                    .then_with(|| tie_breaker(a, b))
-            }),
-            (SortField::Cost, SortDirection::Ascending) => sessions.sort_by(|a, b| {
-                a.cost
-                    .total_cmp(&b.cost)
-                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
-                    .then_with(|| tie_breaker(a, b))
-            }),
-            (SortField::Tokens, SortDirection::Descending) => sessions.sort_by(|a, b| {
-                b.tokens
-                    .total()
-                    .cmp(&a.tokens.total())
-                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
-                    .then_with(|| tie_breaker(a, b))
-            }),
-            (SortField::Tokens, SortDirection::Ascending) => sessions.sort_by(|a, b| {
-                a.tokens
-                    .total()
-                    .cmp(&b.tokens.total())
-                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
-                    .then_with(|| tie_breaker(a, b))
-            }),
-            // "Date" maps to last_active for sessions: most recently active
-            // session first when descending, oldest active first when ascending.
-            (SortField::Date, SortDirection::Descending) => sessions.sort_by(|a, b| {
-                b.last_active_ms
-                    .cmp(&a.last_active_ms)
-                    .then_with(|| tie_breaker(a, b))
-            }),
-            (SortField::Date, SortDirection::Ascending) => sessions.sort_by(|a, b| {
-                a.last_active_ms
-                    .cmp(&b.last_active_ms)
-                    .then_with(|| tie_breaker(a, b))
-            }),
-        }
-
+        sort_usage_rows(
+            &mut sessions,
+            self.sort_field,
+            self.sort_direction,
+            |a, b| {
+                a.client
+                    .cmp(&b.client)
+                    .then_with(|| a.session_id.cmp(&b.session_id))
+            },
+        );
         sessions
     }
 
     pub fn get_sorted_projects(&self) -> Vec<&ProjectUsage> {
         let mut projects: Vec<&ProjectUsage> = self.data.projects.iter().collect();
-
-        let tie_breaker = |a: &&ProjectUsage, b: &&ProjectUsage| {
-            a.label
-                .cmp(&b.label)
-                .then_with(|| a.workspace_key.cmp(&b.workspace_key))
-                .then_with(|| a.group_key.cmp(&b.group_key))
-        };
-
-        match (self.sort_field, self.sort_direction) {
-            (SortField::Cost, SortDirection::Descending) => projects.sort_by(|a, b| {
-                b.cost
-                    .total_cmp(&a.cost)
-                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
-                    .then_with(|| tie_breaker(a, b))
-            }),
-            (SortField::Cost, SortDirection::Ascending) => projects.sort_by(|a, b| {
-                a.cost
-                    .total_cmp(&b.cost)
-                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
-                    .then_with(|| tie_breaker(a, b))
-            }),
-            (SortField::Tokens, SortDirection::Descending) => projects.sort_by(|a, b| {
-                b.tokens
-                    .total()
-                    .cmp(&a.tokens.total())
-                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
-                    .then_with(|| tie_breaker(a, b))
-            }),
-            (SortField::Tokens, SortDirection::Ascending) => projects.sort_by(|a, b| {
-                a.tokens
-                    .total()
-                    .cmp(&b.tokens.total())
-                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
-                    .then_with(|| tie_breaker(a, b))
-            }),
-            // "Date" maps to last_active for projects: most recently active
-            // project first when descending, oldest active first when ascending.
-            (SortField::Date, SortDirection::Descending) => projects.sort_by(|a, b| {
-                b.last_active_ms
-                    .cmp(&a.last_active_ms)
-                    .then_with(|| tie_breaker(a, b))
-            }),
-            (SortField::Date, SortDirection::Ascending) => projects.sort_by(|a, b| {
-                a.last_active_ms
-                    .cmp(&b.last_active_ms)
-                    .then_with(|| tie_breaker(a, b))
-            }),
-        }
-
+        sort_usage_rows(
+            &mut projects,
+            self.sort_field,
+            self.sort_direction,
+            |a, b| {
+                a.label
+                    .cmp(&b.label)
+                    .then_with(|| a.workspace_key.cmp(&b.workspace_key))
+                    .then_with(|| a.group_key.cmp(&b.group_key))
+            },
+        );
         projects
     }
+}
+
+/// The columns the Sessions and Projects tabs sort on. Both tabs order rows
+/// the same way -- the chosen metric, then most recent activity, then a
+/// tab-specific tie-breaker that names the row -- so the ordering lives in
+/// [`sort_usage_rows`] and each tab supplies only its tie-breaker.
+trait SortableUsage {
+    fn cost(&self) -> f64;
+    fn token_total(&self) -> u64;
+    fn last_active_ms(&self) -> i64;
+}
+
+impl SortableUsage for SessionUsage {
+    fn cost(&self) -> f64 {
+        self.cost
+    }
+    fn token_total(&self) -> u64 {
+        self.tokens.total()
+    }
+    fn last_active_ms(&self) -> i64 {
+        self.last_active_ms
+    }
+}
+
+impl SortableUsage for ProjectUsage {
+    fn cost(&self) -> f64 {
+        self.cost
+    }
+    fn token_total(&self) -> u64 {
+        self.tokens.total()
+    }
+    fn last_active_ms(&self) -> i64 {
+        self.last_active_ms
+    }
+}
+
+/// Sort `rows` by `field` in `direction`, then by most recent activity, then
+/// by `tie_breaker`. "Date" is last activity itself: most recently active
+/// first when descending, oldest first when ascending.
+fn sort_usage_rows<T: SortableUsage>(
+    rows: &mut [&T],
+    field: SortField,
+    direction: SortDirection,
+    tie_breaker: impl Fn(&T, &T) -> std::cmp::Ordering,
+) {
+    let metric = |a: &T, b: &T| match field {
+        SortField::Cost => a.cost().total_cmp(&b.cost()),
+        SortField::Tokens => a.token_total().cmp(&b.token_total()),
+        SortField::Date => a.last_active_ms().cmp(&b.last_active_ms()),
+    };
+    rows.sort_by(|a, b| {
+        let primary = match direction {
+            SortDirection::Descending => metric(b, a),
+            SortDirection::Ascending => metric(a, b),
+        };
+        primary
+            .then_with(|| b.last_active_ms().cmp(&a.last_active_ms()))
+            .then_with(|| tie_breaker(a, b))
+    })
 }
 
 #[cfg(test)]

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -662,6 +662,10 @@ impl TryFrom<CachedUsageData> for UsageData {
             // worth round-tripping through the on-disk cache); the first
             // foreground refresh after cache hit will populate it.
             sessions: Vec::new(),
+            // Projects follow the sessions/minutely precedent: recomputed on
+            // each load so the cache schema does not need a version bump; the
+            // first background refresh after cache hit will populate them.
+            projects: Vec::new(),
             graph: graph.transpose()?,
             total_tokens: u.total_tokens,
             total_cost: u.total_cost,

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use chrono::{Datelike, Local, NaiveDate, NaiveDateTime, Timelike};
@@ -182,8 +182,7 @@ pub struct SessionModel {
 /// of the global `GroupBy` the Models tab is using.
 #[derive(Debug, Clone)]
 pub struct ProjectUsage {
-    /// Stable grouping identity from `workspace_bucket` (the workspace key,
-    /// or the repo root under `WorktreeRollup::MergeIntoRepo`).
+    /// Stable workspace/repo identity, or a synthetic category for Codex chats.
     pub group_key: String,
     pub workspace_key: Option<String>,
     /// Display label after the `workspace_label_overrides` disambiguation pass.
@@ -251,9 +250,35 @@ pub struct DataLoader {
 #[cfg(test)]
 const UNKNOWN_WORKSPACE_LABEL: &str = "Unknown workspace";
 
+const CODEX_CHAT_GROUP_KEY: &str = "\0codex-chat";
+const CODEX_CHAT_LABEL: &str = "Codex Chat";
+
 // Workspace bucketing lives in tokscale_core::workspace_bucket so this
 // aggregation and the CLI report agree on worktree rollup and on labeling
 // Claude Code's dash-mangled keys.
+
+fn is_codex_chat_workspace(key: &str) -> bool {
+    // Codex Desktop gives projectless chats a dated directory under Documents.
+    // Match the complete date/slug layout, including historical directories
+    // that no longer exist. Ordinary folders under Documents/Codex stay separate.
+    let Some((_, relative)) = key.rsplit_once("/Documents/Codex/") else {
+        return false;
+    };
+    let Some((date, slug)) = relative.split_once('/') else {
+        return false;
+    };
+    if date.len() != 10
+        || NaiveDate::parse_from_str(date, "%Y-%m-%d").is_err()
+        || slug.is_empty()
+        || matches!(slug, "." | "..")
+        || slug.contains('/')
+    {
+        return false;
+    }
+
+    // A chat directory can become a real repository or a git worktree.
+    !Path::new(key).join(".git").exists()
+}
 
 fn positive_unified_token_total(tokens: &tokscale_core::TokenBreakdown) -> i64 {
     // saturating_add (mirrors tokscale_core::TokenBreakdown::total) so a
@@ -519,19 +544,48 @@ impl DataLoader {
         } else {
             HashMap::new()
         };
-        // Projects always group by repo identity (MergeIntoRepo): Claude Code's
+        // Inspect each distinct Codex path once, rather than probing .git for
+        // every usage event. Keep the raw workspace metadata for other views.
+        let mut codex_chat_workspaces: HashSet<&str> = if self.projects_enabled {
+            messages
+                .iter()
+                .filter(|msg| msg.client == "codex")
+                .filter_map(|msg| msg.workspace_key.as_deref())
+                .collect()
+        } else {
+            HashSet::new()
+        };
+        codex_chat_workspaces.retain(|key| is_codex_chat_workspace(key));
+        let is_codex_chat = |msg: &UnifiedMessage| {
+            msg.client == "codex"
+                && msg
+                    .workspace_key
+                    .as_deref()
+                    .is_some_and(|key| codex_chat_workspaces.contains(key))
+        };
+
+        // Projects otherwise group by repo identity (MergeIntoRepo): Claude Code's
         // dash-mangled slugs and the real paths other clients record must land
         // in one row. Overrides are keyed by group key, so this needs its own
         // pass whenever the Models grouping above uses different semantics.
-        let projects_label_overrides = if self.projects_enabled {
+        let mut projects_label_overrides = if self.projects_enabled {
             tokscale_core::workspace_label_overrides(
-                &messages,
+                messages.iter().filter(|msg| !is_codex_chat(msg)),
                 WorktreeRollup::MergeIntoRepo,
                 &mut workspace_labeler,
             )
         } else {
             HashMap::new()
         };
+        if !codex_chat_workspaces.is_empty() {
+            // Reserve the category label; a real project with the same name
+            // keeps its own identity and is shown with its path instead.
+            for (key, label) in &mut projects_label_overrides {
+                if label == CODEX_CHAT_LABEL {
+                    *label = key.clone();
+                }
+            }
+        }
 
         for msg in &messages {
             let normalized_model =
@@ -557,16 +611,24 @@ impl DataLoader {
                     (String::new(), None, String::new())
                 };
             let (project_group_key, project_key, project_label) = if self.projects_enabled {
-                let (group_key, key, label) = tokscale_core::workspace_bucket(
-                    msg,
-                    WorktreeRollup::MergeIntoRepo,
-                    &mut workspace_labeler,
-                );
-                let label = projects_label_overrides
-                    .get(&group_key)
-                    .cloned()
-                    .unwrap_or(label);
-                (group_key, key, label)
+                if is_codex_chat(msg) {
+                    (
+                        CODEX_CHAT_GROUP_KEY.to_string(),
+                        None,
+                        CODEX_CHAT_LABEL.to_string(),
+                    )
+                } else {
+                    let (group_key, key, label) = tokscale_core::workspace_bucket(
+                        msg,
+                        WorktreeRollup::MergeIntoRepo,
+                        &mut workspace_labeler,
+                    );
+                    let label = projects_label_overrides
+                        .get(&group_key)
+                        .cloned()
+                        .unwrap_or(label);
+                    (group_key, key, label)
+                }
             } else {
                 (String::new(), None, String::new())
             };
@@ -2361,6 +2423,153 @@ mod tests {
         assert_eq!(second.message_count, 2);
         assert!(second.first_active_ms > 0);
         assert_eq!(second.first_active_ms, second.last_active_ms);
+    }
+
+    #[test]
+    fn codex_chat_workspace_requires_the_dated_chat_layout() {
+        for key in [
+            "/Users/alice/Documents/Codex/2026-09-05/ni-shi",
+            "/home/alice/Documents/Codex/2026-09-06/new-chat",
+            "C:/Users/alice/Documents/Codex/2026-09-06/chat",
+        ] {
+            assert!(is_codex_chat_workspace(key), "{key}");
+        }
+        for key in [
+            "/Users/alice/Projects/Codex/2026-09-05/chat",
+            "/Users/alice/Documents/Codex/my-project",
+            "/Users/alice/Documents/Codex/2026-09-05",
+            "/Users/alice/Documents/Codex/2026-09-05/",
+            "/Users/alice/Documents/Codex/2026-02-30/chat",
+            "/Users/alice/Documents/Codex/2026-9-05/chat",
+            "/Users/alice/Documents/Codex/2026-09-05/..",
+            "/Users/alice/Documents/Codex/2026-09-05/chat/nested-project",
+        ] {
+            assert!(!is_codex_chat_workspace(key), "{key}");
+        }
+
+        let dir = TempDir::new().unwrap();
+        for (name, is_worktree) in [("repo", false), ("worktree", true)] {
+            let path = dir.path().join("Documents/Codex/2026-09-05").join(name);
+            std::fs::create_dir_all(&path).unwrap();
+            if is_worktree {
+                std::fs::write(path.join(".git"), "gitdir: /repo/.git/worktrees/chat").unwrap();
+            } else {
+                std::fs::create_dir(path.join(".git")).unwrap();
+            }
+            let key = sessions::normalize_workspace_key(&path.to_string_lossy()).unwrap();
+            assert!(!is_codex_chat_workspace(&key), "{key}");
+        }
+    }
+
+    #[test]
+    fn test_aggregate_messages_projects_merge_codex_chats_without_changing_usage() {
+        let chat_a = "/Users/alice/Documents/Codex/2026-09-05/ni-shi";
+        let chat_b = "/Users/alice/Documents/Codex/2026-09-06/new-chat";
+        let mut messages: Vec<_> = [
+            ("codex", "gpt-5.5", "chat-1", 1.0, Some(chat_a)),
+            ("codex", "gpt-5.5", "chat-1", 2.0, Some(chat_a)),
+            ("codex", "gpt-6-astra", "chat-2", 4.0, Some(chat_b)),
+            ("codex", "gpt-5.5", "repo", 8.0, Some("/repo")),
+            (
+                "claude",
+                "claude-opus-5",
+                "other-client",
+                16.0,
+                Some(chat_a),
+            ),
+            ("codex", "gpt-5.5", "unknown", 32.0, None),
+            (
+                "codex",
+                "gpt-5.5",
+                "same-name",
+                64.0,
+                Some("/real/Codex Chat"),
+            ),
+        ]
+        .into_iter()
+        .map(|(client, model, session, cost, workspace)| {
+            make_workspace_message(client, model, "openai", session, cost, workspace, None)
+        })
+        .collect();
+        messages[0].tokens.cache_read = 20;
+        messages[0].tokens.cache_write = 2;
+        messages[0].tokens.reasoning = 1;
+        messages[2].timestamp += 60_000;
+
+        for grouping in [
+            GroupBy::Model,
+            GroupBy::ClientModel,
+            GroupBy::WorkspaceModel,
+        ] {
+            let baseline = DataLoader::new(None)
+                .aggregate_messages(messages.clone(), &grouping)
+                .unwrap();
+            let usage = DataLoader::new(None)
+                .with_projects_enabled(true)
+                .aggregate_messages(messages.clone(), &grouping)
+                .unwrap();
+
+            assert_eq!(usage.projects.len(), 5);
+            let chat = usage
+                .projects
+                .iter()
+                .find(|p| p.label == CODEX_CHAT_LABEL)
+                .unwrap();
+            assert_eq!(chat.group_key, CODEX_CHAT_GROUP_KEY);
+            assert_eq!(chat.workspace_key, None);
+            assert_eq!(chat.path, None);
+            assert_eq!(chat.session_count, 2);
+            assert_eq!(chat.message_count, 3);
+            assert_eq!(chat.clients, ["codex"]);
+            assert_eq!(chat.models.len(), 2);
+            assert_eq!(chat.cost, 7.0);
+            assert_eq!(chat.tokens.input, 30);
+            assert_eq!(chat.tokens.output, 15);
+            assert_eq!(chat.tokens.cache_read, 20);
+            assert_eq!(chat.tokens.cache_write, 2);
+            assert_eq!(chat.tokens.reasoning, 1);
+            assert_eq!(chat.first_active_ms, messages[0].timestamp);
+            assert_eq!(chat.last_active_ms, messages[2].timestamp);
+
+            let same_name = usage
+                .projects
+                .iter()
+                .find(|p| p.group_key == "/real/Codex Chat")
+                .unwrap();
+            assert_eq!(same_name.label, "/real/Codex Chat");
+            assert_eq!(same_name.cost, 64.0);
+            let other_client = usage
+                .projects
+                .iter()
+                .find(|p| p.group_key == chat_a)
+                .unwrap();
+            assert_eq!(other_client.label, "ni-shi");
+            assert_eq!(other_client.clients, ["claude"]);
+            assert_eq!(other_client.cost, 16.0);
+            assert!(usage
+                .projects
+                .iter()
+                .any(|p| p.label == UNKNOWN_WORKSPACE_LABEL));
+
+            assert_eq!(usage.total_tokens, baseline.total_tokens);
+            assert_eq!(usage.total_cost, baseline.total_cost);
+            assert_eq!(usage.sessions.len(), baseline.sessions.len());
+            assert_eq!(usage.models.len(), baseline.models.len());
+            assert_eq!(
+                usage.projects.iter().map(|p| p.tokens.total()).sum::<u64>(),
+                usage.total_tokens
+            );
+            assert_eq!(
+                usage.projects.iter().map(|p| p.cost).sum::<f64>(),
+                usage.total_cost
+            );
+            if grouping == GroupBy::WorkspaceModel {
+                assert!(usage
+                    .models
+                    .iter()
+                    .any(|m| m.workspace_key.as_deref() == Some(chat_b)));
+            }
+        }
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -2776,6 +2776,103 @@ mod tests {
     }
 
     #[test]
+    fn test_aggregate_messages_projects_keep_a_nested_ambiguous_claude_slug_separate() {
+        // The sibling case above is the shallow shape. Here `a-b/c`, `a/b-c` and
+        // `a/b.c` share one slug, and the tie is found a level below `a`, after
+        // `a-b/c` has already completed. The decoder used to report that deeper
+        // tie as a dead end, so the slug decoded to `a-b/c` and the Claude Code
+        // usage merged into it: 3 rows, `a-b/c` at $11, and every total still
+        // reconciled.
+        let dir = TempDir::new().unwrap();
+        let canonical = std::fs::canonicalize(dir.path()).unwrap();
+        let canonical = canonical.to_string_lossy();
+        let canonical = canonical.strip_prefix(r"\\?\").unwrap_or(&canonical);
+        let root = tokscale_core::sessions::normalize_workspace_key(canonical).unwrap();
+        let outer = format!("{root}/a-b/c");
+        let dashed = format!("{root}/a/b-c");
+        let dotted = format!("{root}/a/b.c");
+        for path in [&outer, &dashed, &dotted] {
+            std::fs::create_dir_all(path).unwrap();
+        }
+        let slug_of = |key: &str| -> String {
+            key.chars()
+                .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+                .collect()
+        };
+        let slug = slug_of(&dotted);
+        assert_eq!(slug, slug_of(&dashed));
+        assert_eq!(slug, slug_of(&outer));
+
+        let loader = DataLoader::new(None).with_projects_enabled(true);
+        let usage = loader
+            .aggregate_messages(
+                vec![
+                    make_workspace_message(
+                        "codex",
+                        "gpt-5.5",
+                        "openai",
+                        "session-1",
+                        1.0,
+                        Some(&outer),
+                        None,
+                    ),
+                    make_workspace_message(
+                        "codex",
+                        "gpt-5.5",
+                        "openai",
+                        "session-2",
+                        2.0,
+                        Some(&dashed),
+                        None,
+                    ),
+                    make_workspace_message(
+                        "codex",
+                        "gpt-5.5",
+                        "openai",
+                        "session-3",
+                        4.0,
+                        Some(&dotted),
+                        None,
+                    ),
+                    make_workspace_message(
+                        "claude",
+                        "claude-opus-5",
+                        "anthropic",
+                        "session-4",
+                        10.0,
+                        Some(&slug),
+                        None,
+                    ),
+                ],
+                &GroupBy::Model,
+            )
+            .unwrap();
+
+        assert_eq!(usage.projects.len(), 4);
+        let by_key = |key: &str| {
+            usage
+                .projects
+                .iter()
+                .find(|p| p.group_key == key)
+                .unwrap_or_else(|| panic!("no project row for {key}"))
+        };
+        assert_eq!(by_key(&outer).cost, 1.0);
+        assert_eq!(by_key(&outer).clients, ["codex"]);
+        assert_eq!(by_key(&dashed).cost, 2.0);
+        assert_eq!(by_key(&dashed).clients, ["codex"]);
+        assert_eq!(by_key(&dotted).cost, 4.0);
+        assert_eq!(by_key(&dotted).clients, ["codex"]);
+        let ambiguous = by_key(&slug);
+        assert_eq!(ambiguous.cost, 10.0);
+        assert_eq!(ambiguous.clients, ["claude"]);
+        assert_eq!(ambiguous.path, None);
+        assert_eq!(
+            usage.projects.iter().map(|p| p.cost).sum::<f64>(),
+            usage.total_cost
+        );
+    }
+
+    #[test]
     fn test_aggregate_messages_workspace_grouping_keeps_unknown_bucket_visible() {
         let loader = DataLoader::new(None);
         let usage = loader

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -177,6 +177,35 @@ pub struct SessionModel {
     pub color_key: String,
 }
 
+/// Per-project (workspace) usage rollup. One row per workspace grouping key
+/// so the Projects tab can show cost/tokens rolled up per project regardless
+/// of the global `GroupBy` the Models tab is using.
+#[derive(Debug, Clone)]
+pub struct ProjectUsage {
+    /// Stable grouping identity from `workspace_bucket` (the workspace key,
+    /// or the repo root under `WorktreeRollup::MergeIntoRepo`).
+    pub group_key: String,
+    pub workspace_key: Option<String>,
+    /// Display label after the `workspace_label_overrides` disambiguation pass.
+    pub label: String,
+    /// Real filesystem path the key resolves to, when it names one.
+    pub path: Option<String>,
+    /// Distinct clients seen in this project, in first-seen order.
+    pub clients: Vec<String>,
+    /// Distinct models used in this project, in first-seen order.
+    pub models: Vec<SessionModel>,
+    pub tokens: TokenBreakdown,
+    pub cost: f64,
+    pub message_count: u32,
+    pub session_count: u32,
+    /// Unix-ms timestamp of the first message observed in this project.
+    /// `0` when every message lacked a usable timestamp.
+    pub first_active_ms: i64,
+    /// Unix-ms timestamp of the most recent message observed in this project.
+    /// `0` when every message lacked a usable timestamp.
+    pub last_active_ms: i64,
+}
+
 #[derive(Debug, Clone)]
 pub struct ContributionDay {
     pub date: NaiveDate,
@@ -199,6 +228,7 @@ pub struct UsageData {
     pub minutely: Vec<MinutelyUsage>,
     pub monthly: Vec<MonthlyUsage>,
     pub sessions: Vec<SessionUsage>,
+    pub projects: Vec<ProjectUsage>,
     pub graph: Option<GraphData>,
     pub total_tokens: u64,
     pub total_cost: f64,
@@ -214,6 +244,7 @@ pub struct DataLoader {
     pub until: Option<String>,
     pub year: Option<String>,
     pub minutely_enabled: bool,
+    pub projects_enabled: bool,
     pub worktree_rollup: WorktreeRollup,
 }
 
@@ -319,6 +350,7 @@ impl DataLoader {
             until: None,
             year: None,
             minutely_enabled: false,
+            projects_enabled: false,
             worktree_rollup: WorktreeRollup::default(),
         }
     }
@@ -335,12 +367,18 @@ impl DataLoader {
             until,
             year,
             minutely_enabled: false,
+            projects_enabled: false,
             worktree_rollup: WorktreeRollup::default(),
         }
     }
 
     pub fn with_minutely_enabled(mut self, enabled: bool) -> Self {
         self.minutely_enabled = enabled;
+        self
+    }
+
+    pub fn with_projects_enabled(mut self, enabled: bool) -> Self {
+        self.projects_enabled = enabled;
         self
     }
 
@@ -463,6 +501,8 @@ impl DataLoader {
         let mut minutely_map: HashMap<NaiveDateTime, MinutelyUsage> = HashMap::new();
         let mut model_session_ids: HashMap<String, HashSet<String>> = HashMap::new();
         let mut session_map: HashMap<String, SessionUsage> = HashMap::new();
+        let mut project_map: HashMap<String, ProjectUsage> = HashMap::new();
+        let mut project_session_ids: HashMap<String, HashSet<String>> = HashMap::new();
         // Memoizes the filesystem probes that resolve a workspace key to a label.
         let mut workspace_labeler = tokscale_core::WorkspaceLabeler::default();
         // Labels are basenames, so two different directories that share one paint
@@ -479,14 +519,28 @@ impl DataLoader {
         } else {
             HashMap::new()
         };
+        // Projects always group by repo identity (MergeIntoRepo): Claude Code's
+        // dash-mangled slugs and the real paths other clients record must land
+        // in one row. Overrides are keyed by group key, so this needs its own
+        // pass whenever the Models grouping above uses different semantics.
+        let projects_label_overrides = if self.projects_enabled {
+            tokscale_core::workspace_label_overrides(
+                &messages,
+                WorktreeRollup::MergeIntoRepo,
+                &mut workspace_labeler,
+            )
+        } else {
+            HashMap::new()
+        };
 
         for msg in &messages {
             let normalized_model =
                 model_name_for_grouping(&msg.client, &msg.provider_id, &msg.model_id);
             let model_key = normalize_model_for_grouping(&msg.model_id);
-            // Resolving a workspace label reads the filesystem, and every grouping
-            // except this one throws it away — the TUI defaults to ClientModel and
-            // auto-refreshes, so paying it unconditionally is pure waste.
+            // Resolving a workspace label reads the filesystem, and groupings
+            // other than WorkspaceModel throw it away — the TUI defaults to
+            // ClientModel and auto-refreshes, so it is only paid when the
+            // workspace grouping or the Projects tab actually consumes it.
             let (workspace_group_key, workspace_key, workspace_label) =
                 if *group_by == GroupBy::WorkspaceModel {
                     let (group_key, key, label) = tokscale_core::workspace_bucket(
@@ -502,6 +556,20 @@ impl DataLoader {
                 } else {
                     (String::new(), None, String::new())
                 };
+            let (project_group_key, project_key, project_label) = if self.projects_enabled {
+                let (group_key, key, label) = tokscale_core::workspace_bucket(
+                    msg,
+                    WorktreeRollup::MergeIntoRepo,
+                    &mut workspace_labeler,
+                );
+                let label = projects_label_overrides
+                    .get(&group_key)
+                    .cloned()
+                    .unwrap_or(label);
+                (group_key, key, label)
+            } else {
+                (String::new(), None, String::new())
+            };
             let key = match group_by {
                 GroupBy::Model => normalized_model.clone(),
                 GroupBy::ClientModel => format!("{}:{}", msg.client, normalized_model),
@@ -1025,6 +1093,92 @@ impl DataLoader {
                     });
                 }
             }
+
+            // Project aggregation: one bucket per repo identity so the Projects
+            // tab rolls up per project no matter which global grouping the
+            // Models tab is using. Gated on `projects_enabled` because the
+            // workspace resolution above is only paid when this or the
+            // WorkspaceModel grouping consumes it.
+            if self.projects_enabled {
+                let project_entry =
+                    project_map
+                        .entry(project_group_key.clone())
+                        .or_insert_with(|| ProjectUsage {
+                            group_key: project_group_key.clone(),
+                            workspace_key: project_key.clone(),
+                            label: project_label.clone(),
+                            path: None,
+                            clients: Vec::new(),
+                            models: Vec::new(),
+                            tokens: TokenBreakdown::default(),
+                            cost: 0.0,
+                            message_count: 0,
+                            session_count: 0,
+                            first_active_ms: 0,
+                            last_active_ms: 0,
+                        });
+
+                project_entry.tokens.input = project_entry
+                    .tokens
+                    .input
+                    .saturating_add(msg.tokens.input.max(0) as u64);
+                project_entry.tokens.output = project_entry
+                    .tokens
+                    .output
+                    .saturating_add(msg.tokens.output.max(0) as u64);
+                project_entry.tokens.cache_read = project_entry
+                    .tokens
+                    .cache_read
+                    .saturating_add(msg.tokens.cache_read.max(0) as u64);
+                project_entry.tokens.cache_write = project_entry
+                    .tokens
+                    .cache_write
+                    .saturating_add(msg.tokens.cache_write.max(0) as u64);
+                project_entry.tokens.reasoning = project_entry
+                    .tokens
+                    .reasoning
+                    .saturating_add(msg.tokens.reasoning.max(0) as u64);
+                project_entry.cost += msg_cost;
+                project_entry.message_count = project_entry
+                    .message_count
+                    .saturating_add(msg.message_count.max(0) as u32);
+
+                let ts = message_timestamp_ms(msg);
+                if ts > 0 {
+                    if project_entry.first_active_ms == 0 || ts < project_entry.first_active_ms {
+                        project_entry.first_active_ms = ts;
+                    }
+                    if ts > project_entry.last_active_ms {
+                        project_entry.last_active_ms = ts;
+                    }
+                }
+
+                if !project_entry.clients.iter().any(|c| c == &msg.client) {
+                    project_entry.clients.push(msg.client.clone());
+                }
+
+                if !project_entry
+                    .models
+                    .iter()
+                    .any(|m| m.display_name == normalized_model)
+                {
+                    project_entry.models.push(SessionModel {
+                        display_name: normalized_model.clone(),
+                        provider: msg.provider_id.clone(),
+                        color_key: model_key.clone(),
+                    });
+                }
+
+                if !msg.session_id.is_empty() {
+                    let session_key = format!("{}:{}", msg.client, msg.session_id);
+                    let project_sessions = project_session_ids
+                        .entry(project_group_key.clone())
+                        .or_default();
+                    if project_sessions.insert(session_key) {
+                        project_entry.session_count += 1;
+                    }
+                }
+            }
         }
 
         let mut models: Vec<ModelUsage> = model_map
@@ -1075,6 +1229,20 @@ impl DataLoader {
                 .then_with(|| a.session_id.cmp(&b.session_id))
         });
 
+        let mut projects: Vec<ProjectUsage> = project_map.into_values().collect();
+        // Path resolution is deferred to here so it runs once per distinct
+        // project (memoized in the labeler), not once per message.
+        for project in &mut projects {
+            project.path = workspace_labeler.path(&project.group_key);
+        }
+        projects.sort_by(|a, b| {
+            b.cost
+                .total_cmp(&a.cost)
+                .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
+                .then_with(|| a.label.cmp(&b.label))
+                .then_with(|| a.group_key.cmp(&b.group_key))
+        });
+
         // Plain `.sum()` panics (debug) / wraps (release) on overflow across
         // many models; a single corrupt/huge bucket must not poison the
         // whole total, so fold with saturating_add like `TokenBreakdown::total`.
@@ -1098,6 +1266,7 @@ impl DataLoader {
             minutely,
             monthly,
             sessions,
+            projects,
             graph: Some(graph),
             total_tokens,
             total_cost,
@@ -2123,6 +2292,196 @@ mod tests {
         assert_eq!(usage.models[0].client, "claude, qwen");
         assert_eq!(usage.models[0].session_count, 2);
         assert_eq!(usage.models[0].cost, 4.0);
+    }
+
+    #[test]
+    fn test_aggregate_messages_projects_roll_up_by_workspace_under_any_grouping() {
+        let loader = DataLoader::new(None).with_projects_enabled(true);
+        let usage = loader
+            .aggregate_messages(
+                vec![
+                    make_workspace_message(
+                        "claude",
+                        "claude-sonnet-4-5-20250929",
+                        "anthropic",
+                        "session-1",
+                        1.25,
+                        Some("/repo-a"),
+                        Some("repo-a"),
+                    ),
+                    make_workspace_message(
+                        "qwen",
+                        "kimi-k2",
+                        "moonshot",
+                        "session-2",
+                        2.75,
+                        Some("/repo-a"),
+                        Some("repo-a"),
+                    ),
+                    make_workspace_message(
+                        "claude",
+                        "claude-sonnet-4-5-20250929",
+                        "anthropic",
+                        "session-3",
+                        5.0,
+                        Some("/repo-b"),
+                        Some("repo-b"),
+                    ),
+                ],
+                &GroupBy::Model,
+            )
+            .unwrap();
+
+        assert_eq!(usage.projects.len(), 2);
+        // Default order is cost descending.
+        let first = &usage.projects[0];
+        assert_eq!(first.group_key, "/repo-b");
+        assert_eq!(first.label, "repo-b");
+        assert_eq!(first.workspace_key.as_deref(), Some("/repo-b"));
+        assert_eq!(first.cost, 5.0);
+        assert_eq!(first.session_count, 1);
+        assert_eq!(first.clients, vec!["claude".to_string()]);
+
+        let second = &usage.projects[1];
+        assert_eq!(second.group_key, "/repo-a");
+        assert_eq!(second.cost, 4.0);
+        assert_eq!(second.session_count, 2);
+        // Clients and models track first-seen order across sources.
+        assert_eq!(
+            second.clients,
+            vec!["claude".to_string(), "qwen".to_string()]
+        );
+        let model_names: Vec<_> = second
+            .models
+            .iter()
+            .map(|m| m.display_name.as_str())
+            .collect();
+        assert_eq!(model_names, vec!["claude-sonnet-4-5", "kimi-k2"]);
+        assert_eq!(second.tokens.total(), 30);
+        assert_eq!(second.message_count, 2);
+        assert!(second.first_active_ms > 0);
+        assert_eq!(second.first_active_ms, second.last_active_ms);
+    }
+
+    #[test]
+    fn test_aggregate_messages_projects_empty_unless_enabled() {
+        let loader = DataLoader::new(None);
+        let usage = loader
+            .aggregate_messages(
+                vec![make_workspace_message(
+                    "claude",
+                    "claude-sonnet-4-5-20250929",
+                    "anthropic",
+                    "session-1",
+                    1.0,
+                    Some("/repo-a"),
+                    Some("repo-a"),
+                )],
+                &GroupBy::Model,
+            )
+            .unwrap();
+
+        assert!(usage.projects.is_empty());
+    }
+
+    #[test]
+    fn test_aggregate_messages_projects_keeps_unknown_workspace_bucket() {
+        let loader = DataLoader::new(None).with_projects_enabled(true);
+        let usage = loader
+            .aggregate_messages(
+                vec![
+                    make_workspace_message(
+                        "claude",
+                        "claude-sonnet-4-5-20250929",
+                        "anthropic",
+                        "session-1",
+                        1.0,
+                        None,
+                        None,
+                    ),
+                    make_workspace_message(
+                        "claude",
+                        "claude-sonnet-4-5-20250929",
+                        "anthropic",
+                        "session-2",
+                        2.0,
+                        Some("/repo-a"),
+                        Some("repo-a"),
+                    ),
+                ],
+                &GroupBy::Model,
+            )
+            .unwrap();
+
+        assert_eq!(usage.projects.len(), 2);
+        assert!(usage.projects.iter().any(|project| {
+            project.workspace_key.is_none()
+                && project.label == UNKNOWN_WORKSPACE_LABEL
+                && (project.cost - 1.0).abs() < f64::EPSILON
+        }));
+        assert!(usage.projects.iter().any(|project| {
+            project.workspace_key.as_deref() == Some("/repo-a")
+                && project.label == "repo-a"
+                && (project.cost - 2.0).abs() < f64::EPSILON
+        }));
+    }
+
+    #[test]
+    fn test_aggregate_messages_projects_merge_path_and_claude_slug() {
+        // Codex records the real path; Claude Code records the dash-mangled
+        // slug. Both describe the same directory, so the Projects tab (repo
+        // identity) must land them in one row.
+        let dir = TempDir::new().unwrap();
+        let project = dir.path().join("my-proj");
+        std::fs::create_dir(&project).unwrap();
+        let canonical = std::fs::canonicalize(&project).unwrap();
+        // Windows canonical paths have a verbatim prefix that is not part of
+        // Claude Code's drive-rooted workspace slug.
+        let canonical = canonical.to_string_lossy();
+        let canonical = canonical.strip_prefix(r"\\?\").unwrap_or(&canonical);
+        let real_key = tokscale_core::sessions::normalize_workspace_key(canonical).unwrap();
+        let slug: String = real_key
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+            .collect();
+
+        let loader = DataLoader::new(None).with_projects_enabled(true);
+        let usage = loader
+            .aggregate_messages(
+                vec![
+                    make_workspace_message(
+                        "codex",
+                        "gpt-5.5",
+                        "openai",
+                        "session-1",
+                        1.0,
+                        Some(&real_key),
+                        None,
+                    ),
+                    make_workspace_message(
+                        "claude",
+                        "claude-opus-5",
+                        "anthropic",
+                        "session-2",
+                        2.0,
+                        Some(&slug),
+                        None,
+                    ),
+                ],
+                &GroupBy::Model,
+            )
+            .unwrap();
+
+        assert_eq!(usage.projects.len(), 1);
+        let project = &usage.projects[0];
+        assert_eq!(project.group_key, real_key);
+        assert_eq!(project.label, "my-proj");
+        assert_eq!(project.cost, 3.0);
+        assert_eq!(project.session_count, 2);
+        assert_eq!(
+            project.clients,
+            vec!["codex".to_string(), "claude".to_string()]
+        );
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -2694,6 +2694,88 @@ mod tests {
     }
 
     #[test]
+    fn test_aggregate_messages_projects_keep_an_ambiguous_claude_slug_separate() {
+        // `a-b` and `a.b` encode to the same Claude Code slug, so with both on
+        // disk the slug is evidence for neither. Merging it into whichever one
+        // the decoder prefers moves that usage onto a project it may never have
+        // touched, and every total still reconciles, so nothing else catches it.
+        let dir = TempDir::new().unwrap();
+        let canonical = std::fs::canonicalize(dir.path()).unwrap();
+        let canonical = canonical.to_string_lossy();
+        let canonical = canonical.strip_prefix(r"\\?\").unwrap_or(&canonical);
+        let root = tokscale_core::sessions::normalize_workspace_key(canonical).unwrap();
+        let dashed = format!("{root}/a-b");
+        let dotted = format!("{root}/a.b");
+        std::fs::create_dir(&dashed).unwrap();
+        std::fs::create_dir(&dotted).unwrap();
+        let slug_of = |key: &str| -> String {
+            key.chars()
+                .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+                .collect()
+        };
+        let slug = slug_of(&dotted);
+        assert_eq!(slug, slug_of(&dashed));
+
+        let loader = DataLoader::new(None).with_projects_enabled(true);
+        let usage = loader
+            .aggregate_messages(
+                vec![
+                    make_workspace_message(
+                        "codex",
+                        "gpt-5.5",
+                        "openai",
+                        "session-1",
+                        1.0,
+                        Some(&dashed),
+                        None,
+                    ),
+                    make_workspace_message(
+                        "codex",
+                        "gpt-5.5",
+                        "openai",
+                        "session-2",
+                        2.0,
+                        Some(&dotted),
+                        None,
+                    ),
+                    make_workspace_message(
+                        "claude",
+                        "claude-opus-5",
+                        "anthropic",
+                        "session-3",
+                        10.0,
+                        Some(&slug),
+                        None,
+                    ),
+                ],
+                &GroupBy::Model,
+            )
+            .unwrap();
+
+        assert_eq!(usage.projects.len(), 3);
+        let by_key = |key: &str| {
+            usage
+                .projects
+                .iter()
+                .find(|p| p.group_key == key)
+                .unwrap_or_else(|| panic!("no project row for {key}"))
+        };
+        assert_eq!(by_key(&dashed).cost, 1.0);
+        assert_eq!(by_key(&dashed).clients, ["codex"]);
+        assert_eq!(by_key(&dotted).cost, 2.0);
+        assert_eq!(by_key(&dotted).clients, ["codex"]);
+        // The slug keeps its own row, and does not claim a path it cannot prove.
+        let ambiguous = by_key(&slug);
+        assert_eq!(ambiguous.cost, 10.0);
+        assert_eq!(ambiguous.clients, ["claude"]);
+        assert_eq!(ambiguous.path, None);
+        assert_eq!(
+            usage.projects.iter().map(|p| p.cost).sum::<f64>(),
+            usage.total_cost
+        );
+    }
+
+    #[test]
     fn test_aggregate_messages_workspace_grouping_keeps_unknown_bucket_visible() {
         let loader = DataLoader::new(None);
         let usage = loader

--- a/crates/tokscale-cli/src/tui/mod.rs
+++ b/crates/tokscale-cli/src/tui/mod.rs
@@ -63,7 +63,11 @@ fn background_data_loader(
     year: Option<String>,
     minutely_enabled: bool,
 ) -> DataLoader {
-    DataLoader::with_filters(None, since, until, year).with_minutely_enabled(minutely_enabled)
+    DataLoader::with_filters(None, since, until, year)
+        .with_minutely_enabled(minutely_enabled)
+        // The Projects tab rolls up workspaces regardless of the global
+        // grouping, so both background loads always pay workspace resolution.
+        .with_projects_enabled(true)
 }
 
 fn background_cache_scope(
@@ -447,6 +451,14 @@ mod tests {
 
         let disabled = background_data_loader(None, None, None, false);
         assert!(!disabled.minutely_enabled);
+    }
+
+    #[test]
+    fn background_loader_enables_projects() {
+        // The Projects tab rolls up workspaces regardless of the global
+        // grouping, so both background loads must resolve workspaces.
+        let loader = background_data_loader(None, None, None, false);
+        assert!(loader.projects_enabled);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -163,6 +163,7 @@ fn current_count_label(app: &App) -> String {
         }
         Tab::Monthly => format!(" ({} months)", app.data.monthly.len()),
         Tab::Sessions => format!(" ({} sessions)", app.data.sessions.len()),
+        Tab::Projects => format!(" ({} projects)", app.data.projects.len()),
         Tab::Stats | Tab::Usage => String::new(),
     }
 }

--- a/crates/tokscale-cli/src/tui/ui/mod.rs
+++ b/crates/tokscale-cli/src/tui/ui/mod.rs
@@ -10,6 +10,7 @@ mod minutely;
 mod models;
 mod monthly;
 mod overview;
+mod projects;
 mod sessions;
 pub mod spinner;
 mod stats;
@@ -55,6 +56,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             Tab::Minutely => minutely::render(frame, app, chunks[1]),
             Tab::Monthly => monthly::render(frame, app, chunks[1]),
             Tab::Sessions => sessions::render(frame, app, chunks[1]),
+            Tab::Projects => projects::render(frame, app, chunks[1]),
             Tab::Stats => stats::render(frame, app, chunks[1]),
             Tab::Usage => usage::render(frame, app, chunks[1]),
         }

--- a/crates/tokscale-cli/src/tui/ui/projects.rs
+++ b/crates/tokscale-cli/src/tui/ui/projects.rs
@@ -1,0 +1,611 @@
+use chrono::{Local, NaiveDateTime, TimeZone};
+use ratatui::prelude::*;
+use ratatui::widgets::{
+    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
+};
+
+use super::widgets::{
+    display_width, fit_workspace_label_to_width, format_cost, format_tokens,
+    get_compact_client_display_name, prefix_to_width, total_tokens_cell, truncate_text,
+    truncate_to_width, viewport_scrollbar_state,
+};
+use crate::tui::app::{App, SortDirection, SortField};
+use crate::tui::data::{ProjectUsage, SessionModel};
+
+/// One column of the wide Projects layout, in left-to-right display order.
+///
+/// Every per-column fact hangs off this enum so the header, cells, constraints
+/// and truncation budgets cannot drift apart: each method is an exhaustive
+/// `match` with no `_` arm, so adding a variant fails to compile until every
+/// one of them has an answer for it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProjectColumn {
+    Rank,
+    Project,
+    Sessions,
+    Sources,
+    Models,
+    Input,
+    Output,
+    CacheRead,
+    CacheWrite,
+    Total,
+    Cost,
+    LastActive,
+}
+
+/// Every variant in display order; the single source of the column set.
+const WIDE_ORDER: [ProjectColumn; 12] = [
+    ProjectColumn::Rank,
+    ProjectColumn::Project,
+    ProjectColumn::Sessions,
+    ProjectColumn::Sources,
+    ProjectColumn::Models,
+    ProjectColumn::Input,
+    ProjectColumn::Output,
+    ProjectColumn::CacheRead,
+    ProjectColumn::CacheWrite,
+    ProjectColumn::Total,
+    ProjectColumn::Cost,
+    ProjectColumn::LastActive,
+];
+
+impl ProjectColumn {
+    fn header(self) -> &'static str {
+        match self {
+            Self::Rank => "#",
+            Self::Project => "Project",
+            Self::Sessions => "Sessions",
+            Self::Sources => "Sources",
+            Self::Models => "Models",
+            Self::Input => "Input",
+            Self::Output => "Output",
+            Self::CacheRead => "Cache Read",
+            Self::CacheWrite => "Cache Write",
+            Self::Total => "Total",
+            Self::Cost => "Cost",
+            Self::LastActive => "Last Active",
+        }
+    }
+
+    /// Cells this column asks the solver for. Project is the sole flexible
+    /// (`Min`) column and absorbs whatever slack or shrinkage the row has left;
+    /// every other column is a fixed `Length` at its natural width.
+    fn constraint(self) -> Constraint {
+        match self {
+            Self::Project => Constraint::Min(18),
+            Self::Rank => Constraint::Length(4),
+            Self::Sessions => Constraint::Length(8),
+            Self::Sources => Constraint::Length(14),
+            Self::Models => Constraint::Length(18),
+            Self::Input | Self::Output | Self::CacheRead | Self::Total | Self::Cost => {
+                Constraint::Length(10)
+            }
+            Self::CacheWrite => Constraint::Length(11),
+            Self::LastActive => Constraint::Length(16),
+        }
+    }
+
+    /// The sort this column is the target of, so the indicator is placed by
+    /// identity rather than by a computed index.
+    fn sort_field(self) -> Option<SortField> {
+        match self {
+            Self::Total => Some(SortField::Tokens),
+            Self::Cost => Some(SortField::Cost),
+            Self::LastActive => Some(SortField::Date),
+            Self::Rank
+            | Self::Project
+            | Self::Sessions
+            | Self::Sources
+            | Self::Models
+            | Self::Input
+            | Self::Output
+            | Self::CacheRead
+            | Self::CacheWrite => None,
+        }
+    }
+
+    fn cell(self, rank: usize, p: &ProjectUsage, app: &App, granted: &[u16]) -> Cell<'static> {
+        match self {
+            Self::Rank => Cell::from(self.fit(rank.to_string(), granted))
+                .style(Style::default().fg(app.theme.muted)),
+            // Not a plain head cut: a workspace label is identified by the ends
+            // of each of its segments, and cutting the tail leaves the prefix
+            // every row shares. Truncated to the width the solver granted this
+            // very column, never to the requested width.
+            Self::Project => Cell::from(fit_workspace_label_to_width(
+                &p.label,
+                self.granted_width(granted),
+            ))
+            .style(
+                Style::default()
+                    .fg(app.theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Self::Sessions => Cell::from(self.fit(p.session_count.to_string(), granted)),
+            Self::Sources => Cell::from(self.fit(sources_label(p), granted))
+                .style(Style::default().fg(app.theme.muted)),
+            Self::Models => build_models_cell(&p.models, self.granted_width(granted), app),
+            Self::Input => Cell::from(self.fit(format_tokens(p.tokens.input), granted))
+                .style(app.theme.metric_input_style()),
+            Self::Output => Cell::from(self.fit(format_tokens(p.tokens.output), granted))
+                .style(app.theme.metric_output_style()),
+            Self::CacheRead => Cell::from(self.fit(format_tokens(p.tokens.cache_read), granted))
+                .style(app.theme.metric_cache_read_style()),
+            Self::CacheWrite => Cell::from(self.fit(format_tokens(p.tokens.cache_write), granted))
+                .style(app.theme.metric_cache_write_style()),
+            Self::Total => Cell::from(self.fit(format_tokens(p.tokens.total()), granted))
+                .style(app.theme.metric_total_style()),
+            Self::Cost => Cell::from(self.fit(format_cost(p.cost), granted))
+                .style(Style::default().fg(Color::Green)),
+            Self::LastActive => Cell::from(
+                self.fit(
+                    ms_to_local_naive(p.last_active_ms)
+                        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+                        .unwrap_or_else(|| "\u{2014}".to_string()),
+                    granted,
+                ),
+            )
+            .style(Style::default().fg(app.theme.muted)),
+        }
+    }
+
+    /// Position in the display order, for indexing into the solved widths.
+    fn index(self) -> usize {
+        WIDE_ORDER.iter().position(|c| *c == self).unwrap_or(0)
+    }
+
+    /// Cells the solver granted this column out of the already-solved `widths`.
+    /// A `Length` is a request, not a guarantee, and `Min` floats, so text is
+    /// cut to what the column actually got rather than to what it asked for.
+    fn granted_width(self, widths: &[u16]) -> usize {
+        widths.get(self.index()).copied().unwrap_or(0) as usize
+    }
+
+    /// Clamp a fixed-width column's text to its granted width. A no-op at
+    /// widths where the request was satisfied; past that a clipped number would
+    /// read as a plausible wrong value, so the cut keeps an ellipsis.
+    fn fit(self, text: String, granted: &[u16]) -> String {
+        truncate_to_width(&text, self.granted_width(granted))
+    }
+}
+
+/// The wide layout's column constraints.
+fn wide_constraints() -> Vec<Constraint> {
+    WIDE_ORDER.iter().map(|c| c.constraint()).collect()
+}
+
+/// Widths the solver grants each wide column at `total` cells. Ratatui's table
+/// solves the same constraint set with one cell of `column_spacing` between
+/// columns, so this mirrors that layout exactly.
+fn wide_table_widths(total: u16) -> Vec<u16> {
+    Layout::horizontal(wide_constraints())
+        .spacing(1)
+        .split(Rect::new(0, 0, total, 1))
+        .iter()
+        .map(|area| area.width)
+        .collect()
+}
+
+/// Distinct clients in first-seen order, compact-named and comma-joined.
+fn sources_label(p: &ProjectUsage) -> String {
+    p.clients
+        .iter()
+        .map(|c| get_compact_client_display_name(c))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.border))
+        .title(Span::styled(
+            " Projects ",
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .style(Style::default().bg(app.theme.background));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let visible_height = inner.height.saturating_sub(1) as usize;
+    app.set_max_visible_items(visible_height);
+
+    let projects = app.get_sorted_projects();
+    if projects.is_empty() {
+        let empty_msg = Paragraph::new("No project usage data found. Press 'r' to refresh.")
+            .style(Style::default().fg(app.theme.muted))
+            .alignment(Alignment::Center);
+        frame.render_widget(empty_msg, inner);
+        return;
+    }
+
+    let is_narrow = app.is_narrow();
+    let is_very_narrow = app.is_very_narrow();
+    let sort_field = app.sort_field;
+    let sort_direction = app.sort_direction;
+    let scroll_offset = app.scroll_offset;
+    let selected_index = app.selected_index;
+    let theme_accent = app.theme.accent;
+    let theme_selection = app.theme.selection;
+    let striped_row_style = app.theme.striped_row_style();
+
+    let sort_indicator = |field: SortField| -> &'static str {
+        if sort_field == field {
+            match sort_direction {
+                SortDirection::Ascending => " ▲",
+                SortDirection::Descending => " ▼",
+            }
+        } else {
+            ""
+        }
+    };
+
+    let wide = !is_narrow && !is_very_narrow;
+
+    let header_cells: Vec<String> = if wide {
+        WIDE_ORDER
+            .iter()
+            .map(|c| {
+                let indicator = c.sort_field().map(sort_indicator).unwrap_or("");
+                format!("{}{}", c.header(), indicator)
+            })
+            .collect()
+    } else {
+        let labels: &[&str] = if is_very_narrow {
+            &["Project", "Cost"]
+        } else {
+            &["Project", "Sessions", "Total", "Cost"]
+        };
+        // The narrow layouts keep hand-picked indices, and `usize::MAX` stands
+        // for "this sort has no column here".
+        let (total_idx, cost_idx) = if is_very_narrow {
+            (usize::MAX, 1)
+        } else {
+            (2, 3)
+        };
+        labels
+            .iter()
+            .enumerate()
+            .map(|(i, h)| {
+                let indicator = if i == total_idx {
+                    sort_indicator(SortField::Tokens)
+                } else if i == cost_idx {
+                    sort_indicator(SortField::Cost)
+                } else {
+                    ""
+                };
+                format!("{}{}", h, indicator)
+            })
+            .collect()
+    };
+
+    let header = Row::new(header_cells.into_iter().map(Cell::from).collect::<Vec<_>>())
+        .style(
+            Style::default()
+                .fg(theme_accent)
+                .add_modifier(Modifier::BOLD),
+        )
+        .height(1);
+
+    let projects_len = projects.len();
+    let start = scroll_offset.min(projects_len);
+    let end = (start + visible_height).min(projects_len);
+
+    if start >= projects_len {
+        return;
+    }
+
+    // Solve the wide layout once per render, not once per cell: the widths
+    // depend only on `inner.width`.
+    let wide_widths = if wide {
+        wide_table_widths(inner.width)
+    } else {
+        Vec::new()
+    };
+
+    let rows: Vec<Row> = projects[start..end]
+        .iter()
+        .enumerate()
+        .map(|(i, usage)| {
+            let idx = i + start;
+            let is_selected = idx == selected_index;
+            let is_striped = idx % 2 == 1;
+
+            let cells: Vec<Cell> = if wide {
+                WIDE_ORDER
+                    .iter()
+                    .map(|c| c.cell(idx + 1, usage, app, &wide_widths))
+                    .collect()
+            } else if is_very_narrow {
+                vec![
+                    Cell::from(truncate_text(&usage.label, 20)).style(
+                        Style::default()
+                            .fg(theme_accent)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Cell::from(format_cost(usage.cost)).style(Style::default().fg(Color::Green)),
+                ]
+            } else {
+                vec![
+                    Cell::from(truncate_text(&usage.label, 24)).style(
+                        Style::default()
+                            .fg(theme_accent)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Cell::from(usage.session_count.to_string()),
+                    total_tokens_cell(usage.tokens.total(), &app.theme),
+                    Cell::from(format_cost(usage.cost)).style(Style::default().fg(Color::Green)),
+                ]
+            };
+
+            let row_style = if is_selected {
+                Style::default().bg(theme_selection)
+            } else if is_striped {
+                striped_row_style
+            } else {
+                Style::default()
+            };
+
+            Row::new(cells).style(row_style).height(1)
+        })
+        .collect();
+
+    let widths: Vec<Constraint> = if wide {
+        wide_constraints()
+    } else if is_very_narrow {
+        vec![Constraint::Percentage(60), Constraint::Percentage(40)]
+    } else {
+        vec![
+            Constraint::Percentage(40),
+            Constraint::Percentage(15),
+            Constraint::Percentage(20),
+            Constraint::Percentage(25),
+        ]
+    };
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .row_highlight_style(Style::default().bg(theme_selection));
+
+    frame.render_widget(table, inner);
+
+    if projects_len > visible_height {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(Some("▲"))
+            .end_symbol(Some("▼"));
+
+        let mut scrollbar_state =
+            viewport_scrollbar_state(projects_len, scroll_offset, visible_height);
+
+        frame.render_stateful_widget(
+            scrollbar,
+            area.inner(Margin {
+                horizontal: 0,
+                vertical: 1,
+            }),
+            &mut scrollbar_state,
+        );
+    }
+}
+
+/// Build a table cell for the Models column with each model name colored by the
+/// same family-shade system used in the Overview and Models tabs, joined with
+/// `", "` and truncated to `max_cells` in terminal cells. Mirrors the Sessions
+/// tab's model cell: a multi-model project always ends in an ellipsis when some
+/// of its models did not fit, so it never renders as a single-model one.
+fn build_models_cell(models: &[SessionModel], max_cells: usize, app: &App) -> Cell<'static> {
+    if models.is_empty() {
+        return Cell::from("\u{2014}".to_string()).style(Style::default().fg(app.theme.muted));
+    }
+
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut budget = max_cells.saturating_sub(usize::from(models.len() > 1));
+    let mut shown = 0usize;
+    let mut ellipsis = false;
+
+    for (i, model) in models.iter().enumerate() {
+        if i > 0 {
+            if budget < 3 {
+                break;
+            }
+            spans.push(Span::styled(", ", Style::default().fg(app.theme.muted)));
+            budget -= 2;
+        }
+
+        if budget == 0 {
+            break;
+        }
+
+        let color = app.model_color_for(&model.provider, &model.color_key);
+        let name = &model.display_name;
+        let model_len = display_width(name);
+
+        if model_len <= budget {
+            spans.push(Span::styled(name.clone(), Style::default().fg(color)));
+            budget -= model_len;
+        } else if budget <= 1 {
+            spans.push(Span::styled("…".to_string(), Style::default().fg(color)));
+            budget = 0;
+            ellipsis = true;
+        } else {
+            let head = prefix_to_width(name, budget - 1);
+            spans.push(Span::styled(
+                format!("{}…", head),
+                Style::default().fg(color),
+            ));
+            budget = 0;
+            ellipsis = true;
+        }
+        shown += 1;
+    }
+
+    // Dropping whole models silently would misreport the project; a truncated
+    // name already carries its own ellipsis, so only mark the clean-break case.
+    if shown < models.len() && !ellipsis {
+        spans.push(Span::styled(
+            "…".to_string(),
+            Style::default().fg(app.theme.muted),
+        ));
+    }
+
+    Cell::from(Line::from(spans))
+}
+
+/// Convert Unix-ms to a local NaiveDateTime for display.
+fn ms_to_local_naive(ms: i64) -> Option<NaiveDateTime> {
+    if ms <= 0 {
+        return None;
+    }
+    let secs = ms / 1000;
+    match Local.timestamp_opt(secs, 0) {
+        chrono::LocalResult::Single(dt) => Some(dt.naive_local()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::app::{Tab, TuiConfig};
+    use crate::tui::data::TokenBreakdown;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn project(label: &str, cost: f64, last_ms: i64) -> ProjectUsage {
+        ProjectUsage {
+            group_key: label.to_string(),
+            workspace_key: Some(label.to_string()),
+            label: label.to_string(),
+            path: None,
+            clients: vec!["opencode".to_string(), "claude".to_string()],
+            models: vec![SessionModel {
+                display_name: "claude-sonnet-4".to_string(),
+                provider: "anthropic".to_string(),
+                color_key: "claude-sonnet-4".to_string(),
+            }],
+            tokens: TokenBreakdown {
+                input: 1_234_567,
+                output: 234_567,
+                cache_read: 45_678_901,
+                cache_write: 2_345_678,
+                reasoning: 0,
+            },
+            cost,
+            message_count: 428,
+            session_count: 3,
+            first_active_ms: last_ms.saturating_sub(3_600_000),
+            last_active_ms: last_ms,
+        }
+    }
+
+    fn make_app(width: u16) -> App {
+        let config = TuiConfig {
+            theme: "blue".to_string(),
+            refresh: 0,
+            sessions_path: None,
+            clients: None,
+            since: None,
+            until: None,
+            year: None,
+            initial_tab: None,
+            ..Default::default()
+        };
+        let mut app = App::new_with_cached_data(config, None).unwrap();
+        app.terminal_width = width;
+        app.current_tab = Tab::Projects;
+        app.sort_field = SortField::Cost;
+        app.sort_direction = SortDirection::Descending;
+        app
+    }
+
+    fn render_body(app: &mut App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app, Rect::new(0, 0, width, height)))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(width as usize)
+            .map(|row| {
+                row.iter()
+                    .map(|c| c.symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn wide_header_lists_every_column() {
+        let mut app = make_app(200);
+        app.data.projects = vec![project("tokscale", 12.3456, 1_736_000_000_000)];
+        let body = render_body(&mut app, 200, 6);
+        let header = body.lines().nth(1).unwrap_or_default();
+        for c in WIDE_ORDER {
+            assert!(
+                header.contains(c.header()),
+                "wide header is missing {:?} ({:?})",
+                c,
+                c.header()
+            );
+        }
+    }
+
+    #[test]
+    fn wide_row_renders_full_values_when_the_row_fits() {
+        let mut app = make_app(200);
+        app.data.projects = vec![project("tokscale", 12.3456, 1_736_000_000_000)];
+        let body = render_body(&mut app, 200, 6);
+        let row = body.lines().nth(2).unwrap_or_default();
+        for expected in [
+            "tokscale", "3", "1.2M", "234K", "45.7M", "2.3M", "49.5M", "$12.35",
+        ] {
+            assert!(row.contains(expected), "row is missing {expected:?}: {row}");
+        }
+    }
+
+    #[test]
+    fn project_column_truncates_to_granted_width_not_requested() {
+        // At any width, the label cell must be cut to what the solver actually
+        // granted the Project column — cutting to the request clips with no
+        // ellipsis when the solver shrinks the column.
+        for total in 60u16..=240 {
+            let granted = wide_table_widths(total);
+            let project_width = ProjectColumn::Project.granted_width(&granted);
+            let label = "a/very/long/workspace/label/that/keeps/going";
+            let fitted = fit_workspace_label_to_width(label, project_width);
+            assert!(
+                display_width(&fitted) <= project_width,
+                "at {total} cols the label exceeds its granted {project_width} cells"
+            );
+        }
+    }
+
+    #[test]
+    fn narrow_and_very_narrow_layouts_render() {
+        let mut app = make_app(70);
+        app.data.projects = vec![project("tokscale", 12.3456, 1_736_000_000_000)];
+        let body = render_body(&mut app, 70, 6);
+        assert!(body.contains("Project"));
+        assert!(body.contains("Sessions"));
+
+        let mut app = make_app(30);
+        app.data.projects = vec![project("tokscale", 12.3456, 1_736_000_000_000)];
+        let body = render_body(&mut app, 30, 6);
+        assert!(body.contains("Project"));
+        assert!(body.contains("Cost"));
+    }
+
+    #[test]
+    fn empty_state_renders_hint() {
+        let mut app = make_app(120);
+        let body = render_body(&mut app, 120, 6);
+        assert!(body.contains("No project usage data found"));
+    }
+}

--- a/crates/tokscale-cli/src/tui/ui/projects.rs
+++ b/crates/tokscale-cli/src/tui/ui/projects.rs
@@ -7,7 +7,7 @@ use ratatui::widgets::{
 use super::widgets::{
     display_width, fit_workspace_label_to_width, format_cost, format_tokens,
     get_compact_client_display_name, prefix_to_width, total_tokens_cell, truncate_text,
-    truncate_to_width, viewport_scrollbar_state,
+    truncate_to_width, viewport_scrollbar_state, MIDDLE_ELLIPSIS,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use crate::tui::data::{ProjectUsage, SessionModel};
@@ -407,7 +407,10 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 /// same family-shade system used in the Overview and Models tabs, joined with
 /// `", "` and truncated to `max_cells` in terminal cells. Mirrors the Sessions
 /// tab's model cell: a multi-model project always ends in an ellipsis when some
-/// of its models did not fit, so it never renders as a single-model one.
+/// of its models did not fit, so it never renders as a single-model one. The
+/// marker is [`MIDDLE_ELLIPSIS`], which is one cell in every terminal locale;
+/// U+2026 is East-Asian-Ambiguous and would be two cells under a CJK locale,
+/// overflowing the budget this cell promises to keep.
 fn build_models_cell(models: &[SessionModel], max_cells: usize, app: &App) -> Cell<'static> {
     if max_cells == 0 {
         return Cell::from("");
@@ -422,7 +425,10 @@ fn build_models_cell(models: &[SessionModel], max_cells: usize, app: &App) -> Ce
     for (i, model) in models.iter().enumerate() {
         if i > 0 {
             if budget < 3 {
-                spans.push(Span::styled("…", Style::default().fg(app.theme.muted)));
+                spans.push(Span::styled(
+                    MIDDLE_ELLIPSIS,
+                    Style::default().fg(app.theme.muted),
+                ));
                 break;
             }
             spans.push(Span::styled(", ", Style::default().fg(app.theme.muted)));
@@ -442,7 +448,7 @@ fn build_models_cell(models: &[SessionModel], max_cells: usize, app: &App) -> Ce
         } else {
             let head = prefix_to_width(name, budget - 1);
             spans.push(Span::styled(
-                format!("{}…", head),
+                format!("{head}{MIDDLE_ELLIPSIS}"),
                 Style::default().fg(color),
             ));
             break;
@@ -470,6 +476,7 @@ mod tests {
     use crate::tui::app::{Tab, TuiConfig};
     use crate::tui::data::TokenBreakdown;
     use ratatui::{backend::TestBackend, Terminal};
+    use unicode_width::UnicodeWidthStr;
 
     fn project(label: &str, cost: f64, last_ms: i64) -> ProjectUsage {
         ProjectUsage {
@@ -671,21 +678,29 @@ mod tests {
         assert_eq!(render_models(&["gpt-5", "k3"], 18), "gpt-5, k3");
     }
 
+    /// Checked in both ambients: `unicode-width` resolves East-Asian-Ambiguous
+    /// characters to one cell by default and to two under `width_cjk`, which is
+    /// what a terminal in a CJK locale does, so a marker that is ambiguous keeps
+    /// the budget on one machine and blows it on another.
     #[test]
     fn models_cell_marks_truncation_within_the_available_width() {
         for (width, expected) in [
             (0, ""),
-            (1, "…"),
-            (5, "gpt-…"),
-            (6, "gpt-5…"),
-            (7, "gpt-5…"),
-            (8, "gpt-5, …"),
+            (1, "⋯"),
+            (5, "gpt-⋯"),
+            (6, "gpt-5⋯"),
+            (7, "gpt-5⋯"),
+            (8, "gpt-5, ⋯"),
         ] {
             let rendered = render_models(&["gpt-5", "k3"], width);
             assert_eq!(rendered, expected, "at {width} columns");
             assert!(display_width(&rendered) <= width as usize);
+            assert!(
+                UnicodeWidthStr::width_cjk(rendered.as_str()) <= width as usize,
+                "at {width} columns in a CJK locale: {rendered:?}"
+            );
         }
-        assert_eq!(render_models(&["a", "🇺🇸x"], 5), "a, …");
+        assert_eq!(render_models(&["a", "🇺🇸x"], 5), "a, ⋯");
         assert_eq!(render_models(&["a", "🇺🇸x"], 6), "a, 🇺🇸x");
     }
 

--- a/crates/tokscale-cli/src/tui/ui/projects.rs
+++ b/crates/tokscale-cli/src/tui/ui/projects.rs
@@ -49,6 +49,7 @@ const WIDE_ORDER: [ProjectColumn; 12] = [
     ProjectColumn::Cost,
     ProjectColumn::LastActive,
 ];
+const COLUMN_SPACING: u16 = 1;
 
 impl ProjectColumn {
     fn header(self) -> &'static str {
@@ -72,17 +73,22 @@ impl ProjectColumn {
     /// (`Min`) column and absorbs whatever slack or shrinkage the row has left;
     /// every other column is a fixed `Length` at its natural width.
     fn constraint(self) -> Constraint {
+        if self == Self::Project {
+            Constraint::Min(self.min_width())
+        } else {
+            Constraint::Length(self.min_width())
+        }
+    }
+
+    fn min_width(self) -> u16 {
         match self {
-            Self::Project => Constraint::Min(18),
-            Self::Rank => Constraint::Length(4),
-            Self::Sessions => Constraint::Length(8),
-            Self::Sources => Constraint::Length(14),
-            Self::Models => Constraint::Length(18),
-            Self::Input | Self::Output | Self::CacheRead | Self::Total | Self::Cost => {
-                Constraint::Length(10)
-            }
-            Self::CacheWrite => Constraint::Length(11),
-            Self::LastActive => Constraint::Length(16),
+            Self::Project | Self::Models => 18,
+            Self::Rank => 4,
+            Self::Sessions => 8,
+            Self::Sources => 14,
+            Self::Input | Self::Output | Self::CacheRead | Self::Total | Self::Cost => 10,
+            Self::CacheWrite => 11,
+            Self::LastActive => 16,
         }
     }
 
@@ -175,12 +181,17 @@ fn wide_constraints() -> Vec<Constraint> {
     WIDE_ORDER.iter().map(|c| c.constraint()).collect()
 }
 
+fn wide_min_width() -> u16 {
+    WIDE_ORDER.iter().map(|c| c.min_width()).sum::<u16>()
+        + COLUMN_SPACING * WIDE_ORDER.len().saturating_sub(1) as u16
+}
+
 /// Widths the solver grants each wide column at `total` cells. Ratatui's table
 /// solves the same constraint set with one cell of `column_spacing` between
 /// columns, so this mirrors that layout exactly.
 fn wide_table_widths(total: u16) -> Vec<u16> {
     Layout::horizontal(wide_constraints())
-        .spacing(1)
+        .spacing(COLUMN_SPACING)
         .split(Rect::new(0, 0, total, 1))
         .iter()
         .map(|area| area.width)
@@ -223,8 +234,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         return;
     }
 
-    let is_narrow = app.is_narrow();
-    let is_very_narrow = app.is_very_narrow();
+    let is_very_narrow = area.width < 60;
     let sort_field = app.sort_field;
     let sort_direction = app.sort_direction;
     let scroll_offset = app.scroll_offset;
@@ -244,7 +254,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         }
     };
 
-    let wide = !is_narrow && !is_very_narrow;
+    let wide = inner.width >= wide_min_width();
 
     let header_cells: Vec<String> = if wide {
         WIDE_ORDER
@@ -368,6 +378,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     };
 
     let table = Table::new(rows, widths)
+        .column_spacing(COLUMN_SPACING)
         .header(header)
         .row_highlight_style(Style::default().bg(theme_selection));
 
@@ -398,58 +409,44 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 /// tab's model cell: a multi-model project always ends in an ellipsis when some
 /// of its models did not fit, so it never renders as a single-model one.
 fn build_models_cell(models: &[SessionModel], max_cells: usize, app: &App) -> Cell<'static> {
+    if max_cells == 0 {
+        return Cell::from("");
+    }
     if models.is_empty() {
         return Cell::from("\u{2014}".to_string()).style(Style::default().fg(app.theme.muted));
     }
 
     let mut spans: Vec<Span<'static>> = Vec::new();
-    let mut budget = max_cells.saturating_sub(usize::from(models.len() > 1));
-    let mut shown = 0usize;
-    let mut ellipsis = false;
+    let mut budget = max_cells;
 
     for (i, model) in models.iter().enumerate() {
         if i > 0 {
             if budget < 3 {
+                spans.push(Span::styled("…", Style::default().fg(app.theme.muted)));
                 break;
             }
             spans.push(Span::styled(", ", Style::default().fg(app.theme.muted)));
             budget -= 2;
         }
 
-        if budget == 0 {
-            break;
-        }
-
         let color = app.model_color_for(&model.provider, &model.color_key);
         let name = &model.display_name;
         let model_len = display_width(name);
 
-        if model_len <= budget {
+        // Leave room to mark omitted models only while more names remain.
+        // The last name can use the full remaining width.
+        let has_more = i + 1 < models.len();
+        if model_len <= budget.saturating_sub(usize::from(has_more)) {
             spans.push(Span::styled(name.clone(), Style::default().fg(color)));
             budget -= model_len;
-        } else if budget <= 1 {
-            spans.push(Span::styled("…".to_string(), Style::default().fg(color)));
-            budget = 0;
-            ellipsis = true;
         } else {
             let head = prefix_to_width(name, budget - 1);
             spans.push(Span::styled(
                 format!("{}…", head),
                 Style::default().fg(color),
             ));
-            budget = 0;
-            ellipsis = true;
+            break;
         }
-        shown += 1;
-    }
-
-    // Dropping whole models silently would misreport the project; a truncated
-    // name already carries its own ellipsis, so only mark the clean-break case.
-    if shown < models.len() && !ellipsis {
-        spans.push(Span::styled(
-            "…".to_string(),
-            Style::default().fg(app.theme.muted),
-        ));
     }
 
     Cell::from(Line::from(spans))
@@ -600,6 +597,96 @@ mod tests {
         let body = render_body(&mut app, 30, 6);
         assert!(body.contains("Project"));
         assert!(body.contains("Cost"));
+    }
+
+    #[test]
+    fn compact_layout_preserves_totals_until_all_wide_columns_fit() {
+        let mut app = make_app(200);
+        app.data.projects = vec![project("tokscale", 12.3456, 1_736_000_000_000)];
+        for width in [80, 100, 120, 140, 151] {
+            let body = render_body(&mut app, width, 6);
+            let header = body.lines().nth(1).unwrap();
+            let row = body.lines().nth(2).unwrap();
+            for label in ["Project", "Sessions", "Total", "Cost ▼"] {
+                assert!(header.contains(label), "at {width} columns: {header}");
+            }
+            assert!(!header.contains("Models"), "at {width} columns: {header}");
+            for value in ["tokscale", "49.5M", "$12.35"] {
+                assert!(row.contains(value), "at {width} columns: {row}");
+            }
+        }
+    }
+
+    #[test]
+    fn wide_layout_fits_at_its_minimum_width() {
+        let mut app = make_app(152);
+        let last_ms = 1_736_000_000_000;
+        app.data.projects = vec![project("tokscale", 12.3456, last_ms)];
+        let body = render_body(&mut app, 152, 6);
+        let header = body.lines().nth(1).unwrap();
+        let row = body.lines().nth(2).unwrap();
+        for column in WIDE_ORDER {
+            assert!(header.contains(column.header()), "{header}");
+        }
+        let last_active = ms_to_local_naive(last_ms)
+            .unwrap()
+            .format("%Y-%m-%d %H:%M")
+            .to_string();
+        for value in ["234K", "45.7M", "2.3M", "49.5M", "$12.35", &last_active] {
+            assert!(row.contains(value), "{row}");
+        }
+    }
+
+    fn render_models(names: &[&str], width: u16) -> String {
+        let app = make_app(200);
+        let models = names
+            .iter()
+            .map(|name| SessionModel {
+                display_name: name.to_string(),
+                provider: "openai".to_string(),
+                color_key: name.to_string(),
+            })
+            .collect::<Vec<_>>();
+        let area = Rect::new(0, 0, width, 1);
+        let mut buffer = Buffer::empty(area);
+        let table = Table::new(
+            [Row::new([build_models_cell(&models, width as usize, &app)])],
+            [Constraint::Length(width)],
+        );
+        Widget::render(table, area, &mut buffer);
+        let mut text = String::new();
+        let mut x = 0;
+        while x < width {
+            let symbol = buffer[(x, 0)].symbol();
+            text.push_str(symbol);
+            x += display_width(symbol).max(1) as u16;
+        }
+        text.trim_end().to_string()
+    }
+
+    #[test]
+    fn models_cell_shows_all_names_when_they_exactly_fit() {
+        assert_eq!(render_models(&["gpt-5", "k3"], 9), "gpt-5, k3");
+        assert_eq!(render_models(&["gpt-5", "k3", "o3"], 13), "gpt-5, k3, o3");
+        assert_eq!(render_models(&["gpt-5", "k3"], 18), "gpt-5, k3");
+    }
+
+    #[test]
+    fn models_cell_marks_truncation_within_the_available_width() {
+        for (width, expected) in [
+            (0, ""),
+            (1, "…"),
+            (5, "gpt-…"),
+            (6, "gpt-5…"),
+            (7, "gpt-5…"),
+            (8, "gpt-5, …"),
+        ] {
+            let rendered = render_models(&["gpt-5", "k3"], width);
+            assert_eq!(rendered, expected, "at {width} columns");
+            assert!(display_width(&rendered) <= width as usize);
+        }
+        assert_eq!(render_models(&["a", "🇺🇸x"], 5), "a, …");
+        assert_eq!(render_models(&["a", "🇺🇸x"], 6), "a, 🇺🇸x");
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -197,7 +197,7 @@ pub fn suffix_to_width(s: &str, max_cells: usize) -> &str {
 /// pushed the rest of the table sideways. U+22EF is Neutral, so it is one cell
 /// in both ambients and the budget this module computes is the width the
 /// terminal actually uses.
-const MIDDLE_ELLIPSIS: &str = "⋯";
+pub(crate) const MIDDLE_ELLIPSIS: &str = "⋯";
 
 /// Fit `s` into `max_cells` by dropping its MIDDLE instead of its tail.
 ///

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3004,8 +3004,8 @@ fn parse_all_messages_streaming<S: MessageSink>(
         sessions::opencodereview::parse_opencodereview_file,
     );
 
-    let kimi_outcomes: Vec<CachedParseOutcome> = scan_result
-        .get(ClientId::Kimi)
+    let kimi_paths = scan_result.get(ClientId::Kimi);
+    let kimi_outcomes: Vec<CachedParseOutcome> = kimi_paths
         .par_iter()
         .map(|path| {
             let parse: fn(&Path) -> Vec<UnifiedMessage> = if sessions::kimi::is_kimi_code_path(path)
@@ -3024,11 +3024,22 @@ fn parse_all_messages_streaming<S: MessageSink>(
             )
         })
         .collect();
-    for outcome in kimi_outcomes {
-        all_messages.extend(outcome.messages);
+    // Keep each path paired with its messages so the workspace lookup can key
+    // on the kimi-code root: workspaces.json/session_index.jsonl are shared by
+    // every session under one root, so they are resolved here instead of being
+    // fingerprinted — watching them would let one new workspace invalidate
+    // every other session's cache entry.
+    let mut kimi_lane: Vec<(PathBuf, Vec<UnifiedMessage>)> =
+        Vec::with_capacity(kimi_outcomes.len());
+    for (path, outcome) in kimi_paths.iter().zip(kimi_outcomes) {
+        kimi_lane.push((path.clone(), outcome.messages));
         if let Some(entry) = outcome.cache_entry {
             source_cache.insert(entry);
         }
+    }
+    sessions::kimi::apply_code_workspaces(&mut kimi_lane);
+    for (_, messages) in kimi_lane {
+        all_messages.extend(messages);
     }
 
     // Parse Qwen files

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3689,8 +3689,8 @@ impl WorkspaceLabeler {
 
     /// The canonical repo identity for `key`: the real filesystem path, with any
     /// worktree suffix stripped. `None` when the key cannot be resolved to a path
-    /// (an opaque client id, or a directory no longer on disk), leaving the
-    /// original key as its own identity.
+    /// (an opaque client id, a directory no longer on disk, or a slug that two
+    /// directories fit), leaving the original key as its own identity.
     ///
     /// Decoding is what makes the rollup actually merge. Claude Code writes a
     /// dash-mangled slug and Codex/OpenCode write real paths, so without this the

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3771,8 +3771,8 @@ pub fn workspace_bucket(
 /// Resolved up front rather than as a post-pass over the rows: the daily
 /// breakdown keys its legend off the label while it aggregates, so fixing the
 /// table afterwards would leave the chart showing the ambiguous name.
-pub fn workspace_label_overrides(
-    messages: &[UnifiedMessage],
+pub fn workspace_label_overrides<'a>(
+    messages: impl IntoIterator<Item = &'a UnifiedMessage>,
     rollup: WorktreeRollup,
     labeler: &mut WorkspaceLabeler,
 ) -> HashMap<String, String> {

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1181,10 +1181,9 @@ fn parser_version(client: ClientId) -> u32 {
         // v3->v4: non-positive wire timestamps (kimi-cli `timestamp`,
         // kimi-code `time`) now fall back to the file mtime instead of
         // anchoring the message in a pre-epoch bucket.
-        // v4->v5: kimi-code sessions now resolve their workspace from
-        // workspaces.json/session_index.jsonl after the cache read; the bump
-        // keeps the resolution logic and the cached message shape in lockstep.
-        ClientId::Kimi => 5,
+        // Workspace indexes are applied after the cache read and do not
+        // change the persisted parser output.
+        ClientId::Kimi => 4,
         // v1->v2: standalone Cline messages subtract cache buckets from gross
         // input tokens, reject non-finite costs, and preserve zero-cost reports.
         // v2->v3: content-aware Cline CLI turn-start classification now
@@ -3358,8 +3357,82 @@ mod tests {
     }
 
     #[test]
-    fn test_kimi_parser_version_invalidates_v4_entries() {
-        assert_eq!(parser_version(ClientId::Kimi), 5);
+    fn test_kimi_parser_version_invalidates_v3_entries() {
+        assert_eq!(parser_version(ClientId::Kimi), 4);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_kimi_v4_cache_reused_with_current_workspace_metadata() {
+        let cache_home = TempDir::new().unwrap();
+        let source_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(cache_home.path());
+        let root = source_home.path().join(".kimi-code");
+        let wire_path = root
+            .join("sessions")
+            .join("workspace")
+            .join("session")
+            .join("agents")
+            .join("main")
+            .join("wire.jsonl");
+        std::fs::create_dir_all(wire_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &wire_path,
+            r#"{"type":"usage.record","model":"kimi-code/kimi-for-coding","usage":{"inputOther":100,"output":50,"inputCacheRead":0,"inputCacheCreation":0},"usageScope":"turn","time":1780319377014}"#,
+        )
+        .unwrap();
+        let mut cached_messages = crate::sessions::kimi::parse_kimi_code_file(&wire_path);
+        assert_eq!(cached_messages.len(), 1);
+        // A full reparse would restore the path-derived session ID, so this
+        // marker distinguishes a cache hit from equivalent parsed usage.
+        cached_messages[0].session_id = "cache-hit-marker".to_string();
+        let identity = CacheIdentity {
+            namespace: "kimi",
+            parser_version: 4,
+        };
+        let fingerprint = SourceFingerprint::from_kimi_path(&wire_path).unwrap();
+        let mut cache = SourceMessageCache::default();
+        cache.insert(CachedSourceEntry::new(
+            identity,
+            &wire_path,
+            fingerprint,
+            cached_messages.clone(),
+            Vec::new(),
+            None,
+        ));
+        cache.save_if_dirty();
+
+        for name in ["first", "renamed"] {
+            let workspace = format!("/projects/{name}");
+            std::fs::write(
+                root.join("workspaces.json"),
+                serde_json::json!({
+                    "version": 1,
+                    "workspaces": { "workspace": { "root": workspace, "name": name } }
+                })
+                .to_string(),
+            )
+            .unwrap();
+            let messages = crate::parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &["kimi".to_string()],
+                None,
+                false,
+                &crate::scanner::ScannerSettings::default(),
+            );
+            assert_eq!(messages.len(), 1);
+            assert_eq!(messages[0].session_id, "cache-hit-marker");
+            assert_eq!(
+                messages[0].workspace_key.as_deref(),
+                Some(workspace.as_str())
+            );
+            assert_eq!(messages[0].workspace_label.as_deref(), Some(name));
+            assert_eq!(messages[0].tokens, cached_messages[0].tokens);
+
+            let persisted = SourceMessageCache::load();
+            let entry = persisted.get(identity, &wire_path).unwrap();
+            assert_eq!(entry.messages, cached_messages);
+        }
     }
 
     /// #1285 took v2 for the compressed-archive decode, so the dedup keys and

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1181,7 +1181,10 @@ fn parser_version(client: ClientId) -> u32 {
         // v3->v4: non-positive wire timestamps (kimi-cli `timestamp`,
         // kimi-code `time`) now fall back to the file mtime instead of
         // anchoring the message in a pre-epoch bucket.
-        ClientId::Kimi => 4,
+        // v4->v5: kimi-code sessions now resolve their workspace from
+        // workspaces.json/session_index.jsonl after the cache read; the bump
+        // keeps the resolution logic and the cached message shape in lockstep.
+        ClientId::Kimi => 5,
         // v1->v2: standalone Cline messages subtract cache buckets from gross
         // input tokens, reject non-finite costs, and preserve zero-cost reports.
         // v2->v3: content-aware Cline CLI turn-start classification now
@@ -3355,8 +3358,8 @@ mod tests {
     }
 
     #[test]
-    fn test_kimi_parser_version_invalidates_v3_entries() {
-        assert_eq!(parser_version(ClientId::Kimi), 4);
+    fn test_kimi_parser_version_invalidates_v4_entries() {
+        assert_eq!(parser_version(ClientId::Kimi), 5);
     }
 
     /// #1285 took v2 for the compressed-archive decode, so the dedup keys and

--- a/crates/tokscale-core/src/sessions/kimi.rs
+++ b/crates/tokscale-core/src/sessions/kimi.rs
@@ -9,7 +9,7 @@
 //!   Token data comes from usage.record lines.
 
 use super::utils::{file_modified_timestamp_ms, for_each_json_line};
-use super::UnifiedMessage;
+use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -139,6 +139,167 @@ fn extract_session_id_from_kimi_code_path(path: &Path) -> String {
         .and_then(|n| n.to_str())
         .unwrap_or("unknown")
         .to_string()
+}
+
+/// The workspace slug and the kimi-code root for a kimi-code wire path.
+/// Path format: <root>/sessions/<SLUG>/<SESSION>/agents/<AGENT>/wire.jsonl
+fn kimi_code_slug_and_root(path: &Path) -> Option<(&str, &Path)> {
+    let agent_dir = path.parent()?; // AGENT
+    let agents_dir = agent_dir.parent()?; // agents
+    let session_dir = agents_dir.parent()?; // SESSION
+    let slug_dir = session_dir.parent()?; // SLUG
+    let sessions_dir = slug_dir.parent()?; // sessions
+    let root = sessions_dir.parent()?; // kimi-code root
+    Some((slug_dir.file_name()?.to_str()?, root))
+}
+
+/// A project root recovered from a kimi-code index, plus the label to display.
+#[derive(Clone)]
+struct KimiCodeWorkspace {
+    key: String,
+    label: Option<String>,
+}
+
+impl KimiCodeWorkspace {
+    /// `name` is the display name kimi-code records in workspaces.json; without
+    /// it the label is the project root's basename.
+    fn from_root(root: &str, name: Option<&str>) -> Option<Self> {
+        let key = normalize_workspace_key(root)?;
+        let label = name
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_string)
+            .or_else(|| workspace_label_from_key(&key));
+        Some(Self { key, label })
+    }
+}
+
+/// The slug -> workspace map from `<root>/workspaces.json`
+/// (`{"version":1,"workspaces":{"<SLUG>":{"root":"/abs/path","name":"..."}}}`).
+fn read_workspaces_index(root: &Path) -> HashMap<String, KimiCodeWorkspace> {
+    let mut by_slug = HashMap::new();
+    let Ok(contents) = std::fs::read_to_string(root.join("workspaces.json")) else {
+        return by_slug;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return by_slug;
+    };
+    let Some(workspaces) = value.get("workspaces").and_then(|v| v.as_object()) else {
+        return by_slug;
+    };
+    for (slug, entry) in workspaces {
+        let workspace = entry.get("root").and_then(|v| v.as_str()).and_then(|root| {
+            KimiCodeWorkspace::from_root(root, entry.get("name").and_then(|v| v.as_str()))
+        });
+        if let Some(workspace) = workspace {
+            by_slug.insert(slug.clone(), workspace);
+        }
+    }
+    by_slug
+}
+
+/// The session -> workspace fallback map from `<root>/session_index.jsonl`
+/// (one JSON object per line with `sessionId`, `sessionDir`, `workDir`), for
+/// sessions whose slug is absent from workspaces.json. Keyed by both the
+/// session id and the session directory's basename, which the wire path's
+/// SESSION component can match as either.
+fn read_session_index(root: &Path) -> HashMap<String, KimiCodeWorkspace> {
+    let mut by_session = HashMap::new();
+    let Ok(contents) = std::fs::read_to_string(root.join("session_index.jsonl")) else {
+        return by_session;
+    };
+    for line in contents.lines() {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let workspace = value
+            .get("workDir")
+            .and_then(|v| v.as_str())
+            .and_then(|work_dir| KimiCodeWorkspace::from_root(work_dir, None));
+        let Some(workspace) = workspace else {
+            continue;
+        };
+        if let Some(session_id) = value.get("sessionId").and_then(|v| v.as_str()) {
+            by_session.insert(session_id.to_string(), workspace.clone());
+        }
+        if let Some(dir_name) = value
+            .get("sessionDir")
+            .and_then(|v| v.as_str())
+            .and_then(|dir| Path::new(dir).file_name())
+            .and_then(|name| name.to_str())
+        {
+            by_session.insert(dir_name.to_string(), workspace);
+        }
+    }
+    by_session
+}
+
+/// Attach workspace identity to kimi-code messages after the cache read.
+///
+/// Runs after the source-message cache, not inside [`parse_kimi_code_file`],
+/// because `workspaces.json` is shared by every session under one kimi-code
+/// root: folding it into each wire file's cache fingerprint would let one new
+/// workspace invalidate every session's entry. Resolving here keeps a
+/// workspaces-only edit free — nothing is invalidated, each root's indexes are
+/// read once per scan rather than once per wire file, and a cache-served
+/// message still gets the current workspace.
+///
+/// Legacy kimi-cli paths carry no workspace data and are left untouched.
+pub fn apply_code_workspaces(sources: &mut [(PathBuf, Vec<UnifiedMessage>)]) {
+    struct RootIndexes {
+        by_slug: HashMap<String, KimiCodeWorkspace>,
+        by_session: HashMap<String, KimiCodeWorkspace>,
+    }
+
+    let mut indexes: HashMap<PathBuf, RootIndexes> = HashMap::new();
+    for (path, messages) in sources.iter() {
+        if messages.is_empty() || !is_kimi_code_path(path) {
+            continue;
+        }
+        let Some((_, root)) = kimi_code_slug_and_root(path) else {
+            continue;
+        };
+        if indexes.contains_key(root) {
+            continue;
+        }
+        indexes.insert(
+            root.to_path_buf(),
+            RootIndexes {
+                by_slug: read_workspaces_index(root),
+                by_session: read_session_index(root),
+            },
+        );
+    }
+
+    if indexes.is_empty() {
+        return;
+    }
+
+    for (path, messages) in sources.iter_mut() {
+        if messages.is_empty() || !is_kimi_code_path(path) {
+            continue;
+        }
+        let Some((slug, root)) = kimi_code_slug_and_root(path) else {
+            continue;
+        };
+        let Some(index) = indexes.get(root) else {
+            continue;
+        };
+        let session_id = extract_session_id_from_kimi_code_path(path);
+        let workspace = index
+            .by_slug
+            .get(slug)
+            .or_else(|| index.by_session.get(&session_id));
+        let Some(workspace) = workspace else {
+            continue;
+        };
+        for message in messages.iter_mut() {
+            if message.client != "kimi" {
+                continue;
+            }
+            message.set_workspace(Some(workspace.key.clone()), workspace.label.clone());
+        }
+    }
 }
 
 /// Strip the "kimi-code/" prefix from model IDs emitted by kimi-code.
@@ -894,5 +1055,127 @@ not valid json at all
             "/home/user/.kimi/sessions/group/uuid/wire.jsonl"
         )));
         assert!(!is_kimi_code_path(std::path::Path::new("wire.jsonl")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Kimi Code workspace resolution tests
+    // -------------------------------------------------------------------------
+
+    const WORKSPACE_WIRE_LINE: &str = r#"{"type":"usage.record","model":"kimi-code/kimi-for-coding","usage":{"inputOther":100,"output":50,"inputCacheRead":0,"inputCacheCreation":0},"usageScope":"turn","time":1780319377014}"#;
+
+    /// Build <tmp>/.kimi-code/sessions/<SLUG>/<SESSION>/agents/main/wire.jsonl
+    /// and return the tempdir guard, the wire path, and the kimi-code root.
+    fn create_kimi_code_layout(
+        slug: &str,
+        session: &str,
+    ) -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join(".kimi-code");
+        let wire_path = root
+            .join("sessions")
+            .join(slug)
+            .join(session)
+            .join("agents")
+            .join("main")
+            .join("wire.jsonl");
+        std::fs::create_dir_all(wire_path.parent().unwrap()).unwrap();
+        std::fs::write(&wire_path, WORKSPACE_WIRE_LINE).unwrap();
+        (dir, wire_path, root)
+    }
+
+    #[test]
+    fn test_apply_code_workspaces_resolves_slug_via_workspaces_json() {
+        let (_dir, wire_path, root) =
+            create_kimi_code_layout("wd_odyssey_4c02790435a7", "sess-abc-123");
+        std::fs::write(
+            root.join("workspaces.json"),
+            r#"{"version":1,"workspaces":{"wd_odyssey_4c02790435a7":{"root":"/home/user/Projects/golang/Odyssey","name":"Odyssey"}}}"#,
+        )
+        .unwrap();
+
+        let mut sources = vec![(wire_path.clone(), parse_kimi_code_file(&wire_path))];
+        apply_code_workspaces(&mut sources);
+
+        let messages = &sources[0].1;
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].workspace_key.as_deref(),
+            Some("/home/user/Projects/golang/Odyssey")
+        );
+        // The sidecar's `name` is preferred over the root's basename.
+        assert_eq!(messages[0].workspace_label.as_deref(), Some("Odyssey"));
+    }
+
+    #[test]
+    fn test_apply_code_workspaces_falls_back_to_session_index() {
+        let (_dir, wire_path, root) = create_kimi_code_layout("wd_gone_0000", "sess-fallback-1");
+        // No workspaces.json entry for this slug; the session index still
+        // knows where the session ran.
+        std::fs::write(
+            root.join("workspaces.json"),
+            r#"{"version":1,"workspaces":{}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("session_index.jsonl"),
+            concat!(
+                r#"{"sessionId":"sess-fallback-1","sessionDir":"/x/sessions/wd_gone_0000/sess-fallback-1","workDir":"/home/user/work/api-server"}"#,
+                "\n",
+                "not json at all\n"
+            ),
+        )
+        .unwrap();
+
+        let mut sources = vec![(wire_path.clone(), parse_kimi_code_file(&wire_path))];
+        apply_code_workspaces(&mut sources);
+
+        let messages = &sources[0].1;
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].workspace_key.as_deref(),
+            Some("/home/user/work/api-server")
+        );
+        // No recorded name: the label is the workDir's basename.
+        assert_eq!(messages[0].workspace_label.as_deref(), Some("api-server"));
+    }
+
+    #[test]
+    fn test_apply_code_workspaces_leaves_missing_slug_untouched() {
+        let (_dir, wire_path, root) = create_kimi_code_layout("wd_unknown_9999", "sess-none-1");
+        std::fs::write(
+            root.join("workspaces.json"),
+            r#"{"version":1,"workspaces":{}}"#,
+        )
+        .unwrap();
+
+        let mut sources = vec![(wire_path.clone(), parse_kimi_code_file(&wire_path))];
+        apply_code_workspaces(&mut sources);
+
+        let messages = &sources[0].1;
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].workspace_key, None);
+        assert_eq!(messages[0].workspace_label, None);
+    }
+
+    #[test]
+    fn test_apply_code_workspaces_ignores_legacy_kimi_cli_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        // Legacy layout: <root>/sessions/GROUP/UUID/wire.jsonl — no `agents`.
+        let wire_path = dir
+            .path()
+            .join(".kimi")
+            .join("sessions")
+            .join("group-1")
+            .join("uuid-1")
+            .join("wire.jsonl");
+        std::fs::create_dir_all(wire_path.parent().unwrap()).unwrap();
+        std::fs::write(&wire_path, WORKSPACE_WIRE_LINE).unwrap();
+
+        let mut sources = vec![(wire_path.clone(), parse_kimi_code_file(&wire_path))];
+        apply_code_workspaces(&mut sources);
+
+        let messages = &sources[0].1;
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].workspace_key, None);
     }
 }

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -859,7 +859,10 @@ pub fn decode_claude_project_slug(key: &str) -> Option<String> {
 
     let (root, remaining) = slug_root_and_remainder(key)?;
     let mut budget = SLUG_DECODE_STEP_BUDGET;
-    resolve_slug_under(&root, remaining, &mut budget)
+    match resolve_slug_under(&root, remaining, &mut budget) {
+        SlugResolution::Resolved(path) => Some(path),
+        SlugResolution::DeadEnd | SlugResolution::Refused => None,
+    }
 }
 
 /// Filesystem probes one slug decode may spend before it gives up.
@@ -910,15 +913,36 @@ fn slug_root_and_remainder(key: &str) -> Option<(PathBuf, &str)> {
     ))
 }
 
+/// What walking one slug remainder under one directory found.
+///
+/// `DeadEnd` and `Refused` are kept apart on purpose. A parent that hears
+/// `DeadEnd` from a child keeps trying that child's siblings; `Refused` means
+/// the slug already fits more than one directory somewhere below (or the walk
+/// ran out of budget before that could be ruled out), and no sibling can make
+/// the answer unique again. When both were `None` a tie found one level down
+/// read as a dead end, and the parent handed back whichever other sibling
+/// completed — a third directory that happened to fit became the grouping
+/// identity for usage from all three.
+#[derive(Debug, PartialEq, Eq)]
+enum SlugResolution {
+    /// Exactly one directory under this node completes the slug.
+    Resolved(String),
+    /// Nothing under this node completes the slug.
+    DeadEnd,
+    /// More than one directory completes the slug, or the walk could not
+    /// finish checking, so no result from this subtree can be shown unique.
+    Refused,
+}
+
 /// Walk `remaining` against the real directories under `dir`.
 ///
 /// A dash in the slug is ambiguous — it may be a `/` boundary, or part of a
 /// directory name that genuinely contains `-`, `.` or `+` — so a single greedy
 /// pass mis-resolves paths like `claude-witness` (one directory, not two). This
 /// consumes one real directory at a time, backtracks when a branch dead-ends,
-/// and refuses when two branches both complete, which makes every result it
-/// does give exact.
-fn resolve_slug_under(dir: &Path, remaining: &str, budget: &mut u32) -> Option<String> {
+/// and refuses when two branches complete at any depth of the walk, which
+/// makes every result it does give exact.
+fn resolve_slug_under(dir: &Path, remaining: &str, budget: &mut u32) -> SlugResolution {
     if remaining.is_empty() {
         // Hand back a normalized key, not a native path. Every consumer compares
         // against forward-slash markers (`workspace_repo_root` looks for
@@ -926,16 +950,23 @@ fn resolve_slug_under(dir: &Path, remaining: &str, budget: &mut u32) -> Option<S
         // returning the native spelling would silently defeat worktree rollup and
         // make a decoded key unequal to the same directory recorded by a client
         // that stores a real path.
-        return normalize_workspace_key(&dir.to_string_lossy());
+        return match normalize_workspace_key(&dir.to_string_lossy()) {
+            Some(path) => SlugResolution::Resolved(path),
+            None => SlugResolution::DeadEnd,
+        };
     }
 
     // One probe for the directory listing this node is about to make.
     if !spend_slug_budget(budget, 1) {
-        return None;
+        return SlugResolution::Refused;
     }
 
-    let matched: Vec<String> = std::fs::read_dir(dir)
-        .ok()?
+    // A directory this process cannot list is a dead end, not a refusal:
+    // nothing under it was shown to fit the slug.
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return SlugResolution::DeadEnd;
+    };
+    let matched: Vec<String> = entries
         .flatten()
         .map(|entry| entry.file_name().to_string_lossy().to_string())
         // Name filter first: it is pure string work, and it rejects nearly every
@@ -947,7 +978,7 @@ fn resolve_slug_under(dir: &Path, remaining: &str, budget: &mut u32) -> Option<S
     // The `stat` per survivor is the other unbounded cost here, so charge for it
     // before paying it.
     if !spend_slug_budget(budget, matched.len() as u32) {
-        return None;
+        return SlugResolution::Refused;
     }
 
     // Longest candidate first: `IngTian.github.io` is the likelier match when a
@@ -974,20 +1005,28 @@ fn resolve_slug_under(dir: &Path, remaining: &str, budget: &mut u32) -> Option<S
     for name in candidates {
         let consumed = slugify_path_segment(&name).len() + 1;
         match resolve_slug_under(&dir.join(&name), &remaining[consumed..], budget) {
-            Some(path) => {
+            SlugResolution::Resolved(path) => {
                 if resolved.is_some() {
-                    return None;
+                    return SlugResolution::Refused;
                 }
                 resolved = Some(path);
             }
-            // The budget ran dry under this branch, so the siblings after it
-            // were never walked and the answer cannot be shown to be unique.
-            None if *budget == 0 => return None,
-            None => {}
+            // A refusal below is final no matter where it came from. A tie under
+            // this child already fits the slug to two directories, and the
+            // siblings still unwalked can only add fits, never remove them; a
+            // budget that ran dry under it left those siblings unchecked. Either
+            // way nothing this level finds afterwards can be shown to be unique,
+            // so it must not fall through to be walked as if the child had
+            // merely dead-ended.
+            SlugResolution::Refused => return SlugResolution::Refused,
+            SlugResolution::DeadEnd => {}
         }
     }
 
-    resolved
+    match resolved {
+        Some(path) => SlugResolution::Resolved(path),
+        None => SlugResolution::DeadEnd,
+    }
 }
 
 /// Whether `remaining` starts with `-` + the encoded form of `name`, ending on a
@@ -1304,9 +1343,14 @@ mod tests {
             assert!(Path::new(&decoded).is_dir(), "decoded to {decoded}");
         }
 
-        // An exhausted budget refuses rather than returning a wrong path.
+        // An exhausted budget refuses rather than returning a wrong path, and
+        // says so as a refusal rather than a dead end, so a parent level cannot
+        // walk past it to a sibling.
         let mut spent = 0u32;
-        assert_eq!(resolve_slug_under(&root, "-a-b", &mut spent), None);
+        assert_eq!(
+            resolve_slug_under(&root, "-a-b", &mut spent),
+            SlugResolution::Refused
+        );
 
         // And an ordinary slug still decodes with the budget in place.
         let plain = root.join("devpro/claude-witness");
@@ -1699,6 +1743,45 @@ mod tests {
             decode_claude_project_slug(&slug_for(&nested)),
             normalize_workspace_key(&nested.to_string_lossy())
         );
+    }
+
+    #[test]
+    fn decode_claude_project_slug_refuses_a_tie_below_a_unique_sibling() {
+        // `a-b/c`, `a/b-c` and `a/b.c` all encode to one slug. Walked
+        // longest-first, `a-b` completes on its own; `a` then finds two
+        // completions underneath it. That tie used to come back as `None`,
+        // which the parent read as a dead end, so the slug decoded to `a-b/c`
+        // and Claude Code usage from both `a/` directories was booked there.
+        let (_temp, root) = canonical_tempdir();
+        for dir in ["a-b/c", "a/b-c", "a/b.c"] {
+            std::fs::create_dir_all(root.join(dir)).unwrap();
+        }
+        let slug = slug_for(&root.join("a/b.c"));
+        assert_eq!(slug, slug_for(&root.join("a/b-c")));
+        assert_eq!(slug, slug_for(&root.join("a-b/c")));
+
+        assert_eq!(decode_claude_project_slug(&slug), None);
+        // What the Projects tab consumes as the grouping identity.
+        let mut labeler = crate::WorkspaceLabeler::default();
+        assert_eq!(labeler.repo_root(&slug), None);
+    }
+
+    #[test]
+    fn decode_claude_project_slug_refuses_a_tie_under_the_first_candidate() {
+        // Mirror shape: the tie sits under `a-b`, the candidate walked first,
+        // and `a/b-c-d` then completes alone. Same swallowed tie in the other
+        // order: the slug decoded to `a/b-c-d`.
+        let (_temp, root) = canonical_tempdir();
+        for dir in ["a-b/c-d", "a-b/c.d", "a/b-c-d"] {
+            std::fs::create_dir_all(root.join(dir)).unwrap();
+        }
+        let slug = slug_for(&root.join("a-b/c.d"));
+        assert_eq!(slug, slug_for(&root.join("a-b/c-d")));
+        assert_eq!(slug, slug_for(&root.join("a/b-c-d")));
+
+        assert_eq!(decode_claude_project_slug(&slug), None);
+        let mut labeler = crate::WorkspaceLabeler::default();
+        assert_eq!(labeler.repo_root(&slug), None);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -846,8 +846,10 @@ fn last_slug_segment(slug: &str) -> Option<String> {
 /// same map to real directory names to find which one the slug came from, which
 /// makes the recovered path exact rather than a guess.
 ///
-/// Returns `None` for keys that are already real paths, or when no directory on
-/// disk matches (a project whose folder has since been deleted or renamed).
+/// Returns `None` for keys that are already real paths, when no directory on
+/// disk matches (a project whose folder has since been deleted or renamed), and
+/// when more than one does (`a.b` beside `a-b`): the answer is adopted as a
+/// grouping identity, so a guess would move usage between projects.
 pub fn decode_claude_project_slug(key: &str) -> Option<String> {
     // A real path (already usable) keeps its separators; `normalize_workspace_key`
     // rewrites Windows backslashes to `/`, so one check covers both platforms.
@@ -913,8 +915,9 @@ fn slug_root_and_remainder(key: &str) -> Option<(PathBuf, &str)> {
 /// A dash in the slug is ambiguous — it may be a `/` boundary, or part of a
 /// directory name that genuinely contains `-`, `.` or `+` — so a single greedy
 /// pass mis-resolves paths like `claude-witness` (one directory, not two). This
-/// consumes one real directory at a time and backtracks when a branch dead-ends,
-/// which makes the result exact wherever the directory still exists on disk.
+/// consumes one real directory at a time, backtracks when a branch dead-ends,
+/// and refuses when two branches both complete, which makes every result it
+/// does give exact.
 fn resolve_slug_under(dir: &Path, remaining: &str, budget: &mut u32) -> Option<String> {
     if remaining.is_empty() {
         // Hand back a normalized key, not a native path. Every consumer compares
@@ -947,8 +950,9 @@ fn resolve_slug_under(dir: &Path, remaining: &str, budget: &mut u32) -> Option<S
         return None;
     }
 
-    // Longest candidate first: prefer `IngTian.github.io` over a shorter
-    // `IngTian` that happens to also exist.
+    // Longest candidate first: `IngTian.github.io` is the likelier match when a
+    // shorter `IngTian` also exists, so the common case completes before the
+    // budget can run out on the long shot.
     let mut candidates: Vec<String> = matched
         .into_iter()
         // `Path::is_dir` follows symlinks where `DirEntry::file_type` would not.
@@ -956,20 +960,34 @@ fn resolve_slug_under(dir: &Path, remaining: &str, budget: &mut u32) -> Option<S
         // through `/var -> /private/var`, and users symlink project roots.
         .filter(|name| dir.join(name).is_dir())
         .collect();
-    // Ties are real: `a.b` and `a-b` encode identically and nothing on disk
-    // distinguishes them, so order deterministically instead of trusting
-    // readdir order.
+    // Order deterministically instead of trusting readdir order, so a budget
+    // that runs out refuses the same slug on every run.
     candidates.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
 
+    // Every candidate is walked, not just the first that completes. `a.b` and
+    // `a-b` encode identically, and when both exist and both complete the slug
+    // nothing on disk says which one Claude Code was launched from. The decoded
+    // path becomes the grouping identity under worktree rollup, so answering
+    // with either would book that usage against a directory the slug may never
+    // have named. A tie here is still fine when only one branch completes.
+    let mut resolved: Option<String> = None;
     for name in candidates {
         let consumed = slugify_path_segment(&name).len() + 1;
-        if let Some(resolved) = resolve_slug_under(&dir.join(&name), &remaining[consumed..], budget)
-        {
-            return Some(resolved);
+        match resolve_slug_under(&dir.join(&name), &remaining[consumed..], budget) {
+            Some(path) => {
+                if resolved.is_some() {
+                    return None;
+                }
+                resolved = Some(path);
+            }
+            // The budget ran dry under this branch, so the siblings after it
+            // were never walked and the answer cannot be shown to be unique.
+            None if *budget == 0 => return None,
+            None => {}
         }
     }
 
-    None
+    resolved
 }
 
 /// Whether `remaining` starts with `-` + the encoded form of `name`, ending on a
@@ -1659,6 +1677,28 @@ mod tests {
         assert_eq!(super::slug_root_and_remainder("Users-me-app"), None);
         assert_eq!(super::slug_root_and_remainder("1--Users-me"), None);
         assert_eq!(super::slug_root_and_remainder(""), None);
+    }
+
+    #[test]
+    fn decode_claude_project_slug_refuses_encode_identical_siblings() {
+        let (_temp, root) = canonical_tempdir();
+        // `.` and `-` both encode to `-`, so these two directories are one slug.
+        std::fs::create_dir_all(root.join("a-b")).unwrap();
+        std::fs::create_dir_all(root.join("a.b")).unwrap();
+        let slug = slug_for(&root.join("a.b"));
+        assert_eq!(slug, slug_for(&root.join("a-b")));
+
+        // Nothing on disk says which one Claude Code was launched from, and a
+        // guess becomes a grouping identity downstream, so refuse.
+        assert_eq!(decode_claude_project_slug(&slug), None);
+
+        // A deeper segment only one sibling can satisfy settles it.
+        let nested = root.join("a-b/src");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert_eq!(
+            decode_claude_project_slug(&slug_for(&nested)),
+            normalize_workspace_key(&nested.to_string_lossy())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add a Projects tab that shows token usage and cost per repository across coding clients. A directory recorded as a Claude Code workspace slug and as a Codex path now appears in one project row, and Git worktrees roll up into their parent repository. Project aggregation is independent of the Models tab's grouping and worktree setting.

- Show project totals, session counts, contributing clients and models, and last activity, with sorting, scrolling, and clipboard support. Use compact columns until the full table fits, and preserve model names that fit the available width.
- Reuse the core workspace identity and label-disambiguation helpers; count sessions by client and session ID.
- Combine Codex Desktop's dated chat directories into a `Codex Chat` row while keeping repository and worktree directories separate.
- Resolve Kimi Code workspaces from `workspaces.json`, with `session_index.jsonl` as a fallback. Resolve shared indexes once per root after reading the source cache, so existing v4 entries receive current workspace metadata without reparsing transcripts.
- Add aggregation, tab-navigation, rendering, and Kimi workspace tests, including a portable fixture for merging Claude slugs with real paths and a regression for workspace updates on v4 cache hits.

## Validation

All checks passed locally on macOS for `5727faca`. The full-feature test run completed with 3,604 passed and 6 ignored; Windows execution remains for the repository's CI.

- `cargo fmt --all -- --check`
- `cargo clippy --offline --locked --workspace --all-features -- -D warnings`
- `cargo test --offline --locked --workspace --all-features --no-fail-fast --quiet`

Rendering regressions cover compact tables at 80, 100, 120, 140, and 151 columns, the full table at 152 columns, model names that exactly fill their cells, and truncation at zero or small widths without splitting emoji graphemes.

## Notes

Project rows are rebuilt during the initial background refresh, following the Sessions tab's cache behavior. This does not change the TUI disk-cache schema.

Narrow-terminal tab-strip overflow and long project-label truncation remain follow-up work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Projects tab to the TUI that rolls up token usage and cost per repository across coding clients. Projects group by repo identity, so Claude Code's dash-mangled workspace slugs and the real paths other clients record land in one row, Git worktrees merge into their parent repo, and Codex Desktop's dated chat directories combine into a `Codex Chat` row.

**New Features**
- Shows project totals, session counts, contributing clients and models, and last activity, with sorting, scrolling, clipboard support, and layouts that adapt to narrow terminals; Sessions and Projects share one sorting path.
- Aggregation is independent of the Models tab's grouping and worktree setting, reusing the core workspace identity and label-disambiguation helpers.
- Resolves Kimi Code workspaces from `workspaces.json` with `session_index.jsonl` as a fallback, applied after the source cache so cached messages get current workspace metadata without invalidating cache entries; the disk-cache schema is unchanged and rows rebuild on the first background refresh.

**Bug Fixes**
- Refuses to decode a Claude Code slug when more than one directory on disk fits it, so the slug stays its own row labeled with the raw key instead of guessing a path and misbooking usage.
- Truncated model labels use a width-stable ellipsis (U+22EF), so cells stay within their promised width even in CJK-locale terminals.

<sup>Written for commit 22edc7e2497bd6e7a93978c1c583280dd700ff62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

