### PR TITLE
fix(submit): report the parser high-water deficit instead of adding nothing silently

### DIFF
--- a/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
+++ b/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
@@ -606,6 +606,41 @@ describe("POST /api/submit antigravity-cli re-attribution high-water", () => {
     ).toBe(260_000);
   });
 
+  it("reports the deficit when the store ages history out from under the high-water", async () => {
+    const store = newStore();
+    installTx(store);
+    const first = submissionBody("antigravity-cli", SESSION_START_DATING);
+    mockSubmit(first);
+    expect((await post(first)).status).toBe(200);
+
+    // The CLI keeps a rolling conversation store, so weeks later a full scan
+    // no longer reaches the credited session at all: it reports 90,000
+    // genuinely new tokens against a 240,000 credited lifetime.
+    installTx(store);
+    const aged = submissionBody("antigravity-cli", [
+      { date: "2026-09-01", tokens: 90_000, messages: 5 },
+    ]);
+    mockSubmit(aged);
+    const response = await post(aged);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+
+    // The bound holds, which is the point of the registry entry: a snapshot
+    // below the credited lifetime is indistinguishable from a re-attribution.
+    expect(json.metrics.totalTokens).toBe(240_000);
+    expect(store.days.map((day) => day.date)).toEqual(["2026-08-07"]);
+
+    // What must not happen silently. Without the warning this response is
+    // identical to one that stored everything.
+    expect(
+      json.warnings.some(
+        (warning: string) =>
+          warning.includes("Added no Antigravity CLI usage") &&
+          warning.includes("150,000"),
+      ),
+    ).toBe(true);
+  });
+
   it("still inflates for a client that is legitimately not registered", async () => {
     // Claude's parser does not re-attribute submitted history, so it is not in
     // SUPPORTED_VERSIONED_PARSERS and takes the plain day-by-day merge path.

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -847,6 +847,17 @@ export async function POST(request: Request) {
             `Ignored ${label} changes because this parser generation or partial snapshot cannot safely advance the device high-water.`
           );
         }
+        if (plan.highWaterDeficit) {
+          // Without this the submit is indistinguishable from a successful
+          // one: the client is listed as scanned, the request returns 200, and
+          // nothing says the device has been contributing zero for this client
+          // since its scan fell below the credited high-water.
+          warnings.push(
+            `Added no ${label} usage because this scan reports ${plan.highWaterDeficit.toLocaleString(
+              "en-US"
+            )} fewer lifetime tokens than this device has already been credited. Local history that is deleted or aged out of the client's own store stays credited, so nothing is added until the scan exceeds the stored high-water again.`
+          );
+        }
       }
       const plannedIncrementClients = [...parserPlans].filter(
         ([, plan]) =>

--- a/packages/frontend/src/lib/db/parserHighWater.ts
+++ b/packages/frontend/src/lib/db/parserHighWater.ts
@@ -127,6 +127,13 @@ export interface ParserHighWaterPlan {
   /** Absolute cells when `mode` is `replace`; omitted otherwise. */
   layoutDays?: Record<string, ClientBreakdownData>;
   nextState?: ParserClientHighWaterState;
+  /**
+   * Lifetime tokens the credited ledger holds beyond what this snapshot
+   * reports. Positive means no growth was allocatable and none can be until
+   * the parser reports at least this much more, which is indistinguishable
+   * from a re-attribution and so is never credited.
+   */
+  highWaterDeficit?: number;
 }
 
 function copyModels(
@@ -813,9 +820,13 @@ export function planParserHighWaterSubmission(args: {
     incomingAggregate
   );
 
+  const highWaterDeficit = positive(
+    previousAggregate.tokens - incomingAggregate.tokens
+  );
   return {
     mode: "incremental",
     increments,
+    ...(highWaterDeficit > 0 ? { highWaterDeficit } : {}),
     nextState: stateAfterCreditedIncrements(
       supportedVersion,
       previousCreditedDays,


### PR DESCRIPTION
Closes #1315 partially -- this is the diagnosability half, not the fix for what is dropped.

## Problem

A device whose versioned-parser scan reports fewer lifetime tokens than it has already been credited can never allocate growth. `allocateIncrements` budgets `positive(incoming - credited)`, and the credited ledger only grows, so once the incoming aggregate falls below it every later submission adds exactly zero.

Nothing says so. `mode` is `incremental`; only `freeze`, `baseline-legacy` and `replace` push a warning. The submit returns 200 with the client listed under "Data to submit", the CLI prints "Successfully submitted!", and the profile silently stops advancing for that client.

That is how `antigravity-cli` contributed nothing from two of my devices for 13 days -- ~388M tokens, ~6,891 messages -- with no signal anywhere. #1315 has the full analysis of *why* the aggregate falls below the ledger for that client (its store prunes old conversations, so a full scan is a rolling window).

## Change

- `ParserHighWaterPlan` carries `highWaterDeficit`: how far the credited lifetime exceeds what this snapshot reports.
- The submit route warns with it, naming the shortfall and why nothing was added.

No change to what is credited. The bound is deliberate -- a snapshot below the credited lifetime is indistinguishable from a re-attribution, which is the whole point of the registry entry -- so this only makes the state visible.

## Tests

New route regression in `submitAntigravityCliHighWater.test.ts`: baseline a device at 240,000 tokens, then submit a scan whose window has aged past it and reports 90,000 genuinely new tokens. Asserts the bound still holds (stored total stays 240,000, no new day) **and** that the response names the 150,000 shortfall.

`bun run test` 1008 passed / 27 skipped, `bun run typecheck` clean, `bun run lint` no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns in the submit response when a device's parser scan reports fewer lifetime tokens than already credited, so a client silently contributing zero now sees why instead of a successful-looking 200. Partially closes #1315 with the diagnosability half.

**Bug Fixes**
- Carries the deficit on the parser high-water plan and names the shortfall in the submit response.
- Does not change crediting behavior; the bound still holds since a snapshot below the credited lifetime is indistinguishable from a re-attribution.

<sup>Written for commit ceae2711aa529ba836856a64113e491563803ec5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

