### PR TITLE
fix(tui): preserve external settings edits when saving preferences

### DIFF
--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -35,7 +35,8 @@ indicatif = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
+# Patch TUI preferences without reserializing unrelated JSON values or numbers.
+serde_json = { workspace = true, features = ["raw_value"] }
 toml = { workspace = true }
 chrono = { workspace = true }
 dirs = { workspace = true }

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -1898,7 +1898,9 @@ impl App {
         };
         self.dialog_stack.set_theme(self.theme.clone());
         self.settings.set_theme(new_theme);
-        if let Err(e) = Settings::update_and_save(|settings| settings.set_theme(new_theme)) {
+        if let Err(e) = Settings::update_and_save(|settings| {
+            settings["colorPalette"] = new_theme.as_str().into();
+        }) {
             self.set_status(&format!(
                 "Theme: {} (save failed: {})",
                 new_theme.as_str(),
@@ -1923,7 +1925,9 @@ impl App {
         } else {
             "off"
         };
-        if let Err(e) = Settings::update_and_save(|settings| settings.tui_light_mode = light_mode) {
+        if let Err(e) = Settings::update_and_save(|settings| {
+            settings["tuiLightMode"] = light_mode.into();
+        }) {
             self.set_status(&format!("Light mode: {} (save failed: {})", state, e));
         } else {
             self.set_status(&format!("Light mode: {}", state));
@@ -2080,7 +2084,7 @@ impl App {
         }
         self.settings.auto_refresh_enabled = self.auto_refresh;
         let save_result = Settings::update_and_save(|settings| {
-            settings.auto_refresh_enabled = self.auto_refresh;
+            settings["autoRefreshEnabled"] = self.auto_refresh.into();
         });
         let msg = if self.auto_refresh {
             format!(
@@ -2102,7 +2106,9 @@ impl App {
         let new_ms = ms.saturating_add(10_000).min(300_000);
         self.auto_refresh_interval = Duration::from_millis(new_ms);
         self.settings.auto_refresh_ms = new_ms;
-        let save_result = Settings::update_and_save(|settings| settings.auto_refresh_ms = new_ms);
+        let save_result = Settings::update_and_save(|settings| {
+            settings["autoRefreshMs"] = new_ms.into();
+        });
         let msg = format!("Refresh interval: {}s", new_ms / 1000);
         if let Err(e) = save_result {
             self.set_status(&format!("{} (save failed: {})", msg, e));
@@ -2116,7 +2122,9 @@ impl App {
         let new_ms = ms.saturating_sub(10_000).max(30_000);
         self.auto_refresh_interval = Duration::from_millis(new_ms);
         self.settings.auto_refresh_ms = new_ms;
-        let save_result = Settings::update_and_save(|settings| settings.auto_refresh_ms = new_ms);
+        let save_result = Settings::update_and_save(|settings| {
+            settings["autoRefreshMs"] = new_ms.into();
+        });
         let msg = format!("Refresh interval: {}s", new_ms / 1000);
         if let Err(e) = save_result {
             self.set_status(&format!("{} (save failed: {})", msg, e));
@@ -4374,6 +4382,10 @@ mod tests {
             expected["autoRefreshMs"] = serde_json::json!(120_000);
             expected["defaultClients"] = serde_json::json!(["claude"]);
             expected["autosubmit"]["enabled"] = serde_json::json!(true);
+            expected["futurePreference"] = serde_json::json!({"enabled": true});
+            expected["usage"]["futureProviderOption"] = serde_json::json!(["keep", 7]);
+            expected["scanner"]["futureScanOption"] = serde_json::json!("keep");
+            expected["nativeTimeoutMs"] = serde_json::json!(1);
             expected[field] = serde_json::to_value(&initial).unwrap()[field].clone();
             fs::write(&path, serde_json::to_vec(&expected).unwrap()).unwrap();
 
@@ -4390,6 +4402,29 @@ mod tests {
                 .unwrap()
                 .contains("save failed"));
         }
+    }
+
+    #[test]
+    fn tui_settings_changes_preserve_sparse_external_edits() {
+        if !settings_test_runs_in_child("tui_settings_changes_preserve_sparse_external_edits") {
+            return;
+        }
+
+        let path = crate::paths::get_config_dir().join("settings.json");
+        let mut app = make_app();
+        app.handle_key_event(key(KeyCode::Char('L')));
+        let saved: serde_json::Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(saved, serde_json::json!({"tuiLightMode": true}));
+
+        let mut external = serde_json::json!({
+            "futurePreference": {"enabled": true},
+            "usage": {"disabledProviders": ["copilot"], "futureProviderOption": "keep"}
+        });
+        fs::write(&path, serde_json::to_vec(&external).unwrap()).unwrap();
+        app.handle_key_event(key(KeyCode::Char('p')));
+        external["colorPalette"] = app.theme.name.as_str().into();
+        let saved: serde_json::Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(saved, external);
     }
 
     #[test]
@@ -4431,7 +4466,7 @@ mod tests {
         fs::write(&path, r#"{"colorPalette":"blue"}"#).unwrap();
         let replacement = r#"{"usage":{"disabledProviders":["copilot"]}}"#;
         let error = Settings::update_and_save(|settings| {
-            settings.tui_light_mode = true;
+            settings["tuiLightMode"] = true.into();
             fs::write(&path, replacement).unwrap();
         })
         .unwrap_err();

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -1898,7 +1898,7 @@ impl App {
         };
         self.dialog_stack.set_theme(self.theme.clone());
         self.settings.set_theme(new_theme);
-        if let Err(e) = self.settings.save() {
+        if let Err(e) = Settings::update_and_save(|settings| settings.set_theme(new_theme)) {
             self.set_status(&format!(
                 "Theme: {} (save failed: {})",
                 new_theme.as_str(),
@@ -1910,6 +1910,7 @@ impl App {
     }
     fn toggle_light_mode(&mut self) {
         self.settings.tui_light_mode = !self.settings.tui_light_mode;
+        let light_mode = self.settings.tui_light_mode;
         let name = self.theme.name;
         self.theme = if self.settings.tui_light_mode {
             Theme::from_name_for_current_terminal_light(name)
@@ -1922,7 +1923,7 @@ impl App {
         } else {
             "off"
         };
-        if let Err(e) = self.settings.save() {
+        if let Err(e) = Settings::update_and_save(|settings| settings.tui_light_mode = light_mode) {
             self.set_status(&format!("Light mode: {} (save failed: {})", state, e));
         } else {
             self.set_status(&format!("Light mode: {}", state));
@@ -2078,7 +2079,9 @@ impl App {
             self.last_auto_refresh = Instant::now();
         }
         self.settings.auto_refresh_enabled = self.auto_refresh;
-        let save_result = self.settings.save();
+        let save_result = Settings::update_and_save(|settings| {
+            settings.auto_refresh_enabled = self.auto_refresh;
+        });
         let msg = if self.auto_refresh {
             format!(
                 "Auto-refresh ON ({}s)",
@@ -2099,7 +2102,7 @@ impl App {
         let new_ms = ms.saturating_add(10_000).min(300_000);
         self.auto_refresh_interval = Duration::from_millis(new_ms);
         self.settings.auto_refresh_ms = new_ms;
-        let save_result = self.settings.save();
+        let save_result = Settings::update_and_save(|settings| settings.auto_refresh_ms = new_ms);
         let msg = format!("Refresh interval: {}s", new_ms / 1000);
         if let Err(e) = save_result {
             self.set_status(&format!("{} (save failed: {})", msg, e));
@@ -2113,7 +2116,7 @@ impl App {
         let new_ms = ms.saturating_sub(10_000).max(30_000);
         self.auto_refresh_interval = Duration::from_millis(new_ms);
         self.settings.auto_refresh_ms = new_ms;
-        let save_result = self.settings.save();
+        let save_result = Settings::update_and_save(|settings| settings.auto_refresh_ms = new_ms);
         let msg = format!("Refresh interval: {}s", new_ms / 1000);
         if let Err(e) = save_result {
             self.set_status(&format!("{} (save failed: {})", msg, e));
@@ -4287,6 +4290,154 @@ mod tests {
             app.handle_key_event(key(KeyCode::Char('p')));
         }
         assert_eq!(app.theme.name, initial_theme);
+    }
+
+    // Other app tests also save settings without taking the serial-test lock.
+    // Give these disk-backed tests their own process instead of changing the
+    // config directory underneath those tests.
+    fn settings_test_runs_in_child(test_name: &str) -> bool {
+        const MARKER: &str = "TOKSCALE_TUI_SETTINGS_TEST";
+        if env::var(MARKER).as_deref() == Ok(test_name) {
+            return true;
+        }
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let output = std::process::Command::new(env::current_exe().unwrap())
+            .args([
+                "--exact",
+                &format!("tui::app::tests::{test_name}"),
+                "--nocapture",
+            ])
+            .env(MARKER, test_name)
+            .env("TOKSCALE_CONFIG_DIR", temp.path())
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(String::from_utf8_lossy(&output.stdout).contains("1 passed"));
+        false
+    }
+
+    #[test]
+    fn tui_settings_changes_preserve_external_edits() {
+        if !settings_test_runs_in_child("tui_settings_changes_preserve_external_edits") {
+            return;
+        }
+
+        let path = crate::paths::get_config_dir().join("settings.json");
+        let initial = Settings {
+            auto_refresh_enabled: true,
+            ..Settings::default()
+        };
+        let cases = [
+            (
+                key(KeyCode::Char('p')),
+                "colorPalette",
+                serde_json::json!(initial.theme_name().next().as_str()),
+            ),
+            (
+                key(KeyCode::Char('L')),
+                "tuiLightMode",
+                serde_json::json!(true),
+            ),
+            (
+                key_with_mod(KeyCode::Char('R'), KeyModifiers::SHIFT),
+                "autoRefreshEnabled",
+                serde_json::json!(false),
+            ),
+            (
+                key(KeyCode::Char('+')),
+                "autoRefreshMs",
+                serde_json::json!(70_000),
+            ),
+            (
+                key(KeyCode::Char('-')),
+                "autoRefreshMs",
+                serde_json::json!(50_000),
+            ),
+        ];
+
+        for (event, field, value) in cases {
+            fs::write(&path, serde_json::to_vec(&initial).unwrap()).unwrap();
+            let mut app = make_app();
+            assert!(app.settings.usage.disabled_providers.is_empty());
+
+            let mut expected = serde_json::to_value(&initial).unwrap();
+            expected["usage"]["disabledProviders"] = serde_json::json!(["copilot"]);
+            expected["colorPalette"] = serde_json::json!("halloween");
+            expected["tuiLightMode"] = serde_json::json!(true);
+            expected["autoRefreshEnabled"] = serde_json::json!(false);
+            expected["autoRefreshMs"] = serde_json::json!(120_000);
+            expected["defaultClients"] = serde_json::json!(["claude"]);
+            expected["autosubmit"]["enabled"] = serde_json::json!(true);
+            expected[field] = serde_json::to_value(&initial).unwrap()[field].clone();
+            fs::write(&path, serde_json::to_vec(&expected).unwrap()).unwrap();
+
+            app.handle_key_event(event);
+
+            expected[field] = value.clone();
+            let saved: serde_json::Value =
+                serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+            assert_eq!(saved, expected, "unexpected settings after {event:?}");
+            assert_eq!(serde_json::to_value(&app.settings).unwrap()[field], value);
+            assert!(!app
+                .status_message
+                .as_deref()
+                .unwrap()
+                .contains("save failed"));
+        }
+    }
+
+    #[test]
+    fn tui_settings_changes_preserve_malformed_external_edits() {
+        if !settings_test_runs_in_child("tui_settings_changes_preserve_malformed_external_edits") {
+            return;
+        }
+
+        let path = crate::paths::get_config_dir().join("settings.json");
+        for event in [key(KeyCode::Char('p')), key(KeyCode::Char('L'))] {
+            fs::write(&path, b"{}").unwrap();
+            let mut app = make_app();
+            let malformed = r#"{"usage":{"disabledProviders":{"copilot":true}}}"#;
+            fs::write(&path, malformed).unwrap();
+
+            app.handle_key_event(event);
+
+            assert_eq!(fs::read_to_string(&path).unwrap(), malformed);
+            assert!(app
+                .status_message
+                .as_deref()
+                .unwrap()
+                .contains("save failed"));
+            if event.code == KeyCode::Char('p') {
+                assert_eq!(app.theme.name, ThemeName::Blue.next());
+            } else {
+                assert!(app.settings.tui_light_mode);
+            }
+        }
+    }
+
+    #[test]
+    fn tui_settings_save_rejects_edits_during_update() {
+        if !settings_test_runs_in_child("tui_settings_save_rejects_edits_during_update") {
+            return;
+        }
+
+        let path = crate::paths::get_config_dir().join("settings.json");
+        fs::write(&path, r#"{"colorPalette":"blue"}"#).unwrap();
+        let replacement = r#"{"usage":{"disabledProviders":["copilot"]}}"#;
+        let error = Settings::update_and_save(|settings| {
+            settings.tui_light_mode = true;
+            fs::write(&path, replacement).unwrap();
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().contains("changed since it was loaded"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), replacement);
     }
 
     // ── handle_key_event: export ────────────────────────────────────

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -4434,24 +4434,25 @@ mod tests {
         }
 
         let path = crate::paths::get_config_dir().join("settings.json");
-        for event in [key(KeyCode::Char('p')), key(KeyCode::Char('L'))] {
-            fs::write(&path, b"{}").unwrap();
-            let mut app = make_app();
-            let malformed = r#"{"usage":{"disabledProviders":{"copilot":true}}}"#;
-            fs::write(&path, malformed).unwrap();
+        for malformed in [r#"{"usage":{"disabledProviders":{"copilot":true}}}"#, "[]"] {
+            for event in [key(KeyCode::Char('p')), key(KeyCode::Char('L'))] {
+                fs::write(&path, b"{}").unwrap();
+                let mut app = make_app();
+                fs::write(&path, malformed).unwrap();
 
-            app.handle_key_event(event);
+                app.handle_key_event(event);
 
-            assert_eq!(fs::read_to_string(&path).unwrap(), malformed);
-            assert!(app
-                .status_message
-                .as_deref()
-                .unwrap()
-                .contains("save failed"));
-            if event.code == KeyCode::Char('p') {
-                assert_eq!(app.theme.name, ThemeName::Blue.next());
-            } else {
-                assert!(app.settings.tui_light_mode);
+                assert_eq!(fs::read_to_string(&path).unwrap(), malformed);
+                assert!(app
+                    .status_message
+                    .as_deref()
+                    .unwrap()
+                    .contains("save failed"));
+                if event.code == KeyCode::Char('p') {
+                    assert_eq!(app.theme.name, ThemeName::Blue.next());
+                } else {
+                    assert!(app.settings.tui_light_mode);
+                }
             }
         }
     }

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -1898,9 +1898,7 @@ impl App {
         };
         self.dialog_stack.set_theme(self.theme.clone());
         self.settings.set_theme(new_theme);
-        if let Err(e) = Settings::update_and_save(|settings| {
-            settings["colorPalette"] = new_theme.as_str().into();
-        }) {
+        if let Err(e) = Settings::update_and_save("colorPalette", new_theme.as_str()) {
             self.set_status(&format!(
                 "Theme: {} (save failed: {})",
                 new_theme.as_str(),
@@ -1925,9 +1923,7 @@ impl App {
         } else {
             "off"
         };
-        if let Err(e) = Settings::update_and_save(|settings| {
-            settings["tuiLightMode"] = light_mode.into();
-        }) {
+        if let Err(e) = Settings::update_and_save("tuiLightMode", light_mode) {
             self.set_status(&format!("Light mode: {} (save failed: {})", state, e));
         } else {
             self.set_status(&format!("Light mode: {}", state));
@@ -2083,9 +2079,7 @@ impl App {
             self.last_auto_refresh = Instant::now();
         }
         self.settings.auto_refresh_enabled = self.auto_refresh;
-        let save_result = Settings::update_and_save(|settings| {
-            settings["autoRefreshEnabled"] = self.auto_refresh.into();
-        });
+        let save_result = Settings::update_and_save("autoRefreshEnabled", self.auto_refresh);
         let msg = if self.auto_refresh {
             format!(
                 "Auto-refresh ON ({}s)",
@@ -2106,9 +2100,7 @@ impl App {
         let new_ms = ms.saturating_add(10_000).min(300_000);
         self.auto_refresh_interval = Duration::from_millis(new_ms);
         self.settings.auto_refresh_ms = new_ms;
-        let save_result = Settings::update_and_save(|settings| {
-            settings["autoRefreshMs"] = new_ms.into();
-        });
+        let save_result = Settings::update_and_save("autoRefreshMs", new_ms);
         let msg = format!("Refresh interval: {}s", new_ms / 1000);
         if let Err(e) = save_result {
             self.set_status(&format!("{} (save failed: {})", msg, e));
@@ -2122,9 +2114,7 @@ impl App {
         let new_ms = ms.saturating_sub(10_000).max(30_000);
         self.auto_refresh_interval = Duration::from_millis(new_ms);
         self.settings.auto_refresh_ms = new_ms;
-        let save_result = Settings::update_and_save(|settings| {
-            settings["autoRefreshMs"] = new_ms.into();
-        });
+        let save_result = Settings::update_and_save("autoRefreshMs", new_ms);
         let msg = format!("Refresh interval: {}s", new_ms / 1000);
         if let Err(e) = save_result {
             self.set_status(&format!("{} (save failed: {})", msg, e));
@@ -4405,6 +4395,38 @@ mod tests {
     }
 
     #[test]
+    fn tui_settings_changes_preserve_unknown_number_precision() {
+        if !settings_test_runs_in_child("tui_settings_changes_preserve_unknown_number_precision") {
+            return;
+        }
+
+        let path = crate::paths::get_config_dir().join("settings.json");
+        let mut app = make_app();
+        for number in [
+            "18446744073709551617",
+            "0.12345678901234567890123456789",
+            "1e400",
+        ] {
+            let nested = format!(r#"{{ "values" : [ {number} ] }}"#);
+            fs::write(
+                &path,
+                format!(r#"{{"futureNumber":{number},"futureObject":{nested}}}"#),
+            )
+            .unwrap();
+            app.handle_key_event(key(KeyCode::Char('p')));
+            let saved = fs::read_to_string(&path).unwrap();
+            assert!(saved.contains(number), "number changed in {saved}");
+            assert!(saved.contains(&nested), "nested JSON changed in {saved}");
+            assert!(saved.contains(app.theme.name.as_str()));
+            assert!(!app
+                .status_message
+                .as_deref()
+                .unwrap()
+                .contains("save failed"));
+        }
+    }
+
+    #[test]
     fn tui_settings_changes_preserve_sparse_external_edits() {
         if !settings_test_runs_in_child("tui_settings_changes_preserve_sparse_external_edits") {
             return;
@@ -4455,25 +4477,6 @@ mod tests {
                 }
             }
         }
-    }
-
-    #[test]
-    fn tui_settings_save_rejects_edits_during_update() {
-        if !settings_test_runs_in_child("tui_settings_save_rejects_edits_during_update") {
-            return;
-        }
-
-        let path = crate::paths::get_config_dir().join("settings.json");
-        fs::write(&path, r#"{"colorPalette":"blue"}"#).unwrap();
-        let replacement = r#"{"usage":{"disabledProviders":["copilot"]}}"#;
-        let error = Settings::update_and_save(|settings| {
-            settings["tuiLightMode"] = true.into();
-            fs::write(&path, replacement).unwrap();
-        })
-        .unwrap_err();
-
-        assert!(error.to_string().contains("changed since it was loaded"));
-        assert_eq!(fs::read_to_string(&path).unwrap(), replacement);
     }
 
     // ── handle_key_event: export ────────────────────────────────────

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -24,10 +24,9 @@ pub const MAX_AUTOSUBMIT_INTERVAL_MINUTES: u64 = 7 * 24 * 60;
 /// An opaque snapshot of the settings files read by
 /// [`Settings::load_with_origin`].
 ///
-/// A caller can save only when loading produced complete settings, and only if
-/// the files that informed that load are unchanged immediately before the
-/// atomic replace. This avoids parsing JSON twice in load-then-save paths
-/// without allowing a stale caller to replace a changed or malformed file.
+/// Saving requires complete settings and checks the source files immediately
+/// before replacement. Tokscale writers coordinate through a sibling lock;
+/// external editors that ignore it can still race the final check and rename.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SettingsOrigin {
     primary_path: Option<PathBuf>,
@@ -701,7 +700,6 @@ impl Settings {
             .write(true)
             .open(lock_path)?;
         lock.lock_exclusive()?;
-        let path = origin.verify_unchanged()?;
         let content = serde_json::to_string_pretty(settings)?;
 
         // Atomic write: write to temp file, sync, then rename
@@ -721,6 +719,9 @@ impl Settings {
             use std::io::Write;
             file.write_all(content.as_bytes())?;
             file.sync_all()?;
+            // Check after staging and syncing: edits made during those slower
+            // operations must leave the destination untouched as well.
+            origin.verify_unchanged()?;
             tokscale_core::fs_atomic::replace_file(&temp_path, path)?;
             Ok(())
         })();

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -63,7 +63,7 @@ impl SettingsOrigin {
         self
     }
 
-    /// Whether a `save()` after this load would preserve the user's data.
+    /// Whether the settings loaded with this origin are complete enough to save.
     ///
     /// False when loading produced defaults rather than complete settings,
     /// where saving would overwrite settings we could not read.
@@ -632,16 +632,27 @@ impl Settings {
             .unwrap_or_default()
     }
 
+    /// Replace the complete settings file with this value.
+    ///
+    /// This cannot detect edits made before this call. Long-lived callers
+    /// changing individual fields should use [`Self::update_and_save`].
     pub fn save(&self) -> Result<()> {
         self.save_with_origin(Self::load_with_origin().1)
     }
 
-    /// Save settings after a caller that loaded them has checked their origin.
+    /// Load the latest settings, change only the requested fields, and save
+    /// using the origin from that same load so intervening edits are rejected.
+    pub(crate) fn update_and_save(update: impl FnOnce(&mut Self)) -> Result<()> {
+        let (mut settings, origin) = Self::load_with_origin();
+        update(&mut settings);
+        settings.save_with_origin(origin)
+    }
+
+    /// Save settings using the origin returned when those settings were loaded.
     ///
-    /// Callers that do not already hold an origin should use [`Self::save`],
-    /// which loads one immediately before writing. The safety guard remains
-    /// here so a supplied unreadable or stale origin can never replace unknown
-    /// settings.
+    /// Keep the settings and origin from the same load together. Callers
+    /// updating individual fields without an origin should use
+    /// [`Self::update_and_save`] to preserve unrelated edits.
     pub(crate) fn save_with_origin(&self, origin: SettingsOrigin) -> Result<()> {
         if !origin.is_safe_to_overwrite() {
             bail!("could not read this machine's tokscale settings, so refusing to replace them");

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -71,6 +71,29 @@ impl SettingsOrigin {
         self.safe_to_overwrite
     }
 
+    fn settings_json(&self) -> Result<serde_json::Value> {
+        if !self.is_safe_to_overwrite() {
+            bail!("could not read this machine's tokscale settings, so refusing to replace them");
+        }
+        let snapshot = match &self.primary_snapshot {
+            SettingsFileSnapshot::Missing => self
+                .legacy_snapshot
+                .as_ref()
+                .map(|(_, snapshot)| snapshot)
+                .unwrap_or(&self.primary_snapshot),
+            snapshot => snapshot,
+        };
+        match snapshot {
+            SettingsFileSnapshot::Present(content) => Ok(serde_json::from_str(content)?),
+            SettingsFileSnapshot::Missing => Ok(serde_json::json!({})),
+            SettingsFileSnapshot::Unreadable => {
+                bail!(
+                    "could not read this machine's tokscale settings, so refusing to replace them"
+                )
+            }
+        }
+    }
+
     fn verify_unchanged(&self) -> Result<&Path> {
         let path = self
             .primary_path
@@ -640,12 +663,14 @@ impl Settings {
         self.save_with_origin(Self::load_with_origin().1)
     }
 
-    /// Load the latest settings, change only the requested fields, and save
-    /// using the origin from that same load so intervening edits are rejected.
-    pub(crate) fn update_and_save(update: impl FnOnce(&mut Self)) -> Result<()> {
-        let (mut settings, origin) = Self::load_with_origin();
+    /// Validate the latest settings, then patch their original JSON so unknown
+    /// fields and unmodified values survive without normalization. Callers must
+    /// assign only the preference being changed, using its JSON field name.
+    pub(crate) fn update_and_save(update: impl FnOnce(&mut serde_json::Value)) -> Result<()> {
+        let (_, origin) = Self::load_with_origin();
+        let mut settings = origin.settings_json()?;
         update(&mut settings);
-        settings.save_with_origin(origin)
+        Self::save_json_with_origin(&settings, origin)
     }
 
     /// Save settings using the origin returned when those settings were loaded.
@@ -654,6 +679,10 @@ impl Settings {
     /// updating individual fields without an origin should use
     /// [`Self::update_and_save`] to preserve unrelated edits.
     pub(crate) fn save_with_origin(&self, origin: SettingsOrigin) -> Result<()> {
+        Self::save_json_with_origin(&serde_json::to_value(self)?, origin)
+    }
+
+    fn save_json_with_origin(settings: &serde_json::Value, origin: SettingsOrigin) -> Result<()> {
         if !origin.is_safe_to_overwrite() {
             bail!("could not read this machine's tokscale settings, so refusing to replace them");
         }
@@ -673,7 +702,7 @@ impl Settings {
             .open(lock_path)?;
         lock.lock_exclusive()?;
         let path = origin.verify_unchanged()?;
-        let content = serde_json::to_string_pretty(self)?;
+        let content = serde_json::to_string_pretty(settings)?;
 
         // Atomic write: write to temp file, sync, then rename
         // Matches the pattern used in tui/cache.rs and pricing/cache.rs
@@ -760,6 +789,24 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn settings_json_preserves_unknown_legacy_members() {
+        let legacy = RawSettings::Present(
+            r#"{"colorPalette":"green","future":{"nested":true}}"#.to_string(),
+        );
+        let origin = SettingsOrigin::from_raw(
+            Some(PathBuf::from("settings.json")),
+            &RawSettings::Missing,
+            Some((Path::new("legacy/settings.json"), &legacy)),
+        )
+        .writable();
+
+        assert_eq!(
+            origin.settings_json().unwrap(),
+            serde_json::json!({"colorPalette": "green", "future": {"nested": true}})
+        );
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -668,6 +668,9 @@ impl Settings {
     pub(crate) fn update_and_save(update: impl FnOnce(&mut serde_json::Value)) -> Result<()> {
         let (_, origin) = Self::load_with_origin();
         let mut settings = origin.settings_json()?;
+        if !settings.is_object() {
+            bail!("settings.json must contain a JSON object; refusing to replace it");
+        }
         update(&mut settings);
         Self::save_json_with_origin(&settings, origin)
     }

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -5,6 +6,7 @@ use std::time::Duration;
 use anyhow::{bail, Result};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
 use tokscale_core::scanner::ScannerSettings;
 
 use super::themes::ThemeName;
@@ -70,7 +72,7 @@ impl SettingsOrigin {
         self.safe_to_overwrite
     }
 
-    fn settings_json(&self) -> Result<serde_json::Value> {
+    fn settings_json(&self) -> Result<BTreeMap<String, Box<RawValue>>> {
         if !self.is_safe_to_overwrite() {
             bail!("could not read this machine's tokscale settings, so refusing to replace them");
         }
@@ -84,7 +86,7 @@ impl SettingsOrigin {
         };
         match snapshot {
             SettingsFileSnapshot::Present(content) => Ok(serde_json::from_str(content)?),
-            SettingsFileSnapshot::Missing => Ok(serde_json::json!({})),
+            SettingsFileSnapshot::Missing => Ok(BTreeMap::new()),
             SettingsFileSnapshot::Unreadable => {
                 bail!(
                     "could not read this machine's tokscale settings, so refusing to replace them"
@@ -662,16 +664,12 @@ impl Settings {
         self.save_with_origin(Self::load_with_origin().1)
     }
 
-    /// Validate the latest settings, then patch their original JSON so unknown
-    /// fields and unmodified values survive without normalization. Callers must
-    /// assign only the preference being changed, using its JSON field name.
-    pub(crate) fn update_and_save(update: impl FnOnce(&mut serde_json::Value)) -> Result<()> {
+    /// Validate the latest settings, then replace one top-level preference.
+    /// Unmodified values retain their original JSON, including number precision.
+    pub(crate) fn update_and_save(field: &str, value: impl Serialize) -> Result<()> {
         let (_, origin) = Self::load_with_origin();
         let mut settings = origin.settings_json()?;
-        if !settings.is_object() {
-            bail!("settings.json must contain a JSON object; refusing to replace it");
-        }
-        update(&mut settings);
+        settings.insert(field.to_string(), serde_json::value::to_raw_value(&value)?);
         Self::save_json_with_origin(&settings, origin)
     }
 
@@ -681,10 +679,10 @@ impl Settings {
     /// updating individual fields without an origin should use
     /// [`Self::update_and_save`] to preserve unrelated edits.
     pub(crate) fn save_with_origin(&self, origin: SettingsOrigin) -> Result<()> {
-        Self::save_json_with_origin(&serde_json::to_value(self)?, origin)
+        Self::save_json_with_origin(self, origin)
     }
 
-    fn save_json_with_origin(settings: &serde_json::Value, origin: SettingsOrigin) -> Result<()> {
+    fn save_json_with_origin(settings: &impl Serialize, origin: SettingsOrigin) -> Result<()> {
         if !origin.is_safe_to_overwrite() {
             bail!("could not read this machine's tokscale settings, so refusing to replace them");
         }
@@ -796,6 +794,28 @@ mod tests {
     }
 
     #[test]
+    fn saving_patched_json_rejects_edits_since_load() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("settings.json");
+        fs::write(&path, r#"{"colorPalette":"blue"}"#).unwrap();
+        let origin =
+            SettingsOrigin::from_raw(Some(path.clone()), &Settings::read_config_file(&path), None)
+                .writable();
+        let mut settings = origin.settings_json().unwrap();
+        settings.insert(
+            "tuiLightMode".into(),
+            serde_json::value::to_raw_value(&true).unwrap(),
+        );
+        let replacement = r#"{"usage":{"disabledProviders":["copilot"]}}"#;
+        fs::write(&path, replacement).unwrap();
+
+        let error = Settings::save_json_with_origin(&settings, origin).unwrap_err();
+
+        assert!(error.to_string().contains("changed since it was loaded"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), replacement);
+    }
+
+    #[test]
     fn settings_json_preserves_unknown_legacy_members() {
         let legacy = RawSettings::Present(
             r#"{"colorPalette":"green","future":{"nested":true}}"#.to_string(),
@@ -808,7 +828,7 @@ mod tests {
         .writable();
 
         assert_eq!(
-            origin.settings_json().unwrap(),
+            serde_json::to_value(origin.settings_json().unwrap()).unwrap(),
             serde_json::json!({"colorPalette": "green", "future": {"nested": true}})
         );
     }


### PR DESCRIPTION
Changing a TUI preference could overwrite edits made to `settings.json` after the TUI started. For example, adding `usage.disabledProviders: ["copilot"]` in another terminal and then pressing `p` or `L` cleared that exclusion.

TUI saves now validate the latest settings, replace only the selected top-level preference in a map of raw JSON values, and save using the origin from that same load. This preserves unknown top-level and nested members, high-precision numbers, sparse files, and unrelated value tokens without normalizing them on disk. The existing serde_json dependency enables `raw_value`; ordinary number parsing remains unchanged. Theme, light mode, auto-refresh, and refresh-interval controls use this path. Invalid files, including array roots, are left untouched and reported through the existing save-error status while the live UI preference remains applied.

The writer stages and syncs its temporary file before checking the origin and entering atomic replacement. The sibling lock coordinates Tokscale writers. An external editor that ignores it can still race the final comparison and replacement; this inherited limitation remains documented.

Regression tests exercise all five save actions after external edits, unknown fields, missing and sparse files, malformed and array-root files, legacy JSON snapshots, raw high-precision/exponent numbers, and a change between loading and saving. Disk-backed TUI tests run in isolated subprocesses to avoid races with other settings tests. External-edit and unknown-field regressions failed before their respective fixes; the array-root test reproduced a panic before object validation, and the precision test reproduced rounding before raw-value preservation.

Validation:
- Full CLI suite on `ef1d29d9`: 1,333 unit tests, 185 CLI integration tests, and 8 TLS policy tests passed; 1 existing test ignored. Command: `cargo test --locked -p tokscale-cli --no-fail-fast -- --test-threads=1` with an isolated `TOKSCALE_CONFIG_DIR`.
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-features -- -D warnings`
- `cargo clippy --locked -p tokscale-cli --bin tokscale --tests -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --workspace`
- `git diff --check`
