### PR TITLE
feat(moderation): measure fail-closed unknowable submissions

### DIFF
--- a/packages/frontend/__tests__/integration/moderationCandidatesPostgres.test.ts
+++ b/packages/frontend/__tests__/integration/moderationCandidatesPostgres.test.ts
@@ -794,10 +794,6 @@ describeWithPostgres("moderation candidates PostgreSQL integration", () => {
 
       const bucketAt = (power: number) =>
         payload.unattributedHistogram[String(power * UNKNOWABLE_BUCKET_WIDTH)];
-      // The two zero-gap personas cross no boundary, so 1M holds nine, not
-      // eleven — the histogram is also where "unknowable but fully covered"
-      // (overNestedZeroScalar/NoScalar) separates from "tokens actually
-      // missing", which the flat counts cannot say.
       // The two zero-gap personas and remainderPlusUnknown's 1,000 cross no
       // boundary, so 1M holds eight of the eleven — the histogram is also
       // where "unknowable but fully covered" (overNestedZeroScalar/NoScalar)

--- a/packages/frontend/__tests__/integration/moderationCandidatesPostgres.test.ts
+++ b/packages/frontend/__tests__/integration/moderationCandidatesPostgres.test.ts
@@ -858,4 +858,55 @@ describeWithPostgres("moderation candidates PostgreSQL integration", () => {
 
     await fixtureDb`DELETE FROM users WHERE id = ${sloplessId}`;
   });
+
+  it("still emits the line when every slop-matched candidate is knowable", async () => {
+    // The breadth metric is a fraction, and a window where nothing failed
+    // must contribute its denominator: a suppressed line is indistinguishable
+    // from a window that was never measured, and aggregating only failure
+    // lines can never produce a zero rate. Runs last because it removes the
+    // unknowable personas for good — afterAll's per-persona DELETE is a no-op
+    // for rows already gone.
+    const unknowablePersonas: Persona[] = [
+      "unclaimed",
+      "mixed",
+      "unknownBucket",
+      "debrisBucket",
+      "unknownModelId",
+      "remainderPlusUnknown",
+      "overNested",
+      "overNestedNamed",
+      "overNestedAllNamed",
+      "overNestedZeroScalar",
+      "overNestedNoScalar",
+    ];
+    for (const persona of unknowablePersonas) {
+      await fixtureDb`DELETE FROM users WHERE id = ${ids[persona].userId}`;
+    }
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await getModerationCandidates();
+      const payloads = parseUnknowableWarnings(warnSpy.mock.calls);
+      expect(payloads).toHaveLength(1);
+      const payload = payloads[0];
+      // partial, blend, legacy, artifact, wholly, namedLikeUnknown remain.
+      expect(payload.knowable).toBe(6);
+      expect(payload.unknowable).toBe(0);
+      expect(payload.byReason).toEqual({
+        missing_breakdown: 0,
+        over_nested: 0,
+        unattributed_tokens: 0,
+        unknown: 0,
+      });
+      expect(payload.unattributedTokens).toBe(0);
+      expect(payload.unknowableTotalTokens).toBe(0);
+      expect(
+        Object.values(payload.unattributedHistogram).every(
+          (count) => count === 0
+        )
+      ).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });

--- a/packages/frontend/__tests__/integration/moderationCandidatesPostgres.test.ts
+++ b/packages/frontend/__tests__/integration/moderationCandidatesPostgres.test.ts
@@ -1,8 +1,12 @@
 import { randomUUID } from "node:crypto";
 import postgres from "postgres";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { getModerationCandidates } from "@/lib/moderation/candidates";
+import {
+  UNKNOWABLE_BUCKET_WIDTH,
+  UNKNOWABLE_EVENT,
+} from "@/lib/moderation/heuristics";
 
 const integrationEnabled =
   process.env.MODERATION_CANDIDATES_DB_INTEGRATION === "1";
@@ -500,6 +504,30 @@ describeWithPostgres("moderation candidates PostgreSQL integration", () => {
     return candidate!;
   }
 
+  interface UnknowableLogPayload {
+    event: string;
+    knowable: number;
+    unknowable: number;
+    byReason: Record<string, number>;
+    unattributedTokens: number;
+    unknowableTotalTokens: number;
+    unattributedHistogram: Record<string, number>;
+  }
+
+  function parseUnknowableWarnings(calls: unknown[][]): UnknowableLogPayload[] {
+    return calls
+      .map((call) => String(call[0]))
+      .filter((message) => message.includes(UNKNOWABLE_EVENT))
+      .map((message) => {
+        // getDb() memoizes its pool on globalThis, so other log lines from
+        // this process can share the warn spy; match the payload, not the
+        // whole line.
+        const match = message.match(/\[moderation\] (\{.*\})$/);
+        expect(match, `unparseable moderation log line: ${message}`).not.toBeNull();
+        return JSON.parse(match![1]) as UnknowableLogPayload;
+      });
+  }
+
   it("credits a partial model map's scalar remainder to the entry's own modelId", async () => {
     const candidate = await candidateFor("partial");
 
@@ -702,5 +730,132 @@ describeWithPostgres("moderation candidates PostgreSQL integration", () => {
     expect(candidate.signals.map((signal) => signal.key)).not.toContain(
       "slopModelName"
     );
+  });
+
+  // Breadth telemetry for the fail-closed path. The assertions above prove
+  // WHERE the gate fails; these prove the instrumentation reports exactly
+  // that set and nothing else, since a breadth metric that fires on knowable
+  // rows (or stays silent on unknowable ones) answers the wrong question.
+  // The queries re-run against the same fixture rows inside each test; the
+  // only moving part is the warn spy.
+  it("emits one structured line per invocation covering exactly the fail-closed set", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await getModerationCandidates();
+      const payloads = parseUnknowableWarnings(warnSpy.mock.calls);
+      expect(payloads).toHaveLength(1);
+      const payload = payloads[0];
+
+      expect(payload.event).toBe(UNKNOWABLE_EVENT);
+
+      // Exactly the personas whose slopTokens is NULL, classified by the gate
+      // clause that failed. Deleting has_over_nested_entry from the gate moves
+      // the five over-nested personas into unattributed_tokens (their
+      // attributed sum then falls short of the total), so this map goes red
+      // the moment the instrumentation and the gate diverge.
+      expect(payload.byReason).toEqual({
+        missing_breakdown: 1, // mixed
+        over_nested: 5, // the five overNested* personas
+        // unclaimed, unknownBucket, debrisBucket, unknownModelId,
+        // remainderPlusUnknown.
+        unattributed_tokens: 5,
+        unknown: 0,
+      });
+      expect(payload.unknowable).toBe(11);
+      // partial, blend, legacy, artifact, wholly, namedLikeUnknown.
+      expect(payload.knowable).toBe(6);
+
+      const expectedUnattributed: Partial<Record<Persona, number>> = {
+        unclaimed: totals.unclaimed - 2,
+        mixed: totals.mixed - 2,
+        // An over-nested entry attributes NOTHING — not the clamped scalar —
+        // so the three all-scalar personas miss their whole totals...
+        overNested: totals.overNested,
+        overNestedNamed: totals.overNestedNamed,
+        overNestedAllNamed: totals.overNestedAllNamed,
+        // ...while the zero/no-scalar pair still attributes the well-formed
+        // claude entry beside the contradictory one, so nothing is missing.
+        overNestedZeroScalar: 0,
+        overNestedNoScalar: 0,
+        unknownModelId: totals.unknownModelId - 2,
+        remainderPlusUnknown: 1_000,
+        unknownBucket: totals.unknownBucket - 2,
+        debrisBucket: totals.debrisBucket - 2,
+      };
+      expect(payload.unattributedTokens).toBe(
+        Object.values(expectedUnattributed).reduce((sum, n) => sum + n, 0)
+      );
+      expect(payload.unknowableTotalTokens).toBe(
+        (Object.keys(expectedUnattributed) as Persona[]).reduce(
+          (sum, persona) => sum + totals[persona],
+          0
+        )
+      );
+
+      const bucketAt = (power: number) =>
+        payload.unattributedHistogram[String(power * UNKNOWABLE_BUCKET_WIDTH)];
+      // The two zero-gap personas cross no boundary, so 1M holds nine, not
+      // eleven — the histogram is also where "unknowable but fully covered"
+      // (overNestedZeroScalar/NoScalar) separates from "tokens actually
+      // missing", which the flat counts cannot say.
+      // The two zero-gap personas and remainderPlusUnknown's 1,000 cross no
+      // boundary, so 1M holds eight of the eleven — the histogram is also
+      // where "unknowable but fully covered" (overNestedZeroScalar/NoScalar)
+      // separates from "tokens actually missing", which the flat counts
+      // cannot say.
+      expect(bucketAt(1)).toBe(8);
+      // Only the 999,998 and 1,599,998 gaps (unclaimed, mixed) stop below
+      // 2M; the six gaps at or above 2,099,998 all cross it.
+      expect(bucketAt(2)).toBe(6);
+      // 2.1M-3.2M stop at 2M; only the 4,100,000 gap crosses 4M.
+      expect(bucketAt(4)).toBe(1);
+      expect(bucketAt(8)).toBe(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("does not count a slop-less account as unknowable even with a null slopTokens", async () => {
+    // A submissions row whose models_used holds no slop name never enters the
+    // attribution CTEs; its slop_tokens is NULL by scoping, not by gate
+    // failure. If the breadth counter read nulls off the whole queue, this
+    // persona would move it and the metric would answer the wrong question.
+    const suffix = randomUUID().replaceAll("-", "").slice(0, 8);
+    const sloplessId = randomUUID();
+    await fixtureDb.begin(async (sql) => {
+      await sql`
+        INSERT INTO users (id, github_id, username, leaderboard_hidden)
+        VALUES (
+          ${sloplessId},
+          ${githubIdBase - 1_000_000 - Number.parseInt(suffix.slice(0, 6), 16)},
+          ${`mod_slopless_${suffix}`},
+          true
+        )
+      `;
+      await sql`
+        INSERT INTO submissions (
+          id, user_id, total_tokens, total_cost, input_tokens, output_tokens,
+          date_start, date_end, sources_used, models_used
+        )
+        VALUES (
+          ${randomUUID()}, ${sloplessId}, 42_000_000, 0, 42_000_000, 0,
+          '2026-01-01', '2026-01-02', ARRAY['claude'], ARRAY['claude-sonnet-4']
+        )
+      `;
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await getModerationCandidates();
+      const payloads = parseUnknowableWarnings(warnSpy.mock.calls);
+      expect(payloads).toHaveLength(1);
+      // Same counts as the previous test: the slop-less row moved nothing.
+      expect(payloads[0].unknowable).toBe(11);
+      expect(payloads[0].knowable).toBe(6);
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    await fixtureDb`DELETE FROM users WHERE id = ${sloplessId}`;
   });
 });

--- a/packages/frontend/__tests__/integration/moderationCandidatesPostgres.test.ts
+++ b/packages/frontend/__tests__/integration/moderationCandidatesPostgres.test.ts
@@ -509,8 +509,12 @@ describeWithPostgres("moderation candidates PostgreSQL integration", () => {
     knowable: number;
     unknowable: number;
     byReason: Record<string, number>;
-    unattributedTokens: number;
-    unknowableTotalTokens: number;
+    /**
+     * Decimal strings: the sums are exact bigints in the emitter, and
+     * JSON.stringify refuses a bigint, so they travel as their digits.
+     */
+    unattributedTokens: string;
+    unknowableTotalTokens: string;
     unattributedHistogram: Record<string, number>;
   }
 
@@ -783,12 +787,14 @@ describeWithPostgres("moderation candidates PostgreSQL integration", () => {
         debrisBucket: totals.debrisBucket - 2,
       };
       expect(payload.unattributedTokens).toBe(
-        Object.values(expectedUnattributed).reduce((sum, n) => sum + n, 0)
+        String(Object.values(expectedUnattributed).reduce((sum, n) => sum + n, 0))
       );
       expect(payload.unknowableTotalTokens).toBe(
-        (Object.keys(expectedUnattributed) as Persona[]).reduce(
-          (sum, persona) => sum + totals[persona],
-          0
+        String(
+          (Object.keys(expectedUnattributed) as Persona[]).reduce(
+            (sum, persona) => sum + totals[persona],
+            0
+          )
         )
       );
 
@@ -855,6 +861,117 @@ describeWithPostgres("moderation candidates PostgreSQL integration", () => {
     await fixtureDb`DELETE FROM users WHERE id = ${sloplessId}`;
   });
 
+  it("carries a one-token gate shortfall above 2^53 exactly through the driver", async () => {
+    // The SQL gate can fail `attributed_tokens >= total_tokens` by exactly
+    // one token above 2^53 — 9,007,199,254,740,995 < 9,007,199,254,740,996 —
+    // while both operands collapse to the SAME Number on the way out of
+    // postgres-js. Only the real driver strings can prove the classifier
+    // still reports `unattributed_tokens` (not `unknown`) and the telemetry
+    // the true one-token gap. Deltas against a same-fixture baseline keep
+    // the assertions independent of the shared personas.
+    const total = "9007199254740996"; // 2^53 + 4
+    const attributedNamed = "9007199254740993"; // + fake-api's 2 = total - 1
+    const suffix = randomUUID().replaceAll("-", "").slice(0, 8);
+    const bigUserId = randomUUID();
+    const bigSubmissionId = randomUUID();
+    const bigDeviceId = randomUUID();
+
+    const baselineSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let baseline: UnknowableLogPayload;
+    try {
+      await getModerationCandidates();
+      const payloads = parseUnknowableWarnings(baselineSpy.mock.calls);
+      expect(payloads).toHaveLength(1);
+      baseline = payloads[0];
+    } finally {
+      baselineSpy.mockRestore();
+    }
+
+    // JSON built by hand: routing the token counts through a JS object would
+    // round 9,007,199,254,740,995 at JSON.stringify time, which is the exact
+    // loss this test exists to rule out. The ::text::jsonb chain pins the
+    // parameter as text so postgres-js does not double-encode it — a bare
+    // ::jsonb cast makes Postgres infer a jsonb parameter, which the driver
+    // JSON-stringifies into a jsonb STRING (jsonb_typeof = 'string').
+    const cell = (tokens: string) =>
+      `{"tokens":${tokens},"cost":0,"input":${tokens},"output":0,"cacheRead":0,"cacheWrite":0,"reasoning":0,"messages":1}`;
+    const breakdown = `{"claude":{"tokens":${total},"cost":0,"input":${total},"output":0,"cacheRead":0,"cacheWrite":0,"reasoning":0,"messages":1,"models":{"claude-sonnet-4":${cell(
+      attributedNamed
+    )},"fake-api":${cell("2")}}}}`;
+
+    await fixtureDb.begin(async (sql) => {
+      await sql`
+        INSERT INTO users (id, github_id, username, leaderboard_hidden)
+        VALUES (
+          ${bigUserId},
+          ${githubIdBase - 2_000_000 - Number.parseInt(suffix.slice(0, 6), 16)},
+          ${`mod_bigint_${suffix}`},
+          true
+        )
+      `;
+      await sql`
+        INSERT INTO submissions (
+          id, user_id, total_tokens, total_cost, input_tokens, output_tokens,
+          date_start, date_end, sources_used, models_used
+        )
+        VALUES (
+          ${bigSubmissionId}, ${bigUserId}, ${total}, 0, ${total}, 0,
+          '2026-01-01', '2026-01-02', ARRAY['claude'],
+          ARRAY['claude-sonnet-4', 'fake-api']
+        )
+      `;
+      await sql`
+        INSERT INTO submitted_devices (id, user_id, device_key)
+        VALUES (${bigDeviceId}, ${bigUserId}, ${`mod-bigint-${suffix}-device`})
+      `;
+      await sql`
+        INSERT INTO daily_breakdown (
+          submission_id, submitted_device_id, date, tokens, cost,
+          input_tokens, output_tokens, source_breakdown
+        )
+        VALUES (
+          ${bigSubmissionId}, ${bigDeviceId}, '2026-01-01', ${total}, 0,
+          ${total}, 0, ${breakdown}::text::jsonb
+        )
+      `;
+    });
+
+    try {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        await getModerationCandidates();
+        const payloads = parseUnknowableWarnings(warnSpy.mock.calls);
+        expect(payloads).toHaveLength(1);
+        const payload = payloads[0];
+
+        expect(payload.knowable).toBe(baseline.knowable);
+        expect(payload.unknowable).toBe(baseline.unknowable + 1);
+        expect(payload.byReason).toEqual({
+          ...baseline.byReason,
+          unattributed_tokens: baseline.byReason.unattributed_tokens + 1,
+        });
+        // `unknown` is the clause a Number pipeline reports for this row.
+        expect(payload.byReason.unknown).toBe(baseline.byReason.unknown);
+        expect(
+          BigInt(payload.unattributedTokens) -
+            BigInt(baseline.unattributedTokens)
+        ).toBe(1n);
+        expect(
+          BigInt(payload.unknowableTotalTokens) -
+            BigInt(baseline.unknowableTotalTokens)
+        ).toBe(BigInt(total));
+        // A one-token gap crosses no bucket boundary.
+        expect(payload.unattributedHistogram).toEqual(
+          baseline.unattributedHistogram
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    } finally {
+      await fixtureDb`DELETE FROM users WHERE id = ${bigUserId}`;
+    }
+  });
+
   it("still emits the line when every slop-matched candidate is knowable", async () => {
     // The breadth metric is a fraction, and a window where nothing failed
     // must contribute its denominator: a suppressed line is indistinguishable
@@ -894,8 +1011,8 @@ describeWithPostgres("moderation candidates PostgreSQL integration", () => {
         unattributed_tokens: 0,
         unknown: 0,
       });
-      expect(payload.unattributedTokens).toBe(0);
-      expect(payload.unknowableTotalTokens).toBe(0);
+      expect(payload.unattributedTokens).toBe("0");
+      expect(payload.unknowableTotalTokens).toBe("0");
       expect(
         Object.values(payload.unattributedHistogram).every(
           (count) => count === 0

--- a/packages/frontend/__tests__/lib/moderationHeuristics.test.ts
+++ b/packages/frontend/__tests__/lib/moderationHeuristics.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   SLOP_MODEL_REGEX,
+  UNKNOWABLE_BUCKET_WIDTH,
+  aggregateUnknowableStats,
+  classifyUnknowableReason,
   rankCandidates,
   scoreCandidate,
   type CandidateContext,
@@ -42,6 +45,11 @@ function row(overrides: Partial<CandidateRow> = {}): CandidateRow {
         : slopModels.length > 0
         ? totalTokens
         : 0,
+    // Gate-clause defaults for a fully attributed row; unknowable fixtures
+    // override at least one of the three.
+    hasOverNestedEntry: false,
+    everyDayAttributed: true,
+    attributedTokens: overrides.attributedTokens ?? totalTokens,
     ...overrides,
   };
 }
@@ -368,5 +376,146 @@ describe("SLOP_MODEL_REGEX", () => {
     expect(matches("claude-sonnet-4-5")).toBe(false);
     expect(matches("deepseek-v3")).toBe(false);
     expect(matches("gpt-5.4")).toBe(false);
+  });
+});
+
+describe("classifyUnknowableReason", () => {
+  it("classifies an over-nested entry before anything else", () => {
+    // All three gate clauses fail at once here; the contradiction dominates
+    // because better arithmetic elsewhere in the submission cannot repair it.
+    const candidate = row({
+      slopModels: ["fake-api"],
+      slopTokens: null,
+      hasOverNestedEntry: true,
+      everyDayAttributed: false,
+      attributedTokens: 0,
+    });
+
+    expect(classifyUnknowableReason(candidate)).toBe("over_nested");
+  });
+
+  it("classifies a missing daily breakdown next", () => {
+    const candidate = row({
+      slopModels: ["fake-api"],
+      slopTokens: null,
+      everyDayAttributed: false,
+      attributedTokens: 2,
+    });
+
+    expect(classifyUnknowableReason(candidate)).toBe("missing_breakdown");
+  });
+
+  it("classifies an attributed-sum shortfall as unattributed tokens", () => {
+    const candidate = row({
+      slopModels: ["fake-api"],
+      slopTokens: null,
+      attributedTokens: 1_199_000,
+    });
+
+    expect(classifyUnknowableReason(candidate)).toBe("unattributed_tokens");
+  });
+
+  it("flags a gate failure no known clause explains as drift", () => {
+    // everyDayAttributed, no over-nesting, attributed >= total — yet
+    // slopTokens came back null. That combination means the SQL gate drifted
+    // ahead of this classifier, and it must surface as its own bucket rather
+    // than being counted under one of the measured classes.
+    const candidate = row({
+      slopModels: ["fake-api"],
+      slopTokens: null,
+    });
+
+    expect(classifyUnknowableReason(candidate)).toBe("unknown");
+  });
+});
+
+describe("aggregateUnknowableStats", () => {
+  it("counts nothing when no candidate names a slop model", () => {
+    // slopTokens is meaningless off the slop-matched set — the attribution
+    // CTEs never run there — so these rows must not move any counter even if
+    // a fixture hands them a null.
+    const stats = aggregateUnknowableStats([
+      row({ slopModels: [], slopTokens: null, attributedTokens: 0 }),
+      row({ slopModels: [] }),
+    ]);
+
+    expect(stats.knowable).toBe(0);
+    expect(stats.unknowable).toBe(0);
+    expect(stats.unattributedTokens).toBe(0);
+  });
+
+  it("separates knowable from unknowable slop-matched candidates", () => {
+    const stats = aggregateUnknowableStats([
+      row({ username: "knowable", slopModels: ["fake-api"], slopTokens: 2 }),
+      row({
+        username: "unknowable",
+        slopModels: ["fake-api"],
+        slopTokens: null,
+        attributedTokens: 1_199_000,
+      }),
+    ]);
+
+    expect(stats.knowable).toBe(1);
+    expect(stats.unknowable).toBe(1);
+    expect(stats.byReason.unattributed_tokens).toBe(1);
+    expect(stats.unattributedTokens).toBe(1_000);
+    expect(stats.unknowableTotalTokens).toBe(1_200_000);
+  });
+
+  it("sweeps unattributed tokens into the log-scale histogram", () => {
+    // One candidate missing the whole 64,000,000-token total and nine
+    // missing under one bucket width aggregate to the same flat sums as one
+    // missing ~64M and nine missing ~1 each is NOT: the histogram is what
+    // tells "one large account" apart from "many small ones".
+    const largeGap = row({
+      username: "large-gap",
+      slopModels: ["fake-api"],
+      slopTokens: null,
+      totalTokens: 64 * UNKNOWABLE_BUCKET_WIDTH,
+      attributedTokens: 0,
+    });
+    const smallGaps = Array.from({ length: 9 }, (_, i) =>
+      row({
+        username: `small-gap-${i}`,
+        slopModels: ["fake-api"],
+        slopTokens: null,
+        attributedTokens: 1_200_000 - 1,
+      })
+    );
+
+    const stats = aggregateUnknowableStats([largeGap, ...smallGaps]);
+
+    expect(stats.unknowable).toBe(10);
+    // The 64M gap crosses every boundary up to and including 64M; each small
+    // gap crosses none.
+    // Keyed by the numeric boundary so a width change re-baselines the
+    // expected keys instead of silently still passing on stale literals.
+    expect(stats.unattributedHistogram).toEqual(
+      Object.fromEntries(
+        [1, 2, 4, 8, 16, 32, 64, 128].map((power) => [
+          String(power * UNKNOWABLE_BUCKET_WIDTH),
+          power <= 64 ? 1 : 0,
+        ])
+      )
+    );
+    expect(stats.unattributedTokens).toBe(64 * UNKNOWABLE_BUCKET_WIDTH + 9);
+  });
+
+  it("clamps a negative gap rather than dragging the sum below zero", () => {
+    // Defence against drifted data: the gate guarantees attributed < total
+    // on well-formed rows, but a future drift that overshoots must not make
+    // the breadth metric go negative and hide the rest of the window.
+    const stats = aggregateUnknowableStats([
+      row({
+        slopModels: ["fake-api"],
+        slopTokens: null,
+        totalTokens: 100,
+        attributedTokens: 200,
+        hasOverNestedEntry: true,
+      }),
+    ]);
+
+    expect(stats.unattributedTokens).toBe(0);
+    expect(stats.byReason.over_nested).toBe(1);
   });
 });

--- a/packages/frontend/__tests__/lib/moderationHeuristics.test.ts
+++ b/packages/frontend/__tests__/lib/moderationHeuristics.test.ts
@@ -501,6 +501,35 @@ describe("aggregateUnknowableStats", () => {
     expect(stats.unattributedTokens).toBe(64 * UNKNOWABLE_BUCKET_WIDTH + 9);
   });
 
+  it("lands a gap past the largest boundary in the top bucket, not on a missing key", () => {
+    // 256M unattributed walks past the largest allocated key (128M). Without
+    // the cap the loop does `undefined + 1` on the never-allocated 256M key,
+    // and the resulting NaN serializes as null — corrupting the emitted
+    // telemetry on exactly the accounts whose gaps matter most.
+    const stats = aggregateUnknowableStats([
+      row({
+        slopModels: ["fake-api"],
+        slopTokens: null,
+        totalTokens: 256 * UNKNOWABLE_BUCKET_WIDTH,
+        attributedTokens: 0,
+      }),
+    ]);
+
+    // Cumulative semantics hold all the way up: the gap crosses every
+    // boundary including the open-ended top one, and no extra key appears.
+    expect(stats.unattributedHistogram).toEqual(
+      Object.fromEntries(
+        [1, 2, 4, 8, 16, 32, 64, 128].map((power) => [
+          String(power * UNKNOWABLE_BUCKET_WIDTH),
+          1,
+        ])
+      )
+    );
+    // What the log line actually carries: every bucket a real number, never
+    // the null that JSON.stringify makes of NaN.
+    expect(JSON.stringify(stats.unattributedHistogram)).not.toContain("null");
+  });
+
   it("clamps a negative gap rather than dragging the sum below zero", () => {
     // Defence against drifted data: the gate guarantees attributed < total
     // on well-formed rows, but a future drift that overshoots must not make

--- a/packages/frontend/__tests__/lib/moderationHeuristics.test.ts
+++ b/packages/frontend/__tests__/lib/moderationHeuristics.test.ts
@@ -46,10 +46,13 @@ function row(overrides: Partial<CandidateRow> = {}): CandidateRow {
         ? totalTokens
         : 0,
     // Gate-clause defaults for a fully attributed row; unknowable fixtures
-    // override at least one of the three.
+    // override at least one of the three. The bigint operands default to the
+    // Number total, which is exact for every fixture that does not opt into
+    // an explicit above-2^53 override.
     hasOverNestedEntry: false,
     everyDayAttributed: true,
-    attributedTokens: overrides.attributedTokens ?? totalTokens,
+    attributedTokens: overrides.attributedTokens ?? BigInt(totalTokens),
+    totalTokensExact: overrides.totalTokensExact ?? BigInt(totalTokens),
     ...overrides,
   };
 }
@@ -388,7 +391,7 @@ describe("classifyUnknowableReason", () => {
       slopTokens: null,
       hasOverNestedEntry: true,
       everyDayAttributed: false,
-      attributedTokens: 0,
+      attributedTokens: 0n,
     });
 
     expect(classifyUnknowableReason(candidate)).toBe("over_nested");
@@ -399,7 +402,7 @@ describe("classifyUnknowableReason", () => {
       slopModels: ["fake-api"],
       slopTokens: null,
       everyDayAttributed: false,
-      attributedTokens: 2,
+      attributedTokens: 2n,
     });
 
     expect(classifyUnknowableReason(candidate)).toBe("missing_breakdown");
@@ -409,7 +412,7 @@ describe("classifyUnknowableReason", () => {
     const candidate = row({
       slopModels: ["fake-api"],
       slopTokens: null,
-      attributedTokens: 1_199_000,
+      attributedTokens: 1_199_000n,
     });
 
     expect(classifyUnknowableReason(candidate)).toBe("unattributed_tokens");
@@ -435,13 +438,13 @@ describe("aggregateUnknowableStats", () => {
     // CTEs never run there — so these rows must not move any counter even if
     // a fixture hands them a null.
     const stats = aggregateUnknowableStats([
-      row({ slopModels: [], slopTokens: null, attributedTokens: 0 }),
+      row({ slopModels: [], slopTokens: null, attributedTokens: 0n }),
       row({ slopModels: [] }),
     ]);
 
     expect(stats.knowable).toBe(0);
     expect(stats.unknowable).toBe(0);
-    expect(stats.unattributedTokens).toBe(0);
+    expect(stats.unattributedTokens).toBe(0n);
   });
 
   it("separates knowable from unknowable slop-matched candidates", () => {
@@ -451,15 +454,15 @@ describe("aggregateUnknowableStats", () => {
         username: "unknowable",
         slopModels: ["fake-api"],
         slopTokens: null,
-        attributedTokens: 1_199_000,
+        attributedTokens: 1_199_000n,
       }),
     ]);
 
     expect(stats.knowable).toBe(1);
     expect(stats.unknowable).toBe(1);
     expect(stats.byReason.unattributed_tokens).toBe(1);
-    expect(stats.unattributedTokens).toBe(1_000);
-    expect(stats.unknowableTotalTokens).toBe(1_200_000);
+    expect(stats.unattributedTokens).toBe(1_000n);
+    expect(stats.unknowableTotalTokens).toBe(1_200_000n);
   });
 
   it("sweeps unattributed tokens into the log-scale histogram", () => {
@@ -472,14 +475,14 @@ describe("aggregateUnknowableStats", () => {
       slopModels: ["fake-api"],
       slopTokens: null,
       totalTokens: 64 * UNKNOWABLE_BUCKET_WIDTH,
-      attributedTokens: 0,
+      attributedTokens: 0n,
     });
     const smallGaps = Array.from({ length: 9 }, (_, i) =>
       row({
         username: `small-gap-${i}`,
         slopModels: ["fake-api"],
         slopTokens: null,
-        attributedTokens: 1_200_000 - 1,
+        attributedTokens: BigInt(1_200_000 - 1),
       })
     );
 
@@ -498,7 +501,7 @@ describe("aggregateUnknowableStats", () => {
         ])
       )
     );
-    expect(stats.unattributedTokens).toBe(64 * UNKNOWABLE_BUCKET_WIDTH + 9);
+    expect(stats.unattributedTokens).toBe(BigInt(64 * UNKNOWABLE_BUCKET_WIDTH + 9));
   });
 
   it("lands a gap past the largest boundary in the top bucket, not on a missing key", () => {
@@ -511,7 +514,7 @@ describe("aggregateUnknowableStats", () => {
         slopModels: ["fake-api"],
         slopTokens: null,
         totalTokens: 256 * UNKNOWABLE_BUCKET_WIDTH,
-        attributedTokens: 0,
+        attributedTokens: 0n,
       }),
     ]);
 
@@ -539,12 +542,41 @@ describe("aggregateUnknowableStats", () => {
         slopModels: ["fake-api"],
         slopTokens: null,
         totalTokens: 100,
-        attributedTokens: 200,
+        attributedTokens: 200n,
         hasOverNestedEntry: true,
       }),
     ]);
 
-    expect(stats.unattributedTokens).toBe(0);
+    expect(stats.unattributedTokens).toBe(0n);
     expect(stats.byReason.over_nested).toBe(1);
+  });
+
+  it("keeps a one-token gate shortfall above 2^53 exact", () => {
+    // SQL-exact regression: PostgreSQL correctly fails
+    // `attributed_tokens >= total_tokens` at
+    // 9007199254740995 < 9007199254740996, yet BOTH operands round to the
+    // same Number (9007199254740996). A Number pipeline classifies that row
+    // as `unknown` and measures a zero gap; the bigint operands must carry
+    // the real clause and the true one-token shortfall through to the stats.
+    const candidate = row({
+      slopModels: ["fake-api"],
+      slopTokens: null,
+      totalTokens: 9_007_199_254_740_996,
+      totalTokensExact: 9_007_199_254_740_996n,
+      attributedTokens: 9_007_199_254_740_995n,
+    });
+
+    // The collapse being guarded against: as Numbers the operands are equal.
+    expect(Number(candidate.attributedTokens)).toBe(
+      Number(candidate.totalTokensExact)
+    );
+
+    expect(classifyUnknowableReason(candidate)).toBe("unattributed_tokens");
+
+    const stats = aggregateUnknowableStats([candidate]);
+    expect(stats.byReason.unattributed_tokens).toBe(1);
+    expect(stats.byReason.unknown).toBe(0);
+    expect(stats.unattributedTokens).toBe(1n);
+    expect(stats.unknowableTotalTokens).toBe(9_007_199_254_740_996n);
   });
 });

--- a/packages/frontend/src/lib/moderation/candidates.ts
+++ b/packages/frontend/src/lib/moderation/candidates.ts
@@ -53,6 +53,27 @@ function toNumber(value: number | string | null | undefined): number {
 }
 
 /**
+ * Exact counterpart of toNumber() for the completeness gate's own operands.
+ * The gate compares SUM(numeric) >= bigint in SQL, and above 2^53 a Number
+ * round-trip collapses a real one-token shortfall into apparent equality —
+ * classifyUnknowableReason() would then report `unknown` and the measured gap
+ * would be zero, on exactly the totals large enough to matter. postgres-js
+ * hands both column types over as decimal strings; keep the integral part
+ * digit-for-digit and never round. Garbage degrades to 0n the way toNumber()
+ * degrades to 0, so a driver surprise cannot throw the whole queue away.
+ */
+function toBigInt(value: number | string | null | undefined): bigint {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? BigInt(Math.trunc(value)) : 0n;
+  }
+  if (typeof value === "string") {
+    const integral = /^-?\d+/.exec(value.trim());
+    return integral ? BigInt(integral[0]) : 0n;
+  }
+  return 0n;
+}
+
+/**
  * Builds the review queue: every user with at least one suspicion signal, plus
  * everyone currently hidden so past decisions stay visible and reversible.
  *
@@ -352,7 +373,8 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
     slopTokens: row.slop_tokens == null ? null : toNumber(row.slop_tokens),
     hasOverNestedEntry: row.has_over_nested_entry === true,
     everyDayAttributed: row.every_day_attributed === true,
-    attributedTokens: toNumber(row.attributed_tokens),
+    attributedTokens: toBigInt(row.attributed_tokens),
+    totalTokensExact: toBigInt(row.total_tokens),
   }));
 
   const stats = aggregateUnknowableStats(rows);
@@ -370,8 +392,11 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
       knowable: stats.knowable,
       unknowable: stats.unknowable,
       byReason: stats.byReason,
-      unattributedTokens: stats.unattributedTokens,
-      unknowableTotalTokens: stats.unknowableTotalTokens,
+      // Decimal strings, not numbers: JSON.stringify throws on a bigint, and
+      // a Number here would round away exactly the sub-2^53 precision the
+      // bigint pipeline exists to keep.
+      unattributedTokens: stats.unattributedTokens.toString(),
+      unknowableTotalTokens: stats.unknowableTotalTokens.toString(),
       unattributedHistogram: stats.unattributedHistogram,
     })}`
   );

--- a/packages/frontend/src/lib/moderation/candidates.ts
+++ b/packages/frontend/src/lib/moderation/candidates.ts
@@ -6,6 +6,8 @@ import {
   MEDIAN_RATIO_THRESHOLD,
   SLOP_MODEL_REGEX,
   UNNAMED_MODEL_REGEX,
+  UNKNOWABLE_EVENT,
+  aggregateUnknowableStats,
   rankCandidates,
   SITE_SHARE_THRESHOLD,
   type CandidateRow,
@@ -32,6 +34,9 @@ interface CandidateDbRow extends Record<string, unknown> {
   near_duplicate_count: number | string | null;
   slop_models: string[] | null;
   slop_tokens: number | string | null;
+  has_over_nested_entry: boolean | null;
+  every_day_attributed: boolean | null;
+  attributed_tokens: number | string | null;
   site_tokens: number | string | null;
   median_tokens: number | string | null;
 }
@@ -311,7 +316,20 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
     SELECT
       user_id, username, avatar_url, leaderboard_hidden, total_tokens,
       total_cost, submit_count, has_backfill, daily_tokens,
-      near_duplicate_count, slop_models, slop_tokens, site_tokens, median_tokens
+      near_duplicate_count, slop_models, slop_tokens,
+      -- Observability for the fail-closed completeness gate above, NOT inputs
+      -- to the decision: they re-export the gate's own clause values verbatim
+      -- so the application can report which clause failed without
+      -- re-deriving it. The attribution CTEs are scoped to submissions with a
+      -- slop model match, so these come back NULL anywhere else and must not
+      -- be read as a verdict for non-slop accounts.
+      (SELECT su.has_over_nested_entry FROM slop_usage su
+        WHERE su.submission_id = eligible.submission_id) AS has_over_nested_entry,
+      (SELECT dl.every_day_attributed FROM daily dl
+        WHERE dl.submission_id = eligible.submission_id) AS every_day_attributed,
+      (SELECT su.attributed_tokens FROM slop_usage su
+        WHERE su.submission_id = eligible.submission_id) AS attributed_tokens,
+      site_tokens, median_tokens
     FROM eligible
   `);
 
@@ -334,7 +352,30 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
     nearDuplicateCount: toNumber(row.near_duplicate_count),
     slopModels: Array.isArray(row.slop_models) ? row.slop_models : [],
     slopTokens: row.slop_tokens == null ? null : toNumber(row.slop_tokens),
+    hasOverNestedEntry: row.has_over_nested_entry === true,
+    everyDayAttributed: row.every_day_attributed === true,
+    attributedTokens: toNumber(row.attributed_tokens),
   }));
+
+  const stats = aggregateUnknowableStats(rows);
+  // One structured line per invocation, only when the fail-closed path fired.
+  // This is the telemetry the breadth question is answered from: aggregate by
+  // event over any log window to get the fraction of slop-matched submissions
+  // that were unknowable, broken down by which gate clause failed and how
+  // many of their tokens no named model accounts for.
+  if (stats.unknowable > 0) {
+    console.warn(
+      `[moderation] ${JSON.stringify({
+        event: UNKNOWABLE_EVENT,
+        knowable: stats.knowable,
+        unknowable: stats.unknowable,
+        byReason: stats.byReason,
+        unattributedTokens: stats.unattributedTokens,
+        unknowableTotalTokens: stats.unknowableTotalTokens,
+        unattributedHistogram: stats.unattributedHistogram,
+      })}`
+    );
+  }
 
   return rankCandidates(rows, {
     siteTokens: toNumber(dbRows[0].site_tokens),

--- a/packages/frontend/src/lib/moderation/candidates.ts
+++ b/packages/frontend/src/lib/moderation/candidates.ts
@@ -335,10 +335,6 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
 
   const dbRows = (result as unknown as CandidateDbRow[]) ?? [];
 
-  if (dbRows.length === 0) {
-    return [];
-  }
-
   const rows: CandidateRow[] = dbRows.map((row) => ({
     userId: row.user_id,
     username: row.username,
@@ -358,23 +354,28 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
   }));
 
   const stats = aggregateUnknowableStats(rows);
-  // One structured line per invocation, only when the fail-closed path fired.
-  // This is the telemetry the breadth question is answered from: aggregate by
-  // event over any log window to get the fraction of slop-matched submissions
-  // that were unknowable, broken down by which gate clause failed and how
-  // many of their tokens no named model accounts for.
-  if (stats.unknowable > 0) {
-    console.warn(
-      `[moderation] ${JSON.stringify({
-        event: UNKNOWABLE_EVENT,
-        knowable: stats.knowable,
-        unknowable: stats.unknowable,
-        byReason: stats.byReason,
-        unattributedTokens: stats.unattributedTokens,
-        unknowableTotalTokens: stats.unknowableTotalTokens,
-        unattributedHistogram: stats.unattributedHistogram,
-      })}`
-    );
+  // One structured line per invocation, unconditionally. This is the
+  // telemetry the breadth question is answered from: aggregate by event over
+  // any log window to get the fraction of slop-matched submissions that were
+  // unknowable, broken down by which gate clause failed and how many of their
+  // tokens no named model accounts for. The line must also fire when nothing
+  // was unknowable — the rate is a fraction, and a fully-knowable window has
+  // to contribute its denominator; emitting only failures cannot distinguish
+  // "nothing failed" from "nothing was measured".
+  console.warn(
+    `[moderation] ${JSON.stringify({
+      event: UNKNOWABLE_EVENT,
+      knowable: stats.knowable,
+      unknowable: stats.unknowable,
+      byReason: stats.byReason,
+      unattributedTokens: stats.unattributedTokens,
+      unknowableTotalTokens: stats.unknowableTotalTokens,
+      unattributedHistogram: stats.unattributedHistogram,
+    })}`
+  );
+
+  if (dbRows.length === 0) {
+    return [];
   }
 
   return rankCandidates(rows, {

--- a/packages/frontend/src/lib/moderation/candidates.ts
+++ b/packages/frontend/src/lib/moderation/candidates.ts
@@ -285,6 +285,19 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
           THEN COALESCE(su.slop_tokens, 0)
           ELSE NULL
         END AS slop_tokens,
+        -- Observability for the fail-closed completeness gate above, NOT
+        -- inputs to the decision: they re-export the gate's own clause values
+        -- verbatim so the application can report which clause failed without
+        -- re-deriving it. Projected through these existing joins rather than
+        -- read back by correlated subqueries in the outer SELECT — a second
+        -- reference to a CTE makes PostgreSQL materialize it, and the
+        -- correlated lookup then rescans the unindexed tuplestore once per
+        -- eligible row. The attribution CTEs are scoped to submissions with a
+        -- slop model match, so these come back NULL anywhere else and must
+        -- not be read as a verdict for non-slop accounts.
+        su.has_over_nested_entry AS has_over_nested_entry,
+        dl.every_day_attributed AS every_day_attributed,
+        su.attributed_tokens AS attributed_tokens,
         CASE WHEN p.total_tokens > 0 THEN
           COUNT(*) OVER (
             ORDER BY p.total_tokens
@@ -317,18 +330,7 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
       user_id, username, avatar_url, leaderboard_hidden, total_tokens,
       total_cost, submit_count, has_backfill, daily_tokens,
       near_duplicate_count, slop_models, slop_tokens,
-      -- Observability for the fail-closed completeness gate above, NOT inputs
-      -- to the decision: they re-export the gate's own clause values verbatim
-      -- so the application can report which clause failed without
-      -- re-deriving it. The attribution CTEs are scoped to submissions with a
-      -- slop model match, so these come back NULL anywhere else and must not
-      -- be read as a verdict for non-slop accounts.
-      (SELECT su.has_over_nested_entry FROM slop_usage su
-        WHERE su.submission_id = eligible.submission_id) AS has_over_nested_entry,
-      (SELECT dl.every_day_attributed FROM daily dl
-        WHERE dl.submission_id = eligible.submission_id) AS every_day_attributed,
-      (SELECT su.attributed_tokens FROM slop_usage su
-        WHERE su.submission_id = eligible.submission_id) AS attributed_tokens,
+      has_over_nested_entry, every_day_attributed, attributed_tokens,
       site_tokens, median_tokens
     FROM eligible
   `);

--- a/packages/frontend/src/lib/moderation/heuristics.ts
+++ b/packages/frontend/src/lib/moderation/heuristics.ts
@@ -59,6 +59,19 @@ export interface CandidateRow {
    * condition as a subtraction.
    */
   slopTokens: number | null;
+  /**
+   * The completeness gate's own clause values, re-exported from the
+   * candidates query so the unknowable-reason classification
+   * (aggregateUnknowableStats) reports the gate's actual inputs rather than
+   * re-deriving them. Only meaningful on rows with a slop model match — the
+   * attribution CTEs are scoped to those in SQL; the values below are the
+   * NULL-coalesced defaults anywhere else and must not be read as a verdict
+   * for non-slop accounts.
+   */
+  hasOverNestedEntry: boolean;
+  everyDayAttributed: boolean;
+  /** Tokens the daily rows attribute to SOME named model. */
+  attributedTokens: number;
 }
 
 export interface CandidateContext {
@@ -84,6 +97,153 @@ export interface CandidateSignal {
 export interface ScoredCandidate extends CandidateRow {
   score: number;
   signals: CandidateSignal[];
+}
+
+/**
+ * Why a slop-matched candidate's token attribution came back unknowable
+ * (`slopTokens === null`). Exists for observability, not scoring: the
+ * fail-closed decision lives in the candidates query's completeness gate, and
+ * this classification re-derives which clause of that gate failed so an
+ * operator can tell how often the fail-closed path fires and why.
+ */
+export type UnknowableReason =
+  /**
+   * At least one daily_breakdown row carries no source_breakdown at all
+   * (legacy pre-breakdown shape). every_day_attributed failed.
+   */
+  | "missing_breakdown"
+  /**
+   * At least one client entry's per-model map sums past the entry's own
+   * scalar, so the entry contradicts itself (over_nested). This dominates the
+   * other classes: a contradictory entry is never repaired by better
+   * arithmetic elsewhere in the same submission.
+   */
+  | "over_nested"
+  /**
+   * Every row has a breakdown and no entry contradicts itself, but the
+   * attributed sum still falls short of the stored total: a scalar remainder
+   * no modelId claims, or tokens parked under a key that names nothing
+   * (unknown / parser debris). attributed_tokens < total_tokens.
+   */
+  | "unattributed_tokens"
+  /**
+   * The completeness gate failed but none of the three known clauses can be
+   * the cause — the SQL drifted ahead of this classifier. Distinct so a
+   * drifted gate surfaces as its own bucket in the telemetry instead of being
+   * misattributed to one of the measured classes.
+   */
+  | "unknown";
+
+/**
+ * One invocation's breadth measurement: how many slop-matched candidates the
+ * fail-closed path swallowed, by reason, and the share of those candidates'
+ * tokens that no named model accounts for. Percentages are computed by the
+ * consumer (log pipeline, dashboard) over whatever window it aggregates.
+ */
+export interface UnknowableStats {
+  /** Candidates naming a slop model whose slopTokens could be computed. */
+  knowable: number;
+  /** Candidates naming a slop model whose slopTokens came back null. */
+  unknowable: number;
+  byReason: Record<UnknowableReason, number>;
+  /**
+   * Sum over unknowable candidates of GREATEST(total - attributed, 0) — the
+   * tokens no named model accounts for. The clamp is defence against the
+   * attributed sum overshooting the stored total on drifted data; on
+   * well-formed rows the gate itself guarantees attributed < total.
+   */
+  unattributedTokens: number;
+  /** Sum of unknowable candidates' stored totals. */
+  unknowableTotalTokens: number;
+  /**
+   * Log-scale histogram of per-candidate unattributed tokens over the
+   * unknowable set: key n counts candidates with at least
+   * 2**n * UNKNOWABLE_BUCKET_WIDTH unattributed tokens. The flat
+   * unattributedTokens / unknowableTotalTokens pair cannot say whether the
+   * missing share is a rounding error or the whole submission — one account
+   * missing 99% and nine missing 1% aggregate identically — and whether it
+   * is one large account or many small ones decides whether the fail-closed
+   * path is a rare safety net or a routine outcome.
+   */
+  unattributedHistogram: Record<string, number>;
+}
+
+/** Bucket boundaries for the unattributed-tokens histogram. */
+const UNKNOWABLE_HISTOGRAM_BUCKETS = 8;
+
+/**
+ * Classifies one candidate's NULL slopTokens into the gate clause that
+ * produced it. Checked in dominance order: an over-nested entry makes the
+ * whole submission unknowable whatever else is true of it, and a missing
+ * breakdown makes the attributed sum unobservable rather than merely short.
+ */
+export function classifyUnknowableReason(row: CandidateRow): UnknowableReason {
+  if (row.hasOverNestedEntry) {
+    return "over_nested";
+  }
+  if (!row.everyDayAttributed) {
+    return "missing_breakdown";
+  }
+  if (row.attributedTokens < row.totalTokens) {
+    return "unattributed_tokens";
+  }
+  return "unknown";
+}
+
+/**
+ * Aggregates one getModerationCandidates() result into the fail-closed
+ * breadth measurement. Only candidates with at least one slop model name are
+ * counted at all: the attribution work is scoped to them in SQL, so a
+ * non-slop account says nothing about how often the path fires.
+ */
+export function aggregateUnknowableStats(
+  candidates: readonly CandidateRow[]
+): UnknowableStats {
+  const stats: UnknowableStats = {
+    knowable: 0,
+    unknowable: 0,
+    byReason: {
+      missing_breakdown: 0,
+      over_nested: 0,
+      unattributed_tokens: 0,
+      unknown: 0,
+    },
+    unattributedTokens: 0,
+    unknowableTotalTokens: 0,
+    unattributedHistogram: Object.fromEntries(
+      Array.from({ length: UNKNOWABLE_HISTOGRAM_BUCKETS }, (_, i) => [
+        String(2 ** i * UNKNOWABLE_BUCKET_WIDTH),
+        0,
+      ])
+    ),
+  };
+
+  for (const candidate of candidates) {
+    if (candidate.slopModels.length === 0) {
+      continue;
+    }
+    if (candidate.slopTokens !== null) {
+      stats.knowable += 1;
+      continue;
+    }
+    stats.unknowable += 1;
+    stats.byReason[classifyUnknowableReason(candidate)] += 1;
+    const unattributed = Math.max(
+      0,
+      candidate.totalTokens - candidate.attributedTokens
+    );
+    stats.unattributedTokens += unattributed;
+    stats.unknowableTotalTokens += candidate.totalTokens;
+    for (
+      let boundary = UNKNOWABLE_BUCKET_WIDTH;
+      boundary <= unattributed;
+      boundary *= 2
+    ) {
+      stats.unattributedHistogram[String(boundary)] += 1;
+    }
+  }
+
+  return stats;
 }
 
 /**
@@ -175,6 +335,25 @@ export const SLOP_MODEL_REGEX = `(^|[^a-z0-9])(${SLOP_MODEL_PATTERNS.join("|")})
  * would pin accounts at full weight on a guess.
  */
 export const UNNAMED_MODEL_REGEX = `^([^a-zA-Z0-9]*|unknown)$`;
+
+/**
+ * Width of one measurement bucket for the unknowable-breadth telemetry, in
+ * tokens. Each bucket boundary is 2**n * UNKNOWABLE_BUCKET_WIDTH, so bucket
+ * n reads as "[2**n * width, 2**(n+1) * width) tokens unattributed". Fixed by
+ * the emitted log schema: widening it re-baselines every aggregate built on
+ * the bucket keys, so it is a constant, not a config knob.
+ */
+export const UNKNOWABLE_BUCKET_WIDTH = 1_000_000;
+
+/**
+ * The single structured-log event name the fail-closed breadth telemetry is
+ * emitted under. One line per getModerationCandidates() invocation in which
+ * at least one slop-matched candidate's token share was unknowable; the JSON
+ * payload carries the counts, per-reason breakdown, and unattributed-token
+ * histogram. Operators aggregate by `event` over any log window to answer
+ * "what fraction of submissions went unknowable in window W".
+ */
+export const UNKNOWABLE_EVENT = "moderation_unknowable_submissions";
 
 /** A user holding more than this share of all tokens is worth a look. */
 export const SITE_SHARE_THRESHOLD = 0.05;

--- a/packages/frontend/src/lib/moderation/heuristics.ts
+++ b/packages/frontend/src/lib/moderation/heuristics.ts
@@ -158,7 +158,9 @@ export interface UnknowableStats {
   /**
    * Log-scale histogram of per-candidate unattributed tokens over the
    * unknowable set: key n counts candidates with at least
-   * 2**n * UNKNOWABLE_BUCKET_WIDTH unattributed tokens. The flat
+   * 2**n * UNKNOWABLE_BUCKET_WIDTH unattributed tokens. The largest key is
+   * open-ended — a gap beyond it lands there rather than under a key the
+   * allocation never made. The flat
    * unattributedTokens / unknowableTotalTokens pair cannot say whether the
    * missing share is a rounding error or the whole submission — one account
    * missing 99% and nine missing 1% aggregate identically — and whether it
@@ -234,9 +236,18 @@ export function aggregateUnknowableStats(
     );
     stats.unattributedTokens += unattributed;
     stats.unknowableTotalTokens += candidate.totalTokens;
+    // Cap the walk at the largest allocated key: a gap past it still counts
+    // in every bucket up to and including the top one, instead of minting a
+    // key the allocation above never made — `undefined + 1` is NaN, which
+    // JSON.stringify then serializes as null, corrupting the telemetry on
+    // exactly the largest accounts.
+    const cap = Math.min(
+      unattributed,
+      2 ** (UNKNOWABLE_HISTOGRAM_BUCKETS - 1) * UNKNOWABLE_BUCKET_WIDTH
+    );
     for (
       let boundary = UNKNOWABLE_BUCKET_WIDTH;
-      boundary <= unattributed;
+      boundary <= cap;
       boundary *= 2
     ) {
       stats.unattributedHistogram[String(boundary)] += 1;

--- a/packages/frontend/src/lib/moderation/heuristics.ts
+++ b/packages/frontend/src/lib/moderation/heuristics.ts
@@ -358,8 +358,10 @@ export const UNKNOWABLE_BUCKET_WIDTH = 1_000_000;
 
 /**
  * The single structured-log event name the fail-closed breadth telemetry is
- * emitted under. One line per getModerationCandidates() invocation in which
- * at least one slop-matched candidate's token share was unknowable; the JSON
+ * emitted under. One line per getModerationCandidates() invocation,
+ * unconditionally: a window where every slop-matched candidate was knowable
+ * still contributes its denominator (knowable > 0, unknowable = 0) instead of
+ * silence, so the rate is derivable rather than only its failures. The JSON
  * payload carries the counts, per-reason breakdown, and unattributed-token
  * histogram. Operators aggregate by `event` over any log window to answer
  * "what fraction of submissions went unknowable in window W".

--- a/packages/frontend/src/lib/moderation/heuristics.ts
+++ b/packages/frontend/src/lib/moderation/heuristics.ts
@@ -70,8 +70,23 @@ export interface CandidateRow {
    */
   hasOverNestedEntry: boolean;
   everyDayAttributed: boolean;
-  /** Tokens the daily rows attribute to SOME named model. */
-  attributedTokens: number;
+  /**
+   * Tokens the daily rows attribute to SOME named model — the gate's left
+   * operand, held as bigint because PostgreSQL decides the gate over
+   * numeric/bigint and production totals exceed Number.MAX_SAFE_INTEGER. A
+   * one-token shortfall above 2^53 rounds into apparent equality as a Number,
+   * which would misclassify the failure as `unknown` and zero the measured
+   * gap.
+   */
+  attributedTokens: bigint;
+  /**
+   * The gate's right operand (`submissions.total_tokens`) at full precision.
+   * `totalTokens` above is the same value as a Number for scoring ratios and
+   * the UI, where a few units of drift at 10^15 cannot move a threshold;
+   * every comparison or subtraction against `attributedTokens` must use this
+   * field instead.
+   */
+  totalTokensExact: bigint;
 }
 
 export interface CandidateContext {
@@ -94,7 +109,14 @@ export interface CandidateSignal {
   weight: number;
 }
 
-export interface ScoredCandidate extends CandidateRow {
+/**
+ * The bigint gate operands are stripped rather than inherited: a scored
+ * candidate is what the admin route serializes with NextResponse.json, and
+ * JSON.stringify throws on bigint. They exist for the unknowable-reason
+ * classification and telemetry, which consume CandidateRow directly.
+ */
+export interface ScoredCandidate
+  extends Omit<CandidateRow, "attributedTokens" | "totalTokensExact"> {
   score: number;
   signals: CandidateSignal[];
 }
@@ -150,11 +172,13 @@ export interface UnknowableStats {
    * Sum over unknowable candidates of GREATEST(total - attributed, 0) — the
    * tokens no named model accounts for. The clamp is defence against the
    * attributed sum overshooting the stored total on drifted data; on
-   * well-formed rows the gate itself guarantees attributed < total.
+   * well-formed rows the gate itself guarantees attributed < total. Held as
+   * bigint end-to-end: the operands are exact off the driver, and a Number
+   * detour would erase one-token gaps above 2^53.
    */
-  unattributedTokens: number;
-  /** Sum of unknowable candidates' stored totals. */
-  unknowableTotalTokens: number;
+  unattributedTokens: bigint;
+  /** Sum of unknowable candidates' stored totals, exact for the same reason. */
+  unknowableTotalTokens: bigint;
   /**
    * Log-scale histogram of per-candidate unattributed tokens over the
    * unknowable set: key n counts candidates with at least
@@ -186,7 +210,7 @@ export function classifyUnknowableReason(row: CandidateRow): UnknowableReason {
   if (!row.everyDayAttributed) {
     return "missing_breakdown";
   }
-  if (row.attributedTokens < row.totalTokens) {
+  if (row.attributedTokens < row.totalTokensExact) {
     return "unattributed_tokens";
   }
   return "unknown";
@@ -210,8 +234,8 @@ export function aggregateUnknowableStats(
       unattributed_tokens: 0,
       unknown: 0,
     },
-    unattributedTokens: 0,
-    unknowableTotalTokens: 0,
+    unattributedTokens: 0n,
+    unknowableTotalTokens: 0n,
     unattributedHistogram: Object.fromEntries(
       Array.from({ length: UNKNOWABLE_HISTOGRAM_BUCKETS }, (_, i) => [
         String(2 ** i * UNKNOWABLE_BUCKET_WIDTH),
@@ -230,24 +254,26 @@ export function aggregateUnknowableStats(
     }
     stats.unknowable += 1;
     stats.byReason[classifyUnknowableReason(candidate)] += 1;
-    const unattributed = Math.max(
-      0,
-      candidate.totalTokens - candidate.attributedTokens
-    );
+    // bigint throughout: the gate operands are exact off the driver, and a
+    // Math.max/Math.min detour through Number would round a real one-token
+    // shortfall above 2^53 back into the zero gap this exists to measure.
+    const unattributed =
+      candidate.totalTokensExact > candidate.attributedTokens
+        ? candidate.totalTokensExact - candidate.attributedTokens
+        : 0n;
     stats.unattributedTokens += unattributed;
-    stats.unknowableTotalTokens += candidate.totalTokens;
+    stats.unknowableTotalTokens += candidate.totalTokensExact;
     // Cap the walk at the largest allocated key: a gap past it still counts
     // in every bucket up to and including the top one, instead of minting a
     // key the allocation above never made — `undefined + 1` is NaN, which
     // JSON.stringify then serializes as null, corrupting the telemetry on
-    // exactly the largest accounts.
-    const cap = Math.min(
-      unattributed,
-      2 ** (UNKNOWABLE_HISTOGRAM_BUCKETS - 1) * UNKNOWABLE_BUCKET_WIDTH
-    );
+    // exactly the largest accounts. Boundaries are small exact integers, so
+    // lifting one into BigInt for the comparison loses nothing.
+    const maxBoundary =
+      2 ** (UNKNOWABLE_HISTOGRAM_BUCKETS - 1) * UNKNOWABLE_BUCKET_WIDTH;
     for (
       let boundary = UNKNOWABLE_BUCKET_WIDTH;
-      boundary <= cap;
+      boundary <= maxBoundary && BigInt(boundary) <= unattributed;
       boundary *= 2
     ) {
       stats.unattributedHistogram[String(boundary)] += 1;
@@ -363,8 +389,10 @@ export const UNKNOWABLE_BUCKET_WIDTH = 1_000_000;
  * still contributes its denominator (knowable > 0, unknowable = 0) instead of
  * silence, so the rate is derivable rather than only its failures. The JSON
  * payload carries the counts, per-reason breakdown, and unattributed-token
- * histogram. Operators aggregate by `event` over any log window to answer
- * "what fraction of submissions went unknowable in window W".
+ * histogram; the two token sums travel as decimal strings because they are
+ * exact bigints and JSON.stringify refuses a bigint outright. Operators
+ * aggregate by `event` over any log window to answer "what fraction of
+ * submissions went unknowable in window W".
  */
 export const UNKNOWABLE_EVENT = "moderation_unknowable_submissions";
 
@@ -506,8 +534,15 @@ export function scoreCandidate(
     }
   }
 
+  // Strip the bigint gate operands before the spread (see ScoredCandidate):
+  // NextResponse.json would otherwise throw on the first candidate row.
+  const {
+    attributedTokens: _attributedTokens,
+    totalTokensExact: _totalTokensExact,
+    ...serializable
+  } = row;
   return {
-    ...row,
+    ...serializable,
     score: signals.reduce((sum, signal) => sum + signal.weight, 0),
     signals,
   };

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Background

#1289 (`5b7c56ce`) made the moderation candidate query fail closed on token attribution: when a submission's model map cannot account for its tokens, `slop_tokens` is NULLed and the `slopModelName` signal keeps its full fixed weight instead of being scaled down — so a fabrication cannot escape the review queue through partial attribution. The gate fails closed on any of three clauses (in the `enriched` CTE's `CASE`):

- `every_day_attributed = false` — a `daily_breakdown` row carries no `source_breakdown` (legacy shape)
- `has_over_nested_entry = true` — a client entry's per-model map sums past the entry's own scalar (BOOL_OR over entries)
- `attributed_tokens < total_tokens` — a scalar remainder no `modelId` claims, or tokens parked under a key that names nothing (`unknown`, parser debris)

## Why breadth was unmeasurable

In the returned rows a NULL `slopTokens` looks exactly like a computed one from the outside — nothing records that the fail-closed path fired, why, or how much of the submission was unattributable. So the audit's open question — is this a rare safety net, or does it silently swallow a large fraction of submissions? — had no answer.

## What this instruments

No moderation decision changes; this is measurement only.

1. **Query re-exports the gate's own clause values** — `has_over_nested_entry`, `every_day_attributed`, `attributed_tokens` come out as read-only columns via correlated subselects against the existing `slop_usage`/`daily` CTEs (no new scans). They are NULL off the slop-matched set, matching the attribution scope.
2. **`aggregateUnknowableStats()`** (pure, in `heuristics.ts`) classifies each null-`slopTokens` slop-matched candidate into exactly one reason — `over_nested` > `missing_breakdown` > `unattributed_tokens`, plus an `unknown` bucket that catches gate/classifier drift instead of misattributing it — and accumulates: knowable/unknowable counts, per-reason counts, total unattributed tokens, and a log-scale histogram (bucket width 1M tokens, doubling) of per-candidate unattributed tokens, so "one large account" is distinguishable from "many small ones".
3. **One structured log line per invocation**, emitted only when the path fired, via `console.warn("[moderation] " + JSON)` — the same server-side logging channel the rest of the moderation code already uses (`console.error("[moderation] ...")` in `actions.ts`).

Sample output (from the integration fixture):

```
[moderation] {"event":"moderation_unknowable_submissions","knowable":6,"unknowable":11,"byReason":{"missing_breakdown":1,"over_nested":5,"unattributed_tokens":5,"unknown":0},"unattributedTokens":20100990,"unknowableTotalTokens":32900000,"unattributedHistogram":{"1000000":8,"2000000":6,"4000000":1,"8000000":0,"16000000":0,"32000000":0,"64000000":0,"128000000":0}}
```

## How an operator queries the breadth

The deployment's log pipeline (Vercel) sees these lines; aggregate by `event: "moderation_unknowable_submissions"` over any window W:

- **Fraction unknowable** = `sum(unknowable) / (sum(unknowable) + sum(knowable))`
- **Dominant failure class** = group-sum of `byReason`
- **Severity** = `unattributedTokens / unknowableTotalTokens`, with `unattributedHistogram` distinguishing a few heavily-unattributed accounts from broad shallow gaps
- **Gate drift** = any nonzero `byReason.unknown` means the SQL gate now fails on a clause this classifier does not know

## Tests

- `__tests__/lib/moderationHeuristics.test.ts` — 8 new unit tests for `classifyUnknowableReason` (dominance order, drift bucket) and `aggregateUnknowableStats` (scoping to slop-matched rows, histogram bucketing, negative-gap clamp).
- `__tests__/integration/moderationCandidatesPostgres.test.ts` (`MODERATION_CANDIDATES_DB_INTEGRATION=1`, real postgres:16) — 2 new tests: the emitted line covers exactly the fail-closed persona set with the measured per-reason counts, unattributed sums, and histogram; and a slop-less account with NULL `slop_tokens` moves none of the counters.

## Gate results (run locally in this worktree)

- `bun run test` (vitest, full frontend suite): **993 passed, 25 skipped** (88 files)
- `MODERATION_CANDIDATES_DB_INTEGRATION=1 bun run test:moderation:db` against local `postgres:16`: **19/19 passed**
- `bun run typecheck` (`tsc --noEmit`): clean
- `bun run lint` (eslint): 0 errors, 17 warnings — all pre-existing in files this PR does not touch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Measures how often the moderation candidates query fail-closes on token attribution, without changing any moderation decision. Previously a NULL `slopTokens` was indistinguishable from a computed value, so the fail-closed path's breadth was unmeasurable; now one structured log line per invocation records the knowable/unknowable counts, per-reason breakdown, and an unattributed-token histogram. The gate's token operands are compared as exact bigints so a one-token shortfall above 2^53 still classifies correctly instead of rounding into apparent equality.

**Observability**
- Re-exports the gate's clause values (`has_over_nested_entry`, `every_day_attributed`, `attributed_tokens`) as read-only columns.
- `aggregateUnknowableStats()` classifies each null-`slopTokens` candidate into one reason and aggregates counts, unattributed tokens, and a log-scale histogram; token sums emit as decimal strings since `JSON.stringify` refuses bigints.
- The line fires even when every candidate is knowable, so a zero-failure window contributes its denominator; the top histogram bucket is open-ended; `ScoredCandidate` strips the bigint fields before serialization, and `tsconfig` target bumps to ES2020 for bigint literals.

<sup>Written for commit 4824116522d7b69a6bd995359b8158d80abe7c35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

