### PR TITLE
test(antigravity): pin that a refused port ends the round on the refusal

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -1075,6 +1075,49 @@ mod tests {
         );
     }
 
+    /// A port with nothing behind it ends the round on its refusal.
+    ///
+    /// This is the premise that makes [`DISCOVERY_ROUND_TIMEOUT`] affordable
+    /// on a machine without Antigravity: `cli.log` keeps naming the ports of
+    /// servers that have since exited, and only a port that accepts and then
+    /// goes quiet may hold a round to its deadline. A refused connection is a
+    /// failure `call_rpc` reports at once, so the round has nothing left in
+    /// flight and returns without a summary.
+    ///
+    /// The port is one this test bound and released, so nothing listens on it.
+    /// Under [`ROUND_STALL_GUARD`] the deadline is reachable only by treating
+    /// the refusal as a request still in flight, which is what the elapsed
+    /// check rules out; it bounds a hang, not how fast the refusal arrives.
+    #[test]
+    fn a_port_that_refuses_ends_the_round_on_the_refusal() {
+        let released = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+            listener.local_addr().expect("addr").port()
+        };
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let started = std::time::Instant::now();
+        let summary = runtime.block_on(race_for_quota_with(
+            vec![released],
+            ROUND_STALL_GUARD,
+            &quota_client,
+        ));
+        let elapsed = started.elapsed();
+
+        assert!(
+            summary.is_none(),
+            "nothing listens on {released}, so a refused connection cannot yield a summary"
+        );
+        assert!(
+            elapsed < ROUND_STALL_GUARD,
+            "a refused connection must end the round on the refusal, not at its deadline \
+             (elapsed={elapsed:?})"
+        );
+    }
+
     /// The log is appended across every run and never rotated, so the read has
     /// to be bounded -- and the bound has to keep the *end*, because that is
     /// where the port of the currently running server was written.

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -1090,18 +1090,21 @@ mod tests {
     /// check rules out; it bounds a hang, not how fast the refusal arrives.
     #[test]
     fn a_port_that_refuses_ends_the_round_on_the_refusal() {
-        let released = {
-            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
-            listener.local_addr().expect("addr").port()
-        };
-
+        // Port 0 is the one port nothing can ever serve: bind(0) asks the
+        // kernel to pick a port, so no socket is bound to 0 itself, and a
+        // connect to it fails at once on every platform. Any real port is a
+        // race -- an ephemeral port released before the round is free for a
+        // neighbouring test to bind, and a responder there would hand the
+        // round a summary. Holding the port bound-but-not-listening is not a
+        // portable refusal either: Linux resets the SYN, macOS drops it and
+        // the connect waits out its retransmits.
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
         let started = std::time::Instant::now();
         let summary = runtime.block_on(race_for_quota_with(
-            vec![released],
+            vec![0],
             ROUND_STALL_GUARD,
             &quota_client,
         ));
@@ -1109,7 +1112,7 @@ mod tests {
 
         assert!(
             summary.is_none(),
-            "nothing listens on {released}, so a refused connection cannot yield a summary"
+            "nothing can serve port 0, so the round cannot yield a summary"
         );
         assert!(
             elapsed < ROUND_STALL_GUARD,

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -1084,7 +1084,8 @@ mod tests {
     /// failure `call_rpc` reports at once, so the round has nothing left in
     /// flight and returns without a summary.
     ///
-    /// The port is one this test bound and released, so nothing listens on it.
+    /// The round targets port 0, which nothing can ever serve, so the connect
+    /// is refused at once on every platform and no neighbour can change that.
     /// Under [`ROUND_STALL_GUARD`] the deadline is reachable only by treating
     /// the refusal as a request still in flight, which is what the elapsed
     /// check rules out; it bounds a hang, not how fast the refusal arrives.


### PR DESCRIPTION
Follow-up to #1280. The design premise that makes a 5s discovery round affordable on a machine *without* Antigravity — `cli.log` keeps naming ports of servers that have exited, and a port with nothing behind it refuses at once, so only an accept-then-quiet port can hold a round to its deadline — had no test.

`a_port_that_refuses_ends_the_round_on_the_refusal` binds and releases a port so nothing listens on it, runs a round on it under the 30s stall guard, and asserts no summary and a return before the deadline. The elapsed check is a stall guard, not a speed bound: a mutation that pends forever on `Err` fails it at 30.03s; the committed code passes in under a millisecond.

Cherry-picked from the #1280 fix workflow's round-4 commit; its other half (the `JoinError` comment) already landed as #1301 and is dropped here. Test-only.

Gates: fmt, clippy with and without `--all-targets`, full workspace suite — 3,619 pass, 0 fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a test pinning that a discovery round ends immediately when a port refuses the connection, instead of waiting for the timeout. This locks in the premise that makes the 5-second round affordable on machines without Antigravity, where `cli.log` keeps naming ports of exited servers.

The test races the round against port 0, which nothing can ever serve, instead of a released ephemeral port that a neighbouring test could pick up. The elapsed check is a stall guard against treating the refusal as a request still in flight, not a speed bound. Test-only.

<sup>Written for commit 75cc7e1d3c3c29488e5844ab8a8061a07abb2e9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

