### PR TITLE
fix(openclaw): count Codex rollouts in per-profile CLI homes

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -12490,6 +12490,125 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn test_openclaw_cli_auth_codex_rollouts_are_owned_once_across_parse_lanes() {
+        // Older OpenClaw versions used a per-profile Codex CLI auth home and
+        // stamped `codex_exec`/`exec` instead of OpenClaw on its rollouts.
+        // The agent-owned path, not that metadata, must decide ownership.
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+        let home = source_home.path();
+
+        let codex_home = home.join(".openclaw/agents/main/agent/cli-auth/codex/default");
+        let sessions = codex_home.join("sessions/2026/08/30");
+        let archived_sessions = codex_home.join("archived_sessions/2026/08/30");
+        std::fs::create_dir_all(&sessions).unwrap();
+        std::fs::create_dir_all(&archived_sessions).unwrap();
+        let rollout = sessions.join(format!(
+            "rollout-2026-08-30T10-00-00-{OPENCLAW_CODEX_THREAD}.jsonl"
+        ));
+        let rollout_body = openclaw_codex_rollout_with_turns(
+            OPENCLAW_CODEX_THREAD,
+            "codex_exec",
+            &[("turn-1", OPENCLAW_CODEX_TURN_1)],
+        )
+        .replace(r#""source":"cli""#, r#""source":"exec""#);
+        std::fs::write(&rollout, &rollout_body).unwrap();
+        // Codex archives can duplicate a live rollout. The shared OpenClaw
+        // dedup must keep one copy after both locations are classified alike.
+        std::fs::write(
+            archived_sessions.join(rollout.file_name().unwrap()),
+            &rollout_body,
+        )
+        .unwrap();
+        std::fs::write(codex_home.join("history.jsonl"), "not a rollout\n").unwrap();
+
+        let mut env = crate::paths::test_env::EnvGuard::capture(&[
+            "CODEX_HOME",
+            "TOKSCALE_EXTRA_DIRS",
+            "TOKSCALE_HEADLESS_DIR",
+        ]);
+        env.remove("CODEX_HOME");
+        env.remove("TOKSCALE_EXTRA_DIRS");
+        env.remove("TOKSCALE_HEADLESS_DIR");
+
+        let both = ["codex".to_string(), "openclaw".to_string()];
+        let expected = vec![
+            (
+                "openclaw".to_string(),
+                OPENCLAW_CODEX_THREAD.to_string(),
+                300,
+                700,
+                50,
+            ),
+            (
+                "openclaw".to_string(),
+                OPENCLAW_CODEX_THREAD.to_string(),
+                400,
+                800,
+                300,
+            ),
+        ];
+        // With the default Codex home, this can only reach the parser through
+        // OpenClaw's agents-root walk; it must not depend on CODEX_HOME overlap.
+        let default_home = parse_all_messages_with_pricing_with_cache_policy(
+            home.to_str().unwrap(),
+            &both,
+            None,
+            true,
+            &scanner::ScannerSettings::default(),
+            SourceCachePolicy::Persistent,
+        );
+        assert_eq!(openclaw_usage_by_client_session(&default_home), expected);
+
+        env.set("CODEX_HOME", &codex_home);
+        let cold = parse_all_messages_with_pricing_with_cache_policy(
+            home.to_str().unwrap(),
+            &both,
+            None,
+            true,
+            &scanner::ScannerSettings::default(),
+            SourceCachePolicy::Persistent,
+        );
+        assert_eq!(openclaw_usage_by_client_session(&cold), expected);
+        let warm = parse_all_messages_with_pricing_with_cache_policy(
+            home.to_str().unwrap(),
+            &both,
+            None,
+            true,
+            &scanner::ScannerSettings::default(),
+            SourceCachePolicy::Persistent,
+        );
+        assert_eq!(openclaw_usage_by_client_session(&warm), expected);
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(home.to_str().unwrap().to_string()),
+            use_env_roots: true,
+            clients: Some(both.to_vec()),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+        assert_eq!(parsed.counts.get(ClientId::OpenClaw), 2);
+        assert_eq!(parsed.counts.get(ClientId::Codex), 0);
+
+        // With OpenClaw absent, a user-selected CODEX_HOME remains Codex's.
+        let codex_only = parse_all_messages_with_pricing_with_cache_policy(
+            home.to_str().unwrap(),
+            &["codex".to_string()],
+            None,
+            true,
+            &scanner::ScannerSettings::default(),
+            SourceCachePolicy::Persistent,
+        );
+        assert_eq!(codex_only.len(), 2);
+        assert!(codex_only.iter().all(|message| message.client == "codex"));
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn test_synthetic_request_keeps_codex_usage_a_synthetic_gateway_served() {
         // `--client synthetic` keeps whatever any client routed through a
         // synthetic gateway; the flush filter is where that is decided, and

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -3625,7 +3625,7 @@ mod tests {
         }
     }
 
-    /// Four retirements in a row, each needing its own number. #1285 took v2
+    /// Successive parser changes each need their own version. #1285 took v2
     /// for the compressed-archive decode. #1278 then needed v3, not a reuse of
     /// 2: a warm v2 cache carries neither the dedup keys nor the reasoning
     /// split, so reusing 2 would have left every reader who already scanned

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1257,7 +1257,11 @@ fn parser_version(client: ClientId) -> u32 {
         // archived spelling. The doctor never writes to those files again, so
         // their fingerprints stay valid and a warm v4 entry would keep serving
         // `archive-tier.<id>` sessions without the parser ever running.
-        ClientId::OpenClaw => 5,
+        // v5->v6 (#1298): legacy per-agent `cli-auth/codex/<profile>` homes
+        // are Codex rollouts OpenClaw owns, rather than OpenClaw transcripts.
+        // Their bytes are unchanged, so v5's cached empty transcript result
+        // must not survive the new path classification.
+        ClientId::OpenClaw => 6,
         // These clients accumulated parser-only invalidations under the old
         // global schema. Their independent counters start from those histories
         // so future changes have an obvious local version to increment.
@@ -3630,10 +3634,12 @@ mod tests {
     /// source cache, so only the version can retire TUI aggregates that
     /// still include them. #1299 needs v5: the doctor's `archive-tier.`
     /// import archives never change on disk, so a v4 entry that named their
-    /// sessions by the archived spelling is served warm forever.
+    /// sessions by the archived spelling is served warm forever. #1298 needs
+    /// v6 because legacy CLI-auth Codex rollout bytes were cached as empty
+    /// OpenClaw transcripts before their path classification changed.
     #[test]
-    fn test_openclaw_parser_version_invalidates_v4_entries() {
-        assert_eq!(parser_version(ClientId::OpenClaw), 5);
+    fn test_openclaw_parser_version_invalidates_v5_entries() {
+        assert_eq!(parser_version(ClientId::OpenClaw), 6);
     }
 
     #[test]
@@ -3974,8 +3980,58 @@ mod tests {
         cache.save_if_dirty();
         let warm = SourceMessageCache::load();
         let cached = warm.get(identity, &source).unwrap();
-        assert_eq!(cached.parser_version, 5);
+        assert_eq!(cached.parser_version, 6);
         assert_eq!(cached.messages, parsed);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn openclaw_v5_empty_shards_are_rejected_before_cli_auth_reclassification() {
+        // Legacy CLI-auth Codex rollout bytes never change after their former
+        // OpenClaw-transcript parse cached them as empty, so v6 must retire the
+        // unchanged v5 shard before the location-based parser can read them.
+        let temp_home = TempDir::new().unwrap();
+        let _cache_env = sandbox_cache_env(temp_home.path());
+        let source = temp_home.path().join(
+            "agents/main/agent/cli-auth/codex/default/sessions/2026/08/30/rollout-2026-08-30T10-00-00-0192f3a4-5b6c-7d8e-9f01-23456789abcd.jsonl",
+        );
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        fs::write(
+            &source,
+            br#"{"timestamp":"2026-08-30T10:00:00Z","type":"session_meta","payload":{"id":"0192f3a4-5b6c-7d8e-9f01-23456789abcd","originator":"codex_exec","source":"exec"}}"#,
+        )
+        .unwrap();
+
+        let identity = CacheIdentity::for_client(ClientId::OpenClaw);
+        let stale_identity = CacheIdentity {
+            parser_version: 5,
+            ..identity
+        };
+        let fingerprint = SourceFingerprint::from_path(&source).unwrap();
+        let stale_entry = CachedSourceEntry::new(
+            stale_identity,
+            &source,
+            fingerprint.clone(),
+            Vec::new(),
+            Vec::new(),
+            None,
+        );
+        let shard = cache_shard_path(identity, &source);
+        ensure_cache_dir(shard.parent().unwrap()).unwrap();
+        write_shard_with_limit(
+            &shard,
+            stale_identity,
+            &[stale_entry],
+            MAX_CACHE_SHARD_BYTES,
+        )
+        .unwrap();
+
+        let cache = SourceMessageCache::load();
+        assert!(
+            cache.get(identity, &source).is_none(),
+            "a v5 empty transcript entry must not mask a legacy CLI-auth rollout"
+        );
+        assert_eq!(SourceFingerprint::from_path(&source).unwrap(), fingerprint);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/openclaw.rs
+++ b/crates/tokscale-core/src/sessions/openclaw.rs
@@ -58,6 +58,11 @@ pub const OPENCLAW_INCOGNITO_AGENT_DB_FILENAME: &str = "incognito-openclaw-agent
 /// `<agents root>/<agentId>/agent/codex-home/sessions/**/rollout-*.jsonl`.
 pub const OPENCLAW_CODEX_HOME_DIRNAME: &str = "codex-home";
 
+/// Legacy OpenClaw CLI authentication homes live under an agent as
+/// `agent/cli-auth/codex/<profile>/`. Their Codex session trees are owned by
+/// that agent even though old rollouts identify their originator as `codex_exec`.
+const OPENCLAW_CLI_AUTH_DIRNAME: &str = "cli-auth";
+
 /// Directory `openclaw doctor` moves legacy JSONL into once the SQLite store
 /// exists, beside the agent's `sessions/`: `<agentId>/session-sqlite-import-
 /// archive/<archive key>.<original basename>.imported-<ts>`. A transcript it
@@ -137,7 +142,7 @@ pub(crate) fn codex_mirror_turn_from_dedup_key(dedup_key: &str) -> Option<CodexM
 pub(crate) enum OpenClawJsonlKind {
     /// A session transcript or published archive: the OpenClaw event format.
     Transcript,
-    /// A Codex rollout inside the agent's `codex-home`: Codex's own format,
+    /// A Codex rollout inside an agent-owned Codex home: Codex's own format,
     /// recording the turns OpenClaw drove through Codex app-server.
     CodexRollout,
     /// Anything else Codex keeps in that home (`history.jsonl`, logs). Not
@@ -146,12 +151,26 @@ pub(crate) enum OpenClawJsonlKind {
 }
 
 /// Classify a JSONL path the OpenClaw scan produced. The agents root is walked
-/// whole, so the per-agent `codex-home` comes along with the transcripts.
+/// whole, so agent-owned Codex homes come along with the transcripts.
 pub(crate) fn classify_openclaw_jsonl(path: &Path) -> OpenClawJsonlKind {
     let components: Vec<&std::ffi::OsStr> = path.components().map(|c| c.as_os_str()).collect();
     for index in 1..components.len() {
         if components[index] == OPENCLAW_CODEX_HOME_DIRNAME && components[index - 1] == "agent" {
             return match components.get(index + 1).and_then(|c| c.to_str()) {
+                Some("sessions") | Some("archived_sessions") => OpenClawJsonlKind::CodexRollout,
+                _ => OpenClawJsonlKind::CodexHomeOther,
+            };
+        }
+        // Do not match a generic `cli-auth` session: the `codex/<profile>`
+        // components make this a Codex home OpenClaw owns, rather than an
+        // OpenClaw transcript whose session happened to use those names.
+        if components[index] == OPENCLAW_CLI_AUTH_DIRNAME
+            && components[index - 1] == "agent"
+            && components
+                .get(index + 1)
+                .is_some_and(|component| *component == "codex")
+        {
+            return match components.get(index + 3).and_then(|c| c.to_str()) {
                 Some("sessions") | Some("archived_sessions") => OpenClawJsonlKind::CodexRollout,
                 _ => OpenClawJsonlKind::CodexHomeOther,
             };
@@ -2122,13 +2141,32 @@ mod tests {
             ),
             CodexRollout
         );
+        for session_root in ["sessions", "archived_sessions"] {
+            assert_eq!(
+                classify_openclaw_jsonl(&root.join(format!(
+                    "main/agent/cli-auth/codex/default/{session_root}/2026/08/30/rollout-2026-08-30T10-00-00-0192f3a4-5b6c-7d8e-9f01-23456789abcd.jsonl"
+                ))),
+                CodexRollout,
+                "legacy cli-auth Codex {session_root} must be OpenClaw-owned"
+            );
+        }
         assert_eq!(
             classify_openclaw_jsonl(&root.join("main/agent/codex-home/history.jsonl")),
+            CodexHomeOther
+        );
+        assert_eq!(
+            classify_openclaw_jsonl(&root.join("main/agent/cli-auth/codex/default/history.jsonl")),
             CodexHomeOther
         );
         // A session that happens to be named like the directory is still a transcript.
         assert_eq!(
             classify_openclaw_jsonl(&root.join("main/sessions/codex-home/sessions/x.jsonl")),
+            Transcript
+        );
+        assert_eq!(
+            classify_openclaw_jsonl(
+                &root.join("main/agent/cli-auth/other/default/sessions/x.jsonl")
+            ),
             Transcript
         );
     }


### PR DESCRIPTION
OpenClaw's CLI-backed Codex runs store rollouts under `agent/cli-auth/codex/<profile>/sessions` and `archived_sessions`. These files were treated as OpenClaw transcripts and produced no usage, even though the same rollout format already works under `agent/codex-home`.

Classify these per-profile homes through the existing OpenClaw-owned Codex path, including old `codex_exec`/`exec` metadata. History files remain excluded, other CLI backends keep their existing behavior, and overlapping Codex scan roots cannot count the same rollout twice. Bump the OpenClaw parser version to invalidate old source and TUI aggregate caches.

Closes #1298.

Validation:

- Core unit suite: 2,134 passed, 2 ignored.
- `cargo clippy --locked -p tokscale-core --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- Regressions cover default discovery, live/archive duplicates, local and streaming parse paths, warm caches, stale cache versions, overlapping `CODEX_HOME`, and Codex-only scans. Validation used isolated fixtures; no live OpenClaw instance was exercised.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenClaw CLI-backed Codex rollouts under `agent/cli-auth/codex/<profile>` not counting toward usage. These files were previously treated as OpenClaw transcripts; now they are classified as Codex rollouts owned by OpenClaw, so they generate usage, deduplicate correctly, and invalidate stale caches. Closes #1298.

<sup>Written for commit 4fb5f114b055a94e4af8fc76d823ee58dc146a4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

