### PR TITLE
fix(submit): reconcile Droid snapshot costs across days

### DIFF
--- a/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
+++ b/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SUPPORTED_VERSIONED_PARSERS } from "../../src/lib/db/parserHighWater";
+import type { ClientBreakdownData } from "../../src/lib/db/helpers";
 
 // End-to-end regression for the Antigravity CLI re-attribution.
 //
@@ -158,14 +159,7 @@ function collectStrings(
   }
 }
 
-type StoredBreakdown = Record<
-  string,
-  {
-    tokens: number;
-    cost?: number;
-    provenance?: { costIsComplete?: boolean };
-  }
->;
+type StoredBreakdown = Record<string, ClientBreakdownData>;
 
 type PersistedDay = {
   id: string;
@@ -687,6 +681,225 @@ describe("POST /api/submit antigravity (IDE) re-attribution high-water", () => {
 });
 
 describe("POST /api/submit droid snapshot layout", () => {
+  function snapshotBody(
+    days: Array<{
+      date: string;
+      costIsComplete: boolean;
+      models: Array<{ modelId: string; tokens: number; cost: number; messages: number }>;
+    }>,
+  ) {
+    const body = submissionBody("droid", []);
+    const dates = days.map(({ date }) => date).sort();
+    return {
+      ...body,
+      meta: { ...body.meta, dateRange: { start: dates[0], end: dates[dates.length - 1] } },
+      contributions: days.map((day) => ({
+        date: day.date,
+        totals: { costIsComplete: day.costIsComplete },
+        clients: day.models.map((model) => ({
+          client: "droid",
+          modelId: model.modelId,
+          tokens: { input: model.tokens, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+          cost: model.cost,
+          messages: model.messages,
+        })),
+      })),
+    };
+  }
+
+  async function submitSnapshot(store: Store, body: ReturnType<typeof snapshotBody>) {
+    installTx(store);
+    mockSubmit(body);
+    const response = await post(body);
+    expect(response.status).toBe(200);
+    return response.json();
+  }
+
+  function expectSnapshotLayout(store: Store, body: ReturnType<typeof snapshotBody>) {
+    for (const day of body.contributions) {
+      const cell = store.days.find((stored) => stored.date === day.date)!.sourceBreakdown.droid;
+      expect(Object.keys(cell.models).sort()).toEqual(day.clients.map(({ modelId }) => modelId).sort());
+      for (const client of day.clients) {
+        expect(cell.models[client.modelId]).toMatchObject({
+          tokens: client.tokens.input,
+          input: client.tokens.input,
+          messages: client.messages,
+        });
+      }
+      const models = Object.values(cell.models);
+      expect(cell.tokens).toBe(models.reduce((sum, model) => sum + model.tokens, 0));
+      expect(cell.messages).toBe(models.reduce((sum, model) => sum + model.messages, 0));
+      expect(cell.cost).toBeCloseTo(models.reduce((sum, model) => sum + model.cost, 0), 8);
+    }
+  }
+
+  const originalSnapshot = () => snapshotBody([{
+    date: "2026-08-07",
+    costIsComplete: false,
+    models: [
+      { modelId: "gemini-3-pro", tokens: 100_000, cost: 100, messages: 2 },
+      { modelId: "unknown", tokens: 2, cost: 0, messages: 2 },
+    ],
+  }]);
+
+  it.each([false, true])("reconciles overlapping partially priced days once per lifetime (legacy=%s)", async (legacy) => {
+    const store = newStore();
+    await submitSnapshot(store, originalSnapshot());
+    if (legacy) {
+      store.device.parserVersions = {};
+      store.device.parserStates = {};
+    }
+    const rewritten = snapshotBody([
+      { date: "2026-08-07", costIsComplete: false, models: [
+        { modelId: "gemini-3-pro", tokens: 40_000, cost: 40, messages: 1 },
+        { modelId: "unknown", tokens: 1, cost: 0, messages: 1 },
+      ] },
+      { date: "2026-08-08", costIsComplete: false, models: [
+        { modelId: "gemini-3-pro", tokens: 60_000, cost: 60, messages: 1 },
+        { modelId: "unknown", tokens: 1, cost: 0, messages: 1 },
+      ] },
+    ]);
+    for (let replay = 0; replay < 3; replay++) {
+      const json = await submitSnapshot(store, rewritten);
+      expectSnapshotLayout(store, rewritten);
+      expect(storedTokens(store)).toBe(100_002);
+      expect(storedCost(store)).toBe(100);
+      expect(json.metrics.totalCost).toBe(100);
+      expect(store.days.every(({ sourceBreakdown }) => sourceBreakdown.droid.provenance?.costIsComplete === false)).toBe(true);
+    }
+  });
+
+  it("removes moved models from an incomplete source day without duplicating their cost", async () => {
+    const store = newStore();
+    await submitSnapshot(store, originalSnapshot());
+    const rewritten = snapshotBody([
+      { date: "2026-08-07", costIsComplete: false, models: [
+        { modelId: "unknown", tokens: 2, cost: 0, messages: 2 },
+      ] },
+      { date: "2026-08-08", costIsComplete: true, models: [
+        { modelId: "gemini-3-pro", tokens: 100_000, cost: 100, messages: 2 },
+      ] },
+    ]);
+    for (let replay = 0; replay < 2; replay++) {
+      await submitSnapshot(store, rewritten);
+      expectSnapshotLayout(store, rewritten);
+      expect(storedCost(store)).toBe(100);
+    }
+  });
+
+  it("keeps only the lifetime deficit across replays and clears it when pricing recovers", async () => {
+    const store = newStore();
+    await submitSnapshot(store, originalSnapshot());
+    const rewritten = snapshotBody([
+      { date: "2026-08-07", costIsComplete: false, models: [
+        { modelId: "gemini-3-pro", tokens: 40_000, cost: 10, messages: 1 },
+        { modelId: "unknown", tokens: 1, cost: 0, messages: 1 },
+      ] },
+      { date: "2026-08-08", costIsComplete: false, models: [
+        { modelId: "gemini-3-pro", tokens: 60_000, cost: 20, messages: 1 },
+        { modelId: "unknown", tokens: 1, cost: 0, messages: 1 },
+      ] },
+    ]);
+    await submitSnapshot(store, rewritten);
+    expect(storedCost(store)).toBeCloseTo(100, 8);
+    expectSnapshotLayout(store, rewritten);
+    const beforeReplay = structuredClone(store.days);
+    await submitSnapshot(store, rewritten);
+    expect(store.days).toEqual(beforeReplay);
+
+    // A complete resubmit supplies the authoritative price and may correct
+    // a prior floor downward, including cost inflated by the old merge.
+    for (const day of rewritten.contributions) day.totals.costIsComplete = true;
+    await submitSnapshot(store, rewritten);
+    expect(storedCost(store)).toBe(30);
+    expectSnapshotLayout(store, rewritten);
+    expect(store.days.every(({ sourceBreakdown }) => sourceBreakdown.droid.provenance?.costIsComplete !== false)).toBe(true);
+  });
+
+  it("keeps rounding residuals on the same dates and models after new rows become updates", async () => {
+    const store = newStore();
+    const models = ["z-model", "a-model", "m-model", "b-model"].map((modelId) => ({
+      modelId, tokens: 1, cost: 0, messages: 1,
+    }));
+    const original = snapshotBody([{
+      date: "2026-08-07", costIsComplete: false,
+      models: models.map((model, index) => ({ ...model, cost: index === 0 ? 0.0014 : 0 })),
+    }]);
+    await submitSnapshot(store, original);
+    const rewritten = snapshotBody(["2026-08-07", "2026-08-08", "2026-08-09", "2026-08-10"].map((date) => ({
+      date, costIsComplete: false, models,
+    })));
+    await submitSnapshot(store, rewritten);
+    expect(storedCost(store)).toBeCloseTo(0.0014, 10);
+    expectSnapshotLayout(store, rewritten);
+    const beforeReplay = structuredClone(store.days);
+    await submitSnapshot(store, rewritten);
+    expect(store.days).toEqual(beforeReplay);
+    rewritten.contributions.reverse();
+    for (const day of rewritten.contributions) day.clients.reverse();
+    await submitSnapshot(store, rewritten);
+    expect(store.days).toEqual(beforeReplay);
+    expectSnapshotLayout(store, rewritten);
+  });
+
+  it("allocates a lifetime deficit only to incomplete Droid days", async () => {
+    const store = newStore();
+    await submitSnapshot(store, originalSnapshot());
+    const rewritten = snapshotBody([
+      { date: "2026-08-07", costIsComplete: false, models: [
+        { modelId: "unknown", tokens: 2, cost: 0, messages: 2 },
+      ] },
+      { date: "2026-08-08", costIsComplete: true, models: [
+        { modelId: "gemini-3-pro", tokens: 100_000, cost: 60, messages: 2 },
+      ] },
+    ]);
+    for (let replay = 0; replay < 3; replay++) {
+      await submitSnapshot(store, rewritten);
+      expectSnapshotLayout(store, rewritten);
+      expect(storedCost(store)).toBe(100);
+      const incomplete = store.days.find(({ date }) => date === "2026-08-07")!.sourceBreakdown.droid;
+      const complete = store.days.find(({ date }) => date === "2026-08-08")!.sourceBreakdown.droid;
+      expect(incomplete.cost).toBe(40);
+      expect(incomplete.provenance?.costIsComplete).toBe(false);
+      expect(complete.cost).toBe(60);
+      expect(complete.models["gemini-3-pro"].cost).toBe(60);
+      expect(complete.provenance?.costIsComplete).not.toBe(false);
+    }
+  });
+
+  it("repairs previously retained model tokens and lets complete pricing correct inflated spend", async () => {
+    const store = newStore();
+    await submitSnapshot(store, originalSnapshot());
+    // Model the already-persisted shape produced by the old day-floor merge.
+    const oldCell = store.days[0].sourceBreakdown.droid;
+    oldCell.models["moved-model"] = { ...oldCell.models["gemini-3-pro"], cost: 60 };
+    oldCell.cost = 160;
+
+    const incomplete = originalSnapshot();
+    await submitSnapshot(store, incomplete);
+    expectSnapshotLayout(store, incomplete);
+    expect(storedCost(store)).toBe(160);
+    const complete = originalSnapshot();
+    complete.contributions[0].totals.costIsComplete = true;
+    await submitSnapshot(store, complete);
+    expectSnapshotLayout(store, complete);
+    expect(storedCost(store)).toBe(100);
+  });
+
+  it("freezes an incomplete partial rescan after a replacement", async () => {
+    const store = newStore();
+    await submitSnapshot(store, originalSnapshot());
+    await submitSnapshot(store, originalSnapshot());
+    const beforePartial = structuredClone(store.days);
+    const partial = snapshotBody([{
+      date: "2026-08-09", costIsComplete: false,
+      models: [{ modelId: "gemini-3-pro", tokens: 200_000, cost: 20, messages: 5 }],
+    }]);
+    partial.scanScope.fullHistory = false;
+    await submitSnapshot(store, partial);
+    expect(store.days).toEqual(beforePartial);
+  });
+
   it("replaces stored Droid days when a full snapshot re-dates the same lifetime", async () => {
     const { store, firstJson, secondJson } = await submitOldThenNew("droid");
 
@@ -741,7 +954,8 @@ describe("POST /api/submit droid snapshot layout", () => {
 
     const startDay = store.days.find((day) => day.date === "2026-08-07");
     expect(startDay?.sourceBreakdown.droid.tokens).toBe(40_000);
-    expect(Number(startDay?.sourceBreakdown.droid.cost)).toBe(240);
+    expect(Number(startDay?.sourceBreakdown.droid.cost)).toBe(40);
+    expect(storedCost(store)).toBe(240);
     expect(startDay?.sourceBreakdown.droid.provenance?.costIsComplete).toBe(
       false,
     );
@@ -838,6 +1052,31 @@ function droidAndClaudeBody(
 }
 
 describe("POST /api/submit droid snapshot layout sibling clients", () => {
+  it("does not floor complete Droid pricing because another client's day is incomplete", async () => {
+    const store = newStore();
+    const first = droidAndClaudeBody([
+      { date: "2026-08-07", droid: 100_000 },
+      { date: "2026-08-08", claude: 1_000 },
+    ]);
+    installTx(store);
+    mockSubmit(first);
+    expect((await post(first)).status).toBe(200);
+
+    const corrected = droidAndClaudeBody([
+      { date: "2026-08-07", droid: 100_000 },
+      { date: "2026-08-08", claude: 1_000 },
+    ]);
+    corrected.contributions[0].clients[0].cost = 50;
+    Object.assign(corrected.contributions[1], { totals: { costIsComplete: false } });
+    installTx(store);
+    mockSubmit(corrected);
+    expect((await post(corrected)).status).toBe(200);
+    const droid = store.days.find(({ date }) => date === "2026-08-07")!.sourceBreakdown.droid;
+    expect(droid.cost).toBe(50);
+    expect(droid.provenance?.costIsComplete).not.toBe(false);
+    expect(store.days.find(({ date }) => date === "2026-08-08")!.sourceBreakdown.claude.cost).toBe(1);
+  });
+
   it("does not report a sibling client as disappeared from a day the snapshot only emptied of Droid", async () => {
     const store = newStore();
 

--- a/packages/frontend/__tests__/lib/helpers.test.ts
+++ b/packages/frontend/__tests__/lib/helpers.test.ts
@@ -226,9 +226,42 @@ describe("applyCostCompleteness", () => {
 });
 
 describe("reapplyReplaceLayoutCostFloors", () => {
+  function incompleteClient(tokens: number, messages: number, modelCount: number): ClientBreakdownData {
+    return {
+      ...makeClient(tokens, messages, modelCount),
+      provenance: { schemaVersion: 1, messageCount: messages, modelCount, costIsComplete: false },
+    };
+  }
+
+  it("does not overspend a rounded deficit across days", () => {
+    const rows = Array.from({ length: 4 }, () => ({
+      sourceBreakdown: { droid: incompleteClient(1, 1, 1) },
+    }));
+    reapplyReplaceLayoutCostFloors(rows, new Map([["droid", 0.0002]]), new Set(["droid"]));
+    expect(rows.reduce((sum, row) => sum + row.sourceBreakdown.droid.cost, 0)).toBeCloseTo(0.0002, 10);
+    expect(rows.every(({ sourceBreakdown }) => sourceBreakdown.droid.cost >= 0)).toBe(true);
+    const beforeReplay = structuredClone(rows);
+    reapplyReplaceLayoutCostFloors(rows, new Map([["droid", 0.0002]]), new Set(["droid"]));
+    expect(rows).toEqual(beforeReplay);
+  });
+
+  it("never subtracts a rounded remainder from the last model", () => {
+    const cell = incompleteClient(1, 1, 4);
+    cell.tokens = 4;
+    cell.messages = 4;
+    reapplyReplaceLayoutCostFloors(
+      [{ sourceBreakdown: { droid: cell } }],
+      new Map([["droid", 0.0002]]),
+      new Set(["droid"]),
+    );
+    expect(Object.values(cell.models).every(({ cost }) => cost >= 0)).toBe(true);
+    expect(Object.values(cell.models).reduce((sum, model) => sum + model.cost, 0)).toBeCloseTo(0.0002, 10);
+    expect(cell.cost).toBeCloseTo(0.0002, 10);
+  });
+
   it("spreads a pre-rewrite cost floor onto days that had no stored cell", () => {
-    const first = makeClient(120_000, 6, 1) as ClientBreakdownData;
-    const second = makeClient(120_000, 6, 1) as ClientBreakdownData;
+    const first = incompleteClient(120_000, 6, 1);
+    const second = incompleteClient(120_000, 6, 1);
     const rows = [{ sourceBreakdown: { droid: first } }, { sourceBreakdown: { droid: second } }];
 
     reapplyReplaceLayoutCostFloors(
@@ -243,7 +276,7 @@ describe("reapplyReplaceLayoutCostFloors", () => {
   });
 
   it("splits a cell's cost floor across models by token share", () => {
-    const cell = makeClient(100_000, 4, 2) as ClientBreakdownData;
+    const cell = incompleteClient(100_000, 4, 2);
     cell.models["model-0"].tokens = 75_000;
     cell.models["model-1"].tokens = 25_000;
     cell.tokens = 100_000;

--- a/packages/frontend/__tests__/lib/helpers.test.ts
+++ b/packages/frontend/__tests__/lib/helpers.test.ts
@@ -259,6 +259,28 @@ describe("reapplyReplaceLayoutCostFloors", () => {
     expect(cell.cost).toBeCloseTo(0.0002, 10);
   });
 
+  it("assigns rounding residuals by model ID order regardless of host locale", () => {
+    const cell = incompleteClient(1, 1, 1);
+    const model = cell.models["model-0"];
+    cell.models = Object.fromEntries(
+      ["ä-model", "z-model", "a-model"].map((id) => [id, { ...model }]),
+    );
+    cell.tokens = 3;
+    cell.messages = 3;
+
+    reapplyReplaceLayoutCostFloors(
+      [{ sourceBreakdown: { droid: cell } }],
+      new Map([["droid", 0.0001]]),
+      new Set(["droid"]),
+    );
+
+    // Locale collation can put ä before z; ordinal ordering always puts it
+    // last, so the same model receives the undistributed 0.0001 on any host.
+    expect(cell.models["a-model"].cost).toBe(0);
+    expect(cell.models["z-model"].cost).toBe(0);
+    expect(cell.models["ä-model"].cost).toBe(0.0001);
+  });
+
   it("spreads a pre-rewrite cost floor onto days that had no stored cell", () => {
     const first = incompleteClient(120_000, 6, 1);
     const second = incompleteClient(120_000, 6, 1);

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -96,9 +96,13 @@ function applyReplaceLayouts(
     if (!isReplacePlan(plan) || !plan.layoutDays) continue;
     const next = ownValue(plan.layoutDays, date);
     if (next) {
+      // A replacement is the authoritative token/model layout. Old same-day
+      // models may now belong to another date, so carrying their fields or
+      // cost floors forward would count them twice. Restore any incomplete
+      // cost deficit once across the client's lifetime after all cells exist.
       merged[client] = applyCostCompleteness(
         next,
-        ownValue(merged, client),
+        undefined,
         incomingCostIsComplete
       );
     } else {
@@ -889,6 +893,7 @@ export async function POST(request: Request) {
 
       const toUpdate: Array<{
         id: string;
+        date: string;
         tokens: number;
         cost: string;
         inputTokens: number;
@@ -903,7 +908,11 @@ export async function POST(request: Request) {
 
       for (const incomingDay of daysToProcess.values()) {
         if (incomingDay.totals?.costIsComplete === false) {
-          for (const client of replaceClients) incompleteReplaceClients.add(client);
+          for (const client of replaceClients) {
+            if (ownValue(parserPlans.get(client)?.layoutDays ?? {}, incomingDay.date)) {
+              incompleteReplaceClients.add(client);
+            }
+          }
         }
         const incomingClientBreakdown = foldIncomingClientContributions(
           incomingDay.clients
@@ -1038,6 +1047,7 @@ export async function POST(request: Request) {
 
           toUpdate.push({
             id: existingDay.id,
+            date: incomingDay.date,
             tokens: dayTotals.tokens,
             cost: dayTotals.cost.toFixed(4),
             inputTokens: dayTotals.inputTokens,
@@ -1084,12 +1094,17 @@ export async function POST(request: Request) {
         }
       }
 
+      // Keep rounding residuals on the same dates when a new row becomes an
+      // UPDATE on replay, regardless of the incoming contribution order.
+      const mergedRows = [...toInsert, ...toUpdate].sort((a, b) =>
+        a.date.localeCompare(b.date)
+      );
       reapplyReplaceLayoutCostFloors(
-        [...toInsert, ...toUpdate],
+        mergedRows,
         replaceCostFloors,
         incompleteReplaceClients
       );
-      for (const row of [...toInsert, ...toUpdate]) {
+      for (const row of mergedRows) {
         const dayTotals = recalculateDayTotals(row.sourceBreakdown);
         row.tokens = dayTotals.tokens;
         row.cost = dayTotals.cost.toFixed(4);

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -1096,8 +1096,9 @@ export async function POST(request: Request) {
 
       // Keep rounding residuals on the same dates when a new row becomes an
       // UPDATE on replay, regardless of the incoming contribution order.
+      // ISO date strings sort chronologically without host-locale collation.
       const mergedRows = [...toInsert, ...toUpdate].sort((a, b) =>
-        a.date.localeCompare(b.date)
+        a.date < b.date ? -1 : a.date > b.date ? 1 : 0
       );
       reapplyReplaceLayoutCostFloors(
         mergedRows,

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -418,19 +418,24 @@ function addClientCostFloor(
   extra: number
 ): void {
   if (extra <= 0) return;
-  const models = Object.values(cell.models ?? {});
+  const models = Object.entries(cell.models ?? {})
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([, model]) => model);
   if (models.length === 0) {
     cell.cost = quantizeCost((cell.cost || 0) + extra);
   } else {
     const tokenTotal = models.reduce((sum, model) => sum + (model.tokens || 0), 0);
     let assigned = 0;
     for (let i = 0; i < models.length; i++) {
-      const share =
+      const remaining = quantizeCost(extra - assigned);
+      const share = Math.min(
+        remaining,
         i === models.length - 1
-          ? quantizeCost(extra - assigned)
+          ? remaining
           : tokenTotal > 0
             ? quantizeCost((extra * (models[i].tokens || 0)) / tokenTotal)
-            : quantizeCost(extra / models.length);
+            : quantizeCost(extra / models.length)
+      );
       models[i].cost = quantizeCost((models[i].cost || 0) + share);
       assigned = quantizeCost(assigned + share);
     }
@@ -445,9 +450,11 @@ function addClientCostFloor(
 }
 
 /**
- * Same-day cost floors cannot follow tokens that a snapshot layout moves onto
- * a day with no previously stored cell. Re-apply the pre-rewrite client total
- * across the new cells so an unpriced re-date cannot drop lifetime cost.
+ * Reconcile exact replacement cells against the pre-rewrite client lifetime
+ * cost. Same-day/model floors would duplicate spend when usage moves between
+ * dates; only the lifetime deficit may be added to the incoming layout.
+ * Complete days retain their exact prices; only incomplete cells can absorb
+ * the deficit. Callers must preserve the incoming per-cell completeness tags.
  */
 export function reapplyReplaceLayoutCostFloors(
   rows: Array<{ sourceBreakdown: Record<string, ClientBreakdownData> }>,
@@ -465,16 +472,24 @@ export function reapplyReplaceLayoutCostFloors(
     const current = cells.reduce((sum, cell) => sum + (cell.cost || 0), 0);
     const deficit = quantizeCost(floor - current);
     if (deficit <= 0) continue;
-    const tokenTotal = cells.reduce((sum, cell) => sum + (cell.tokens || 0), 0);
+    const incompleteCells = cells.filter(
+      (cell) => cell.provenance?.costIsComplete === false
+    );
+    const tokenTotal = incompleteCells.reduce((sum, cell) => sum + (cell.tokens || 0), 0);
     let assigned = 0;
-    for (let i = 0; i < cells.length; i++) {
-      const share =
-        i === cells.length - 1
-          ? quantizeCost(deficit - assigned)
+    for (let i = 0; i < incompleteCells.length; i++) {
+      // Rounded proportional shares can exhaust the deficit before the last
+      // cell. Cap each allocation so the remainder never goes negative.
+      const remaining = quantizeCost(deficit - assigned);
+      const share = Math.min(
+        remaining,
+        i === incompleteCells.length - 1
+          ? remaining
           : tokenTotal > 0
-            ? quantizeCost((deficit * cells[i].tokens) / tokenTotal)
-            : quantizeCost(deficit / cells.length);
-      addClientCostFloor(cells[i], share);
+            ? quantizeCost((deficit * incompleteCells[i].tokens) / tokenTotal)
+            : quantizeCost(deficit / incompleteCells.length)
+      );
+      addClientCostFloor(incompleteCells[i], share);
       assigned = quantizeCost(assigned + share);
     }
   }

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -418,8 +418,10 @@ function addClientCostFloor(
   extra: number
 ): void {
   if (extra <= 0) return;
+  // Use ordinal string order: localeCompare follows the host's collation,
+  // which could move a rounding residual to another model on replay.
   const models = Object.entries(cell.models ?? {})
-    .sort(([a], [b]) => a.localeCompare(b))
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
     .map(([, model]) => model);
   if (models.length === 0) {
     cell.cost = quantizeCost((cell.cost || 0) + extra);


### PR DESCRIPTION
Full Droid snapshots that re-date usage could duplicate spend and retain moved models when pricing was incomplete. A $100 snapshot split into $40/$60 across two days stored $160, and moving a model entirely off a retained day left 100,002 nested model tokens beside a two-token client total. This fixes the replacement path introduced in #1267.

Replacement cells now use the incoming token/model/message layout, with incomplete cost reconciled once against the device/client lifetime floor. Any deficit is allocated only to incomplete Droid days, preserving exact prices on complete days. The fix also prevents an incomplete day containing only another client from blocking a complete Droid price correction, caps rounded allocations at the remaining deficit, and keeps rounding residuals stable across replays and input ordering changes.

Added regressions cover both inflation cases, legacy baseline adoption, replay, pricing recovery, existing corrupted model maps, partial-scan freezing, sibling clients, and rounding. Existing stale model entries are repaired by the next qualifying full snapshot. Previously inflated spend still needs a fully priced resubmit to correct it downward; incomplete pricing cannot establish that the stored floor was wrong.

Validation:

- Frontend suite: 1,006 tests passed.
- PostgreSQL 16: migration replay and 27 moderation/reconciliation integration tests passed.
- TypeScript checking passed; changed-file ESLint passed with one existing unused-variable warning.
- The new accounting, sibling-client, and rounding regressions failed before the production fix and passed afterward.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Droid full snapshot cost reconciliation so re-dated usage no longer duplicates spend or keeps moved models. A $100 snapshot split into $40/$60 across two days previously stored $160; now the lifetime cost deficit is applied once, only to incomplete Droid days, and complete days keep their exact prices.

- Replacement cells adopt the incoming token/model/message layout, and the pre-rewrite floor is reconciled against the lifetime total only.
- Rounded allocations are capped at the remaining deficit so totals never overshoot, and ordinal model/date ordering keeps rounding residuals stable across replays, contribution order, and host locale.
- An incomplete day containing only another client no longer blocks a complete Droid price correction.
- Previously inflated spend needs a fully priced resubmit to come down; incomplete pricing cannot prove the stored floor was wrong, and stale model entries are repaired by the next qualifying full snapshot.

<sup>Written for commit 76739a337a1f4714d45ecfb8a81c71eca9e879cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

