### PR TITLE
docs(antigravity): say what a panicked probe actually does to the round

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -461,11 +461,13 @@ async fn race_for_quota_with(
     while let Ok(Some(joined)) = tokio::time::timeout_at(deadline, requests.join_next()).await {
         // A `JoinError` carries no rank, so a panicked request is never
         // marked settled. If it outranked the best answer, the early break
-        // below can no longer fire and the loop runs until `join_next` has
-        // drained the set and yields `None` -- every other request has
-        // finished by then, so the round ends when the slowest of them does,
-        // not at the deadline. `call_rpc` reports every failure it has as
-        // `Err`, so this is the unreachable arm rather than the failure path.
+        // below can no longer fire, and the round ends at the earlier of two
+        // points: `join_next` draining the set and yielding `None` once every
+        // surviving request has finished, or `timeout_at` returning `Err` at
+        // the deadline -- which is what happens when a lower-ranked survivor
+        // has accepted the connection and gone quiet. `call_rpc` reports
+        // every failure it has as `Err`, so this is the unreachable arm
+        // rather than the failure path.
         let Ok((rank, answer)) = joined else { continue };
         settled[rank] = true;
         if let Some(summary) = answer {

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -459,10 +459,13 @@ async fn race_for_quota_with(
     let mut best: Option<(usize, QuotaSummary)> = None;
 
     while let Ok(Some(joined)) = tokio::time::timeout_at(deadline, requests.join_next()).await {
-        // A `JoinError` carries no rank, so a panicked request cannot be
-        // marked settled and the round runs to its deadline instead of
-        // returning early. `call_rpc` reports every failure it has as `Err`,
-        // so this is the unreachable arm rather than the failure path.
+        // A `JoinError` carries no rank, so a panicked request is never
+        // marked settled. If it outranked the best answer, the early break
+        // below can no longer fire and the loop runs until `join_next` has
+        // drained the set and yields `None` -- every other request has
+        // finished by then, so the round ends when the slowest of them does,
+        // not at the deadline. `call_rpc` reports every failure it has as
+        // `Err`, so this is the unreachable arm rather than the failure path.
         let Ok((rank, answer)) = joined else { continue };
         settled[rank] = true;
         if let Some(summary) = answer {


### PR DESCRIPTION
Follow-up to #1280. The comment on the `JoinError` arm of `race_for_quota_with` said a panicked request makes "the round run to its deadline instead of returning early". It does not: the loop `continue`s without marking that rank settled, which disarms the early break if the panic outranked the best answer, but `join_next` yields `None` once every other request has finished and the `while let` ends there — the round ends with the slowest surviving request, not at the deadline.

Found by the adversarial verifier on the merged tree, by mutation: make the rank-0 request panic and the rank-1 answer is returned as soon as it lands, well inside the deadline.

Comment-only. No test is added on purpose: the arm is unreachable (`call_rpc` returns every failure as `Err`), and pinning it would need a test-only way to make a request panic, which #1280 removed from this module deliberately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the comment on the `JoinError` arm in `race_for_quota_with` to describe what a panicked request actually does to the round. The old comment claimed the round runs to its deadline; in reality, the round ends at whichever comes first: `join_next` draining the set once every surviving request finishes, or `timeout_at` returning `Err` at the deadline when a lower-ranked survivor goes quiet. This is a comment-only change with no behavior change.

<sup>Written for commit 440e7c2a1afa9208c1cb0c7c75d67ef61fbbd38f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

