### PR TITLE
ci(rustdoc): gate cargo doc and fix broken intra-doc links

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -52,6 +52,32 @@ jobs:
       - name: Run Clippy (strict)
         run: cargo clippy --locked --workspace --all-features -- -D warnings
 
+  rustdoc:
+    name: Rustdoc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.98.0
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: rustdoc-${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            rustdoc-${{ runner.os }}-cargo-
+      - name: Build docs (deny warnings)
+        # Doc comments are not compiled by clippy: broken intra-doc links,
+        # bare URLs, and `<...>` placeholders parsed as HTML tags only fail
+        # here.
+        run: RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --workspace
+
   # Windows is a first-class target - `build-native.yml` ships
   # x86_64/aarch64-pc-windows-msvc artifacts - but until #997 nothing ever
   # *executed* a test there, so Windows-only defects reached users unseen.

--- a/crates/tokscale-cli/src/commands/apple_fm.rs
+++ b/crates/tokscale-cli/src/commands/apple_fm.rs
@@ -36,7 +36,7 @@
 //! `objc_retain`) on macOS 26.2, so it is NOT a valid liveness check for "is FM
 //! working on this box". This module uses only the non-streaming
 //! `FMLanguageModelSessionRespondWithSchema` path (a PROGRAMMATIC
-//! GenerationSchema built via [`imp::build_schema`], NOT the JSON-Schema-string
+//! GenerationSchema built via `imp::build_schema`, NOT the JSON-Schema-string
 //! `...FromJSON` variant) and is unaffected. For end-to-end verification use the
 //! `#[ignore]`d live test in this module (`live_summarize_smoke`), not the
 //! streaming example.

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5530,7 +5530,7 @@ fn run_graph_command(
 /// This deliberately does NOT upload: backfilled aggregates cannot be verified
 /// the way locally-scanned sessions are, so submitting them requires
 /// server-side support for tagging backfilled data distinctly from live CLI
-/// usage. See https://github.com/junhoyeo/tokscale/issues/888.
+/// usage. See <https://github.com/junhoyeo/tokscale/issues/888>.
 fn run_import_command(
     file: String,
     format: String,

--- a/crates/tokscale-cli/src/trae.rs
+++ b/crates/tokscale-cli/src/trae.rs
@@ -46,7 +46,7 @@ pub mod auth {
     //! Cache filenames: `credentials-solo.json` (Solo) and `credentials-ide.json` (Ide).
     //! These are fixed names, not derived from the report client id (`client_str()`).
     //! Cache directory: `<tokscale config dir>/trae-cache/`, where the
-    //! config dir is resolved by [`paths::get_config_dir`] and honors
+    //! config dir is resolved by `paths::get_config_dir` and honors
     //! `TOKSCALE_CONFIG_DIR` plus XDG defaults (typically
     //! `~/.config/tokscale` on Linux/macOS).
 

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -9,7 +9,7 @@ pub enum PathRoot {
     /// the XDG config home on Linux. When an explicit home is supplied — or,
     /// on Windows, when the resolved home is not the Win32 profile — this root
     /// is derived from that home using the matching platform convention; see
-    /// [`app_data_follows_home`].
+    /// `app_data_follows_home`.
     AppData,
     EnvVar {
         var: &'static str,

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -75,7 +75,7 @@ pub(crate) fn strip_parenthesized_reasoning_tier(model_id: &str) -> Option<&str>
 
 /// Canonical model identity — the model id that leaves the machine.
 ///
-/// This is [`normalize_syntactic`] with **no alias folding**: purely structural
+/// This is `normalize_syntactic` with **no alias folding**: purely structural
 /// canonicalization (lowercase, strip a `(reasoning-tier)` suffix, strip a
 /// trailing `-YYYYMMDD` date, rewrite `.`→`-` inside claude version numbers, and
 /// fold an `anthropic/claude-…` prefix). It never consults the user's

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -48,7 +48,7 @@ pub struct ScannerSettings {
     /// [`ScanResult::opencode_dbs`] list; duplicates (by canonical path)
     /// are removed and non-existent entries are silently skipped so stale
     /// config does not break the scan. WAL/SHM sidecar files are rejected
-    /// with the same [`is_opencode_db_filename`] check used for
+    /// with the same `is_opencode_db_filename` check used for
     /// auto-discovery.
     #[serde(default)]
     pub opencode_db_paths: Vec<PathBuf>,

--- a/crates/tokscale-core/src/sessions/antigravity_cli.rs
+++ b/crates/tokscale-core/src/sessions/antigravity_cli.rs
@@ -23,7 +23,7 @@
 //!   - `#21` (string, optional)  → model display label (`Gemini 3.6 Flash (High)`)
 //!   - `#9` (message)            → per-generation wall-clock time. Two layouts
 //!     exist depending on the agy version, both handled by
-//!     [`generation_timestamp_ms`]:
+//!     `generation_timestamp_ms`:
 //!     - agy ≤ 1.1.17: `#9.#4` = `{#1: seconds, #2: nanos}` Timestamp.
 //!     - agy 1.1.18: `#4` is gone. `#9` instead carries `#2` = `u64::MAX` (an
 //!       `int64` -1 "unset" sentinel, never a time) and a new `#10` holding 8
@@ -51,7 +51,7 @@
 //! - `trajectory_metadata_blob.#1.#1` (string)                  → workspace URI
 //!
 //! `#19` is optional in practice: some continuation turns omit it while still
-//! writing `#21`. [`SessionModels`] recovers the machine id for those rows from
+//! writing `#21`. `SessionModels` recovers the machine id for those rows from
 //! the rest of the same conversation. `#21` was present on every row observed so
 //! far, including the ones missing `#19`, but nothing here requires it — a row
 //! carrying neither field is handled too. `#21` serves only as a join key

--- a/crates/tokscale-core/src/sessions/freebuff.rs
+++ b/crates/tokscale-core/src/sessions/freebuff.rs
@@ -1,6 +1,6 @@
 //! Freebuff session parser
 //!
-//! Freebuff (https://github.com/CodebuffAI/freebuff) is not a separate program
+//! Freebuff (<https://github.com/CodebuffAI/freebuff>) is not a separate program
 //! from Codebuff: it is the same CLI compiled with `FREEBUFF_MODE=true`, a
 //! free-only build that strips paid features. It therefore resolves the same
 //! config dir (`~/.config/manicode[-dev|-staging]`) and writes the same

--- a/crates/tokscale-core/src/sessions/fx.rs
+++ b/crates/tokscale-core/src/sessions/fx.rs
@@ -18,19 +18,19 @@
 //!
 //! Cache split. The two sidecars are read back differently because they sit at
 //! different scopes. `session.json` is per-session, so it is a related file of
-//! the snapshot's cache fingerprint ([`fx_session_meta_path`]) and a
+//! the snapshot's cache fingerprint (`fx_session_meta_path`) and a
 //! sidecar-only edit invalidates exactly that one entry. `index.json` is one
 //! file shared by every session, so it is deliberately *not* in any
 //! fingerprint — appending a new session to it would otherwise invalidate every
 //! other session's entry. Its title is resolved after the cache instead, by
-//! [`apply_session_titles`], which reads the index once per scan and writes the
+//! `apply_session_titles`, which reads the index once per scan and writes the
 //! title onto freshly parsed and cache-served messages alike. Titles are
 //! collected per sessions directory, because an fx session id is only unique
 //! within one `sessions/` tree.
 //!
 //! Cost provenance. `total_cost` is optional on the wire at both levels, so its
 //! presence is preserved rather than defaulted: a snapshot that never carried a
-//! cost must not be submitted as an authoritative $0.00. See [`reported_cost`].
+//! cost must not be submitted as an authoritative $0.00. See `reported_cost`.
 
 use super::utils::{file_modified_timestamp_ms, read_file_or_none};
 use super::{normalize_workspace_key, workspace_label_from_key, CostSource, UnifiedMessage};

--- a/crates/tokscale-core/src/sessions/kilo.rs
+++ b/crates/tokscale-core/src/sessions/kilo.rs
@@ -6,7 +6,7 @@
 //! Kilo stores assistant turns in OpenCode's message schema, so the parse
 //! itself lives in [`super::opencode_schema`]; only the places where Kilo's
 //! behaviour departs from OpenCode's are declared here, as
-//! [`OpenCodeSchemaConfig::kilo`].
+//! `OpenCodeSchemaConfig::kilo`.
 
 use super::opencode_schema::{parse_opencode_schema_sqlite, OpenCodeSchemaConfig};
 use super::utils::file_modified_timestamp_ms;

--- a/crates/tokscale-core/src/sessions/kimi.rs
+++ b/crates/tokscale-core/src/sessions/kimi.rs
@@ -2,10 +2,10 @@
 //!
 //! Parses wire.jsonl from both `kimi-cli` and `kimi-code`.
 //!
-//! ~/.kimi/sessions/[GROUP_ID]/[SESSION_UUID]/wire.jsonl
+//! `~/.kimi/sessions/[GROUP_ID]/[SESSION_UUID]/wire.jsonl`
 //!   Token data comes from StatusUpdate messages.
 //!
-//! ~/.kimi-code/sessions/[WORKSPACE]/[SESSION]/agents/[AGENT]/wire.jsonl
+//! `~/.kimi-code/sessions/[WORKSPACE]/[SESSION]/agents/[AGENT]/wire.jsonl`
 //!   Token data comes from usage.record lines.
 
 use super::utils::{file_modified_timestamp_ms, for_each_json_line};

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -4,8 +4,8 @@
 //! 1. File-based (Kiro CLI): ~/.kiro/sessions/cli/*.json + *.jsonl
 //! 2. Kiro IDE globalStorage snapshots
 //! 3. SQLite-based: ~/Library/Application Support/kiro-cli/data.sqlite3
-//!    (conversations_v2 table with history[*].request_metadata)
-//! 4. File-based (Kiro IDE): ~/.kiro/sessions/<workspace>/sess_<uuid>/
+//!    (conversations_v2 table with `history[*].request_metadata`)
+//! 4. File-based (Kiro IDE): `~/.kiro/sessions/<workspace>/sess_<uuid>/`
 //!    session.json (metadata) + messages.jsonl (conversation). This is the
 //!    VS Code-based Kiro IDE layout, distinct from the CLI's cli/*.json layout.
 //!

--- a/crates/tokscale-core/src/sessions/micode.rs
+++ b/crates/tokscale-core/src/sessions/micode.rs
@@ -6,7 +6,7 @@
 //! MiMo Code stores assistant turns in OpenCode's message schema, so the parse
 //! itself lives in [`super::opencode_schema`]; only the places where MiMo's
 //! behaviour departs from OpenCode's are declared here, as
-//! [`OpenCodeSchemaConfig::micode`].
+//! `OpenCodeSchemaConfig::micode`.
 
 use super::opencode_schema::{parse_opencode_schema_sqlite, OpenCodeSchemaConfig};
 use super::UnifiedMessage;

--- a/crates/tokscale-core/src/sessions/mux.rs
+++ b/crates/tokscale-core/src/sessions/mux.rs
@@ -1,6 +1,6 @@
 //! Mux (coder/mux) session parser
 //!
-//! Parses session-usage.json files from ~/.mux/sessions/<workspaceId>/session-usage.json
+//! Parses session-usage.json files from `~/.mux/sessions/<workspaceId>/session-usage.json`
 
 use super::utils::{file_modified_timestamp_ms, read_file_or_none};
 use super::UnifiedMessage;

--- a/crates/tokscale-core/src/sessions/omp.rs
+++ b/crates/tokscale-core/src/sessions/omp.rs
@@ -1,7 +1,7 @@
 //! Oh My Pi (omp) session parser
 //!
 //! Oh My Pi is a pi-mono descendant and writes the same session JSONL record
-//! format, so parsing delegates to [`super::pi::parse_pi_format_file`]; only the
+//! format, so parsing delegates to `super::pi::parse_pi_format_file`; only the
 //! scan root and client id differ.
 //!
 //! Layout is one level deeper than Pi's. A top-level session is

--- a/crates/tokscale-core/src/sessions/openclaw.rs
+++ b/crates/tokscale-core/src/sessions/openclaw.rs
@@ -601,7 +601,7 @@ pub(crate) struct OpenClawSqliteScan {
 /// app-server as its agent runtime) are read like any other: OpenClaw mirrors
 /// the final assistant message of each Codex turn into its own transcript with
 /// the usage of that turn's last model response. Those rows come out keyed by
-/// the Codex thread and turn (see [`CODEX_MIRROR_DEDUP_PREFIX`]); the caller
+/// the Codex thread and turn (see `CODEX_MIRROR_DEDUP_PREFIX`); the caller
 /// swaps each for the rollout's record of that turn when it has read one, and
 /// keeps it otherwise, so the usage is never silently dropped. The legacy JSONL
 /// parser never filtered on the harness either.

--- a/crates/tokscale-core/src/sessions/opencode_schema.rs
+++ b/crates/tokscale-core/src/sessions/opencode_schema.rs
@@ -10,7 +10,7 @@
 //! The clients differ only in *policy* (which tables exist, how duplicates
 //! collapse, whether epochs are seconds or milliseconds, which fallbacks
 //! apply). Every such difference is an explicit field on
-//! [`OpenCodeSchemaConfig`], which is `Copy` and built from a per-client
+//! `OpenCodeSchemaConfig`, which is `Copy` and built from a per-client
 //! `const fn` constructor. The driver is a plain `fn` taking that config by
 //! value rather than a generic over the message type or the row callback:
 //! generics would monomorphize per client and *grow* the binary, which is the
@@ -39,7 +39,7 @@ use std::path::Path;
 /// The shape is the permissive union of every variant the OpenCode-schema
 /// clients emit: a field that is mandatory for one client is optional here, and
 /// the per-client strictness is re-applied at parse time from
-/// [`OpenCodeSchemaConfig`]. Keeping the strictness in the config rather than in
+/// `OpenCodeSchemaConfig`. Keeping the strictness in the config rather than in
 /// the type is what lets one `Deserialize` impl serve all three clients without
 /// changing what any of them accept.
 #[derive(Debug, Deserialize)]
@@ -145,7 +145,7 @@ pub struct OpenCodeSchemaTokens {
     pub output: i64,
     pub reasoning: Option<i64>,
     /// Optional in the union type. Clients that require a well-formed cache
-    /// object set [`OpenCodeSchemaConfig::strict_cache`], which restores the
+    /// object set `OpenCodeSchemaConfig::strict_cache`, which restores the
     /// drop-the-message behaviour their own derive used to produce.
     #[serde(default)]
     pub cache: Option<OpenCodeSchemaCache>,

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -2,13 +2,13 @@
 //!
 //! Parses JSONL files from `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl`. Current
 //! OMP builds write a `title` metadata record before the `session` header in
-//! newly-created session files; see [`PRE_SESSION_METADATA_TYPES`].
+//! newly-created session files; see `PRE_SESSION_METADATA_TYPES`.
 //!
-//! Pi descendants reuse this record layout verbatim, so [`parse_pi_format_file`]
+//! Pi descendants reuse this record layout verbatim, so `parse_pi_format_file`
 //! is shared: see `sessions::kimchi` for Kimchi, `sessions::senpi` for Senpi (OmO Native),
 //! `sessions::omp` for Oh My Pi, which owns the `~/.omp/agent/sessions` root, and
 //! `sessions::prime_agent` for Prime Agent, which enters the same parser through
-//! [`parse_pi_format_rlm_file_with_observer`].
+//! `parse_pi_format_rlm_file_with_observer`.
 //!
 //! [`PI_FORMAT_PARSER_BASE_VERSION`] defines the shared base parser version for these
 //! clients, ensuring format-level changes in `pi.rs` invalidate cached messages
@@ -257,7 +257,7 @@ pub struct PiUsage {
     pub cache_write: Option<i64>,
     #[allow(dead_code)]
     pub total_tokens: Option<i64>,
-    /// Parsed so the omission in [`PiUsage::to_breakdown`] is a real decision
+    /// Parsed so the omission in `PiUsage::to_breakdown` is a real decision
     /// rather than an accident of the schema, but never summed.
     #[allow(dead_code)]
     pub reasoning: Option<i64>,

--- a/crates/tokscale-core/src/sessions/roocode.rs
+++ b/crates/tokscale-core/src/sessions/roocode.rs
@@ -1,8 +1,8 @@
 //! Roo Code task parser
 //!
 //! Parses task-based logs from VS Code globalStorage directories:
-//! - tasks/<taskId>/ui_messages.json
-//! - tasks/<taskId>/api_conversation_history.json
+//! - `tasks/<taskId>/ui_messages.json`
+//! - `tasks/<taskId>/api_conversation_history.json`
 
 use super::utils::{extract_i64, parse_timestamp_str, read_file_or_none};
 use super::UnifiedMessage;

--- a/crates/tokscale-core/src/sessions/senpi.rs
+++ b/crates/tokscale-core/src/sessions/senpi.rs
@@ -1,7 +1,7 @@
 //! Senpi (OmO Native) session parser
 //!
 //! Senpi is a pi-mono descendant using the same JSONL record format, so parsing
-//! delegates to [`super::pi::parse_pi_format_file`]; only the scan root and
+//! delegates to `super::pi::parse_pi_format_file`; only the scan root and
 //! client id differ. Two divergences from Pi matter here: `usage.reasoning` is
 //! parsed but never summed, because senpi documents it as a subset of `output`
 //! while tokscale totals reasoning as its own additive bucket; and


### PR DESCRIPTION
## Background

`main` currently fails `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace`: 31 rustdoc errors across `tokscale-core` (28) and `tokscale-cli` (3) — public doc comments linking to private items (`private_intra_doc_links`), path placeholders like `[GROUP_ID]` parsed as intra-doc links (`broken_intra_doc_links`), `<taskId>`-style placeholders parsed as unclosed HTML tags (`invalid_html_tags`), and bare URLs (`bare_urls`). Nothing in CI gates rustdoc, so these accumulated silently — #1299 merged with its own doc link broken.

## Before / after

| | errors from `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace` |
|---|---|
| Before (origin/main) | 31 (exit 101) |
| After (this branch) | 0 (exit 0, clean workspace doc build) |

## Fixes (all comment-only; no visibility changes)

Every private item linked from public docs is an internal implementation detail, so the fix is uniform: `[item]` → `` `item` `` (code formatting, no navigable link implied). Doc meaning is unchanged.

**crates/tokscale-core:**
- `src/clients.rs` — `AppData` doc: `[app_data_follows_home]`
- `src/lib.rs` — `canonical_model_id` doc: `[normalize_syntactic]`
- `src/scanner.rs` — `opencode_db_paths` doc: `[is_opencode_db_filename]`
- `src/sessions/antigravity_cli.rs` — module doc: `[generation_timestamp_ms]`, `[SessionModels]`
- `src/sessions/fx.rs` — module doc: `[fx_session_meta_path]`, `[apply_session_titles]`, `[reported_cost]`
- `src/sessions/kilo.rs` / `micode.rs` — module docs: `[OpenCodeSchemaConfig::kilo]` / `::micode`
- `src/sessions/openclaw.rs` — `parse_openclaw_sqlite` doc: `[CODEX_MIRROR_DEDUP_PREFIX]`
- `src/sessions/opencode_schema.rs` — module + `OpenCodeSchemaMessage` + `cache` docs: three `[OpenCodeSchemaConfig…]` links
- `src/sessions/pi.rs` — module doc (`[PRE_SESSION_METADATA_TYPES]`, `[parse_pi_format_file]`, `[parse_pi_format_rlm_file_with_observer]`) and `PiUsage::reasoning` doc (`[PiUsage::to_breakdown]`)
- `src/sessions/omp.rs` / `senpi.rs` — module docs: `[super::pi::parse_pi_format_file]`
- `src/sessions/freebuff.rs` — bare URL → `<https://github.com/CodebuffAI/freebuff>`
- `src/sessions/kimi.rs` — `[GROUP_ID]`/`[SESSION_UUID]`/`[WORKSPACE]`/`[SESSION]`/`[AGENT]` placeholders: path lines wrapped in backticks
- `src/sessions/kiro.rs` — `history[*]` and `~/.kiro/sessions/<workspace>/sess_<uuid>/` wrapped in backticks
- `src/sessions/mux.rs` — `~/.mux/sessions/<workspaceId>/…` wrapped in backticks
- `src/sessions/roocode.rs` — `tasks/<taskId>/…` lines wrapped in backticks

**crates/tokscale-cli:**
- `src/commands/apple_fm.rs` — `[imp::build_schema]` (private `imp` module)
- `src/trae.rs` — `[paths::get_config_dir]` (private `paths` module)
- `src/main.rs` — bare issue URL → `<https://github.com/junhoyeo/tokscale/issues/888>`

## CI gate

Added a `rustdoc` job to `.github/workflows/test_coverage.yml` (next to the existing `lint` job, same toolchain pin `dtolnay/rust-toolchain@1.98.0` + cargo cache pattern):

```
RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --workspace
```

Doc comments are not compiled by clippy, so this lint class only fails here. The job inherits the workflow's existing `paths:` filter, which already lists `rust-toolchain.toml`, so the toolchain-paths checker from #1294 passes (verified locally: `scripts/check-workflow-toolchain-paths.py` reports OK for all 5 Rust workflows).

## Proof the gate bites

- Pre-fix (working tree stashed back to origin/main state): `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace` → **exit 101, 31 errors** (28 tokscale-core + 3 tokscale-cli).
- Post-fix (this branch): same command → **exit 0**, `Finished` with no warnings.

## Gates run locally

- `cargo test -p tokscale-cli`: 1489 passed, 0 failed
- `cargo test -p tokscale-core`: 2171 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- `python3 scripts/check-workflow-toolchain-paths.py` + `bash scripts/test-workflow-toolchain-paths.sh`: pass


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 31 rustdoc warnings in `tokscale-core` and `tokscale-cli` so `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace` now builds cleanly, and adds a CI job that fails on doc warnings.

**Bug Fixes**
- Doc changes are comment-only: private item links and path placeholders wrapped in backticks, bare URLs converted to autolinks.

**CI gate**
- Adds a `rustdoc` job to `test_coverage.yml` running `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --workspace` on the pinned toolchain.
- Doc comments aren't compiled by clippy, so this lint class only fails here.

<sup>Written for commit fbc4c3f7f08bb6e91e61a8a059da2dd53efbb41e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

