### PR TITLE
fix(submit): bound the parser high-water by the store's retention floor

### DIFF
--- a/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
+++ b/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
@@ -648,16 +648,15 @@ describe("POST /api/submit antigravity-cli re-attribution high-water", () => {
     ).toBe(true);
   });
 
-  it("credits the new window when the reported retention floor clears the stored days", async () => {
+  it("keeps the lifetime bound when an unverified retention floor clears the stored days", async () => {
     const store = newStore();
     installTx(store);
     const first = submissionBody("antigravity-cli", SESSION_START_DATING);
     mockSubmit(first);
     expect((await post(first)).status).toBe(200);
 
-    // Same aged-out scan as above, except the parser now reports how far back
-    // its own store still reaches. The 2026-08-07 session is no longer on
-    // disk, so it cannot be what these 90,000 tokens were moved from.
+    // A client-controlled floor cannot establish that the old session was
+    // actually pruned rather than moved to this newly dated cell.
     installTx(store);
     const aged = submissionBody(
       "antigravity-cli",
@@ -669,16 +668,14 @@ describe("POST /api/submit antigravity-cli re-attribution high-water", () => {
     expect(response.status).toBe(200);
     const json = await response.json();
 
-    expect(json.metrics.totalTokens).toBe(330_000);
-    expect(store.days.map((day) => day.date)).toEqual([
-      "2026-08-07",
-      "2026-09-01",
-    ]);
+    expect(json.metrics.totalTokens).toBe(240_000);
+    expect(store.days.map((day) => day.date)).toEqual(["2026-08-07"]);
     expect(
       (json.warnings ?? []).some((warning: string) =>
-        warning.includes("Added no Antigravity CLI tokens"),
+        warning.includes("Added no Antigravity CLI tokens") &&
+        warning.includes("150,000"),
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("warns about token deficit while retaining newly credited messages", async () => {

--- a/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
+++ b/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
@@ -397,6 +397,7 @@ function installTx(store: Store) {
 function submissionBody(
   client: string,
   days: Array<{ date: string; tokens: number; messages: number }>,
+  retentionFloor?: string,
 ) {
   const dates = days.map((day) => day.date).sort();
   return {
@@ -408,7 +409,13 @@ function submissionBody(
     },
     // The CLI declares generation 1 for every client but Copilot, so a real
     // Antigravity CLI submit carries exactly this.
-    scanScope: { parserVersions: { [client]: 1 }, fullHistory: true },
+    scanScope: {
+      parserVersions: { [client]: 1 },
+      fullHistory: true,
+      ...(retentionFloor
+        ? { retentionFloors: { [client]: retentionFloor } }
+        : {}),
+    },
     summary: { clients: [client] },
     years: [],
     contributions: days.map((day) => ({
@@ -639,6 +646,63 @@ describe("POST /api/submit antigravity-cli re-attribution high-water", () => {
           warning.includes("150,000"),
       ),
     ).toBe(true);
+  });
+
+  it("credits the new window when the reported retention floor clears the stored days", async () => {
+    const store = newStore();
+    installTx(store);
+    const first = submissionBody("antigravity-cli", SESSION_START_DATING);
+    mockSubmit(first);
+    expect((await post(first)).status).toBe(200);
+
+    // Same aged-out scan as above, except the parser now reports how far back
+    // its own store still reaches. The 2026-08-07 session is no longer on
+    // disk, so it cannot be what these 90,000 tokens were moved from.
+    installTx(store);
+    const aged = submissionBody(
+      "antigravity-cli",
+      [{ date: "2026-09-01", tokens: 90_000, messages: 5 }],
+      "2026-09-01",
+    );
+    mockSubmit(aged);
+    const response = await post(aged);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+
+    expect(json.metrics.totalTokens).toBe(330_000);
+    expect(store.days.map((day) => day.date)).toEqual([
+      "2026-08-07",
+      "2026-09-01",
+    ]);
+    expect(
+      (json.warnings ?? []).some((warning: string) =>
+        warning.includes("Added no Antigravity CLI usage"),
+      ),
+    ).toBe(false);
+  });
+
+  it("credits nothing when a re-attribution happens under a retention floor", async () => {
+    const store = newStore();
+    installTx(store);
+    const first = submissionBody("antigravity-cli", SESSION_START_DATING);
+    mockSubmit(first);
+    expect((await post(first)).status).toBe(200);
+
+    // The floor is derived from session start times still on disk, so a
+    // re-dated session keeps its own start: the floor does not advance past
+    // the credited day and the lifetime bound still sees all 240,000.
+    installTx(store);
+    const rescan = submissionBody(
+      "antigravity-cli",
+      PER_GENERATION_DATING,
+      "2026-08-07",
+    );
+    mockSubmit(rescan);
+    const response = await post(rescan);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+
+    expect(json.metrics.totalTokens).toBe(240_000);
   });
 
   it("still inflates for a client that is legitimately not registered", async () => {

--- a/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
+++ b/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
@@ -606,6 +606,41 @@ describe("POST /api/submit antigravity-cli re-attribution high-water", () => {
     ).toBe(260_000);
   });
 
+  it("reports the deficit when the store ages history out from under the high-water", async () => {
+    const store = newStore();
+    installTx(store);
+    const first = submissionBody("antigravity-cli", SESSION_START_DATING);
+    mockSubmit(first);
+    expect((await post(first)).status).toBe(200);
+
+    // The CLI keeps a rolling conversation store, so weeks later a full scan
+    // no longer reaches the credited session at all: it reports 90,000
+    // genuinely new tokens against a 240,000 credited lifetime.
+    installTx(store);
+    const aged = submissionBody("antigravity-cli", [
+      { date: "2026-09-01", tokens: 90_000, messages: 5 },
+    ]);
+    mockSubmit(aged);
+    const response = await post(aged);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+
+    // The bound holds, which is the point of the registry entry: a snapshot
+    // below the credited lifetime is indistinguishable from a re-attribution.
+    expect(json.metrics.totalTokens).toBe(240_000);
+    expect(store.days.map((day) => day.date)).toEqual(["2026-08-07"]);
+
+    // What must not happen silently. Without the warning this response is
+    // identical to one that stored everything.
+    expect(
+      json.warnings.some(
+        (warning: string) =>
+          warning.includes("Added no Antigravity CLI usage") &&
+          warning.includes("150,000"),
+      ),
+    ).toBe(true);
+  });
+
   it("still inflates for a client that is legitimately not registered", async () => {
     // Claude's parser does not re-attribute submitted history, so it is not in
     // SUPPORTED_VERSIONED_PARSERS and takes the plain day-by-day merge path.

--- a/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
+++ b/packages/frontend/__tests__/api/submitAntigravityCliHighWater.test.ts
@@ -642,7 +642,7 @@ describe("POST /api/submit antigravity-cli re-attribution high-water", () => {
     expect(
       json.warnings.some(
         (warning: string) =>
-          warning.includes("Added no Antigravity CLI usage") &&
+          warning.includes("Added no Antigravity CLI tokens") &&
           warning.includes("150,000"),
       ),
     ).toBe(true);
@@ -676,9 +676,34 @@ describe("POST /api/submit antigravity-cli re-attribution high-water", () => {
     ]);
     expect(
       (json.warnings ?? []).some((warning: string) =>
-        warning.includes("Added no Antigravity CLI usage"),
+        warning.includes("Added no Antigravity CLI tokens"),
       ),
     ).toBe(false);
+  });
+
+  it("warns about token deficit while retaining newly credited messages", async () => {
+    const store = newStore();
+    const first = submissionBody("antigravity-cli", SESSION_START_DATING);
+    installTx(store);
+    mockSubmit(first);
+    expect((await post(first)).status).toBe(200);
+
+    const smaller = submissionBody("antigravity-cli", [
+      { date: "2026-09-01", tokens: 90_000, messages: 20 },
+    ], "2026-08-07");
+    installTx(store);
+    mockSubmit(smaller);
+    const response = await post(smaller);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    const added = store.days.find((day) => day.date === "2026-09-01")!.sourceBreakdown["antigravity-cli"];
+    expect(added.tokens).toBe(0);
+    expect(added.messages).toBe(8);
+    expect(json.metrics.totalTokens).toBe(240_000);
+    expect(json.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining("150,000"),
+    ]));
+    expect(json.warnings.some((warning: string) => warning.includes("Added no Antigravity CLI usage"))).toBe(false);
   });
 
   it("credits nothing when a re-attribution happens under a retention floor", async () => {
@@ -703,6 +728,30 @@ describe("POST /api/submit antigravity-cli re-attribution high-water", () => {
     const json = await response.json();
 
     expect(json.metrics.totalTokens).toBe(240_000);
+  });
+
+  it("ignores a retention floor contradicted by an older incoming day", async () => {
+    const store = newStore();
+    const first = submissionBody("antigravity-cli", [
+      { date: "2026-08-07", tokens: 100_000, messages: 5 },
+      { date: "2026-08-08", tokens: 200_000, messages: 5 },
+    ]);
+    installTx(store);
+    mockSubmit(first);
+    expect((await post(first)).status).toBe(200);
+
+    const moved = submissionBody("antigravity-cli", [
+      { date: "2026-08-07", tokens: 100_000, messages: 5 },
+      { date: "2026-09-01", tokens: 200_000, messages: 5 },
+    ], "2026-08-08");
+    for (let replay = 0; replay < 2; replay++) {
+      installTx(store);
+      mockSubmit(moved);
+      const response = await post(moved);
+      expect(response.status).toBe(200);
+      expect((await response.json()).metrics.totalTokens).toBe(300_000);
+      expect(store.days.map(({ date }) => date)).toEqual(["2026-08-07", "2026-08-08"]);
+    }
   });
 
   it("still inflates for a client that is legitimately not registered", async () => {

--- a/packages/frontend/__tests__/lib/parserHighWater.test.ts
+++ b/packages/frontend/__tests__/lib/parserHighWater.test.ts
@@ -1527,3 +1527,73 @@ describe("droid parser high-water", () => {
     expect(plan.increments).toEqual({});
   });
 });
+
+describe("store retention floor", () => {
+  function floored(
+    state: ParserClientHighWaterState,
+    incomingDays: Record<string, ClientBreakdownData>,
+    retentionFloor?: string
+  ) {
+    return planParserHighWaterSubmission({
+      client: "copilot",
+      incomingVersion: 2,
+      fullHistory: true,
+      retentionFloor,
+      existingLegacyDays: {},
+      incomingDays,
+      state,
+    });
+  }
+
+  const credited = baseline(
+    {},
+    snapshot(contribution("2026-07-01", 100), contribution("2026-07-02", 200))
+  ).nextState!;
+
+  it("credits growth the parser can still see once older days age out of its store", () => {
+    const plan = floored(
+      credited,
+      snapshot(contribution("2026-08-01", 50)),
+      "2026-08-01"
+    );
+
+    expect(plan.mode).toBe("incremental");
+    expect(plan.increments["2026-08-01"].tokens).toBe(50);
+    expect(plan.highWaterDeficit).toBeUndefined();
+  });
+
+  it("adds nothing and reports the deficit without a floor", () => {
+    const plan = floored(credited, snapshot(contribution("2026-08-01", 50)));
+
+    expect(plan.mode).toBe("incremental");
+    expectCreditedNothing(plan);
+    expect(plan.highWaterDeficit).toBe(250);
+  });
+
+  it("keeps counting days the floor does not clear", () => {
+    // Only 2026-07-01 falls below the floor, so 200 of the 300 credited
+    // tokens still bound the 250 the snapshot reports.
+    const plan = floored(
+      credited,
+      snapshot(contribution("2026-07-02", 200), contribution("2026-08-01", 50)),
+      "2026-07-02"
+    );
+
+    expect(plan.increments["2026-08-01"].tokens).toBe(50);
+    expect(plan.increments["2026-07-02"]).toBeUndefined();
+  });
+
+  it("cannot re-credit a forgiven day the snapshot still reports", () => {
+    // A floor is only a claim about the store's reach. Per-cell capacity is
+    // read from the full credited ledger regardless, so the day it forgave
+    // has no room left even when the budget reopens.
+    const plan = floored(
+      credited,
+      snapshot(contribution("2026-07-01", 100), contribution("2026-07-02", 200)),
+      "2026-08-01"
+    );
+
+    expectCreditedNothing(plan);
+    expect(plan.nextState?.aggregate.tokens).toBe(300);
+  });
+});

--- a/packages/frontend/__tests__/lib/parserHighWater.test.ts
+++ b/packages/frontend/__tests__/lib/parserHighWater.test.ts
@@ -1528,7 +1528,7 @@ describe("droid parser high-water", () => {
   });
 });
 
-describe("store retention floor", () => {
+describe("unverified retention floor", () => {
   function floored(
     state: ParserClientHighWaterState,
     incomingDays: Record<string, ClientBreakdownData>,
@@ -1550,7 +1550,19 @@ describe("store retention floor", () => {
     snapshot(contribution("2026-07-01", 100), contribution("2026-07-02", 200))
   ).nextState!;
 
-  it("credits growth the parser can still see once older days age out of its store", () => {
+  it("keeps the lifetime bound when an unverified floor advances with a re-dated snapshot", () => {
+    const plan = floored(
+      credited,
+      snapshot(contribution("2026-08-01", 300)),
+      "2026-08-01"
+    );
+
+    expect(plan.mode).toBe("incremental");
+    expectCreditedNothing(plan);
+    expect(plan.nextState?.aggregate.tokens).toBe(300);
+  });
+
+  it("does not let an unverified floor erase a token deficit", () => {
     const plan = floored(
       credited,
       snapshot(contribution("2026-08-01", 50)),
@@ -1558,35 +1570,22 @@ describe("store retention floor", () => {
     );
 
     expect(plan.mode).toBe("incremental");
-    expect(plan.increments["2026-08-01"].tokens).toBe(50);
-    expect(plan.highWaterDeficit).toBeUndefined();
-  });
-
-  it("adds nothing and reports the deficit without a floor", () => {
-    const plan = floored(credited, snapshot(contribution("2026-08-01", 50)));
-
-    expect(plan.mode).toBe("incremental");
     expectCreditedNothing(plan);
     expect(plan.highWaterDeficit).toBe(250);
   });
 
-  it("keeps counting days the floor does not clear", () => {
-    // Only 2026-07-01 falls below the floor, so 200 of the 300 credited
-    // tokens still bound the 250 the snapshot reports.
+  it("does not let a floor remove a subset of credited days from the baseline", () => {
     const plan = floored(
       credited,
       snapshot(contribution("2026-07-02", 200), contribution("2026-08-01", 50)),
       "2026-07-02"
     );
 
-    expect(plan.increments["2026-08-01"].tokens).toBe(50);
-    expect(plan.increments["2026-07-02"]).toBeUndefined();
+    expectCreditedNothing(plan);
+    expect(plan.nextState?.aggregate.tokens).toBe(300);
   });
 
-  it("cannot re-credit a forgiven day the snapshot still reports", () => {
-    // A floor is only a claim about the store's reach. Per-cell capacity is
-    // read from the full credited ledger regardless, so the day it forgave
-    // has no room left even when the budget reopens.
+  it("does not re-credit a known day under an unverified floor", () => {
     const plan = floored(
       credited,
       snapshot(contribution("2026-07-01", 100), contribution("2026-07-02", 200)),
@@ -1597,7 +1596,7 @@ describe("store retention floor", () => {
     expect(plan.nextState?.aggregate.tokens).toBe(300);
   });
 
-  it("does not use a below-floor replay to credit a moved cell twice", () => {
+  it("keeps the lifetime bound for a re-dated snapshot with an unverified floor", () => {
     const plan = floored(
       credited,
       snapshot(contribution("2026-07-01", 100), contribution("2026-08-01", 200)),
@@ -1607,7 +1606,7 @@ describe("store retention floor", () => {
     expect(plan.nextState?.aggregate.tokens).toBe(300);
   });
 
-  it("falls back to the lifetime bound when a legacy snapshot contradicts its floor", () => {
+  it("keeps the lifetime bound at a legacy transition with an unverified floor", () => {
     const plan = planParserHighWaterSubmission({
       client: "copilot",
       incomingVersion: 2,
@@ -1621,32 +1620,7 @@ describe("store retention floor", () => {
     expect(plan.nextState?.aggregate.tokens).toBe(300);
   });
 
-  it("credits each retained window once as the floor advances", () => {
-    const first = floored(credited, snapshot(contribution("2026-08-01", 50)), "2026-08-01");
-    const replay = floored(first.nextState!, snapshot(contribution("2026-08-01", 50)), "2026-08-01");
-    expectCreditedNothing(replay);
-
-    const advanced = floored(replay.nextState!, snapshot(contribution("2026-09-01", 20)), "2026-09-01");
-    expect(advanced.increments["2026-09-01"].tokens).toBe(20);
-    expect(advanced.nextState?.aggregate.tokens).toBe(370);
-    expect(advanced.nextState?.days["2026-07-01"].tokens).toBe(100);
-    expect(advanced.nextState?.days["2026-08-01"].tokens).toBe(50);
-    expectCreditedNothing(floored(advanced.nextState!, snapshot(contribution("2026-09-01", 20)), "2026-09-01"));
-  });
-
-  it("does not count restored history as growth when the floor retreats or disappears", () => {
-    const first = floored(credited, snapshot(contribution("2026-08-01", 50)), "2026-08-01");
-    const restored = snapshot(
-      contribution("2026-07-01", 100), contribution("2026-07-02", 200), contribution("2026-08-01", 50)
-    );
-    for (const floor of ["2026-07-01", undefined]) {
-      const plan = floored(first.nextState!, restored, floor);
-      expectCreditedNothing(plan);
-      expect(plan.nextState?.aggregate.tokens).toBe(350);
-    }
-  });
-
-  it("does not let a retention floor unfreeze a partial snapshot", () => {
+  it("does not let an unverified floor unfreeze a partial snapshot", () => {
     const plan = planParserHighWaterSubmission({
       client: "copilot", incomingVersion: 2, fullHistory: false,
       retentionFloor: "2026-09-01", existingLegacyDays: {},

--- a/packages/frontend/__tests__/lib/parserHighWater.test.ts
+++ b/packages/frontend/__tests__/lib/parserHighWater.test.ts
@@ -1596,4 +1596,63 @@ describe("store retention floor", () => {
     expectCreditedNothing(plan);
     expect(plan.nextState?.aggregate.tokens).toBe(300);
   });
+
+  it("does not use a below-floor replay to credit a moved cell twice", () => {
+    const plan = floored(
+      credited,
+      snapshot(contribution("2026-07-01", 100), contribution("2026-08-01", 200)),
+      "2026-07-02"
+    );
+    expectCreditedNothing(plan);
+    expect(plan.nextState?.aggregate.tokens).toBe(300);
+  });
+
+  it("falls back to the lifetime bound when a legacy snapshot contradicts its floor", () => {
+    const plan = planParserHighWaterSubmission({
+      client: "copilot",
+      incomingVersion: 2,
+      fullHistory: true,
+      retentionFloor: "2026-07-02",
+      existingLegacyDays: credited.days,
+      incomingDays: snapshot(contribution("2026-07-01", 100), contribution("2026-08-01", 200)),
+    });
+    expect(plan.mode).toBe("baseline-legacy");
+    expectCreditedNothing(plan);
+    expect(plan.nextState?.aggregate.tokens).toBe(300);
+  });
+
+  it("credits each retained window once as the floor advances", () => {
+    const first = floored(credited, snapshot(contribution("2026-08-01", 50)), "2026-08-01");
+    const replay = floored(first.nextState!, snapshot(contribution("2026-08-01", 50)), "2026-08-01");
+    expectCreditedNothing(replay);
+
+    const advanced = floored(replay.nextState!, snapshot(contribution("2026-09-01", 20)), "2026-09-01");
+    expect(advanced.increments["2026-09-01"].tokens).toBe(20);
+    expect(advanced.nextState?.aggregate.tokens).toBe(370);
+    expect(advanced.nextState?.days["2026-07-01"].tokens).toBe(100);
+    expect(advanced.nextState?.days["2026-08-01"].tokens).toBe(50);
+    expectCreditedNothing(floored(advanced.nextState!, snapshot(contribution("2026-09-01", 20)), "2026-09-01"));
+  });
+
+  it("does not count restored history as growth when the floor retreats or disappears", () => {
+    const first = floored(credited, snapshot(contribution("2026-08-01", 50)), "2026-08-01");
+    const restored = snapshot(
+      contribution("2026-07-01", 100), contribution("2026-07-02", 200), contribution("2026-08-01", 50)
+    );
+    for (const floor of ["2026-07-01", undefined]) {
+      const plan = floored(first.nextState!, restored, floor);
+      expectCreditedNothing(plan);
+      expect(plan.nextState?.aggregate.tokens).toBe(350);
+    }
+  });
+
+  it("does not let a retention floor unfreeze a partial snapshot", () => {
+    const plan = planParserHighWaterSubmission({
+      client: "copilot", incomingVersion: 2, fullHistory: false,
+      retentionFloor: "2026-09-01", existingLegacyDays: {},
+      incomingDays: snapshot(contribution("2026-09-01", 50)), state: credited,
+    });
+    expect(plan.mode).toBe("freeze");
+    expect(plan.increments).toEqual({});
+  });
 });

--- a/packages/frontend/__tests__/lib/submissionProvenance.test.ts
+++ b/packages/frontend/__tests__/lib/submissionProvenance.test.ts
@@ -103,6 +103,34 @@ describe("submission provenance", () => {
 
 
 describe("submission scan scope", () => {
+  it.each(["2025-02-31", "2025-02-29", "2026-04-31", "2026-13-01", "2026-00-01", "2026-01-00", "2026-1-01"])(
+    "rejects impossible retention floor %s", (floor) => {
+      const body = buildSubmission();
+      body.scanScope = {
+        parserVersions: { codex: 1 },
+        fullHistory: true,
+        retentionFloors: { codex: floor },
+      };
+      const result = validateSubmission(body);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toEqual(expect.arrayContaining([
+        expect.stringContaining("scanScope.retentionFloors.codex"),
+      ]));
+    },
+  );
+
+  it.each(["2024-02-29", "2026-05-11"])("preserves valid calendar floor %s", (floor) => {
+    const body = buildSubmission();
+    body.scanScope = {
+      parserVersions: { codex: 1 },
+      fullHistory: true,
+      retentionFloors: { codex: floor },
+    };
+    const result = validateSubmission(body);
+    expect(result.errors).toEqual([]);
+    expect(result.data?.scanScope?.retentionFloors).toEqual({ codex: floor });
+  });
+
   it("accepts parser identity separately from full-history eligibility", () => {
     const full = buildSubmission();
     full.scanScope = { parserVersions: { codex: 1 }, fullHistory: true };

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -847,6 +847,17 @@ export async function POST(request: Request) {
             `Ignored ${label} changes because this parser generation or partial snapshot cannot safely advance the device high-water.`
           );
         }
+        if (plan.highWaterDeficit) {
+          // Without this the submit is indistinguishable from a successful
+          // one: the client is listed as scanned, the request returns 200, and
+          // nothing says the device has been contributing zero for this client
+          // since its scan fell below the credited high-water.
+          warnings.push(
+            `Added no ${label} usage because this scan reports ${plan.highWaterDeficit.toLocaleString(
+              "en-US"
+            )} fewer lifetime tokens than this device has already been credited. Local history that is deleted or aged out of the client's own store stays credited, so nothing is added until the scan exceeds the stored high-water again.`
+          );
+        }
       }
       const plannedIncrementClients = [...parserPlans].filter(
         ([, plan]) =>

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -823,6 +823,14 @@ export async function POST(request: Request) {
                 client
               ),
           fullHistory: data.scanScope?.fullHistory === true,
+          retentionFloor: isBackfill
+            ? undefined
+            : ownValue(
+                data.scanScope?.retentionFloors as
+                  | Record<string, string>
+                  | undefined,
+                client
+              ),
           existingLegacyDays: existingClientDays,
           incomingDays: foldParserClientSnapshot(data.contributions, client),
           state: ownValue(deviceParserStates, client),

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -856,14 +856,12 @@ export async function POST(request: Request) {
           );
         }
         if (plan.highWaterDeficit) {
-          // Without this the submit is indistinguishable from a successful
-          // one: the client is listed as scanned, the request returns 200, and
-          // nothing says the device has been contributing zero for this client
-          // since its scan fell below the credited high-water.
+          // This deficit bounds tokens only. Message growth has an independent
+          // budget and may still be credited, so do not claim all usage froze.
           warnings.push(
-            `Added no ${label} usage because this scan reports ${plan.highWaterDeficit.toLocaleString(
+            `Added no ${label} tokens because this scan reports ${plan.highWaterDeficit.toLocaleString(
               "en-US"
-            )} fewer lifetime tokens than this device has already been credited. Local history that is deleted or aged out of the client's own store stays credited, so nothing is added until the scan exceeds the stored high-water again.`
+            )} fewer tokens than this device's credited baseline. Stored history is preserved. No tokens are added until the scan exceeds that baseline; new messages may still be credited.`
           );
         }
       }

--- a/packages/frontend/src/lib/db/parserHighWater.ts
+++ b/packages/frontend/src/lib/db/parserHighWater.ts
@@ -321,6 +321,34 @@ function aggregateSnapshot(
   return aggregate;
 }
 
+/**
+ * Credited/observed cells the client's own store can still reach.
+ *
+ * `retentionFloor` is the earliest session start surviving in that store, so a
+ * cell older than it describes usage the parser can no longer report at all.
+ * Keeping such cells in the budget baseline makes the lifetime bound
+ * unsatisfiable forever once a rolling store ages history out.
+ */
+function daysAtOrAfter(
+  days: Record<string, ClientBreakdownData>,
+  retentionFloor: string
+): Record<string, ClientBreakdownData> {
+  const reachable = createSafeRecord<ClientBreakdownData>();
+  for (const [date, day] of Object.entries(days)) {
+    if (date >= retentionFloor) reachable[date] = day;
+  }
+  return reachable;
+}
+
+function budgetBaseline(
+  days: Record<string, ClientBreakdownData>,
+  unfloored: ParserAggregateHighWater,
+  retentionFloor: string | undefined
+): ParserAggregateHighWater {
+  if (retentionFloor == null) return unfloored;
+  return aggregateSnapshot(daysAtOrAfter(days, retentionFloor));
+}
+
 const PARSER_HIGH_WATER_STATE_VERSION = 2;
 
 function normalizeStateDays(
@@ -455,13 +483,27 @@ function allocateIncrements(
   previousObservedDays: Record<string, ClientBreakdownData>,
   incomingDays: Record<string, ClientBreakdownData>,
   previousAggregate: ParserAggregateHighWater,
-  incomingAggregate: ParserAggregateHighWater
+  incomingAggregate: ParserAggregateHighWater,
+  retentionFloor?: string
 ): Record<string, ClientBreakdownData> {
-  let tokenBudget = positive(incomingAggregate.tokens - previousAggregate.tokens);
-  let messageBudget = positive(
-    incomingAggregate.messages - previousAggregate.messages
+  const creditedBudgetAggregate = budgetBaseline(
+    previousCreditedDays,
+    previousAggregate,
+    retentionFloor
   );
-  const previousObservedAggregate = aggregateSnapshot(previousObservedDays);
+  let tokenBudget = positive(
+    incomingAggregate.tokens - creditedBudgetAggregate.tokens
+  );
+  let messageBudget = positive(
+    incomingAggregate.messages - creditedBudgetAggregate.messages
+  );
+  // Per-cell capacity below still reads the FULL credited ledger, so a
+  // forgiven day that the parser somehow re-reports cannot be credited twice.
+  const previousObservedAggregate = aggregateSnapshot(
+    retentionFloor == null
+      ? previousObservedDays
+      : daysAtOrAfter(previousObservedDays, retentionFloor)
+  );
   const inclusiveInputBudget = positive(
     incomingAggregate.inputIncludingCacheRead -
       previousObservedAggregate.inputIncludingCacheRead
@@ -685,6 +727,16 @@ function validState(
  * actually written advance the credited ledger, so growth cannot be lost.
  * Date/model reshuffles and deleted local history never erase stored rows.
  *
+ * A parser that reports a `retentionFloor` narrows the lifetime baseline to
+ * the credited cells its store can still reach. Without it a client with a
+ * rolling store stops contributing permanently the moment its window falls
+ * below the credited lifetime: every later scan reports less than is already
+ * stored, so the bound allows nothing. Cells below the floor keep their stored
+ * rows and their per-cell caps; they only stop counting against the budget.
+ * The floor is derived from session start times still on disk, which a
+ * re-attribution cannot move, so it does not reopen the budget for the
+ * re-dating this bound exists to contain.
+ *
  * SNAPSHOT_LAYOUT_CLIENTS are the deliberate exception to both absolutes
  * above: once a full snapshot's aggregate covers the credited one, the stored
  * layout is replaced outright so the web graph matches the TUI, which also
@@ -695,6 +747,12 @@ export function planParserHighWaterSubmission(args: {
   client: string;
   incomingVersion?: number;
   fullHistory: boolean;
+  /**
+   * Earliest `YYYY-MM-DD` the client's own store still reaches, as reported by
+   * the parser from the store's contents. Absent keeps the unbounded lifetime
+   * baseline, which is what every CLI that does not report a floor gets.
+   */
+  retentionFloor?: string;
   existingLegacyDays: Record<string, ClientBreakdownData>;
   incomingDays: Record<string, ClientBreakdownData>;
   state?: ParserClientHighWaterState;
@@ -764,7 +822,8 @@ export function planParserHighWaterSubmission(args: {
           args.existingLegacyDays,
           args.incomingDays,
           legacyAggregate,
-          incomingAggregate
+          incomingAggregate,
+          args.retentionFloor
         )
       : createSafeRecord<ClientBreakdownData>();
     const nextState = hasLegacy
@@ -817,11 +876,13 @@ export function planParserHighWaterSubmission(args: {
     previousObservedDays,
     args.incomingDays,
     previousAggregate,
-    incomingAggregate
+    incomingAggregate,
+    args.retentionFloor
   );
 
   const highWaterDeficit = positive(
-    previousAggregate.tokens - incomingAggregate.tokens
+    budgetBaseline(previousCreditedDays, previousAggregate, args.retentionFloor)
+      .tokens - incomingAggregate.tokens
   );
   return {
     mode: "incremental",

--- a/packages/frontend/src/lib/db/parserHighWater.ts
+++ b/packages/frontend/src/lib/db/parserHighWater.ts
@@ -128,10 +128,9 @@ export interface ParserHighWaterPlan {
   layoutDays?: Record<string, ClientBreakdownData>;
   nextState?: ParserClientHighWaterState;
   /**
-   * Lifetime tokens the credited ledger holds beyond what this snapshot
-   * reports. Positive means no growth was allocatable and none can be until
-   * the parser reports at least this much more, which is indistinguishable
-   * from a re-attribution and so is never credited.
+   * Tokens the credited baseline (within the optional retention window)
+   * holds beyond this snapshot. Positive means no token growth is allocatable;
+   * messages have an independent budget and can still advance.
    */
   highWaterDeficit?: number;
 }
@@ -790,6 +789,15 @@ export function planParserHighWaterSubmission(args: {
     };
   }
 
+  // A floor claims no usage before it is still reachable. A snapshot that
+  // includes an older cell contradicts that claim: keeping those tokens in
+  // the incoming total while removing them from the baseline funds duplicate
+  // credit on a moved date. Keep the lifetime bound for that whole snapshot.
+  const reportedFloor = args.retentionFloor;
+  const retentionFloor = reportedFloor != null &&
+    Object.keys(args.incomingDays).every((date) => date >= reportedFloor)
+    ? reportedFloor
+    : undefined;
   const incomingAggregate = aggregateSnapshot(args.incomingDays);
   if (args.state && !validState(args.state, supportedVersion)) {
     return { mode: "freeze", increments: {} };
@@ -823,7 +831,7 @@ export function planParserHighWaterSubmission(args: {
           args.incomingDays,
           legacyAggregate,
           incomingAggregate,
-          args.retentionFloor
+          retentionFloor
         )
       : createSafeRecord<ClientBreakdownData>();
     const nextState = hasLegacy
@@ -877,11 +885,11 @@ export function planParserHighWaterSubmission(args: {
     args.incomingDays,
     previousAggregate,
     incomingAggregate,
-    args.retentionFloor
+    retentionFloor
   );
 
   const highWaterDeficit = positive(
-    budgetBaseline(previousCreditedDays, previousAggregate, args.retentionFloor)
+    budgetBaseline(previousCreditedDays, previousAggregate, retentionFloor)
       .tokens - incomingAggregate.tokens
   );
   return {

--- a/packages/frontend/src/lib/db/parserHighWater.ts
+++ b/packages/frontend/src/lib/db/parserHighWater.ts
@@ -128,9 +128,9 @@ export interface ParserHighWaterPlan {
   layoutDays?: Record<string, ClientBreakdownData>;
   nextState?: ParserClientHighWaterState;
   /**
-   * Tokens the credited baseline (within the optional retention window)
-   * holds beyond this snapshot. Positive means no token growth is allocatable;
-   * messages have an independent budget and can still advance.
+   * Tokens the credited lifetime baseline holds beyond this snapshot. Positive
+   * means no token growth is allocatable; messages have an independent budget
+   * and can still advance.
    */
   highWaterDeficit?: number;
 }
@@ -320,34 +320,6 @@ function aggregateSnapshot(
   return aggregate;
 }
 
-/**
- * Credited/observed cells the client's own store can still reach.
- *
- * `retentionFloor` is the earliest session start surviving in that store, so a
- * cell older than it describes usage the parser can no longer report at all.
- * Keeping such cells in the budget baseline makes the lifetime bound
- * unsatisfiable forever once a rolling store ages history out.
- */
-function daysAtOrAfter(
-  days: Record<string, ClientBreakdownData>,
-  retentionFloor: string
-): Record<string, ClientBreakdownData> {
-  const reachable = createSafeRecord<ClientBreakdownData>();
-  for (const [date, day] of Object.entries(days)) {
-    if (date >= retentionFloor) reachable[date] = day;
-  }
-  return reachable;
-}
-
-function budgetBaseline(
-  days: Record<string, ClientBreakdownData>,
-  unfloored: ParserAggregateHighWater,
-  retentionFloor: string | undefined
-): ParserAggregateHighWater {
-  if (retentionFloor == null) return unfloored;
-  return aggregateSnapshot(daysAtOrAfter(days, retentionFloor));
-}
-
 const PARSER_HIGH_WATER_STATE_VERSION = 2;
 
 function normalizeStateDays(
@@ -482,32 +454,27 @@ function allocateIncrements(
   previousObservedDays: Record<string, ClientBreakdownData>,
   incomingDays: Record<string, ClientBreakdownData>,
   previousAggregate: ParserAggregateHighWater,
-  incomingAggregate: ParserAggregateHighWater,
-  retentionFloor?: string
+  incomingAggregate: ParserAggregateHighWater
 ): Record<string, ClientBreakdownData> {
-  const creditedBudgetAggregate = budgetBaseline(
-    previousCreditedDays,
-    previousAggregate,
-    retentionFloor
-  );
-  let tokenBudget = positive(
-    incomingAggregate.tokens - creditedBudgetAggregate.tokens
-  );
+  // Keep the complete credited lifetime in the budget. A client-reported
+  // retention boundary cannot prove that a missing old cell was pruned rather
+  // than re-dated into this snapshot, so excluding it could credit it twice.
+  let tokenBudget = positive(incomingAggregate.tokens - previousAggregate.tokens);
   let messageBudget = positive(
-    incomingAggregate.messages - creditedBudgetAggregate.messages
+    incomingAggregate.messages - previousAggregate.messages
   );
   // Per-cell capacity below still reads the FULL credited ledger, so a
-  // forgiven day that the parser somehow re-reports cannot be credited twice.
-  const previousObservedAggregate = aggregateSnapshot(
-    retentionFloor == null
-      ? previousObservedDays
-      : daysAtOrAfter(previousObservedDays, retentionFloor)
-  );
+  // re-reported day cannot be credited twice.
+  const previousObservedAggregate = aggregateSnapshot(previousObservedDays);
   const inclusiveInputBudget = positive(
     incomingAggregate.inputIncludingCacheRead -
       previousObservedAggregate.inputIncludingCacheRead
   );
-  const dates = Object.keys(incomingDays).sort((a, b) => b.localeCompare(a));
+  // Residual allocation is intentionally newest-first. ISO day keys sort by
+  // code point, avoiding a host's default locale changing which cell wins.
+  const dates = Object.keys(incomingDays).sort((a, b) =>
+    a === b ? 0 : a < b ? 1 : -1
+  );
   const cells = dates.flatMap((date) => {
     const incoming = incomingDays[date];
     const creditedModels = modelsForHighWater(
@@ -726,16 +693,6 @@ function validState(
  * actually written advance the credited ledger, so growth cannot be lost.
  * Date/model reshuffles and deleted local history never erase stored rows.
  *
- * A parser that reports a `retentionFloor` narrows the lifetime baseline to
- * the credited cells its store can still reach. Without it a client with a
- * rolling store stops contributing permanently the moment its window falls
- * below the credited lifetime: every later scan reports less than is already
- * stored, so the bound allows nothing. Cells below the floor keep their stored
- * rows and their per-cell caps; they only stop counting against the budget.
- * The floor is derived from session start times still on disk, which a
- * re-attribution cannot move, so it does not reopen the budget for the
- * re-dating this bound exists to contain.
- *
  * SNAPSHOT_LAYOUT_CLIENTS are the deliberate exception to both absolutes
  * above: once a full snapshot's aggregate covers the credited one, the stored
  * layout is replaced outright so the web graph matches the TUI, which also
@@ -747,9 +704,9 @@ export function planParserHighWaterSubmission(args: {
   incomingVersion?: number;
   fullHistory: boolean;
   /**
-   * Earliest `YYYY-MM-DD` the client's own store still reaches, as reported by
-   * the parser from the store's contents. Absent keeps the unbounded lifetime
-   * baseline, which is what every CLI that does not report a floor gets.
+   * Client-reported earliest `YYYY-MM-DD` still retained locally. It is
+   * preserved for the submission protocol but cannot relax the high-water
+   * without server-verifiable evidence of that retention transition.
    */
   retentionFloor?: string;
   existingLegacyDays: Record<string, ClientBreakdownData>;
@@ -789,15 +746,6 @@ export function planParserHighWaterSubmission(args: {
     };
   }
 
-  // A floor claims no usage before it is still reachable. A snapshot that
-  // includes an older cell contradicts that claim: keeping those tokens in
-  // the incoming total while removing them from the baseline funds duplicate
-  // credit on a moved date. Keep the lifetime bound for that whole snapshot.
-  const reportedFloor = args.retentionFloor;
-  const retentionFloor = reportedFloor != null &&
-    Object.keys(args.incomingDays).every((date) => date >= reportedFloor)
-    ? reportedFloor
-    : undefined;
   const incomingAggregate = aggregateSnapshot(args.incomingDays);
   if (args.state && !validState(args.state, supportedVersion)) {
     return { mode: "freeze", increments: {} };
@@ -830,8 +778,7 @@ export function planParserHighWaterSubmission(args: {
           args.existingLegacyDays,
           args.incomingDays,
           legacyAggregate,
-          incomingAggregate,
-          retentionFloor
+          incomingAggregate
         )
       : createSafeRecord<ClientBreakdownData>();
     const nextState = hasLegacy
@@ -884,13 +831,11 @@ export function planParserHighWaterSubmission(args: {
     previousObservedDays,
     args.incomingDays,
     previousAggregate,
-    incomingAggregate,
-    retentionFloor
+    incomingAggregate
   );
 
   const highWaterDeficit = positive(
-    budgetBaseline(previousCreditedDays, previousAggregate, retentionFloor)
-      .tokens - incomingAggregate.tokens
+    previousAggregate.tokens - incomingAggregate.tokens
   );
   return {
     mode: "incremental",

--- a/packages/frontend/src/lib/db/parserHighWater.ts
+++ b/packages/frontend/src/lib/db/parserHighWater.ts
@@ -127,6 +127,13 @@ export interface ParserHighWaterPlan {
   /** Absolute cells when `mode` is `replace`; omitted otherwise. */
   layoutDays?: Record<string, ClientBreakdownData>;
   nextState?: ParserClientHighWaterState;
+  /**
+   * Lifetime tokens the credited ledger holds beyond what this snapshot
+   * reports. Positive means no growth was allocatable and none can be until
+   * the parser reports at least this much more, which is indistinguishable
+   * from a re-attribution and so is never credited.
+   */
+  highWaterDeficit?: number;
 }
 
 function copyModels(
@@ -813,9 +820,13 @@ export function planParserHighWaterSubmission(args: {
     incomingAggregate
   );
 
+  const highWaterDeficit = positive(
+    previousAggregate.tokens - incomingAggregate.tokens
+  );
   return {
     mode: "incremental",
     increments,
+    ...(highWaterDeficit > 0 ? { highWaterDeficit } : {}),
     nextState: stateAfterCreditedIncrements(
       supportedVersion,
       previousCreditedDays,

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -230,6 +230,11 @@ const SubmissionDataSchema = z.preprocess(normalizeLegacySources, z.object({
   scanScope: z.object({
     parserVersions: z.record(SourceSchema, NonNegativeIntegerSchema.min(1)),
     fullHistory: z.boolean(),
+    // Earliest date each parser's own store still reaches. Clients whose store
+    // never prunes omit it; the high-water bound then stays unbounded.
+    retentionFloors: z
+      .record(SourceSchema, z.string().regex(/^\d{4}-\d{2}-\d{2}$/))
+      .optional(),
   }).optional(),
   summary: DataSummarySchema,
   years: z.array(YearSummarySchema),

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -29,8 +29,8 @@ const TOKEN_ABSOLUTE_TOLERANCE = 100;
 const NonNegativeIntegerSchema = z.number().finite().int().min(0).max(Number.MAX_SAFE_INTEGER);
 const NonNegativeNumberSchema = z.number().finite().min(0);
 
-// Floors participate in lexical day comparisons, so a date-shaped string
-// that UTC would normalize into a different day must not reach the planner.
+// Keep the protocol field calendar-safe even while the allocator deliberately
+// treats its client-reported value as unverified metadata.
 const RetentionFloorSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine(
   (value) => {
     const parsed = new Date(`${value}T00:00:00.000Z`);
@@ -240,8 +240,8 @@ const SubmissionDataSchema = z.preprocess(normalizeLegacySources, z.object({
   scanScope: z.object({
     parserVersions: z.record(SourceSchema, NonNegativeIntegerSchema.min(1)),
     fullHistory: z.boolean(),
-    // Earliest date each parser's own store still reaches. Clients whose store
-    // never prunes omit it; the high-water bound then stays unbounded.
+    // Retained protocol metadata. The high-water cannot yet use it as proof
+    // that local history was pruned.
     retentionFloors: z
       .record(SourceSchema, RetentionFloorSchema)
       .optional(),

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -29,6 +29,16 @@ const TOKEN_ABSOLUTE_TOLERANCE = 100;
 const NonNegativeIntegerSchema = z.number().finite().int().min(0).max(Number.MAX_SAFE_INTEGER);
 const NonNegativeNumberSchema = z.number().finite().min(0);
 
+// Floors participate in lexical day comparisons, so a date-shaped string
+// that UTC would normalize into a different day must not reach the planner.
+const RetentionFloorSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine(
+  (value) => {
+    const parsed = new Date(`${value}T00:00:00.000Z`);
+    return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+  },
+  { message: "Invalid calendar date" },
+);
+
 const TokenBreakdownSchema = z.object({
   input: NonNegativeIntegerSchema,
   output: NonNegativeIntegerSchema,
@@ -233,7 +243,7 @@ const SubmissionDataSchema = z.preprocess(normalizeLegacySources, z.object({
     // Earliest date each parser's own store still reaches. Clients whose store
     // never prunes omit it; the high-water bound then stays unbounded.
     retentionFloors: z
-      .record(SourceSchema, z.string().regex(/^\d{4}-\d{2}-\d{2}$/))
+      .record(SourceSchema, RetentionFloorSchema)
       .optional(),
   }).optional(),
   summary: DataSummarySchema,


### PR DESCRIPTION
Full scans of a rolling conversation store can stay below the device's credited lifetime after old sessions are pruned, leaving no token budget for new usage. This accepts and calendar-validates optional `scanScope.retentionFloors[client]` metadata for a future retention-aware protocol.

The current server deliberately keeps the full lifetime high-water even when a client reports a floor. A client-controlled floor cannot prove that old history was pruned rather than re-dated into the incoming snapshot, so using it to reduce the baseline could duplicate previously credited usage. Calendar-invalid floor values are rejected, and token-deficit warnings distinguish tokens from independently credited messages.

Updated against current main, including the merged deficit warning from #1316, with both merge conflicts resolved. Tests cover coordinated floor advances with re-dated snapshots, legacy baselines, partial scans, calendar validation, and positive message increments during a token deficit.

Related: #1315. Retention recovery is intentionally not enabled: a future implementation must persist and validate an authenticated, monotonic store-boundary transition before allowing a floor to relax the high-water. A CLI-reported timestamp alone is insufficient under the current submission trust model.

Validation:

- Frontend suite: 1,028 tests passed.
- TypeScript and ESLint on all changed files passed.
- PostgreSQL 16 migration replay and 27 reconciliation/moderation integration tests passed.
- Calendar, message-warning, and moved-cell regressions were reproduced before their fixes.
