### PR TITLE
feat(usage): support disabling subscription providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,6 +917,9 @@ Tokscale stores settings in `~/.config/tokscale/settings.json`:
   "colorPalette": "blue",
   "includeUnusedModels": false,
   "defaultClients": ["opencode", "claude"],
+  "usage": {
+    "disabledProviders": ["copilot"]
+  },
   "scanner": {
     "extraScanPaths": {
       "codex": [
@@ -940,6 +943,7 @@ Tokscale stores settings in `~/.config/tokscale/settings.json`:
 | `autoRefreshMs` | number | `60000` | Auto-refresh interval (30000-3600000ms) |
 | `nativeTimeoutMs` | number | `300000` | Maximum time for native subprocess processing (5000-3600000ms) |
 | `defaultClients` | string[] | `[]` | Client filter applied when no `--client/-c` flag is passed. Accepts the same ids as `--client` (e.g. `["opencode", "claude", "synthetic"]`). Unknown ids are silently dropped. CLI flags always override this list completely — no merging. |
+| `usage.disabledProviders` | string[] | `[]` | Subscription-usage providers to skip before credential discovery or network access. Valid ids (case-insensitive; surrounding whitespace ignored): `claude`, `codex`, `zai`, `amp`, `antigravity`, `copilot`, `grok`, `kimi`, `minimax`, `minimax-token-plan`, `warp`, `sakana`, and `opencode-go`. Unknown ids are ignored. Disabled providers are also hidden from cached TUI cards and diagnostics. Changes apply to the next `tokscale usage` run or TUI launch/refresh. |
 | `light.writeCache` | boolean | `false` | When true, `tokscale --light` overwrites the TUI cache atomically after rendering. CLI flags `--write-cache` / `--no-write-cache` override per-invocation. |
 | `minutelyTabEnabled` | boolean | `false` | Show the per-minute Minutely tab in the TUI and aggregate per-minute usage during data loading. Default-off because minute-granularity is a niche/diagnostic view for most users and the per-minute bucketing has a non-trivial cost on large datasets. |
 | `autosubmit` | object | disabled | Saved `tokscale autosubmit` state: interval, client/date filters, scheduler backend, last run time, and last error. Prefer `tokscale autosubmit enable/status/disable` over editing this object by hand. |

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -435,16 +435,16 @@ pub fn load_run_config(
 }
 
 pub fn record_run_success(now_ms: i64) -> Result<()> {
-    let mut settings = crate::tui::settings::Settings::load();
+    let (mut settings, origin) = crate::tui::settings::Settings::load_with_origin();
     settings.autosubmit.last_run_at_ms = Some(now_ms);
     settings.autosubmit.last_error = None;
-    settings.save()
+    settings.save_with_origin(origin)
 }
 
 pub fn record_run_error(error: &str) -> Result<()> {
-    let mut settings = crate::tui::settings::Settings::load();
+    let (mut settings, origin) = crate::tui::settings::Settings::load_with_origin();
     settings.autosubmit.last_error = Some(error.to_string());
-    settings.save()
+    settings.save_with_origin(origin)
 }
 
 /// Today, in the zone this device buckets day keys into.

--- a/crates/tokscale-cli/src/commands/config.rs
+++ b/crates/tokscale-cli/src/commands/config.rs
@@ -8,7 +8,7 @@ use anyhow::{bail, Result};
 use colored::Colorize;
 use tokscale_core::bucket_tz::BucketTimezone;
 
-use crate::tui::settings::Settings;
+use crate::tui::settings::{Settings, SettingsOrigin};
 
 /// The settings `tokscale config` can address.
 ///
@@ -39,7 +39,7 @@ pub fn run_get(key: &str) -> Result<()> {
 
 pub fn run_set(key: &str, value: &str) -> Result<()> {
     let key = normalize_key(key)?;
-    let mut settings = load_for_write()?;
+    let (mut settings, origin) = load_for_write()?;
 
     match key {
         "timezone" => {
@@ -55,7 +55,7 @@ pub fn run_set(key: &str, value: &str) -> Result<()> {
             }
             reject_timezone_rekey(previous.as_deref(), &resolved)?;
             settings.scanner.bucket_timezone = Some(resolved.clone());
-            settings.save()?;
+            settings.save_with_origin(origin)?;
 
             println!("{} timezone = {}", "set".green().bold(), resolved.bold());
             match previous {
@@ -79,13 +79,13 @@ pub fn run_set(key: &str, value: &str) -> Result<()> {
 
 pub fn run_unset(key: &str) -> Result<()> {
     let key = normalize_key(key)?;
-    let mut settings = load_for_write()?;
+    let (mut settings, origin) = load_for_write()?;
 
     match key {
         "timezone" => {
             reject_timezone_unset(settings.scanner.bucket_timezone.as_deref())?;
             let previous = settings.scanner.bucket_timezone.take();
-            settings.save()?;
+            settings.save_with_origin(origin)?;
 
             match previous {
                 Some(previous) => println!("{} timezone (was {previous})", "unset".green().bold()),
@@ -120,7 +120,7 @@ pub fn run_list() -> Result<()> {
 /// config and UI preferences to fix one field. `tokscale config` is a
 /// deliberate, interactive command, so it says so and stops instead of guessing
 /// which is worse.
-fn load_for_write() -> Result<Settings> {
+fn load_for_write() -> Result<(Settings, SettingsOrigin)> {
     let (settings, origin) = Settings::load_with_origin();
     if !origin.is_safe_to_overwrite() {
         // Deliberately does not name settings.json: this also fires when the
@@ -132,7 +132,7 @@ fn load_for_write() -> Result<Settings> {
              is readable and writable, and that settings.json in it is valid JSON."
         );
     }
-    Ok(settings)
+    Ok((settings, origin))
 }
 
 fn normalize_key(key: &str) -> Result<&'static str> {

--- a/crates/tokscale-cli/src/commands/usage/antigravity.rs
+++ b/crates/tokscale-cli/src/commands/usage/antigravity.rs
@@ -698,9 +698,9 @@ mod tests {
     /// every other provider and read the developer's real credentials, so these
     /// tests stop at the one entry.
     fn registered_antigravity_provider() -> (fn() -> bool, Fetch) {
-        let (_, has_credentials, fetch) = usage_providers(Fetch::Multi(fetch_all))
+        let (_, _, has_credentials, fetch) = usage_providers(Fetch::Multi(fetch_all))
             .into_iter()
-            .find(|(provider, _, _)| *provider == PROVIDER)
+            .find(|(_, provider, _, _)| *provider == PROVIDER)
             .expect("Antigravity is a registered usage provider");
         (has_credentials, fetch)
     }

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -351,6 +351,7 @@ fn load_cache_at(path: &std::path::Path) -> Option<Vec<UsageOutput>> {
 #[cfg_attr(test, allow(dead_code))]
 pub fn load_cache() -> Option<Vec<UsageOutput>> {
     load_cache_at(&cache_path()?)
+        .map(|outputs| filter_disabled_outputs(outputs, &disabled_provider_ids()))
 }
 
 // ── Public API ──
@@ -370,19 +371,31 @@ impl Fetch {
     }
 }
 
-type UsageProvider = (&'static str, fn() -> bool, Fetch);
+type UsageProvider = (&'static str, &'static str, fn() -> bool, Fetch);
 
 fn usage_providers(codex_fetch: Fetch) -> Vec<UsageProvider> {
     vec![
         (
+            "claude",
             "Claude",
             claude::has_credentials,
             Fetch::Single(claude::fetch),
         ),
-        ("Codex", codex::has_credentials, codex_fetch),
-        ("Z.ai", zai::has_credentials, Fetch::Single(zai::fetch)),
-        ("Amp", amp::has_credentials, Fetch::Single(amp::fetch)),
+        ("codex", "Codex", codex::has_credentials, codex_fetch),
         (
+            "zai",
+            "Z.ai",
+            zai::has_credentials,
+            Fetch::Single(zai::fetch),
+        ),
+        (
+            "amp",
+            "Amp",
+            amp::has_credentials,
+            Fetch::Single(amp::fetch),
+        ),
+        (
+            "antigravity",
             "Antigravity",
             antigravity::has_credentials,
             // One output per model group: Antigravity meters Gemini models and
@@ -390,38 +403,82 @@ fn usage_providers(codex_fetch: Fetch) -> Vec<UsageProvider> {
             Fetch::Multi(antigravity::fetch_all),
         ),
         (
+            "copilot",
             "Copilot",
             copilot::has_credentials,
             Fetch::Single(copilot::fetch),
         ),
         (
+            "grok",
             "Grok Build",
             grok::has_credentials,
             Fetch::Single(grok::fetch),
         ),
-        ("Kimi", kimi::has_credentials, Fetch::Single(kimi::fetch)),
         (
+            "kimi",
+            "Kimi",
+            kimi::has_credentials,
+            Fetch::Single(kimi::fetch),
+        ),
+        (
+            "minimax",
             "MiniMax",
             minimax::has_credentials,
             Fetch::Single(minimax::fetch),
         ),
         (
+            "minimax-token-plan",
             "MiniMax Token Plan",
             minimax_tokenplan::has_credentials,
             Fetch::Multi(minimax_tokenplan::fetch_all),
         ),
-        ("Warp/Oz", warp::has_credentials, Fetch::Single(warp::fetch)),
         (
+            "warp",
+            "Warp/Oz",
+            warp::has_credentials,
+            Fetch::Single(warp::fetch),
+        ),
+        (
+            "sakana",
             "Sakana",
             sakana::has_credentials,
             Fetch::Single(sakana::fetch),
         ),
         (
+            "opencode-go",
             "OpenCode Go",
             opencode_go::has_credentials,
             Fetch::Multi(opencode_go::fetch_all),
         ),
     ]
+}
+
+fn disabled_provider_ids() -> std::collections::HashSet<String> {
+    crate::tui::settings::Settings::load()
+        .usage
+        .disabled_providers
+        .into_iter()
+        .map(|id| id.trim().to_ascii_lowercase())
+        .filter(|id| !id.is_empty())
+        .collect()
+}
+
+fn filter_disabled_outputs(
+    outputs: impl IntoIterator<Item = UsageOutput>,
+    disabled: &std::collections::HashSet<String>,
+) -> Vec<UsageOutput> {
+    outputs
+        .into_iter()
+        .filter(|output| {
+            provider_id_for_label(&output.provider).is_none_or(|id| !disabled.contains(id))
+        })
+        .collect()
+}
+
+fn provider_id_for_label(label: &str) -> Option<&'static str> {
+    usage_providers(Fetch::Multi(codex::fetch_all))
+        .into_iter()
+        .find_map(|(id, provider, _, _)| (provider == label).then_some(id))
 }
 
 fn fetch_provider_report(
@@ -443,13 +500,31 @@ pub fn fetch_all_report_with_intent(intent: UsageFetchIntent) -> UsageFetchRepor
 }
 
 fn fetch_all_report_with_codex(codex_fetch: fn() -> UsageFetchReport) -> UsageFetchReport {
+    let disabled = disabled_provider_ids();
+    fetch_all_report_from_providers(
+        usage_providers(Fetch::Multi(codex::fetch_all)),
+        &disabled,
+        codex_fetch,
+    )
+}
+
+fn fetch_all_report_from_providers(
+    providers: Vec<UsageProvider>,
+    disabled: &std::collections::HashSet<String>,
+    codex_fetch: fn() -> UsageFetchReport,
+) -> UsageFetchReport {
     let mut active: Vec<UsageProvider> = Vec::new();
     // Observability (#947): when a provider is filtered out for lack of
     // credentials, log what was probed so a missing quota card can be traced
     // to credential detection rather than the fetch path.
-    for (provider, has, fetch) in usage_providers(Fetch::Multi(codex::fetch_all)) {
+    for (id, provider, has, fetch) in providers {
+        // This check is deliberately before `has()`: probing some providers
+        // imports auth state, which users explicitly opted out of touching.
+        if disabled.contains(id) {
+            continue;
+        }
         if has() {
-            active.push((provider, has, fetch));
+            active.push((id, provider, has, fetch));
         } else {
             tracing::debug!(
                 provider,
@@ -470,7 +545,7 @@ fn fetch_all_report_with_codex(codex_fetch: fn() -> UsageFetchReport) -> UsageFe
     std::thread::scope(|scope| {
         let handles = active
             .into_iter()
-            .map(|(provider, _, fetch)| {
+            .map(|(_, provider, _, fetch)| {
                 let handle = if provider == "Codex" {
                     scope.spawn(codex_fetch)
                 } else {
@@ -493,6 +568,10 @@ fn fetch_all_report_with_codex(codex_fetch: fn() -> UsageFetchReport) -> UsageFe
                 )),
             }
         }
+        report.outputs = filter_disabled_outputs(report.outputs, disabled);
+        report.diagnostics.retain(|diagnostic| {
+            provider_id_for_label(&diagnostic.provider).is_none_or(|id| !disabled.contains(id))
+        });
         report
     })
 }
@@ -608,7 +687,39 @@ pub fn run(json: bool, _light: bool, debug: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
     use tempfile::TempDir;
+
+    static COUNTERS: OnceLock<Mutex<(usize, usize)>> = OnceLock::new();
+
+    fn counters() -> &'static Mutex<(usize, usize)> {
+        COUNTERS.get_or_init(|| Mutex::new((0, 0)))
+    }
+
+    fn counted_has_credentials() -> bool {
+        counters().lock().unwrap().0 += 1;
+        true
+    }
+
+    fn counted_fetch() -> Result<UsageOutput> {
+        counters().lock().unwrap().1 += 1;
+        Ok(sample_output("Copilot"))
+    }
+
+    fn empty_codex_fetch() -> UsageFetchReport {
+        UsageFetchReport::default()
+    }
+
+    fn copilot_report_fetch() -> UsageFetchReport {
+        UsageFetchReport {
+            outputs: vec![sample_output("Copilot")],
+            diagnostics: vec![UsageFetchDiagnostic::new(
+                "Copilot",
+                None,
+                "stale diagnostic",
+            )],
+        }
+    }
 
     #[test]
     fn subscription_cache_public_helpers_are_noop_in_tests() {
@@ -633,6 +744,73 @@ mod tests {
         assert!(expected.exists());
         clear_cache_at(&expected);
         assert!(!expected.exists());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn disabled_provider_skips_credential_probe_and_fetch() {
+        *counters().lock().unwrap() = (0, 0);
+        let disabled = std::collections::HashSet::from(["copilot".to_string()]);
+
+        let report = fetch_all_report_from_providers(
+            vec![(
+                "copilot",
+                "Copilot",
+                counted_has_credentials,
+                Fetch::Single(counted_fetch),
+            )],
+            &disabled,
+            empty_codex_fetch,
+        );
+
+        assert!(report.outputs.is_empty());
+        assert!(report.diagnostics.is_empty());
+        assert_eq!(*counters().lock().unwrap(), (0, 0));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn enabled_provider_still_probes_and_fetches() {
+        *counters().lock().unwrap() = (0, 0);
+
+        let report = fetch_all_report_from_providers(
+            vec![(
+                "copilot",
+                "Copilot",
+                counted_has_credentials,
+                Fetch::Single(counted_fetch),
+            )],
+            &std::collections::HashSet::new(),
+            empty_codex_fetch,
+        );
+
+        assert_eq!(report.outputs.len(), 1);
+        assert_eq!(*counters().lock().unwrap(), (1, 1));
+    }
+
+    #[test]
+    fn disabled_providers_filter_cached_cards() {
+        let disabled = std::collections::HashSet::from(["copilot".to_string()]);
+        let outputs = filter_disabled_outputs(
+            vec![sample_output("Copilot"), sample_output("Codex")],
+            &disabled,
+        );
+
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].provider, "Codex");
+    }
+
+    #[test]
+    fn disabled_providers_filter_fetch_diagnostics() {
+        let disabled = std::collections::HashSet::from(["copilot".to_string()]);
+        let report = fetch_all_report_from_providers(
+            vec![("codex", "Codex", || true, Fetch::Multi(|| Ok(Vec::new())))],
+            &disabled,
+            copilot_report_fetch,
+        );
+
+        assert!(report.outputs.is_empty());
+        assert!(report.diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{bail, Result};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use tokscale_core::scanner::ScannerSettings;
 
@@ -20,32 +21,84 @@ pub const DEFAULT_AUTOSUBMIT_INTERVAL_MINUTES: u64 = 24 * 60;
 pub const MIN_AUTOSUBMIT_INTERVAL_MINUTES: u64 = 15;
 pub const MAX_AUTOSUBMIT_INTERVAL_MINUTES: u64 = 7 * 24 * 60;
 
-/// Where the value [`Settings::load_with_origin`] returned came from.
+/// An opaque snapshot of the settings files read by
+/// [`Settings::load_with_origin`].
 ///
-/// Only [`SettingsOrigin::Unreadable`] carries a real obligation: the returned
-/// `Settings` is `Settings::default()` and has nothing to do with what is on
-/// disk, so writing it back replaces every setting the user had with a default.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SettingsOrigin {
-    /// No settings file exists. Defaults *are* the file's contents, so writing
-    /// one loses nothing.
-    Absent,
-    /// A settings file was read and parsed. The returned value is what it says.
-    Parsed,
-    /// A settings file exists but its contents could not be recovered — invalid
-    /// JSON, a field with an incompatible type, or an I/O error that is not
-    /// "no such file". Whatever the user had is still on disk and still
-    /// unknown to us.
+/// A caller can save only when loading produced complete settings, and only if
+/// the files that informed that load are unchanged immediately before the
+/// atomic replace. This avoids parsing JSON twice in load-then-save paths
+/// without allowing a stale caller to replace a changed or malformed file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsOrigin {
+    primary_path: Option<PathBuf>,
+    primary_snapshot: SettingsFileSnapshot,
+    legacy_snapshot: Option<(PathBuf, SettingsFileSnapshot)>,
+    safe_to_overwrite: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SettingsFileSnapshot {
+    Missing,
+    Present(String),
     Unreadable,
 }
 
 impl SettingsOrigin {
+    fn from_raw(
+        primary_path: Option<PathBuf>,
+        primary: &RawSettings,
+        legacy: Option<(&Path, &RawSettings)>,
+    ) -> Self {
+        Self {
+            primary_path,
+            primary_snapshot: SettingsFileSnapshot::from_raw(primary),
+            legacy_snapshot: legacy
+                .map(|(path, raw)| (path.to_path_buf(), SettingsFileSnapshot::from_raw(raw))),
+            safe_to_overwrite: false,
+        }
+    }
+
+    fn writable(mut self) -> Self {
+        self.safe_to_overwrite = true;
+        self
+    }
+
     /// Whether a `save()` after this load would preserve the user's data.
     ///
-    /// False only for [`SettingsOrigin::Unreadable`], where saving would
-    /// overwrite settings we could not read with defaults we invented.
-    pub fn is_safe_to_overwrite(self) -> bool {
-        !matches!(self, Self::Unreadable)
+    /// False when loading produced defaults rather than complete settings,
+    /// where saving would overwrite settings we could not read.
+    pub fn is_safe_to_overwrite(&self) -> bool {
+        self.safe_to_overwrite
+    }
+
+    fn verify_unchanged(&self) -> Result<&Path> {
+        let path = self
+            .primary_path
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("could not resolve the tokscale settings location"))?;
+        if SettingsFileSnapshot::from_raw(&Settings::read_config_file(path))
+            != self.primary_snapshot
+        {
+            bail!("settings.json changed since it was loaded; refusing to replace it");
+        }
+        if let Some((legacy_path, legacy_snapshot)) = &self.legacy_snapshot {
+            if SettingsFileSnapshot::from_raw(&Settings::read_config_file(legacy_path))
+                != *legacy_snapshot
+            {
+                bail!("settings.json changed since it was loaded; refusing to replace it");
+            }
+        }
+        Ok(path)
+    }
+}
+
+impl SettingsFileSnapshot {
+    fn from_raw(raw: &RawSettings) -> Self {
+        match raw {
+            RawSettings::Missing => Self::Missing,
+            RawSettings::Present(content) => Self::Present(content.clone()),
+            RawSettings::Unreadable => Self::Unreadable,
+        }
     }
 }
 
@@ -486,11 +539,14 @@ impl Settings {
     /// able to tell those two cases apart, so it can decline instead of
     /// replacing data it never saw.
     pub fn load_with_origin() -> (Self, SettingsOrigin) {
-        let primary = match Self::config_path() {
-            Ok(path) => Self::read_config_file(&path),
+        let (primary_path, primary) = match Self::config_path() {
+            Ok(path) => {
+                let raw = Self::read_config_file(&path);
+                (Some(path), raw)
+            }
             // Cannot even resolve where settings live. Not "absent": a save
             // would fail the same way, so do not report this as writable.
-            Err(_) => RawSettings::Unreadable,
+            Err(_) => (None, RawSettings::Unreadable),
         };
 
         // Transparent macOS fallback: pre-fix releases wrote settings.json under
@@ -506,11 +562,20 @@ impl Settings {
         // only when it is missing — that is what it did before this function
         // reported an origin, and narrowing it would lose the legacy file to a
         // permissions error on the new path.
-        let legacy = match primary {
+        let legacy_path = match primary {
             RawSettings::Present(_) => None,
             _ if crate::paths::is_config_dir_overridden() => None,
-            _ => Self::legacy_macos_path().map(|legacy| Self::read_config_file(&legacy)),
+            _ => Self::legacy_macos_path(),
         };
+        let legacy = legacy_path.as_deref().map(Self::read_config_file);
+
+        // Snapshot the primary rather than the selected `raw`: a valid legacy
+        // macOS fallback is deliberately saved to a still-missing primary path.
+        let origin = SettingsOrigin::from_raw(
+            primary_path,
+            &primary,
+            legacy_path.as_deref().zip(legacy.as_ref()),
+        );
 
         // `save()` writes to the primary path whatever was read, so an
         // unreadable primary stays unreadable even when the legacy file
@@ -532,14 +597,12 @@ impl Settings {
         };
 
         match raw {
-            RawSettings::Missing => (Self::default(), SettingsOrigin::Absent),
-            RawSettings::Unreadable => (Self::default(), SettingsOrigin::Unreadable),
+            RawSettings::Missing => (Self::default(), origin.writable()),
+            RawSettings::Unreadable => (Self::default(), origin),
             RawSettings::Present(content) => match serde_json::from_str::<Settings>(&content) {
-                Ok(settings) if primary_was_unreadable => {
-                    (settings.normalize(), SettingsOrigin::Unreadable)
-                }
-                Ok(settings) => (settings.normalize(), SettingsOrigin::Parsed),
-                Err(_) => (Self::default(), SettingsOrigin::Unreadable),
+                Ok(settings) if primary_was_unreadable => (settings.normalize(), origin),
+                Ok(settings) => (settings.normalize(), origin.writable()),
+                Err(_) => (Self::default(), origin),
             },
         }
     }
@@ -577,13 +640,28 @@ impl Settings {
     ///
     /// Callers that do not already hold an origin should use [`Self::save`],
     /// which loads one immediately before writing. The safety guard remains
-    /// here so a supplied unreadable origin can never replace unknown settings.
+    /// here so a supplied unreadable or stale origin can never replace unknown
+    /// settings.
     pub(crate) fn save_with_origin(&self, origin: SettingsOrigin) -> Result<()> {
         if !origin.is_safe_to_overwrite() {
             bail!("could not read this machine's tokscale settings, so refusing to replace them");
         }
 
-        let path = Self::config_path()?;
+        let path = origin
+            .primary_path
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("could not resolve the tokscale settings location"))?;
+        // Coordinate Tokscale writers across the final comparison and rename.
+        // A non-cooperating editor can still race an atomic rename, but any edit
+        // present at this final check is rejected rather than overwritten.
+        let lock_path = path.with_file_name(".settings.lock");
+        let lock = fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(lock_path)?;
+        lock.lock_exclusive()?;
+        let path = origin.verify_unchanged()?;
         let content = serde_json::to_string_pretty(self)?;
 
         // Atomic write: write to temp file, sync, then rename
@@ -603,7 +681,7 @@ impl Settings {
             use std::io::Write;
             file.write_all(content.as_bytes())?;
             file.sync_all()?;
-            tokscale_core::fs_atomic::replace_file(&temp_path, &path)?;
+            tokscale_core::fs_atomic::replace_file(&temp_path, path)?;
             Ok(())
         })();
 
@@ -1129,7 +1207,7 @@ mod tests {
         fs::write(&path, malformed).unwrap();
 
         let (settings, origin) = Settings::load_with_origin();
-        assert_eq!(origin, SettingsOrigin::Unreadable);
+        assert!(!origin.is_safe_to_overwrite());
         assert_eq!(settings.color_palette, Settings::default().color_palette);
         assert_eq!(fs::read_to_string(&path).unwrap(), malformed);
     }
@@ -1189,15 +1267,74 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let _config_dir = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
 
+        let (_, origin) = Settings::load_with_origin();
         let settings = Settings {
             color_palette: "green".to_string(),
             ..Settings::default()
         };
-        settings.save_with_origin(SettingsOrigin::Absent).unwrap();
+        settings.save_with_origin(origin).unwrap();
 
         let saved: Settings =
             serde_json::from_str(&fs::read_to_string(temp.path().join("settings.json")).unwrap())
                 .unwrap();
         assert_eq!(saved.color_palette, "green");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn save_with_origin_refuses_to_replace_settings_changed_after_load() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _config_dir = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+
+        let path = temp.path().join("settings.json");
+        fs::write(&path, r#"{"colorPalette":"blue"}"#).unwrap();
+        let (settings, origin) = Settings::load_with_origin();
+
+        let replacement = r#"{"colorPalette":"halloween"}"#;
+        fs::write(&path, replacement).unwrap();
+
+        let save_error = settings.save_with_origin(origin).unwrap_err();
+        assert!(save_error
+            .to_string()
+            .contains("changed since it was loaded"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), replacement);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn save_with_origin_refuses_to_replace_malformed_settings_created_after_load() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _config_dir = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+
+        let (settings, origin) = Settings::load_with_origin();
+        let path = temp.path().join("settings.json");
+        let malformed = r#"{"usage":{"disabledProviders":{"copilot":true}}}"#;
+        fs::write(&path, malformed).unwrap();
+
+        let save_error = settings.save_with_origin(origin).unwrap_err();
+        assert!(save_error
+            .to_string()
+            .contains("changed since it was loaded"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), malformed);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn save_with_origin_refuses_to_replace_settings_made_malformed_after_load() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _config_dir = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+
+        let path = temp.path().join("settings.json");
+        fs::write(&path, r#"{"colorPalette":"blue"}"#).unwrap();
+        let (settings, origin) = Settings::load_with_origin();
+
+        let malformed = r#"{"usage":{"disabledProviders":{"copilot":true}}}"#;
+        fs::write(&path, malformed).unwrap();
+
+        let save_error = settings.save_with_origin(origin).unwrap_err();
+        assert!(save_error
+            .to_string()
+            .contains("changed since it was loaded"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), malformed);
     }
 }

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -391,7 +391,7 @@ pub fn pin_bucket_timezone_if_unset(home_dir: &Option<String>) {
     };
 
     settings.scanner.bucket_timezone = Some(zone);
-    if let Err(error) = settings.save() {
+    if let Err(error) = settings.save_with_origin(origin) {
         tracing::debug!(%error, "failed to persist scanner.bucketTimezone");
     }
 }
@@ -570,7 +570,16 @@ impl Settings {
     }
 
     pub fn save(&self) -> Result<()> {
-        if !Self::load_with_origin().1.is_safe_to_overwrite() {
+        self.save_with_origin(Self::load_with_origin().1)
+    }
+
+    /// Save settings after a caller that loaded them has checked their origin.
+    ///
+    /// Callers that do not already hold an origin should use [`Self::save`],
+    /// which loads one immediately before writing. The safety guard remains
+    /// here so a supplied unreadable origin can never replace unknown settings.
+    pub(crate) fn save_with_origin(&self, origin: SettingsOrigin) -> Result<()> {
+        if !origin.is_safe_to_overwrite() {
             bail!("could not read this machine's tokscale settings, so refusing to replace them");
         }
 
@@ -1142,13 +1151,49 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn save_with_origin_refuses_to_replace_unreadable_settings() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _config_dir = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+
+        let path = temp.path().join("settings.json");
+        let malformed = r#"{"usage":{"disabledProviders":{"copilot":true}}}"#;
+        fs::write(&path, malformed).unwrap();
+
+        let (settings, origin) = Settings::load_with_origin();
+        let save_error = settings.save_with_origin(origin).unwrap_err();
+        assert!(save_error.to_string().contains("refusing to replace them"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), malformed);
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn save_initializes_missing_settings() {
         let temp = tempfile::TempDir::new().unwrap();
         let _config_dir = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
 
-        let mut settings = Settings::default();
-        settings.color_palette = "green".to_string();
+        let settings = Settings {
+            color_palette: "green".to_string(),
+            ..Settings::default()
+        };
         settings.save().unwrap();
+
+        let saved: Settings =
+            serde_json::from_str(&fs::read_to_string(temp.path().join("settings.json")).unwrap())
+                .unwrap();
+        assert_eq!(saved.color_palette, "green");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn save_with_origin_initializes_missing_settings() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _config_dir = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+
+        let settings = Settings {
+            color_palette: "green".to_string(),
+            ..Settings::default()
+        };
+        settings.save_with_origin(SettingsOrigin::Absent).unwrap();
 
         let saved: Settings =
             serde_json::from_str(&fs::read_to_string(temp.path().join("settings.json")).unwrap())

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -82,6 +82,17 @@ pub struct LightSettings {
     pub write_cache: bool,
 }
 
+/// Subscription-usage providers hidden from both `tokscale usage` and the TUI.
+///
+/// Values are stable provider ids rather than display labels so a copy of the
+/// settings file continues to work when a provider's branding changes.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UsageSettings {
+    #[serde(default, deserialize_with = "deserialize_string_array_lossy")]
+    pub disabled_providers: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AutosubmitSettings {
@@ -192,6 +203,10 @@ pub struct Settings {
     pub default_clients: Vec<String>,
     #[serde(default)]
     pub light: LightSettings,
+    /// Subscription-usage providers to skip before credential discovery or
+    /// network access. Unknown ids are ignored by the usage provider registry.
+    #[serde(default)]
+    pub usage: UsageSettings,
     /// Opt-in toggle for the per-minute breakdown tab. Default is `false`
     /// to keep the tab strip focused on the daily/hourly views most users
     /// want and to skip the minute-bucket aggregation cost in DataLoader
@@ -263,6 +278,7 @@ impl Default for Settings {
             scanner: ScannerSettings::default(),
             default_clients: Vec::new(),
             light: LightSettings::default(),
+            usage: UsageSettings::default(),
             minutely_tab_enabled: false,
             autosubmit: AutosubmitSettings::default(),
             model_aliases: tokscale_core::ModelAliasMap::default(),
@@ -1008,6 +1024,27 @@ mod tests {
         assert_eq!(
             round_trip["minutelyTabEnabled"],
             serde_json::Value::Bool(true)
+        );
+    }
+
+    #[test]
+    fn usage_disabled_providers_defaults_for_legacy_settings() {
+        let parsed: Settings = serde_json::from_str(r#"{"colorPalette":"blue"}"#).unwrap();
+        assert!(parsed.usage.disabled_providers.is_empty());
+    }
+
+    #[test]
+    fn usage_disabled_providers_keeps_valid_string_entries() {
+        let parsed: Settings = serde_json::from_str(
+            r#"{"usage":{"disabledProviders":["copilot", null, 42, " CODEX "]}}"#,
+        )
+        .unwrap();
+        assert_eq!(parsed.usage.disabled_providers, ["copilot", " CODEX "]);
+
+        let serialized = serde_json::to_value(&parsed).unwrap();
+        assert_eq!(
+            serialized["usage"]["disabledProviders"],
+            serde_json::json!(["copilot", " CODEX "])
         );
     }
 }

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use tokscale_core::scanner::ScannerSettings;
 
@@ -89,7 +89,10 @@ pub struct LightSettings {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UsageSettings {
-    #[serde(default, deserialize_with = "deserialize_string_array_lossy")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_disabled_providers_string_array_lossy"
+    )]
     pub disabled_providers: Vec<String>,
 }
 
@@ -248,6 +251,23 @@ where
         .into_iter()
         .flatten()
         .filter_map(|v| v.as_str().map(|s| s.to_string()))
+        .collect())
+}
+
+/// Lossy deserializer for `usage.disabledProviders`: individual non-string
+/// array members are ignored, but the field itself must be an array. A wrong
+/// top-level shape means the settings file could not be faithfully recovered,
+/// so callers that may save it must keep it untouched.
+fn deserialize_disabled_providers_string_array_lossy<'de, D>(
+    deserializer: D,
+) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let values = Vec::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(values
+        .into_iter()
+        .filter_map(|value| value.as_str().map(ToString::to_string))
         .collect())
 }
 
@@ -550,6 +570,10 @@ impl Settings {
     }
 
     pub fn save(&self) -> Result<()> {
+        if !Self::load_with_origin().1.is_safe_to_overwrite() {
+            bail!("could not read this machine's tokscale settings, so refusing to replace them");
+        }
+
         let path = Self::config_path()?;
         let content = serde_json::to_string_pretty(self)?;
 
@@ -613,6 +637,32 @@ impl Settings {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
 
     #[test]
     fn explicit_home_config_path_uses_unix_dot_config_layout() {
@@ -1034,6 +1084,17 @@ mod tests {
     }
 
     #[test]
+    fn usage_disabled_providers_rejects_a_non_array_field() {
+        for invalid in ["null", "true", "42", r#"{"copilot":true}"#, r#""copilot""#] {
+            let json = format!(r#"{{"usage":{{"disabledProviders":{invalid}}}}}"#);
+            assert!(
+                serde_json::from_str::<Settings>(&json).is_err(),
+                "disabledProviders must reject {invalid}"
+            );
+        }
+    }
+
+    #[test]
     fn usage_disabled_providers_keeps_valid_string_entries() {
         let parsed: Settings = serde_json::from_str(
             r#"{"usage":{"disabledProviders":["copilot", null, 42, " CODEX "]}}"#,
@@ -1046,5 +1107,52 @@ mod tests {
             serialized["usage"]["disabledProviders"],
             serde_json::json!(["copilot", " CODEX "])
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn load_with_origin_marks_invalid_disabled_providers_as_unreadable() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _config_dir = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+
+        let path = temp.path().join("settings.json");
+        let malformed = r#"{"usage":{"disabledProviders":{"copilot":true}}}"#;
+        fs::write(&path, malformed).unwrap();
+
+        let (settings, origin) = Settings::load_with_origin();
+        assert_eq!(origin, SettingsOrigin::Unreadable);
+        assert_eq!(settings.color_palette, Settings::default().color_palette);
+        assert_eq!(fs::read_to_string(&path).unwrap(), malformed);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn save_refuses_to_replace_unreadable_settings() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _config_dir = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+
+        let path = temp.path().join("settings.json");
+        let malformed = r#"{"usage":{"disabledProviders":{"copilot":true}}}"#;
+        fs::write(&path, malformed).unwrap();
+
+        let save_error = Settings::load().save().unwrap_err();
+        assert!(save_error.to_string().contains("refusing to replace them"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), malformed);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn save_initializes_missing_settings() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _config_dir = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+
+        let mut settings = Settings::default();
+        settings.color_palette = "green".to_string();
+        settings.save().unwrap();
+
+        let saved: Settings =
+            serde_json::from_str(&fs::read_to_string(temp.path().join("settings.json")).unwrap())
+                .unwrap();
+        assert_eq!(saved.color_palette, "green");
     }
 }

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -6492,6 +6492,7 @@ fn test_auto_pinning_never_overwrites_a_settings_file_it_could_not_read() {
     for unreadable in [
         r#"{"colorPalette": "green", "scanner": {"#,
         r#"{"colorPalette": 42, "scanner": {"extraScanPaths": {"claude": ["/data"]}}}"#,
+        r#"{"usage":{"disabledProviders":{"copilot":true}}}"#,
     ] {
         let tmp = create_bucket_timezone_fixture_dir();
         let settings_path = settings_json_path(tmp.path());
@@ -6518,25 +6519,29 @@ fn test_auto_pinning_never_overwrites_a_settings_file_it_could_not_read() {
 /// contents were never recovered.
 #[test]
 fn test_config_set_refuses_to_overwrite_unreadable_settings() {
-    let tmp = create_bucket_timezone_fixture_dir();
-    let settings_path = settings_json_path(tmp.path());
-    fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
-    let unreadable = r#"{"scanner": {"extraScanPaths": "not-a-map"}}"#;
-    fs::write(&settings_path, unreadable).unwrap();
+    for unreadable in [
+        r#"{"scanner": {"extraScanPaths": "not-a-map"}}"#,
+        r#"{"usage":{"disabledProviders":{"copilot":true}}}"#,
+    ] {
+        let tmp = create_bucket_timezone_fixture_dir();
+        let settings_path = settings_json_path(tmp.path());
+        fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        fs::write(&settings_path, unreadable).unwrap();
 
-    cmd_with_home(tmp.path())
-        .args(["config", "set", "timezone", "Asia/Seoul"])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "could not read this machine's tokscale settings",
-        ));
+        cmd_with_home(tmp.path())
+            .args(["config", "set", "timezone", "Asia/Seoul"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(
+                "could not read this machine's tokscale settings",
+            ));
 
-    assert_eq!(
-        fs::read_to_string(&settings_path).unwrap(),
-        unreadable,
-        "a refused write must leave the file untouched"
-    );
+        assert_eq!(
+            fs::read_to_string(&settings_path).unwrap(),
+            unreadable,
+            "a refused write must leave the file untouched"
+        );
+    }
 }
 
 /// A `bucketTimezone` that does not name a zone the tz database knows is not a


### PR DESCRIPTION
`tokscale usage` and the TUI currently probe and fetch every detected provider, including unused subscriptions. Add `usage.disabledProviders` to `settings.json` so a user can exclude providers before credential discovery, auth import, or network access.

```json
{
  "usage": {
    "disabledProviders": ["copilot"]
  }
}
```

The setting uses stable provider IDs, accepts case/whitespace variations, and ignores unknown IDs. Disabled providers are also filtered from cached TUI cards and fetch diagnostics. Existing defaults and cache expiry/write behavior are unchanged; settings take effect on the next CLI run or TUI launch/refresh. The README lists supported IDs.

Closes #1243.

Validation:

- CLI unit suite: 1,303 passed, 1 ignored.
- `cargo clippy --locked -p tokscale-cli --all-features -- -D warnings` and `cargo fmt --all -- --check` passed.
- Tests verify that disabled providers trigger neither credential probes nor fetches, enabled providers still run, cached cards and diagnostics are filtered, and legacy settings load with the default behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`tokscale usage` and the TUI now honor `usage.disabledProviders`. Previously, they probed every detected provider; disabled providers are skipped before credential discovery or network access and removed from cached cards and fetch diagnostics.

- The setting accepts stable, case-insensitive provider IDs, trims surrounding whitespace, ignores unknown IDs, and is documented in the README.
- Non-string array entries are ignored, while a non-array value keeps settings unreadable; writes refuse to replace unreadable or changed-since-load files.
- Legacy settings, cache behavior, and defaults remain unchanged. Changes apply on the next `tokscale usage` run or TUI launch/refresh.

Closes #1243.

<sup>Written for commit 71897dc3d99631e6deb8e7e23cb7003b57dc829d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

