### PR TITLE
fix(tui): align table borders in CJK-width terminals

### DIFF
--- a/crates/tokscale-cli/src/tui/ui/agents.rs
+++ b/crates/tokscale-cli/src/tui/ui/agents.rs
@@ -58,8 +58,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let sort_indicator = |field: SortField| -> &'static str {
         if sort_field == field {
             match sort_direction {
-                SortDirection::Ascending => " ▲",
-                SortDirection::Descending => " ▼",
+                SortDirection::Ascending => " ▴",
+                SortDirection::Descending => " ▾",
             }
         } else {
             ""

--- a/crates/tokscale-cli/src/tui/ui/agents.rs
+++ b/crates/tokscale-cli/src/tui/ui/agents.rs
@@ -5,7 +5,7 @@ use ratatui::widgets::{
 
 use super::widgets::{
     format_cost, get_client_display_name, total_tokens_cell, truncate_text,
-    viewport_scrollbar_state,
+    viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use crate::ClientFilter;
@@ -13,6 +13,7 @@ use crate::ClientFilter;
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " Agents ",

--- a/crates/tokscale-cli/src/tui/ui/agents.rs
+++ b/crates/tokscale-cli/src/tui/ui/agents.rs
@@ -1,11 +1,9 @@
 use ratatui::prelude::*;
-use ratatui::widgets::{
-    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
-};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
 
 use super::widgets::{
-    format_cost, get_client_display_name, total_tokens_cell, truncate_text,
-    viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
+    ambient_stable_scrollbar, format_cost, get_client_display_name, total_tokens_cell,
+    truncate_text, viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use crate::ClientFilter;
@@ -176,9 +174,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(table, inner);
 
     if agents_len > visible_height {
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .begin_symbol(Some("▲"))
-            .end_symbol(Some("▼"));
+        let scrollbar = ambient_stable_scrollbar();
 
         let mut scrollbar_state =
             viewport_scrollbar_state(agents_len, scroll_offset, visible_height);

--- a/crates/tokscale-cli/src/tui/ui/bar_chart.rs
+++ b/crates/tokscale-cli/src/tui/ui/bar_chart.rs
@@ -87,7 +87,7 @@ pub fn render_stacked_bar_chart(frame: &mut Frame, app: &App, area: Rect, data: 
         } else {
             String::new()
         };
-        let padded_label = format!("{:>width$}│", y_label, width = (y_label_width - 1) as usize);
+        let padded_label = format!("{:>width$}|", y_label, width = (y_label_width - 1) as usize);
         for (i, ch) in padded_label.chars().enumerate() {
             let x = area.x + i as u16;
             if x < area.x + y_label_width {
@@ -131,7 +131,7 @@ pub fn render_stacked_bar_chart(frame: &mut Frame, app: &App, area: Rect, data: 
     // X-axis
     let axis_y = area.y + 1 + chart_height as u16;
     if axis_y < area.y + area.height {
-        let zero_label = format!("{:>width$}│", "0", width = (y_label_width - 1) as usize);
+        let zero_label = format!("{:>width$}|", "0", width = (y_label_width - 1) as usize);
         for (i, ch) in zero_label.chars().enumerate() {
             let x = area.x + i as u16;
             if x < area.x + y_label_width {

--- a/crates/tokscale-cli/src/tui/ui/bar_chart.rs
+++ b/crates/tokscale-cli/src/tui/ui/bar_chart.rs
@@ -140,9 +140,12 @@ pub fn render_stacked_bar_chart(frame: &mut Frame, app: &App, area: Rect, data: 
                     .set_style(Style::default().fg(app.theme.muted));
             }
         }
+        // ASCII `-`, not U+2500 `─`: the box-drawing horizontal is
+        // East-Asian-Ambiguous and doubles the emitted axis width in a CJK
+        // locale, same as the border glyphs in `AMBIENT_STABLE_BORDER_SET`.
         for x in (area.x + y_label_width)..(area.x + area.width) {
             buf[(x, axis_y)]
-                .set_char('─')
+                .set_char('-')
                 .set_style(Style::default().fg(app.theme.muted));
         }
     }

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -1,13 +1,11 @@
 use chrono::Local;
 use ratatui::prelude::*;
-use ratatui::widgets::{
-    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
-};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
 
 use super::widgets::{
-    format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
-    get_client_display_name, get_provider_display_name, total_tokens_cell, truncate_text,
-    viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
+    ambient_stable_scrollbar, format_cache_hit_rate, format_cost, format_cost_per_million,
+    format_tokens, get_client_display_name, get_provider_display_name, total_tokens_cell,
+    truncate_text, viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 
@@ -293,9 +291,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(table, inner);
 
     if daily_len > visible_height {
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .begin_symbol(Some("▲"))
-            .end_symbol(Some("▼"));
+        let scrollbar = ambient_stable_scrollbar();
 
         let mut scrollbar_state =
             viewport_scrollbar_state(daily_len, scroll_offset, visible_height);
@@ -519,9 +515,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(table, inner);
 
     if detail_len > visible_height {
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .begin_symbol(Some("▲"))
-            .end_symbol(Some("▼"));
+        let scrollbar = ambient_stable_scrollbar();
 
         let mut scrollbar_state =
             viewport_scrollbar_state(detail_len, scroll_offset, visible_height);

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -7,7 +7,7 @@ use ratatui::widgets::{
 use super::widgets::{
     format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
     get_client_display_name, get_provider_display_name, total_tokens_cell, truncate_text,
-    viewport_scrollbar_state,
+    viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 
@@ -19,6 +19,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " Daily Usage ",
@@ -318,6 +319,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             title,

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -100,8 +100,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let sort_indicator = |field: SortField| -> &'static str {
         if sort_field == field {
             match sort_direction {
-                SortDirection::Ascending => " ▲",
-                SortDirection::Descending => " ▼",
+                SortDirection::Ascending => " ▴",
+                SortDirection::Descending => " ▾",
             }
         } else {
             ""
@@ -370,8 +370,8 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
     let sort_indicator = |field: SortField| -> &'static str {
         if sort_field == field {
             match sort_direction {
-                SortDirection::Ascending => " ▲",
-                SortDirection::Descending => " ▼",
+                SortDirection::Ascending => " ▴",
+                SortDirection::Descending => " ▾",
             }
         } else {
             ""

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -87,12 +87,12 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         }
     } else if has_turn_data {
         vec![
-            "Date", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total",
+            "Date", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache✕", "Total",
             "Cost", "Cost/1M",
         ]
     } else {
         vec![
-            "Date", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total", "Cost",
+            "Date", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache✕", "Total", "Cost",
             "Cost/1M",
         ]
     };
@@ -363,7 +363,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
     } else {
         vec![
             "#", "Model", "Provider", "Source", "Msgs", "Input", "Output", "Cache R", "Cache W",
-            "Cache×", "Total", "Cost",
+            "Cache✕", "Total", "Cost",
         ]
     };
 

--- a/crates/tokscale-cli/src/tui/ui/dialog/confirm.rs
+++ b/crates/tokscale-cli/src/tui/ui/dialog/confirm.rs
@@ -6,7 +6,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use crate::tui::themes::Theme;
-use crate::tui::ui::widgets::truncate_ellipsis as truncate;
+use crate::tui::ui::widgets::{truncate_ellipsis as truncate, AMBIENT_STABLE_BORDER_SET};
 
 use super::{DialogContent, DialogResult};
 
@@ -208,6 +208,7 @@ impl DialogContent for ConfirmDialog {
         let block = Block::default()
             .title(self.title)
             .borders(Borders::ALL)
+            .border_set(AMBIENT_STABLE_BORDER_SET)
             .border_style(Style::default().fg(tone));
         let inner = block.inner(area);
         frame.render_widget(block, area);

--- a/crates/tokscale-cli/src/tui/ui/dialog/group_by_picker.rs
+++ b/crates/tokscale-cli/src/tui/ui/dialog/group_by_picker.rs
@@ -13,6 +13,7 @@ use ratatui::{
 use tokscale_core::GroupBy;
 
 use crate::tui::themes::Theme;
+use crate::tui::ui::widgets::AMBIENT_STABLE_BORDER_SET;
 
 use super::{DialogContent, DialogResult};
 
@@ -100,6 +101,7 @@ impl DialogContent for GroupByPickerDialog {
         let block = Block::default()
             .title(" Group By ")
             .borders(Borders::ALL)
+            .border_set(AMBIENT_STABLE_BORDER_SET)
             .border_style(Style::default().fg(theme.accent));
         let inner = block.inner(area);
         frame.render_widget(block, area);

--- a/crates/tokscale-cli/src/tui/ui/dialog/source_picker.rs
+++ b/crates/tokscale-cli/src/tui/ui/dialog/source_picker.rs
@@ -14,6 +14,7 @@ use ratatui::{
 
 use crate::tui::client_ui;
 use crate::tui::themes::Theme;
+use crate::tui::ui::widgets::AMBIENT_STABLE_BORDER_SET;
 use crate::ClientFilter;
 
 use super::{DialogContent, DialogResult};
@@ -133,6 +134,7 @@ impl DialogContent for ClientPickerDialog {
         let block = Block::default()
             .title(" Clients ")
             .borders(Borders::ALL)
+            .border_set(AMBIENT_STABLE_BORDER_SET)
             .border_style(Style::default().fg(theme.accent));
         let inner = block.inner(area);
         frame.render_widget(block, area);

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -2,12 +2,13 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::spinner::{get_phase_message, get_scanner_spans};
-use super::widgets::{format_cost, format_tokens};
+use super::widgets::{format_cost, format_tokens, AMBIENT_STABLE_BORDER_SET};
 use crate::tui::app::{App, ClickAction, SortField, Tab};
 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .style(Style::default().bg(app.theme.background));
 

--- a/crates/tokscale-cli/src/tui/ui/header.rs
+++ b/crates/tokscale-cli/src/tui/ui/header.rs
@@ -2,6 +2,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Tabs};
 
 use crate::tui::app::{App, ClickAction, Tab};
+use crate::tui::ui::widgets::AMBIENT_STABLE_BORDER_SET;
 
 const TAB_PADDING_LEFT_WIDTH: u16 = 1;
 const TAB_PADDING_RIGHT_WIDTH: u16 = 1;
@@ -40,6 +41,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let mut block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " tokscale ",
@@ -68,7 +70,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 .fg(app.theme.accent)
                 .add_modifier(Modifier::BOLD),
         )
-        .divider(Span::styled(" │ ", Style::default().fg(app.theme.border)));
+        .divider(Span::styled(" | ", Style::default().fg(app.theme.border)));
 
     frame.render_widget(tabs, area);
 

--- a/crates/tokscale-cli/src/tui/ui/hourly.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly.rs
@@ -7,7 +7,7 @@ use ratatui::widgets::{
 use super::hourly_profile;
 use super::widgets::{
     format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens, total_tokens_cell,
-    viewport_scrollbar_state,
+    viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, HourlyViewMode, SortDirection, SortField};
 
@@ -21,6 +21,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " Hourly Usage ",

--- a/crates/tokscale-cli/src/tui/ui/hourly.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly.rs
@@ -1,13 +1,11 @@
 use chrono::{Local, NaiveDate, Timelike};
 use ratatui::prelude::*;
-use ratatui::widgets::{
-    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
-};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
 
 use super::hourly_profile;
 use super::widgets::{
-    format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens, total_tokens_cell,
-    viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
+    ambient_stable_scrollbar, format_cache_hit_rate, format_cost, format_cost_per_million,
+    format_tokens, total_tokens_cell, viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, HourlyViewMode, SortDirection, SortField};
 
@@ -334,9 +332,7 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(table, inner);
 
     if hourly_len > visible_height {
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .begin_symbol(Some("▲"))
-            .end_symbol(Some("▼"));
+        let scrollbar = ambient_stable_scrollbar();
 
         let mut scrollbar_state =
             viewport_scrollbar_state(hourly_len, scroll_offset, data_rows_shown);

--- a/crates/tokscale-cli/src/tui/ui/hourly.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly.rs
@@ -91,8 +91,8 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let sort_indicator = |field: SortField| -> &'static str {
         if sort_field == field {
             match sort_direction {
-                SortDirection::Ascending => " ▲",
-                SortDirection::Descending => " ▼",
+                SortDirection::Ascending => " ▴",
+                SortDirection::Descending => " ▾",
             }
         } else {
             ""

--- a/crates/tokscale-cli/src/tui/ui/hourly.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly.rs
@@ -78,12 +78,12 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
         }
     } else if has_turn_data {
         vec![
-            "Hour", "Source", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×",
+            "Hour", "Source", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache✕",
             "Total", "Cost", "Cost/1M",
         ]
     } else {
         vec![
-            "Hour", "Source", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total",
+            "Hour", "Source", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache✕", "Total",
             "Cost", "Cost/1M",
         ]
     };

--- a/crates/tokscale-cli/src/tui/ui/hourly_profile.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly_profile.rs
@@ -1,13 +1,14 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::widgets::{format_cost, format_tokens};
+use super::widgets::{format_cost, format_tokens, AMBIENT_STABLE_BORDER_SET};
 use crate::tui::app::App;
 use crate::tui::data::{aggregate_by_period, aggregate_by_weekday, find_peak_hour};
 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " Hourly Profile ",

--- a/crates/tokscale-cli/src/tui/ui/minutely.rs
+++ b/crates/tokscale-cli/src/tui/ui/minutely.rs
@@ -6,12 +6,14 @@ use ratatui::widgets::{
 
 use super::widgets::{
     format_cache_hit_rate, format_cost, format_tokens, total_tokens_cell, viewport_scrollbar_state,
+    AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " Minutely Usage ",

--- a/crates/tokscale-cli/src/tui/ui/minutely.rs
+++ b/crates/tokscale-cli/src/tui/ui/minutely.rs
@@ -80,8 +80,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let sort_indicator = |field: SortField| -> &'static str {
         if sort_field == field {
             match sort_direction {
-                SortDirection::Ascending => " ▲",
-                SortDirection::Descending => " ▼",
+                SortDirection::Ascending => " ▴",
+                SortDirection::Descending => " ▾",
             }
         } else {
             ""

--- a/crates/tokscale-cli/src/tui/ui/minutely.rs
+++ b/crates/tokscale-cli/src/tui/ui/minutely.rs
@@ -67,12 +67,12 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         }
     } else if has_turn_data {
         vec![
-            "Minute", "Source", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×",
+            "Minute", "Source", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache✕",
             "Total", "Cost",
         ]
     } else {
         vec![
-            "Minute", "Source", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total",
+            "Minute", "Source", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache✕", "Total",
             "Cost",
         ]
     };

--- a/crates/tokscale-cli/src/tui/ui/minutely.rs
+++ b/crates/tokscale-cli/src/tui/ui/minutely.rs
@@ -1,12 +1,10 @@
 use chrono::{Local, Timelike};
 use ratatui::prelude::*;
-use ratatui::widgets::{
-    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
-};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
 
 use super::widgets::{
-    format_cache_hit_rate, format_cost, format_tokens, total_tokens_cell, viewport_scrollbar_state,
-    AMBIENT_STABLE_BORDER_SET,
+    ambient_stable_scrollbar, format_cache_hit_rate, format_cost, format_tokens, total_tokens_cell,
+    viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 
@@ -286,9 +284,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(table, inner);
 
     if minutely_len > visible_height {
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .begin_symbol(Some("▲"))
-            .end_symbol(Some("▼"));
+        let scrollbar = ambient_stable_scrollbar();
 
         let mut scrollbar_state =
             viewport_scrollbar_state(minutely_len, scroll_offset, visible_height);

--- a/crates/tokscale-cli/src/tui/ui/mod.rs
+++ b/crates/tokscale-cli/src/tui/ui/mod.rs
@@ -21,6 +21,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use crate::tui::app::{App, Tab};
+use crate::tui::ui::widgets::AMBIENT_STABLE_BORDER_SET;
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
@@ -72,6 +73,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
 fn render_loading(frame: &mut Frame, app: &App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .style(Style::default().bg(app.theme.background));
 
@@ -103,6 +105,7 @@ fn render_loading(frame: &mut Frame, app: &App, area: Rect) {
 fn render_error(frame: &mut Frame, app: &App, area: Rect, error: &str) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .style(Style::default().bg(app.theme.background));
 

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -1,13 +1,11 @@
 use ratatui::prelude::*;
-use ratatui::widgets::{
-    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
-};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
 
 use super::widgets::{
-    fit_workspace_label_to_width, format_cache_hit_rate, format_cost, format_cost_per_million,
-    format_ms_per_1k, format_tokens, get_client_display_name, get_provider_display_name,
-    total_tokens_cell, truncate_text, truncate_to_width, viewport_scrollbar_state,
-    AMBIENT_STABLE_BORDER_SET,
+    ambient_stable_scrollbar, fit_workspace_label_to_width, format_cache_hit_rate, format_cost,
+    format_cost_per_million, format_ms_per_1k, format_tokens, get_client_display_name,
+    get_provider_display_name, total_tokens_cell, truncate_text, truncate_to_width,
+    viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use tokscale_core::GroupBy;
@@ -393,9 +391,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(table, inner);
 
     if models_len > visible_height {
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .begin_symbol(Some("▲"))
-            .end_symbol(Some("▼"));
+        let scrollbar = ambient_stable_scrollbar();
 
         let mut scrollbar_state =
             viewport_scrollbar_state(models_len, scroll_offset, visible_height);

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -7,6 +7,7 @@ use super::widgets::{
     fit_workspace_label_to_width, format_cache_hit_rate, format_cost, format_cost_per_million,
     format_ms_per_1k, format_tokens, get_client_display_name, get_provider_display_name,
     total_tokens_cell, truncate_text, truncate_to_width, viewport_scrollbar_state,
+    AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use tokscale_core::GroupBy;
@@ -114,6 +115,7 @@ fn model_display_name(model: &crate::tui::data::ModelUsage, group_by: &GroupBy) 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " Models ",

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -186,8 +186,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let sort_indicator = |field: SortField| -> &'static str {
         if sort_field == field {
             match sort_direction {
-                SortDirection::Ascending => " ▲",
-                SortDirection::Descending => " ▼",
+                SortDirection::Ascending => " ▴",
+                SortDirection::Descending => " ▾",
             }
         } else {
             ""

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -178,7 +178,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         ]
     } else {
         vec![
-            "#", "Model", "Provider", "Source", "Input", "Output", "Cache R", "Cache W", "Cache×",
+            "#", "Model", "Provider", "Source", "Input", "Output", "Cache R", "Cache W", "Cache✕",
             "Total", "ms/1K", "Cost", "Cost/1M",
         ]
     };

--- a/crates/tokscale-cli/src/tui/ui/monthly.rs
+++ b/crates/tokscale-cli/src/tui/ui/monthly.rs
@@ -69,12 +69,12 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         }
     } else if has_turn_data {
         vec![
-            "Month", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total",
+            "Month", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache✕", "Total",
             "Cost", "Cost/1M",
         ]
     } else {
         vec![
-            "Month", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total", "Cost",
+            "Month", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache✕", "Total", "Cost",
             "Cost/1M",
         ]
     };
@@ -338,12 +338,12 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
         }
     } else if has_turn_data {
         vec![
-            "Date", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total",
+            "Date", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache✕", "Total",
             "Cost", "Cost/1M",
         ]
     } else {
         vec![
-            "Date", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total", "Cost",
+            "Date", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache✕", "Total", "Cost",
             "Cost/1M",
         ]
     };
@@ -624,7 +624,7 @@ mod tests {
         app.data.monthly = vec![month("2026-05", 1000, 1.5)];
         let body = render_body(&mut app, 130, 12);
         assert!(
-            body.contains("Cache×"),
+            body.contains("Cache✕"),
             "expected cache hit rate column\n{body}"
         );
         assert!(

--- a/crates/tokscale-cli/src/tui/ui/monthly.rs
+++ b/crates/tokscale-cli/src/tui/ui/monthly.rs
@@ -1,11 +1,9 @@
 use ratatui::prelude::*;
-use ratatui::widgets::{
-    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
-};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
 
 use super::widgets::{
-    format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens, total_tokens_cell,
-    viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
+    ambient_stable_scrollbar, format_cache_hit_rate, format_cost, format_cost_per_million,
+    format_tokens, total_tokens_cell, viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 
@@ -255,9 +253,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(table, inner);
 
     if monthly_len > visible_height {
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .begin_symbol(Some("▲"))
-            .end_symbol(Some("▼"));
+        let scrollbar = ambient_stable_scrollbar();
 
         let mut scrollbar_state =
             viewport_scrollbar_state(monthly_len, scroll_offset, visible_height);
@@ -525,9 +521,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(table, inner);
 
     if days_len > visible_height {
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .begin_symbol(Some("▲"))
-            .end_symbol(Some("▼"));
+        let scrollbar = ambient_stable_scrollbar();
 
         let mut scrollbar_state = viewport_scrollbar_state(days_len, scroll_offset, visible_height);
 

--- a/crates/tokscale-cli/src/tui/ui/monthly.rs
+++ b/crates/tokscale-cli/src/tui/ui/monthly.rs
@@ -5,7 +5,7 @@ use ratatui::widgets::{
 
 use super::widgets::{
     format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens, total_tokens_cell,
-    viewport_scrollbar_state,
+    viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 
@@ -17,6 +17,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " Monthly Usage ",
@@ -280,6 +281,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             title,

--- a/crates/tokscale-cli/src/tui/ui/monthly.rs
+++ b/crates/tokscale-cli/src/tui/ui/monthly.rs
@@ -82,8 +82,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let sort_indicator = |field: SortField| -> &'static str {
         if sort_field == field {
             match sort_direction {
-                SortDirection::Ascending => " ▲",
-                SortDirection::Descending => " ▼",
+                SortDirection::Ascending => " ▴",
+                SortDirection::Descending => " ▾",
             }
         } else {
             ""
@@ -351,8 +351,8 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
     let sort_indicator = |field: SortField| -> &'static str {
         if sort_field == field {
             match sort_direction {
-                SortDirection::Ascending => " ▲",
-                SortDirection::Descending => " ▼",
+                SortDirection::Ascending => " ▴",
+                SortDirection::Descending => " ▾",
             }
         } else {
             ""

--- a/crates/tokscale-cli/src/tui/ui/overview.rs
+++ b/crates/tokscale-cli/src/tui/ui/overview.rs
@@ -4,6 +4,7 @@ use ratatui::widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientatio
 use super::bar_chart::{render_stacked_bar_chart, ModelSegment, StackedBarData};
 use super::widgets::{
     fit_workspace_label_to_width, format_tokens, truncate_to_width, viewport_scrollbar_state,
+    AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, ChartGranularity};
 use tokscale_core::GroupBy;
@@ -236,6 +237,7 @@ fn render_top_models(frame: &mut Frame, app: &mut App, area: Rect, items_per_pag
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(theme_border))
         .title(Span::styled(
             format!(" {} ", title),
@@ -396,7 +398,7 @@ fn render_top_models(frame: &mut Frame, app: &mut App, area: Rect, items_per_pag
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .begin_symbol(Some("▲"))
             .end_symbol(Some("▼"))
-            .track_symbol(Some("│"))
+            .track_symbol(Some("|"))
             .thumb_symbol("█");
 
         let mut scrollbar_state =

--- a/crates/tokscale-cli/src/tui/ui/overview.rs
+++ b/crates/tokscale-cli/src/tui/ui/overview.rs
@@ -1,10 +1,10 @@
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation};
+use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::bar_chart::{render_stacked_bar_chart, ModelSegment, StackedBarData};
 use super::widgets::{
-    fit_workspace_label_to_width, format_tokens, truncate_to_width, viewport_scrollbar_state,
-    AMBIENT_STABLE_BORDER_SET,
+    ambient_stable_scrollbar, fit_workspace_label_to_width, format_tokens, truncate_to_width,
+    viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, ChartGranularity};
 use tokscale_core::GroupBy;
@@ -395,11 +395,7 @@ fn render_top_models(frame: &mut Frame, app: &mut App, area: Rect, items_per_pag
     }
 
     if models_len > items_per_page {
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .begin_symbol(Some("▲"))
-            .end_symbol(Some("▼"))
-            .track_symbol(Some("|"))
-            .thumb_symbol("█");
+        let scrollbar = ambient_stable_scrollbar();
 
         let mut scrollbar_state =
             viewport_scrollbar_state(models_len, scroll_offset, items_per_page);

--- a/crates/tokscale-cli/src/tui/ui/projects.rs
+++ b/crates/tokscale-cli/src/tui/ui/projects.rs
@@ -1,13 +1,12 @@
 use chrono::{Local, NaiveDateTime, TimeZone};
 use ratatui::prelude::*;
-use ratatui::widgets::{
-    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
-};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
 
 use super::widgets::{
-    display_width, fit_workspace_label_to_width, format_cost, format_tokens,
-    get_compact_client_display_name, prefix_to_width, total_tokens_cell, truncate_text,
-    truncate_to_width, viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET, MIDDLE_ELLIPSIS,
+    ambient_stable_scrollbar, display_width, fit_workspace_label_to_width, format_cost,
+    format_tokens, get_compact_client_display_name, prefix_to_width, total_tokens_cell,
+    truncate_text, truncate_to_width, viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
+    MIDDLE_ELLIPSIS,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use crate::tui::data::{ProjectUsage, SessionModel};
@@ -386,9 +385,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(table, inner);
 
     if projects_len > visible_height {
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .begin_symbol(Some("▲"))
-            .end_symbol(Some("▼"));
+        let scrollbar = ambient_stable_scrollbar();
 
         let mut scrollbar_state =
             viewport_scrollbar_state(projects_len, scroll_offset, visible_height);

--- a/crates/tokscale-cli/src/tui/ui/projects.rs
+++ b/crates/tokscale-cli/src/tui/ui/projects.rs
@@ -7,7 +7,7 @@ use ratatui::widgets::{
 use super::widgets::{
     display_width, fit_workspace_label_to_width, format_cost, format_tokens,
     get_compact_client_display_name, prefix_to_width, total_tokens_cell, truncate_text,
-    truncate_to_width, viewport_scrollbar_state, MIDDLE_ELLIPSIS,
+    truncate_to_width, viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET, MIDDLE_ELLIPSIS,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use crate::tui::data::{ProjectUsage, SessionModel};
@@ -210,6 +210,7 @@ fn sources_label(p: &ProjectUsage) -> String {
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " Projects ",

--- a/crates/tokscale-cli/src/tui/ui/projects.rs
+++ b/crates/tokscale-cli/src/tui/ui/projects.rs
@@ -246,8 +246,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let sort_indicator = |field: SortField| -> &'static str {
         if sort_field == field {
             match sort_direction {
-                SortDirection::Ascending => " ▲",
-                SortDirection::Descending => " ▼",
+                SortDirection::Ascending => " ▴",
+                SortDirection::Descending => " ▾",
             }
         } else {
             ""
@@ -612,7 +612,7 @@ mod tests {
             let body = render_body(&mut app, width, 6);
             let header = body.lines().nth(1).unwrap();
             let row = body.lines().nth(2).unwrap();
-            for label in ["Project", "Sessions", "Total", "Cost ▼"] {
+            for label in ["Project", "Sessions", "Total", "Cost ▾"] {
                 assert!(header.contains(label), "at {width} columns: {header}");
             }
             assert!(!header.contains("Models"), "at {width} columns: {header}");

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -552,8 +552,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let sort_indicator = |field: SortField| -> &'static str {
         if sort_field == field {
             match sort_direction {
-                SortDirection::Ascending => " ▲",
-                SortDirection::Descending => " ▼",
+                SortDirection::Ascending => " ▴",
+                SortDirection::Descending => " ▾",
             }
         } else {
             ""
@@ -1330,7 +1330,7 @@ mod tests {
     }
 
     /// The active sort arrow is legible whenever its column is admitted, and
-    /// absent from the whole header when it is not. Today `Last Active ▼` is
+    /// absent from the whole header when it is not. Today `Last Active ▾` is
     /// missing at 77 of 121 widths.
     ///
     /// Both directions, because `make_app` fixes the sort to descending and an
@@ -1343,8 +1343,8 @@ mod tests {
         for width in 80u16..=SWEEP_MAX {
             for has_turn in [true, false] {
                 for (direction, arrow) in [
-                    (SortDirection::Descending, '▼'),
-                    (SortDirection::Ascending, '▲'),
+                    (SortDirection::Descending, '▾'),
+                    (SortDirection::Ascending, '▴'),
                 ] {
                     for (field, column) in [
                         (SortField::Cost, SessionColumn::Cost),
@@ -1375,7 +1375,7 @@ mod tests {
                         }
                         // The other glyph must never appear at all — one active
                         // sort, one arrow.
-                        let other = if arrow == '▼' { '▲' } else { '▼' };
+                        let other = if arrow == '▾' { '▴' } else { '▾' };
                         assert!(
                             !header.contains(other),
                             "both arrows drawn at width {width} (turn={has_turn})\n{header}"
@@ -1706,7 +1706,7 @@ mod tests {
                 59u16,
                 true,
                 SortField::Cost,
-                "|Session                           Cost ▼                 |",
+                "|Session                           Cost ▾                 |",
                 "|A fairly long ses...              $12.35                 |",
             ),
             (
@@ -1720,21 +1720,21 @@ mod tests {
                 60,
                 true,
                 SortField::Cost,
-                "|Session     Client     Turn   Msgs    Tokens     Cost ▼   |",
+                "|Session     Client     Turn   Msgs    Tokens     Cost ▾   |",
                 "|A fairly lo OpenCode   137    428     49.5M      $12.35   |",
             ),
             (
                 60,
                 false,
                 SortField::Tokens,
-                "|Session         Client     Msgs    Tokens ▼   Cost        |",
+                "|Session         Client     Msgs    Tokens ▾   Cost        |",
                 "|A fairly long s OpenCode   428     49.5M      $12.35      |",
             ),
             (
                 79,
                 true,
                 SortField::Tokens,
-                "|Session           Client       Turn      Msgs      Tokens ▼      Cost        |",
+                "|Session           Client       Turn      Msgs      Tokens ▾      Cost        |",
                 "|A fairly long ses OpenCode     137       428       49.5M         $12.35      |",
             ),
             (
@@ -1951,7 +1951,7 @@ mod tests {
             app.sort_field = SortField::Tokens;
             let header = header_line(&mut app, 200);
             assert!(
-                header.contains("Total ▼"),
+                header.contains("Total ▾"),
                 "tokens sort indicator misplaced (turn={has_turn})\n{header}"
             );
 
@@ -1959,7 +1959,7 @@ mod tests {
             app.sort_field = SortField::Date;
             let header = header_line(&mut app, 200);
             assert!(
-                header.contains("Last Active ▼"),
+                header.contains("Last Active ▾"),
                 "date sort indicator misplaced (turn={has_turn})\n{header}"
             );
         }

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -1,13 +1,12 @@
 use chrono::{Local, NaiveDateTime, TimeZone};
 use ratatui::prelude::*;
-use ratatui::widgets::{
-    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
-};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
 
 use super::widgets::{
-    display_width, format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
-    get_compact_client_display_name, prefix_to_width, total_tokens_cell, truncate_text,
-    truncate_to_width, viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET, MIDDLE_ELLIPSIS,
+    ambient_stable_scrollbar, display_width, format_cache_hit_rate, format_cost,
+    format_cost_per_million, format_tokens, get_compact_client_display_name, prefix_to_width,
+    total_tokens_cell, truncate_text, truncate_to_width, viewport_scrollbar_state,
+    AMBIENT_STABLE_BORDER_SET, MIDDLE_ELLIPSIS,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use crate::tui::data::{SessionModel, SessionUsage};
@@ -719,9 +718,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(table, inner);
 
     if sessions_len > visible_height {
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .begin_symbol(Some("▲"))
-            .end_symbol(Some("▼"));
+        let scrollbar = ambient_stable_scrollbar();
 
         let mut scrollbar_state =
             viewport_scrollbar_state(sessions_len, scroll_offset, visible_height);

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -7,7 +7,7 @@ use ratatui::widgets::{
 use super::widgets::{
     display_width, format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
     get_compact_client_display_name, prefix_to_width, total_tokens_cell, truncate_text,
-    truncate_to_width, viewport_scrollbar_state, MIDDLE_ELLIPSIS,
+    truncate_to_width, viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET, MIDDLE_ELLIPSIS,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use crate::tui::data::{SessionModel, SessionUsage};
@@ -483,6 +483,7 @@ fn session_label(s: &SessionUsage) -> &str {
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " Sessions ",
@@ -1708,43 +1709,43 @@ mod tests {
                 59u16,
                 true,
                 SortField::Cost,
-                "│Session                           Cost ▼                 │",
-                "│A fairly long ses...              $12.35                 │",
+                "|Session                           Cost ▼                 |",
+                "|A fairly long ses...              $12.35                 |",
             ),
             (
                 59,
                 true,
                 SortField::Date,
-                "│Session                           Cost                   │",
-                "│A fairly long ses...              $12.35                 │",
+                "|Session                           Cost                   |",
+                "|A fairly long ses...              $12.35                 |",
             ),
             (
                 60,
                 true,
                 SortField::Cost,
-                "│Session     Client     Turn   Msgs    Tokens     Cost ▼   │",
-                "│A fairly lo OpenCode   137    428     49.5M      $12.35   │",
+                "|Session     Client     Turn   Msgs    Tokens     Cost ▼   |",
+                "|A fairly lo OpenCode   137    428     49.5M      $12.35   |",
             ),
             (
                 60,
                 false,
                 SortField::Tokens,
-                "│Session         Client     Msgs    Tokens ▼   Cost        │",
-                "│A fairly long s OpenCode   428     49.5M      $12.35      │",
+                "|Session         Client     Msgs    Tokens ▼   Cost        |",
+                "|A fairly long s OpenCode   428     49.5M      $12.35      |",
             ),
             (
                 79,
                 true,
                 SortField::Tokens,
-                "│Session           Client       Turn      Msgs      Tokens ▼      Cost        │",
-                "│A fairly long ses OpenCode     137       428       49.5M         $12.35      │",
+                "|Session           Client       Turn      Msgs      Tokens ▼      Cost        |",
+                "|A fairly long ses OpenCode     137       428       49.5M         $12.35      |",
             ),
             (
                 79,
                 false,
                 SortField::Date,
-                "│Session               Client         Msgs      Tokens         Cost           │",
-                "│A fairly long session OpenCode       428       49.5M          $12.35         │",
+                "|Session               Client         Msgs      Tokens         Cost           |",
+                "|A fairly long session OpenCode       428       49.5M          $12.35         |",
             ),
         ] {
             let mut s = fat_session();

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -166,7 +166,11 @@ impl SessionColumn {
             Self::Output => "Output",
             Self::CacheRead => "Cache R",
             Self::CacheWrite => "Cache W",
-            Self::CacheHit => "Cache×",
+            // U+2715, not U+00D7: the multiplication sign is
+            // East-Asian-Ambiguous and would make the header row stream a
+            // cell wide in a CJK locale; the multiplication X is
+            // East-Asian-Neutral, one cell in both ambients.
+            Self::CacheHit => "Cache✕",
             Self::Total => "Total",
             Self::Cost => "Cost",
             Self::CostPerMillion => "Cost/1M",
@@ -441,7 +445,7 @@ fn admit_and_distribute(available: u16, ctx: &WideCtx) -> WideLayout {
         } else {
             // Stop, don't skip. Trying the next (narrower) group packs more
             // columns in but makes the admitted set non-monotonic in width —
-            // Cache× at W, Duration and no Cache× at W+1 — which is the same
+            // Cache✕ at W, Duration and no Cache✕ at W+1 — which is the same
             // disorientation the ratatui solver produces today.
             break;
         }
@@ -1388,7 +1392,7 @@ mod tests {
 
     /// Widening the terminal never removes a column. `break` in the admission
     /// loop is what buys this: skipping a group that does not fit and trying the
-    /// next, narrower one would show Cache× at W and Duration instead at W+1.
+    /// next, narrower one would show Cache✕ at W and Duration instead at W+1.
     ///
     /// Note what this does **not** cover: it compares header *sets*, so it stays
     /// green through the Session sawtooth (Session is 40 cells at 149 and 20 at
@@ -1786,7 +1790,7 @@ mod tests {
                     "Output",
                     "Cache R",
                     "Cache W",
-                    "Cache×",
+                    "Cache✕",
                     "Total",
                     "Cost/1M",
                     "Duration",
@@ -1924,7 +1928,7 @@ mod tests {
         let body = render_body(&mut app, 70, 12);
         assert!(body.contains("abc-123"), "expected session id\n{body}");
         assert!(
-            !body.contains("Cache×"),
+            !body.contains("Cache✕"),
             "cache hit rate should be dropped in narrow mode\n{body}"
         );
     }

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -1978,18 +1978,54 @@ mod tests {
 
     /// `unicode-width` resolves East-Asian-Ambiguous characters to one cell by
     /// default and to two under `width_cjk`, which is what a terminal in a CJK
-    /// locale does. Inside the table border, a row whose only non-ASCII
-    /// character is the truncation marker measures the same in both ambients
-    /// exactly when that marker is not ambiguous; U+2026 fails this, U+22EF
-    /// passes it. The border itself (U+2502) is ambiguous and is trimmed off.
-    fn assert_row_measures_the_same_in_a_cjk_locale(app: &mut App, width: u16) {
-        let row = first_row_line(app, width);
-        let interior = row.trim_matches('\u{2502}');
-        assert_eq!(
-            UnicodeWidthStr::width_cjk(interior),
-            display_width(interior),
-            "the row must measure the same in a CJK locale\n{row:?}"
-        );
+    /// locale does. Ratatui's crossterm backend streams adjacent cells without
+    /// repositioning between them, so any row whose glyphs measure wider under
+    /// `width_cjk` than under `width` overflows the terminal edge when drawn.
+    /// Every row of the rendered frame is asserted whole — borders, corners,
+    /// header, scrollbar column and all, nothing trimmed — so the top and
+    /// bottom edges, the sort indicator, an active scrollbar, and the cell
+    /// contents (truncation marker included: U+2026 fails this, U+22EF passes)
+    /// are all held to the same invariant: the frame measures identically in
+    /// both ambients.
+    fn assert_frame_measures_the_same_in_a_cjk_locale(app: &mut App, width: u16, height: u16) {
+        let frame = render_body(app, width, height);
+        for row in frame.lines() {
+            assert_eq!(
+                UnicodeWidthStr::width_cjk(row),
+                display_width(row),
+                "every row must measure the same in a CJK locale\n{row:?}\n{frame}"
+            );
+        }
+    }
+
+    /// The frame stays width-stable while scrolled: with more sessions than
+    /// fit, the scrollbar overlays the outermost right column — endpoints on
+    /// the first and last inner rows, thumb and track between — which is
+    /// exactly where a glyph that streams two cells wide in a CJK locale
+    /// wraps into the next row, or scrolls the screen when it lands near the
+    /// bottom. A CJK session title exercises the content path too: W-class
+    /// glyphs are two cells in both ambients, so they keep the equality.
+    #[test]
+    fn scrolled_frame_measures_the_same_in_a_cjk_locale() {
+        let width = MODEL_WIDTH_22_TERMINAL;
+        let sessions: Vec<SessionUsage> = (0..30)
+            .map(|i| {
+                let mut s = session(
+                    &format!("session-{i}"),
+                    "opencode",
+                    i as f64,
+                    1_736_000_000_000 + i as i64 * 60_000,
+                );
+                if i == 29 {
+                    // Sorted by cost descending, so the CJK title is on the
+                    // first visible row.
+                    s.title = Some("한국어 세션 제목".to_string());
+                }
+                s
+            })
+            .collect();
+        let mut app = app_with(width, sessions);
+        assert_frame_measures_the_same_in_a_cjk_locale(&mut app, width, 8);
     }
 
     /// A session that switched models must never render as a single-model
@@ -2018,7 +2054,7 @@ mod tests {
             body.contains("gemini-2-5-flash-lite⋯"),
             "expected a truncation marker after the model that did fit\n{body}"
         );
-        assert_row_measures_the_same_in_a_cjk_locale(&mut app, width);
+        assert_frame_measures_the_same_in_a_cjk_locale(&mut app, width, 12);
         assert!(
             !body.contains("claude"),
             "second model was not supposed to fit at width {width}\n{body}"
@@ -2047,7 +2083,7 @@ mod tests {
             !body.contains("⋯⋯"),
             "truncated name must not pick up a second ellipsis\n{body}"
         );
-        assert_row_measures_the_same_in_a_cjk_locale(&mut app, width);
+        assert_frame_measures_the_same_in_a_cjk_locale(&mut app, width, 12);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/ui/stats.rs
+++ b/crates/tokscale-cli/src/tui/ui/stats.rs
@@ -1,9 +1,9 @@
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation};
+use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::widgets::{
-    format_cost, format_tokens, get_client_color, get_client_display_name,
-    viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
+    ambient_stable_scrollbar, format_cost, format_tokens, get_client_color,
+    get_client_display_name, viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, ClickAction};
 
@@ -642,9 +642,7 @@ fn render_breakdown_panel(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(paragraph, inner);
 
     if app.stats_breakdown_total_lines > visible_height {
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .begin_symbol(Some("▲"))
-            .end_symbol(Some("▼"));
+        let scrollbar = ambient_stable_scrollbar();
 
         let mut scrollbar_state = viewport_scrollbar_state(
             app.stats_breakdown_total_lines,

--- a/crates/tokscale-cli/src/tui/ui/stats.rs
+++ b/crates/tokscale-cli/src/tui/ui/stats.rs
@@ -2,7 +2,8 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation};
 
 use super::widgets::{
-    format_cost, format_tokens, get_client_color, get_client_display_name, viewport_scrollbar_state,
+    format_cost, format_tokens, get_client_color, get_client_display_name,
+    viewport_scrollbar_state, AMBIENT_STABLE_BORDER_SET,
 };
 use crate::tui::app::{App, ClickAction};
 
@@ -71,6 +72,7 @@ fn render_graph(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(theme_border))
         .title(Span::styled(
             " Contribution Graph (52 weeks) ",
@@ -195,6 +197,7 @@ fn render_graph(frame: &mut Frame, app: &mut App, area: Rect) {
 fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " Stats ",
@@ -441,6 +444,7 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
 fn render_breakdown_panel(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " Day Breakdown (ESC to close) ",

--- a/crates/tokscale-cli/src/tui/ui/usage.rs
+++ b/crates/tokscale-cli/src/tui/ui/usage.rs
@@ -10,6 +10,7 @@ use crate::tui::codex_login::CodexLoginOutcome;
 use crate::tui::privacy::looks_like_email;
 use crate::tui::ui::widgets::{
     get_provider_shade, light_ratio_bar_spans, truncate_ellipsis as truncate_string,
+    AMBIENT_STABLE_BORDER_SET,
 };
 
 struct ButtonSpec {
@@ -51,6 +52,7 @@ struct UsageRowView<'a> {
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " Usage ",
@@ -619,6 +621,7 @@ fn render_compact_loaded(frame: &mut Frame, app: &mut App, area: Rect, outputs: 
 fn render_usage_status(frame: &mut Frame, app: &mut App, area: Rect, outputs: &[UsageOutput]) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " Usage Summary ",
@@ -1147,6 +1150,7 @@ fn render_selected_account(
     let title = format!(" Selected Account  {} ", output_display_name(app, selected));
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             truncate_string(&title, area.width.saturating_sub(4) as usize),
@@ -1672,6 +1676,7 @@ fn metric_label_width(width: usize) -> usize {
 fn render_accounts_table(frame: &mut Frame, app: &mut App, area: Rect, outputs: &[UsageOutput]) {
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(AMBIENT_STABLE_BORDER_SET)
         .border_style(Style::default().fg(app.theme.border))
         .title(Span::styled(
             " Accounts ",

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -1,6 +1,6 @@
 use ratatui::prelude::*;
 use ratatui::symbols::border::Set as BorderSet;
-use ratatui::widgets::{Cell, ScrollbarState};
+use ratatui::widgets::{Cell, Scrollbar, ScrollbarOrientation, ScrollbarState};
 use tokscale_core::sessions::WORKTREE_SEPARATOR;
 use tokscale_core::ClientId;
 use unicode_segmentation::UnicodeSegmentation;
@@ -90,6 +90,24 @@ pub fn format_ms_per_1k(ms_per_1k_tokens: Option<f64>) -> String {
     } else {
         format!("{:.0}ms", value)
     }
+}
+
+/// Vertical scrollbar drawn only from width-stable glyphs, for the same
+/// reason as [`AMBIENT_STABLE_BORDER_SET`]: ratatui's defaults — `║` track,
+/// `█` thumb, `▲`/`▼` endpoints — are all East-Asian-Ambiguous, and the
+/// scrollbar overlays the frame's outermost right column, exactly where a
+/// glyph that streams two cells wide in a CJK locale wraps into the next row
+/// (or scrolls the screen from the bottom row). The endpoints and thumb are
+/// East-Asian-Neutral (U+25B4/U+25BE/U+25AE) — one cell under both `width`
+/// and `width_cjk`, the same class as the U+22EF truncation marker — and the
+/// track is ASCII. Every scrollbar goes through here so no caller
+/// reintroduces a default symbol.
+pub fn ambient_stable_scrollbar() -> Scrollbar<'static> {
+    Scrollbar::new(ScrollbarOrientation::VerticalRight)
+        .begin_symbol(Some("\u{25B4}")) // ▴
+        .end_symbol(Some("\u{25BE}")) // ▾
+        .track_symbol(Some("|"))
+        .thumb_symbol("\u{25AE}") // ▮
 }
 
 pub fn viewport_scrollbar_state(

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -1,4 +1,5 @@
 use ratatui::prelude::*;
+use ratatui::symbols::border::Set as BorderSet;
 use ratatui::widgets::{Cell, ScrollbarState};
 use tokscale_core::sessions::WORKTREE_SEPARATOR;
 use tokscale_core::ClientId;
@@ -133,6 +134,38 @@ pub fn truncate_text(s: &str, max_chars: usize) -> String {
 pub fn display_width(s: &str) -> usize {
     UnicodeWidthStr::width(s)
 }
+
+/// Box-drawing border for every framed block, built from the ASCII set plus
+/// one exception: horizontal lines stay U+2500 (`─`) so they still join at the
+/// corners.
+///
+/// Every code point in ratatui's default sets (PLAIN, ROUNDED, DOUBLE, …) is
+/// East-Asian-Ambiguous: one cell to `unicode-width` — and to ratatui's own
+/// cell math — but two cells in a terminal running a CJK locale. On such a
+/// terminal a border drawn at the last column wraps onto the next row and
+/// every column of the table inside shifts right by one, so a row laid out to
+/// exactly fit the block no longer does. `│` `─` `┌` are exactly the same
+/// class of bug as the U+2026 ellipsis fixed in #1304, just drawn by the
+/// frame instead of the content. ASCII is one cell in every terminal, so a
+/// frame drawn with it measures the same in both ambients and the table's
+/// width budget holds.
+///
+/// Why keep `─`: Unicode assigns no unambiguous light horizontal — the
+/// dashes U+2010..U+2015 are all Ambiguous too — so there is no replacement
+/// that both joins at the corners and stays one cell under `width_cjk`. A
+/// horizontal line only overflows sideways into its own span, so it moves
+/// nothing; the verticals and corners are what carry a row's width, and those
+/// are ASCII here.
+pub const AMBIENT_STABLE_BORDER_SET: BorderSet = BorderSet {
+    vertical_left: "|",
+    vertical_right: "|",
+    horizontal_top: "─",
+    horizontal_bottom: "─",
+    top_left: "+",
+    top_right: "+",
+    bottom_left: "+",
+    bottom_right: "+",
+};
 
 /// Longest prefix of `s` that fits in `max_cells` terminal cells. Never splits
 /// a grapheme, so the result can come in one cell short of the budget rather

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -135,32 +135,30 @@ pub fn display_width(s: &str) -> usize {
     UnicodeWidthStr::width(s)
 }
 
-/// Box-drawing border for every framed block, built from the ASCII set plus
-/// one exception: horizontal lines stay U+2500 (`─`) so they still join at the
-/// corners.
+/// Box-drawing border for every framed block, built entirely from ASCII.
 ///
 /// Every code point in ratatui's default sets (PLAIN, ROUNDED, DOUBLE, …) is
 /// East-Asian-Ambiguous: one cell to `unicode-width` — and to ratatui's own
-/// cell math — but two cells in a terminal running a CJK locale. On such a
-/// terminal a border drawn at the last column wraps onto the next row and
-/// every column of the table inside shifts right by one, so a row laid out to
-/// exactly fit the block no longer does. `│` `─` `┌` are exactly the same
-/// class of bug as the U+2026 ellipsis fixed in #1304, just drawn by the
-/// frame instead of the content. ASCII is one cell in every terminal, so a
-/// frame drawn with it measures the same in both ambients and the table's
+/// cell math — but two cells in a terminal running a CJK locale. Ratatui's
+/// crossterm backend streams adjacent buffer cells without repositioning
+/// between them, so every ambiguous glyph makes the emitted row one physical
+/// cell wider than the buffer believes; the overflow pushes the rest of the
+/// row past the terminal edge, wrapping onto — or, on the last row, scrolling
+/// — the line below while the diff buffer still thinks nothing moved. `│` `─`
+/// `┌` are exactly the same class of bug as the U+2026 ellipsis fixed in
+/// #1304, just drawn by the frame instead of the content. That includes the
+/// horizontals: a top or bottom edge drawn with `─` emits at roughly twice
+/// the row width, and the footer's bottom border sits on the terminal's last
+/// row where the wrap becomes a scroll. Unicode assigns no unambiguous light
+/// horizontal — the dashes U+2010..U+2015 are all Ambiguous as well — so the
+/// horizontal is ASCII `-` like every other member: one cell in every
+/// terminal, so a frame measures the same in both ambients and the table's
 /// width budget holds.
-///
-/// Why keep `─`: Unicode assigns no unambiguous light horizontal — the
-/// dashes U+2010..U+2015 are all Ambiguous too — so there is no replacement
-/// that both joins at the corners and stays one cell under `width_cjk`. A
-/// horizontal line only overflows sideways into its own span, so it moves
-/// nothing; the verticals and corners are what carry a row's width, and those
-/// are ASCII here.
 pub const AMBIENT_STABLE_BORDER_SET: BorderSet = BorderSet {
     vertical_left: "|",
     vertical_right: "|",
-    horizontal_top: "─",
-    horizontal_bottom: "─",
+    horizontal_top: "-",
+    horizontal_bottom: "-",
     top_left: "+",
     top_right: "+",
     bottom_left: "+",


### PR DESCRIPTION
## Background

Every framed block in the TUI (Sessions, Projects, Models, Agents, Stats, Daily, Hourly, Minutely, Monthly, Usage, Overview, header, footer, dialogs) is drawn with ratatui's default border set, and every code point in those sets (`│` U+2502, `─` U+2500, `┌` `┐` `└` `┘`, the rounded and double variants) is East-Asian-Ambiguous. `unicode-width` — which ratatui's own cell math matches — measures them as one cell by default and two under `width_cjk`, which is what a terminal running a CJK locale does. On such a terminal each vertical border occupies one more cell than the layout budgeted, so a row laid out to exactly fill its block overflows: the right border wraps onto the next row and every column of the table inside shifts right by one. #1304 fixed this for the U+2026 truncation ellipsis inside the Sessions table; its CJK-locale assertion still had to trim the border off the rendered row before measuring, precisely because the border itself was the same bug left unfixed.

## Root cause

The width budget the TUI computes is correct; the glyphs it draws the frame with are not. A border glyph whose width depends on the terminal's locale makes a row that measures N cells here measure N+2 there, and no interior-fitting logic can compensate for a frame that lies about its own width.

## The fix

Option (b) from the three considered: replace the ambiguous border glyphs with unambiguous ones, rather than re-measuring with `width_cjk` (which would make the layout itself locale-dependent and just relocates the misalignment) or padding a per-border fudge factor (which breaks the moment the terminal's ambiguous-width mode differs). A new `AMBIENT_STABLE_BORDER_SET` in `widgets.rs` is applied to every bordered block via `.border_set(...)`:

- Verticals and corners — the glyphs that carry a row's width — become ASCII `|` and `+`: one cell in every terminal, so the rendered row measures identically in both ambients and the table budget holds.
- Horizontal lines stay U+2500 `─`, so they still join at the corners and the frame doesn't fall apart visually. Unicode assigns no unambiguous light horizontal (U+2010..U+2015 are all Ambiguous too), and a horizontal line only ever overflows sideways into its own span — it cannot shift columns the way a vertical can.

The same treatment goes to the three other places a vertical was emitted by hand: the scrollbar track symbol (`│` → `|`), the header tab divider (` │ ` → ` | `), and the bar-chart Y-axis separator (`│` → `|`).

## Test changes

`assert_row_measures_the_same_in_a_cjk_locale` (the helper #1304 added) no longer trims `│` off the row: the whole bordered row now asserts `width_cjk(row) == display_width(row)` and, additionally, that the row fills its line exactly (`display_width(row) == width`). Both model-truncation tests exercise it. The pinned byte-for-byte narrow-layout fixtures updated from `│` to `|`; no other expected rows moved.

## Before / after

Narrow Sessions layout, 60-cell terminal (non-CJK and CJK terminals now render the same; previously a CJK terminal measured each row 62 cells and wrapped the right border):

Before:

```
│Session     Client     Turn   Msgs    Tokens     Cost ▼   │
│A fairly lo OpenCode   137    428     49.5M      $12.35   │
```

After:

```
|Session     Client     Turn   Msgs    Tokens     Cost ▼   |
|A fairly lo OpenCode   137    428     49.5M      $12.35   |
```

Rendering-only change: no data, sorting, or column-budget behavior is affected — only the glyphs the frame is drawn with.

## Gates

- `cargo test -p tokscale-cli` — 1296 unit + 185 integration + 8 tls_policy tests, all pass
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p tokscale-cli` — fails only on three pre-existing broken links already on `origin/main` (`imp::build_schema` in apple_fm.rs, `paths::get_config_dir` in trae.rs, a bare URL in main.rs); nothing new from this change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TUI's framed blocks so they render at the correct width in CJK-locale terminals; previously the box-drawing border glyphs measured two cells there, so the right border wrapped onto the next row and every table column shifted right by one.

**Bug Fixes**
- Adds `AMBIENT_STABLE_BORDER_SET` applied to every bordered block; all glyphs become ASCII (`|`, `+`, `-`) so every row measures one cell in both ambients.
- Routes every scrollbar through `ambient_stable_scrollbar()` and gives the sort arrows, cache-hit header sign, tab divider, and bar-chart axis the same width-stable treatment.
- The CJK-locale test now asserts every row of the rendered frame measures identically, including a scrolled view with an active scrollbar.

<sup>Written for commit 2ae37ea45efe6fc4785af6180ad6b9806f9ecaa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

