### PR TITLE
fix(core): parse MiMo Code and fx on the local report path

### DIFF
--- a/crates/tokscale-cli/src/commands/report.rs
+++ b/crates/tokscale-cli/src/commands/report.rs
@@ -13,7 +13,9 @@ use tokscale_core::content_extractor::SessionContent;
 use tokscale_core::content_extractor::{extract_session_content, metadata_only_content};
 use tokscale_core::pricing::PricingService;
 use tokscale_core::wiki::{WikiDb, WikiEntry};
-use tokscale_core::{parse_local_clients, LocalParseOptions, ParsedMessage, TokenBreakdown};
+use tokscale_core::{
+    parse_local_clients, CostSource, LocalParseOptions, ParsedMessage, TokenBreakdown,
+};
 
 pub struct ReportOptions {
     pub json: bool,
@@ -107,10 +109,6 @@ pub fn run_report(opts: ReportOptions) -> Result<()> {
 }
 
 fn populate_wiki_from_sessions(db: &WikiDb, opts: &ReportOptions) -> Result<()> {
-    let existing = db
-        .get_existing_session_ids()
-        .map_err(|e| anyhow::anyhow!("{}", e))?;
-
     let parsed = parse_local_clients(LocalParseOptions {
         home_dir: opts.home_dir.clone(),
         use_env_roots: opts.home_dir.is_none(),
@@ -124,9 +122,24 @@ fn populate_wiki_from_sessions(db: &WikiDb, opts: &ReportOptions) -> Result<()> 
 
     let pricing = load_pricing_service();
 
+    record_new_sessions(db, &parsed.messages, pricing.as_deref())
+}
+
+/// Aggregate `messages` per session and record every session the wiki has not
+/// seen yet. Recorded sessions are never rewritten, so the figures computed
+/// here are the ones the wiki keeps.
+fn record_new_sessions(
+    db: &WikiDb,
+    messages: &[ParsedMessage],
+    pricing: Option<&PricingService>,
+) -> Result<()> {
+    let existing = db
+        .get_existing_session_ids()
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
     let mut session_map: HashMap<String, SessionAgg> = HashMap::new();
 
-    for msg in &parsed.messages {
+    for msg in messages {
         let agg = session_map
             .entry(msg.session_id.clone())
             .or_insert_with(|| SessionAgg {
@@ -150,7 +163,7 @@ fn populate_wiki_from_sessions(db: &WikiDb, opts: &ReportOptions) -> Result<()> 
         agg.total_input = agg.total_input.saturating_add(msg.input);
         agg.total_output = agg.total_output.saturating_add(msg.output);
         agg.total_cache_read = agg.total_cache_read.saturating_add(msg.cache_read);
-        agg.total_cost += compute_msg_cost(msg, pricing.as_deref());
+        agg.total_cost += compute_msg_cost(msg, pricing);
         // NOTE: the wiki `report` view intentionally groups on the raw model_id
         // and does not apply `modelAliases` folding (nor the grouping
         // normalization every other report uses). Wiki entries are persisted
@@ -1548,10 +1561,17 @@ fn load_pricing_service() -> Option<std::sync::Arc<PricingService>> {
     fresh.or_else(|| PricingService::load_cached_any_age().map(std::sync::Arc::new))
 }
 
-/// Computes a message's cost using the canonical [`PricingService`], honoring
+/// Computes a message's cost. A provider-reported cost is used as-is, the same
+/// way the submit lane never reprices an authoritative figure: some sources
+/// (fx session snapshots, for one) report a cost for a row that carries no
+/// tokens at all, and pricing that row from its tokens would record $0.00.
+/// Anything else is priced with the canonical [`PricingService`], honoring
 /// per-model rates and every billed token type (input/output/cache read/cache
 /// write/reasoning). Returns 0.0 when no pricing dataset is available.
 fn compute_msg_cost(msg: &ParsedMessage, pricing: Option<&PricingService>) -> f64 {
+    if msg.cost_source == CostSource::ProviderReported {
+        return msg.cost;
+    }
     let Some(pricing) = pricing else {
         return 0.0;
     };
@@ -1631,6 +1651,8 @@ mod tests {
             duration_ms: None,
             message_count: 1,
             agent: None,
+            cost: 0.0,
+            cost_source: CostSource::Unknown,
         }
     }
 
@@ -1776,6 +1798,84 @@ mod tests {
     fn compute_msg_cost_without_pricing_is_zero() {
         let msg = parsed_message("claude-haiku-4");
         assert_eq!(compute_msg_cost(&msg, None), 0.0);
+    }
+
+    #[test]
+    fn compute_msg_cost_keeps_a_provider_reported_cost() {
+        let pricing = test_pricing_service();
+        let mut msg = parsed_message("claude-haiku-4");
+        let estimated = compute_msg_cost(&msg, Some(&pricing));
+        assert!(estimated > 0.0);
+
+        msg.cost = 0.42;
+        msg.cost_source = CostSource::ProviderReported;
+        assert_eq!(compute_msg_cost(&msg, Some(&pricing)), 0.42);
+        // An authoritative figure does not need a pricing dataset at all.
+        assert_eq!(compute_msg_cost(&msg, None), 0.42);
+
+        // A parser-side cost that is not authoritative never overrides the
+        // canonical pricing of the tokens.
+        msg.cost_source = CostSource::Estimated;
+        assert_eq!(compute_msg_cost(&msg, Some(&pricing)), estimated);
+    }
+
+    #[test]
+    fn wiki_keeps_the_reported_cost_of_a_token_free_fx_session() {
+        // fx can snapshot a session with a positive `total_cost`, no per-model
+        // entries and zero tokens; the parser attributes it to `fx-unknown`
+        // with the reported cost. Pricing that row from its tokens yields $0,
+        // and the wiki never rewrites a session it has already recorded, so
+        // the wrong figure would stick for good.
+        let home = tempfile::TempDir::new().unwrap();
+        let session = home.path().join(".fx/sessions/sess-1");
+        std::fs::create_dir_all(&session).unwrap();
+        std::fs::write(
+            session.join("session.json"),
+            r#"{"workspace_root":"/Users/alice/repo","updated_at_ms":1780000000000}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            session.join("usage-v2.json"),
+            r#"{"schema_version":1,"session_id":"sess-1","snapshot":{"schema_version":2,"total_cost":0.014,"request_count":1,"models":[]}}"#,
+        )
+        .unwrap();
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(home.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["fx".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: Default::default(),
+        })
+        .unwrap();
+        let fx: Vec<&ParsedMessage> = parsed
+            .messages
+            .iter()
+            .filter(|msg| msg.client == "fx")
+            .collect();
+        assert_eq!(fx.len(), 1, "one fx-unknown row expected");
+        assert_eq!(
+            fx[0].input + fx[0].output + fx[0].cache_read + fx[0].cache_write + fx[0].reasoning,
+            0,
+            "the fixture must carry no tokens for the cost to come from the snapshot"
+        );
+
+        let db = WikiDb::open(&home.path().join("wiki.db")).unwrap();
+        record_new_sessions(&db, &parsed.messages, None).unwrap();
+
+        let entry = db
+            .get_entry("sess-1")
+            .unwrap()
+            .expect("the fx session must be recorded");
+        assert_eq!(entry.client, "fx");
+        assert_eq!(entry.models_used, vec!["fx-unknown".to_string()]);
+        assert!(
+            (entry.total_cost - 0.014).abs() < 1e-9,
+            "wiki must keep the provider-reported cost, got {}",
+            entry.total_cost
+        );
     }
 
     fn titled_entry(session_id: &str, title: &str) -> WikiEntry {

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -5226,6 +5226,21 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     };
     counts.set(ClientId::OpenCode, opencode_count);
 
+    // MiMo Code: SQLite database(s). Dedup by the payload's own message id the
+    // same way the submit path does -- MiMo writes channel-suffixed databases,
+    // so one session can appear in `mimocode.db` and `mimocode-<channel>.db`.
+    let mut micode_seen: HashSet<String> = HashSet::new();
+    let micode_msgs: Vec<ParsedMessage> = scan_result
+        .micode_dbs
+        .iter()
+        .flat_map(|db_path| sessions::micode::parse_micode_sqlite(db_path))
+        .filter(|msg| should_keep_deduped_message(&mut micode_seen, msg))
+        .map(|msg| unified_to_parsed(&msg))
+        .collect();
+    let micode_count = summed_parsed_message_count(&micode_msgs);
+    counts.set(ClientId::MiMoCode, micode_count);
+    messages.extend(micode_msgs);
+
     let claude_home = PathBuf::from(&home_dir);
     let claude_msgs_raw: Vec<(String, ParsedMessage)> = scan_result
         .get(ClientId::Claude)
@@ -5949,6 +5964,24 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let mux_count = summed_parsed_message_count(&mux_msgs);
     counts.set(ClientId::Mux, mux_count);
     messages.extend(mux_msgs);
+
+    // fx (vercel-labs/fx) per-session usage snapshots. Session titles are not
+    // applied here: `ParsedMessage` has no title field, so the shared
+    // `sessions/index.json` lookup the submit lane runs would have nothing to
+    // write to.
+    let fx_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Fx)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::fx::parse_fx_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let fx_count = summed_parsed_message_count(&fx_msgs);
+    counts.set(ClientId::Fx, fx_count);
+    messages.extend(fx_msgs);
 
     // Kilo CLI: SQLite database
     let _kilo_count: i32 = if let Some(db_path) = &scan_result.kilo_db {
@@ -10220,6 +10253,111 @@ mod tests {
                 .map(|m| &m.client)
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_local_clients_includes_micode_and_fx() {
+        // Regression: MiMo Code and fx both declare `parse_local: true`, and
+        // the submit path (parse_all_messages_with_pricing_with_env_strategy)
+        // parses both, so their usage did reach the leaderboard. But
+        // parse_local_clients had no block for either client, so every command
+        // built on it saw nothing: `tokscale clients` reported a zero message
+        // count, and the `tokscale report` session wiki and `tokscale wrapped`
+        // agent breakdown showed none of the usage. Pin the local path
+        // specifically -- this is the mirror of the opencodereview gap below,
+        // and a green submit-path test cannot catch it either way.
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+
+        let micode_dir = source_home.path().join(".local/share/mimocode");
+        std::fs::create_dir_all(&micode_dir).unwrap();
+        {
+            let conn = rusqlite::Connection::open(micode_dir.join("mimocode.db")).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE message (
+                    id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    data TEXT NOT NULL
+                );",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+                rusqlite::params![
+                    "row-1",
+                    "micode-session",
+                    r#"{"id":"micode-msg-1","role":"assistant","modelID":"mimo-vl-8b","providerID":"xiaomi","cost":0.05,"tokens":{"input":1000,"output":200,"cache":{"read":0,"write":0}},"time":{"created":1780000000000}}"#
+                ],
+            )
+            .unwrap();
+        }
+
+        let fx_session = source_home.path().join(".fx/sessions/sess-1");
+        std::fs::create_dir_all(&fx_session).unwrap();
+        std::fs::write(
+            fx_session.join("session.json"),
+            r#"{"workspace_root":"/Users/alice/repo","updated_at_ms":1780000000000}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            fx_session.join("usage-v2.json"),
+            r#"{"schema_version":1,"session_id":"sess-1","snapshot":{"schema_version":2,"total_cost":0.01,"request_count":2,"models":[{"model":"zai/glm-5.2","total_cost":0.01,"input_tokens":1539,"output_tokens":441,"cache_read_tokens":1069,"cache_write_tokens":7,"reasoning_tokens":3,"request_count":2}]}}"#,
+        )
+        .unwrap();
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(source_home.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["micode".to_string(), "fx".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+
+        let micode = parsed
+            .messages
+            .iter()
+            .filter(|msg| msg.client == "micode")
+            .collect::<Vec<_>>();
+        assert_eq!(
+            micode.len(),
+            1,
+            "MiMo Code assistant row must reach the local parse, got {:?}",
+            parsed
+                .messages
+                .iter()
+                .map(|m| &m.client)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(micode[0].input, 1000);
+        assert_eq!(micode[0].output, 200);
+        assert_eq!(parsed.counts.get(ClientId::MiMoCode), 1);
+
+        let fx = parsed
+            .messages
+            .iter()
+            .filter(|msg| msg.client == "fx")
+            .collect::<Vec<_>>();
+        assert_eq!(
+            fx.len(),
+            1,
+            "fx per-model row must reach the local parse, got {:?}",
+            parsed
+                .messages
+                .iter()
+                .map(|m| &m.client)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(fx[0].input, 1539);
+        assert_eq!(fx[0].output, 441);
+        assert_eq!(fx[0].workspace_key.as_deref(), Some("/Users/alice/repo"));
+        // fx records `request_count` as the row's message count, so the client
+        // count is the summed count and not the row count.
+        assert_eq!(parsed.counts.get(ClientId::Fx), 2);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -355,6 +355,13 @@ pub struct ParsedMessage {
     pub duration_ms: Option<i64>,
     pub message_count: i32,
     pub agent: Option<String>,
+    /// Cost in USD as the parser reported it. This lane applies no pricing, so
+    /// the figure is only meaningful when `cost_source` is
+    /// [`CostSource::ProviderReported`]; consumers price every other row from
+    /// its tokens, exactly as the submit lane reprices only rows without an
+    /// authoritative cost.
+    pub cost: f64,
+    pub cost_source: CostSource,
 }
 
 pub struct ParsedMessages {
@@ -5965,8 +5972,12 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::Mux, mux_count);
     messages.extend(mux_msgs);
 
-    // fx (vercel-labs/fx) per-session usage snapshots. Session titles are not
-    // applied here: `ParsedMessage` has no title field, so the shared
+    // fx (vercel-labs/fx) per-session usage snapshots. `parse_fx_file` leaves
+    // `date` empty for the streaming loader's `refresh_derived_fields` to fill
+    // in; this lane converts straight to `ParsedMessage`, so derive it here or
+    // the `year`/`since`/`until` filters below compare against "". The pinned-
+    // zone rebucket pass still runs afterwards. Session titles are not applied
+    // here: `ParsedMessage` has no title field, so the shared
     // `sessions/index.json` lookup the submit lane runs would have nothing to
     // write to.
     let fx_msgs: Vec<ParsedMessage> = scan_result
@@ -5975,7 +5986,10 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
         .flat_map(|path| {
             sessions::fx::parse_fx_file(path)
                 .into_iter()
-                .map(|msg| unified_to_parsed(&msg))
+                .map(|mut msg| {
+                    msg.refresh_derived_fields();
+                    unified_to_parsed(&msg)
+                })
                 .collect::<Vec<_>>()
         })
         .collect();
@@ -6400,6 +6414,8 @@ fn unified_to_parsed(msg: &UnifiedMessage) -> ParsedMessage {
         duration_ms: msg.duration_ms,
         message_count: msg.message_count,
         agent: msg.agent.clone(),
+        cost: msg.cost,
+        cost_source: msg.cost_source,
     }
 }
 
@@ -10358,6 +10374,182 @@ mod tests {
         // fx records `request_count` as the row's message count, so the client
         // count is the summed count and not the row count.
         assert_eq!(parsed.counts.get(ClientId::Fx), 2);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_local_clients_keeps_provider_reported_cost() {
+        // `ParsedMessage` used to carry tokens only, so every consumer of the
+        // local lane had to price rows from tokens. fx can report a positive
+        // `total_cost` for a snapshot with no per-model entries and no tokens
+        // at all (the synthetic `fx-unknown` row), and MiMo Code embeds a
+        // per-message cost; both are authoritative on the submit lane and must
+        // reach the local consumers with their provenance intact.
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+
+        let micode_dir = source_home.path().join(".local/share/mimocode");
+        std::fs::create_dir_all(&micode_dir).unwrap();
+        {
+            let conn = rusqlite::Connection::open(micode_dir.join("mimocode.db")).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE message (
+                    id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    data TEXT NOT NULL
+                );",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+                rusqlite::params![
+                    "row-1",
+                    "micode-session",
+                    r#"{"id":"micode-msg-1","role":"assistant","modelID":"mimo-vl-8b","providerID":"xiaomi","cost":0.05,"tokens":{"input":1000,"output":200,"cache":{"read":0,"write":0}},"time":{"created":1780000000000}}"#
+                ],
+            )
+            .unwrap();
+        }
+
+        let fx_session = source_home.path().join(".fx/sessions/sess-1");
+        std::fs::create_dir_all(&fx_session).unwrap();
+        std::fs::write(
+            fx_session.join("session.json"),
+            r#"{"workspace_root":"/Users/alice/repo","updated_at_ms":1780000000000}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            fx_session.join("usage-v2.json"),
+            r#"{"schema_version":1,"session_id":"sess-1","snapshot":{"schema_version":2,"total_cost":0.014,"request_count":1,"models":[]}}"#,
+        )
+        .unwrap();
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(source_home.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["micode".to_string(), "fx".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+
+        let fx = parsed
+            .messages
+            .iter()
+            .filter(|msg| msg.client == "fx")
+            .collect::<Vec<_>>();
+        assert_eq!(fx.len(), 1);
+        assert_eq!(fx[0].model_id, "fx-unknown");
+        assert_eq!(
+            fx[0].input + fx[0].output + fx[0].cache_read + fx[0].cache_write + fx[0].reasoning,
+            0
+        );
+        assert!((fx[0].cost - 0.014).abs() < 1e-9, "fx cost {}", fx[0].cost);
+        assert_eq!(fx[0].cost_source, sessions::CostSource::ProviderReported);
+
+        let micode = parsed
+            .messages
+            .iter()
+            .filter(|msg| msg.client == "micode")
+            .collect::<Vec<_>>();
+        assert_eq!(micode.len(), 1);
+        assert!(
+            (micode[0].cost - 0.05).abs() < 1e-9,
+            "micode cost {}",
+            micode[0].cost
+        );
+        assert_eq!(
+            micode[0].cost_source,
+            sessions::CostSource::ProviderReported
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_local_clients_fx_rows_carry_a_derived_date() {
+        // `parse_fx_file` leaves `date` empty and relies on the streaming
+        // loader's `refresh_derived_fields` to derive it from the timestamp.
+        // The local lane converts straight to `ParsedMessage`, so without a
+        // refresh of its own every fx row reached the date filters with
+        // `date == ""`: `year` and `since` dropped all of them, and `until`
+        // alone admitted rows past the cutoff. Default scanner settings pin no
+        // zone, so the post-parse rebucket pass cannot repair the key either.
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+
+        let timestamp = 1_780_000_000_000_i64;
+        let fx_session = source_home.path().join(".fx/sessions/sess-1");
+        std::fs::create_dir_all(&fx_session).unwrap();
+        std::fs::write(
+            fx_session.join("session.json"),
+            format!(r#"{{"workspace_root":"/Users/alice/repo","updated_at_ms":{timestamp}}}"#),
+        )
+        .unwrap();
+        std::fs::write(
+            fx_session.join("usage-v2.json"),
+            r#"{"schema_version":1,"session_id":"sess-1","snapshot":{"schema_version":2,"total_cost":0.01,"request_count":2,"models":[{"model":"zai/glm-5.2","total_cost":0.01,"input_tokens":1539,"output_tokens":441,"request_count":2}]}}"#,
+        )
+        .unwrap();
+
+        // The day every other parser derives for this instant on this host.
+        let expected_date = UnifiedMessage::new(
+            "fx",
+            "glm-5.2",
+            "zai",
+            "sess-1",
+            timestamp,
+            TokenBreakdown::default(),
+            0.0,
+        )
+        .date;
+        assert_eq!(expected_date.len(), 10, "{expected_date:?}");
+        let year = expected_date[..4].to_string();
+        let day_before = chrono::NaiveDate::parse_from_str(&expected_date, "%Y-%m-%d")
+            .unwrap()
+            .pred_opt()
+            .unwrap()
+            .format("%Y-%m-%d")
+            .to_string();
+
+        let fx_rows = |since: Option<String>, until: Option<String>, year: Option<String>| {
+            parse_local_clients(LocalParseOptions {
+                home_dir: Some(source_home.path().to_str().unwrap().to_string()),
+                use_env_roots: false,
+                clients: Some(vec!["fx".to_string()]),
+                since,
+                until,
+                year,
+                scanner_settings: scanner::ScannerSettings::default(),
+            })
+            .unwrap()
+            .messages
+            .into_iter()
+            .filter(|msg| msg.client == "fx")
+            .collect::<Vec<_>>()
+        };
+
+        let unfiltered = fx_rows(None, None, None);
+        assert_eq!(unfiltered.len(), 1);
+        assert_eq!(unfiltered[0].date, expected_date);
+
+        assert_eq!(
+            fx_rows(None, None, Some(year)).len(),
+            1,
+            "the matching year must keep the fx row"
+        );
+        assert_eq!(
+            fx_rows(Some(expected_date.clone()), None, None).len(),
+            1,
+            "a since cutoff on the row's own day must keep it"
+        );
+        assert!(
+            fx_rows(None, Some(day_before), None).is_empty(),
+            "an until cutoff before the row's day must reject it"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

MiMo Code and fx usage never shows up in `tokscale report`, and `tokscale clients` prints a zero message count for both, even though both clients scan and submit fine.

## Cause

`MiMoCode` and `Fx` both declare `parse_local: true` in `define_clients!` (`crates/tokscale-core/src/clients.rs`), and the submit path parses both: MiMo Code from `scan_result.micode_dbs` at `crates/tokscale-core/src/lib.rs:2047`, fx from `scan_result.get(ClientId::Fx)` at `crates/tokscale-core/src/lib.rs:3133`. `parse_local_clients` (same file, from line 5134) has a block for every other locally parsed client and none for these two, so it returns no rows and sets no count for either.

Everything built on `parse_local_clients` therefore sees nothing. `tokscale report` builds its whole table from the wiki DB, and `populate_wiki_from_sessions` (`crates/tokscale-cli/src/commands/report.rs:114`) fills that DB from `parse_local_clients` alone, so a MiMo Code or fx session is never recorded. `run_clients_command` (`crates/tokscale-cli/src/main.rs:4266`) asks for every `parse_local()` client and then prints `parsed.counts.get(client)`, so both rows read 0 no matter how much local data exists.

This is the mirror of #986, where opencodereview was parsed locally but missing from the submit path.

## Fix

MiMo Code goes in after the OpenCode block and reads `scan_result.micode_dbs`, deduplicating on the payload message id through the existing `should_keep_deduped_message` helper. That part matters: MiMo writes channel-suffixed databases, so one session can appear in both `mimocode.db` and `mimocode-<channel>.db`, and the submit lane already collapses them the same way.

fx goes in after the Mux block and reads `scan_result.get(ClientId::Fx)`. Session titles are deliberately not applied here, because `ParsedMessage` has no title field for the shared `sessions/index.json` lookup to write to.

Both count through `summed_parsed_message_count` rather than the row count, so an fx row contributes its `request_count`.

## Verification

The new test writes a `~/.local/share/mimocode/mimocode.db` with one assistant row and a `~/.fx/sessions/sess-1/usage-v2.json` snapshot, then asserts both reach `parse_local_clients` with their token buckets and client counts.

With the test applied to an otherwise unmodified tree:

```
$ cargo test --locked -p tokscale-core --all-features --lib -- test_parse_local_clients_includes_micode_and_fx
assertion `left == right` failed: MiMo Code assistant row must reach the local parse, got []
  left: 0
 right: 1
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2110 filtered out
```

With the fix:

```
$ cargo fmt --all -- --check
(clean)

$ cargo clippy --locked -p tokscale-core --all-features --all-targets -- -D warnings
(no warnings)

$ cargo test --locked -p tokscale-core --all-features --no-fail-fast
test result: ok. 2109 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
(plus the eight integration binaries, all ok)
```

The same suite on `main` before the change was 2108 passed, 0 failed, so the only difference is the new test. Ran on macOS 15 with rustc 1.95.0. The test uses only tempdirs and fixed literals, with no clock, locale or timezone dependence, so it behaves the same on the Windows leg.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the local report path so MiMo Code and fx usage now appears in `tokscale report` and `tokscale clients` instead of always showing zero, and preserves provider-reported dates and costs so the figures are correct.

- `parse_local_clients` now parses MiMo Code from `scan_result.micode_dbs`, deduplicating by payload message id since one session can appear in both `mimocode.db` and `mimocode-<channel>.db`, and fx from per-session usage snapshots.
- fx rows now derive their date before conversion so `year`/`since`/`until` filters work on the local lane.
- `ParsedMessage` now carries `cost` and `cost_source`; `compute_msg_cost` uses a provider-reported cost as-is, so a token-free fx session records its snapshot cost instead of $0.00.
- Both clients count through summed message counts, so an fx row contributes its `request_count`.

<sup>Written for commit 8891eb3cbd8ded415cbe693d53342e25846d4c55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

