### PR TITLE
fix(pi): deduplicate forked/continued sessions across files

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2652,7 +2652,11 @@ fn parse_all_messages_streaming<S: MessageSink>(
         }
     }
 
-    parse_cached_lane(
+    // Pi branch/fork copies prior assistant records into a new session file
+    // (#1306). The parser stamps cross-session keys (`responseId` preferred);
+    // this lane drops the copies — first-wins in scan order, same key survives
+    // warm cache hits.
+    parse_cached_lane_deduped(
         &scan_result,
         &mut source_cache,
         pricing,
@@ -2733,7 +2737,9 @@ fn parse_all_messages_streaming<S: MessageSink>(
         }
     }
 
-    parse_cached_lane(
+    // Senpi and Omp share the Pi record format and its fork-copy behavior
+    // (#1306); dedup the same way as the Pi lane.
+    parse_cached_lane_deduped(
         &scan_result,
         &mut source_cache,
         pricing,
@@ -2742,7 +2748,7 @@ fn parse_all_messages_streaming<S: MessageSink>(
         sessions::senpi::parse_senpi_file,
     );
 
-    parse_cached_lane(
+    parse_cached_lane_deduped(
         &scan_result,
         &mut source_cache,
         pricing,
@@ -5594,15 +5600,19 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::OpenClaw, openclaw_count);
     messages.extend(openclaw_msgs);
 
-    let pi_msgs: Vec<ParsedMessage> = scan_result
+    // Pi branch/fork copies prior assistant records into a new session file
+    // (#1306); the parser stamps cross-session keys, drop the copies here too
+    // so the export/submission totals match the live scan.
+    let pi_msgs_raw: Vec<UnifiedMessage> = scan_result
         .get(ClientId::Pi)
         .par_iter()
-        .flat_map(|path| {
-            sessions::pi::parse_pi_file(path)
-                .into_iter()
-                .map(|msg| unified_to_parsed(&msg))
-                .collect::<Vec<_>>()
-        })
+        .flat_map(|path| sessions::pi::parse_pi_file(path))
+        .collect();
+    let mut pi_seen: HashSet<String> = HashSet::new();
+    let pi_msgs: Vec<ParsedMessage> = pi_msgs_raw
+        .into_iter()
+        .filter(|message| should_keep_deduped_message(&mut pi_seen, message))
+        .map(|message| unified_to_parsed(&message))
         .collect();
     let pi_count = pi_msgs.len() as i32;
     counts.set(ClientId::Pi, pi_count);
@@ -5665,29 +5675,31 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::Reasonix, reasonix_count);
     messages.extend(reasonix_msgs);
 
-    let senpi_msgs: Vec<ParsedMessage> = scan_result
+    let senpi_msgs_raw: Vec<UnifiedMessage> = scan_result
         .get(ClientId::Senpi)
         .par_iter()
-        .flat_map(|path| {
-            sessions::senpi::parse_senpi_file(path)
-                .into_iter()
-                .map(|msg| unified_to_parsed(&msg))
-                .collect::<Vec<_>>()
-        })
+        .flat_map(|path| sessions::senpi::parse_senpi_file(path))
+        .collect();
+    let mut senpi_seen: HashSet<String> = HashSet::new();
+    let senpi_msgs: Vec<ParsedMessage> = senpi_msgs_raw
+        .into_iter()
+        .filter(|message| should_keep_deduped_message(&mut senpi_seen, message))
+        .map(|message| unified_to_parsed(&message))
         .collect();
     let senpi_count = senpi_msgs.len() as i32;
     counts.set(ClientId::Senpi, senpi_count);
     messages.extend(senpi_msgs);
 
-    let omp_msgs: Vec<ParsedMessage> = scan_result
+    let omp_msgs_raw: Vec<UnifiedMessage> = scan_result
         .get(ClientId::Omp)
         .par_iter()
-        .flat_map(|path| {
-            sessions::omp::parse_omp_file(path)
-                .into_iter()
-                .map(|msg| unified_to_parsed(&msg))
-                .collect::<Vec<_>>()
-        })
+        .flat_map(|path| sessions::omp::parse_omp_file(path))
+        .collect();
+    let mut omp_seen: HashSet<String> = HashSet::new();
+    let omp_msgs: Vec<ParsedMessage> = omp_msgs_raw
+        .into_iter()
+        .filter(|message| should_keep_deduped_message(&mut omp_seen, message))
+        .map(|message| unified_to_parsed(&message))
         .collect();
     let omp_count = omp_msgs.len() as i32;
     counts.set(ClientId::Omp, omp_count);

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -10068,6 +10068,64 @@ mod tests {
         }
     }
 
+    /// Regression for the PR #1323 review question: when two Pi session files
+    /// carry the same `responseId` with CONFLICTING usage (a fork copy that
+    /// drifted), the surviving copy must be the first one in scan-path order,
+    /// deterministically — not an arbitrary one. The scanner sorts paths
+    /// (`scanner.rs` "Sort for deterministic ordering"), rayon
+    /// `par_iter().flat_map().collect()` preserves that order (doc-tested
+    /// upstream; `ListReducer` appends right after left), and the dedup filter
+    /// runs sequentially over the result. This test would flake if any of
+    /// those three legs were unordered.
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_local_clients_pi_conflicting_fork_copies_first_wins() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let _cache_env = redirect_cache_home(cache_home.path());
+
+        let sessions_dir = source_home
+            .path()
+            .join(".pi/agent/sessions/--fixture--");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let record = |session: &str, input: i64, output: i64| {
+            let total = input + output;
+            format!(
+                r#"{{"type":"session","id":"{session}","timestamp":"2026-09-06T12:00:00.000Z","cwd":"/tmp/demo"}}"#,
+            ) + "\n"
+                + &format!(
+                    r#"{{"type":"message","id":"entry-fork-copy","parentId":"{session}","timestamp":"2026-09-06T12:00:00.000Z","message":{{"role":"assistant","provider":"openai-codex","model":"gpt-6-astra","responseId":"resp-demo-fork","usage":{{"input":{input},"output":{output},"cacheRead":0,"cacheWrite":0,"totalTokens":{total}}}}}}}"#
+                )
+                + "\n"
+        };
+        // Sorted scan order: session-a.jsonl (input 100) before
+        // session-b.jsonl (input 999, conflicting usage, same responseId).
+        std::fs::write(sessions_dir.join("session-a.jsonl"), record("session-a", 100, 20))
+            .unwrap();
+        std::fs::write(sessions_dir.join("session-b.jsonl"), record("session-b", 999, 999))
+            .unwrap();
+
+        // Repeat to smoke out any order nondeterminism in the parallel
+        // parse + flatten: every run must keep session-a's copy.
+        for _ in 0..25 {
+            let parsed = parse_local_clients(LocalParseOptions {
+                home_dir: Some(source_home.path().to_str().unwrap().to_string()),
+                use_env_roots: false,
+                clients: Some(vec!["pi".to_string()]),
+                since: None,
+                until: None,
+                year: None,
+                scanner_settings: scanner::ScannerSettings::default(),
+            })
+            .unwrap();
+
+            assert_eq!(parsed.counts.get(ClientId::Pi), 1);
+            assert_eq!(parsed.messages.len(), 1);
+            assert_eq!(parsed.messages[0].input, 100);
+            assert_eq!(parsed.messages[0].output, 20);
+        }
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_parse_local_clients_kimi_deduplicates_repeated_status_updates() {

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -10084,9 +10084,7 @@ mod tests {
         let source_home = tempfile::TempDir::new().unwrap();
         let _cache_env = redirect_cache_home(cache_home.path());
 
-        let sessions_dir = source_home
-            .path()
-            .join(".pi/agent/sessions/--fixture--");
+        let sessions_dir = source_home.path().join(".pi/agent/sessions/--fixture--");
         std::fs::create_dir_all(&sessions_dir).unwrap();
         let record = |session: &str, input: i64, output: i64| {
             let total = input + output;
@@ -10100,10 +10098,16 @@ mod tests {
         };
         // Sorted scan order: session-a.jsonl (input 100) before
         // session-b.jsonl (input 999, conflicting usage, same responseId).
-        std::fs::write(sessions_dir.join("session-a.jsonl"), record("session-a", 100, 20))
-            .unwrap();
-        std::fs::write(sessions_dir.join("session-b.jsonl"), record("session-b", 999, 999))
-            .unwrap();
+        std::fs::write(
+            sessions_dir.join("session-a.jsonl"),
+            record("session-a", 100, 20),
+        )
+        .unwrap();
+        std::fs::write(
+            sessions_dir.join("session-b.jsonl"),
+            record("session-b", 999, 999),
+        )
+        .unwrap();
 
         // Repeat to smoke out any order nondeterminism in the parallel
         // parse + flatten: every run must keep session-a's copy.

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1115,12 +1115,14 @@ const SHARED_PARSER_FAMILIES: &[SharedParserFamily] = &[
             // +1: Pi subagent sessions now derive agent attribution from
             // session_info names; version-1 caches carry those messages
             // without agent metadata.
-            (ClientId::Pi, 1),
+            (ClientId::Pi, 2),
             // +1: Kimchi's Pi-compatible messages now carry stable
             // namespaced deduplication keys.
             (ClientId::Kimchi, 1),
-            (ClientId::Omp, 0),
-            (ClientId::Senpi, 0),
+            // +1: Standard Pi/OMP/Senpi parser now emits cross-session
+            // namespaced dedup keys (same behavior as Kimchi/Prime).
+            (ClientId::Omp, 1),
+            (ClientId::Senpi, 1),
             // +3 for Prime Agent's independent history. v1->v2 strips a
             // leading BOM and recovers records containing undecodable
             // bytes; its accounting scan also continues past those records
@@ -4240,10 +4242,10 @@ mod tests {
             (
                 "pi-format",
                 &[
-                    (ClientId::Pi, 1),
+                    (ClientId::Pi, 2),
                     (ClientId::Kimchi, 1),
-                    (ClientId::Omp, 0),
-                    (ClientId::Senpi, 0),
+                    (ClientId::Omp, 1),
+                    (ClientId::Senpi, 1),
                     (ClientId::PrimeAgent, 3),
                 ],
             ),

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -350,6 +350,13 @@ pub fn parse_pi_file(path: &Path) -> Vec<UnifiedMessage> {
 /// `client` is the tokscale client id stamped on every emitted message, and
 /// `fallback_provider` is used only when the message carries no provider and
 /// the model name is not recognizable.
+///
+/// Deduplication is cross-session (`PiParseOptions::standard_deduped`):
+/// Pi branch/fork creates a new session file and copies prior assistant
+/// records into it verbatim (#1306), so a per-session key would count every
+/// copied record once per file. The parser emits a session-independent key —
+/// `message.responseId` preferred, the entry id plus immutable event fields
+/// as fallback — and the Pi lane drops repeats during aggregation.
 pub(crate) fn parse_pi_format_file(
     path: &Path,
     client: &str,
@@ -360,15 +367,18 @@ pub(crate) fn parse_pi_format_file(
         path,
         client,
         fallback_provider,
-        None,
-        PiParseOptions::standard(),
+        Some(client),
+        PiParseOptions::standard_deduped(),
         &mut observer,
     )
 }
 
-/// Parse a Pi-format session and retain message ids in namespaced dedup keys.
-/// Pi-compatible clients that need cross-file deduplication can opt into this
-/// without changing the historical output of the shared Pi and Senpi parsers.
+/// Parse a Pi-format session and retain message ids in namespaced,
+/// session-scoped dedup keys (`{client}:{session_id}:{message_id}`).
+///
+/// Used by Kimchi, which predates the cross-session dedup the standard lane
+/// adopted for #1306 and is versioned separately; do not "unify" this with
+/// `parse_pi_format_file` without a Kimchi cache-version bump.
 pub(crate) fn parse_pi_format_file_with_dedup(
     path: &Path,
     client: &str,
@@ -442,6 +452,17 @@ impl PiParseOptions {
         Self {
             rlm_session_name_as_agent: false,
             cross_session_dedup: false,
+            lossy_line_reader: false,
+        }
+    }
+
+    /// Standard byte-strict parsing with cross-session deduplication: the
+    /// Pi/Senpi/Omp lanes, whose clients all fork sessions by copying prior
+    /// assistant records into a new file (#1306).
+    const fn standard_deduped() -> Self {
+        Self {
+            rlm_session_name_as_agent: false,
+            cross_session_dedup: true,
             lossy_line_reader: false,
         }
     }
@@ -1150,5 +1171,112 @@ not valid json
 
         // then
         assert!(messages.is_empty());
+    }
+
+    /// The record shape from the token-monitor synthetic repro
+    /// (Javis603/token-monitor#627, tokscale#1306): a Pi branch copies the
+    /// parent's assistant entries into a new session file verbatim —
+    /// same `message.responseId`, same entry id, same usage — and only the
+    /// session header differs.
+    fn fork_fixture(session_id: &str, extra_message: Option<&str>) -> String {
+        let copied = format!(
+            r#"{{"type":"message","id":"entry-fork-copy","parentId":"{session_id}","timestamp":"2026-09-06T12:00:00.000Z","message":{{"role":"assistant","provider":"openai-codex","model":"gpt-6-astra","responseId":"resp-demo-fork","usage":{{"input":100,"output":20,"cacheRead":300,"cacheWrite":0,"totalTokens":420}}}}}}"#
+        );
+        let mut lines = vec![
+            format!(
+                r#"{{"type":"session","id":"{session_id}","timestamp":"2026-09-06T12:00:00.000Z","cwd":"/tmp/demo"}}"#
+            ),
+            copied,
+        ];
+        if let Some(message) = extra_message {
+            lines.push(message.to_string());
+        }
+        lines.join("\n") + "\n"
+    }
+
+    #[test]
+    fn fork_copies_across_session_files_share_a_response_level_key() {
+        let parent = create_test_file(&fork_fixture("session-demo-1", None));
+        let child = create_test_file(&fork_fixture("session-demo-2", None));
+
+        let parent_messages = parse_pi_file(parent.path());
+        let child_messages = parse_pi_file(child.path());
+
+        assert_eq!(parent_messages.len(), 1);
+        assert_eq!(child_messages.len(), 1);
+        // Session-independent identity: the key must not embed the session id.
+        let parent_key = parent_messages[0].dedup_key.as_deref().unwrap();
+        let child_key = child_messages[0].dedup_key.as_deref().unwrap();
+        assert_eq!(parent_key, child_key);
+        assert_eq!(parent_key, "pi:response:resp-demo-fork");
+    }
+
+    #[test]
+    fn fork_copy_plus_new_turns_only_the_prefix_collapses() {
+        // given: the child file copies the parent's record and then continues
+        // with a genuinely new response. Only the copied prefix must share a
+        // key; the new turn must survive.
+        let new_turn = r#"{"type":"message","id":"entry-child-new","parentId":"session-demo-2","timestamp":"2026-09-06T12:01:00.000Z","message":{"role":"assistant","provider":"openai-codex","model":"gpt-6-astra","responseId":"resp-demo-child-new","usage":{"input":7,"output":3,"cacheRead":0,"cacheWrite":0,"totalTokens":10}}}"#;
+        let parent = create_test_file(&fork_fixture("session-demo-1", None));
+        let child = create_test_file(&fork_fixture("session-demo-2", Some(new_turn)));
+
+        let parent_messages = parse_pi_file(parent.path());
+        let child_messages = parse_pi_file(child.path());
+
+        assert_eq!(parent_messages.len(), 1);
+        assert_eq!(child_messages.len(), 2);
+        let child_keys: Vec<&str> = child_messages
+            .iter()
+            .map(|message| message.dedup_key.as_deref().unwrap())
+            .collect();
+        assert_eq!(child_keys[0], "pi:response:resp-demo-fork");
+        assert_eq!(child_keys[1], "pi:response:resp-demo-child-new");
+        assert!(child_keys[1] != child_keys[0]);
+    }
+
+    #[test]
+    fn different_response_ids_stay_separate_even_with_identical_content() {
+        // given: two genuinely separate calls with the same usage but
+        // different response ids must not merge (regenerate/retry case).
+        let file = create_test_file(concat!(
+            r#"{"type":"session","id":"session-demo-1","timestamp":"2026-09-06T12:00:00.000Z","cwd":"/tmp/demo"}"#,
+            "\n",
+            r#"{"type":"message","id":"entry-a","parentId":"session-demo-1","timestamp":"2026-09-06T12:00:00.000Z","message":{"role":"assistant","provider":"openai-codex","model":"gpt-6-astra","responseId":"resp-A","usage":{"input":100,"output":20,"cacheRead":300,"cacheWrite":0,"totalTokens":420}}}"#,
+            "\n",
+            r#"{"type":"message","id":"entry-b","parentId":"session-demo-1","timestamp":"2026-09-06T12:00:01.000Z","message":{"role":"assistant","provider":"openai-codex","model":"gpt-6-astra","responseId":"resp-B","usage":{"input":100,"output":20,"cacheRead":300,"cacheWrite":0,"totalTokens":420}}}"#,
+            "\n",
+        ));
+
+        let messages = parse_pi_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_ne!(messages[0].dedup_key, messages[1].dedup_key);
+    }
+
+    #[test]
+    fn missing_response_id_falls_back_to_entry_identity_across_files() {
+        // given: no responseId, but the fork preserves the entry id and the
+        // immutable event fields — those form the fallback key, and it must
+        // still be session-independent.
+        let record = r#"{"type":"message","id":"entry-no-resp","parentId":"SESSION","timestamp":"2026-09-06T12:00:00.000Z","message":{"role":"assistant","provider":"openai-codex","model":"gpt-6-astra","usage":{"input":100,"output":20,"cacheRead":300,"cacheWrite":0,"totalTokens":420}}}"#;
+        let make = |session: &str| {
+            format!(
+                r#"{{"type":"session","id":"{session}","timestamp":"2026-09-06T12:00:00.000Z","cwd":"/tmp/demo"}}"#
+            ) + "\n"
+                + &record.replace("SESSION", session)
+                + "\n"
+        };
+        let parent = create_test_file(&make("session-a"));
+        let child = create_test_file(&make("session-b"));
+
+        let parent_messages = parse_pi_file(parent.path());
+        let child_messages = parse_pi_file(child.path());
+
+        assert_eq!(parent_messages.len(), 1);
+        assert_eq!(child_messages.len(), 1);
+        let parent_key = parent_messages[0].dedup_key.as_deref().unwrap();
+        let child_key = child_messages[0].dedup_key.as_deref().unwrap();
+        assert_eq!(parent_key, child_key);
+        assert!(parent_key.starts_with("pi:message:entry-no-resp:"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1306 (upstream of Javis603/token-monitor#627). Pi branch/fork creates a new session file and copies prior assistant records into it verbatim — same `message.responseId`, entry id, timestamp, and usage. The standard Pi lane parsed each file independently with no dedup namespace, so every copied record was counted once per session file. Reported usage scaled linearly with the number of fork files.

## Root cause

Two layers, both fixed here:

1. **Parser** (`sessions/pi.rs`): `parse_pi_format_file` passed `None` as the dedup namespace with `PiParseOptions::standard()` (`cross_session_dedup: false`), so emitted messages carried no `dedup_key` at all. It now passes `Some(client)` with a new `PiParseOptions::standard_deduped()` preset (`cross_session_dedup: true`), emitting session-independent keys: `message.responseId` preferred (`pi:response:<id>`), entry id + timestamp/provider/model/usage counters as fallback (`pi:message:<id>:<ts>:<provider>:<model>:<tokens>`).
2. **Aggregation** (`lib.rs`): the Pi/Senpi/Omp lanes used `parse_cached_lane` with no dedup filter, so even keyed messages would all be kept. All three lanes now use `parse_cached_lane_deduped` (live scan) and an explicit `should_keep_deduped_message` filter in the export/submission path (`parse_local_clients`), first-wins in scan order.

Senpi and Omp share the Pi record format and its fork-copy behavior, so they get the same treatment. Kimchi keeps its session-scoped keys (`parse_pi_format_file_with_dedup`) — unchanged, no cache churn.

## Cache versioning

Parser version bumps in `message_cache.rs`: Pi 1→2, Omp 0→1, Senpi 0→1. Cached messages produced by the old parser carry no cross-session keys and must be reparsed; Kimchi (1) and PrimeAgent (3) are unchanged.

## Verification

**Unit tests** (4 new, in `pi.rs`):
- `fork_copies_across_session_files_share_a_response_level_key` — two files, identical copied record, different session headers → identical `pi:response:resp-demo-fork` key.
- `fork_copy_plus_new_turns_only_the_prefix_collapses` — child copies the prefix *and* continues with a new turn: only the prefix shares a key; the new turn (`resp-demo-child-new`) survives. Pins the exact regression shape Roy flagged.
- `different_response_ids_stay_separate_even_with_identical_content` — same usage, different response ids → two distinct keys (regenerate/retry case; no content hashing).
- `missing_response_id_falls_back_to_entry_identity_across_files` — no responseId: fallback key from entry id + immutable fields is still session-independent.

`cargo test -p tokscale-core`: 2138 passed, 0 failed. `cargo test -p tokscale-cli`: all pass.

**Black-box repro** (the synthetic bundle attached to token-monitor#627, `repro/run_repro.py`, run against a build of this branch):

| scenario | before (bundle baseline) | after (this branch) |
|---|---|---|
| F1 (1 file) | 1 msg / 100 in | 1 msg / 100 in |
| F2 (2 files, same response) | 2 msg / 200 in | **1 msg / 100 in** |
| F3 (3 files, same response) | 3 msg / 300 in | **1 msg / 100 in** |
| V0–V5 visibility matrix | unchanged | unchanged |

Note the script's `--verify results/synthetic-summary.json` encodes the *broken* behavior, so F2/F3 "FAIL" there is the fix working: fork scaling is now flat (1/1/1).

## Test plan

- [x] Unit regression tests (above)
- [x] Black-box synthetic repro against built binary (above)
- [x] Full core + CLI suites pass
- [ ] Follow-up (optional): Roy offered to add a replayed-prefix vector (parent log + child log with copied prefix + new turns) to the AgentMeasure conformance pack once this lands; can be lifted into `tests/fixtures/` as a persistent integration fixture.

## Notes for reviewers

- Deliberately no content/prompt hashing — identical text can be separate calls; identity is `responseId`/entry id only, per the reporter's request.
- Dedup is per-client-namespaced (`pi:`, `senpi:`, `omp:`), so identical bare ids from different clients never merge (acceptance case 5).
- Same response id with conflicting usage metadata across files currently keeps the first in scan order (deterministic). A "conflicting usage under one id" diagnostic could be a follow-up; the reporter's acceptance cases only require count-1 for that shape.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-counting of Pi fork/branch sessions, where assistant records copied into new session files were counted once per file, making reported usage scale linearly with the number of fork files.

- Copied records now share a session-independent dedup key (`message.responseId` preferred, entry id plus immutable fields as fallback).
- Both the live scan and export/submission path drop repeats, first-wins in scan order; a regression test pins this determinism even when fork copies conflict on usage.
- Senpi and Omp lanes get the same fix since they share the Pi record format.
- Parser cache versions bump for Pi (1→2), Omp (0→1), and Senpi (0→1); old caches reparse automatically. Kimchi is unchanged.

<sup>Written for commit 7ff0360807584f97b2d2eca27e3c13496ae3a392. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

