### PR TITLE
fix(dsh): read versioned session.v<N>.jsonl transcripts

### DIFF
--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -625,8 +625,19 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 // `compression: none` writes the same rows to a plain
                 // `session.jsonl` in the same directory — so both spellings
                 // are session logs and the parser sniffs the frame magic.
+                // Current DSH versions the on-disk format in the file name
+                // (`session.v<N>.jsonl[.zstd]`), so accept those too.
                 "dsh-session-log" => {
-                    file_name == "session.jsonl.zstd" || file_name == "session.jsonl"
+                    let base = file_name.strip_suffix(".zstd").unwrap_or(file_name);
+                    base == "session.jsonl"
+                        || base
+                            .strip_prefix("session.v")
+                            .and_then(|rest| rest.strip_suffix(".jsonl"))
+                            .map(|version| {
+                                !version.is_empty()
+                                    && version.bytes().all(|b| b.is_ascii_digit())
+                            })
+                            .unwrap_or(false)
                 }
                 "wire.jsonl" => file_name == "wire.jsonl",
                 // fx (vercel-labs/fx): one `usage-v2.json` per session
@@ -3399,9 +3410,26 @@ mod tests {
         fs::create_dir_all(&plain_dir).unwrap();
         File::create(plain_dir.join("session.jsonl")).unwrap();
 
-        // Non-matching siblings must be excluded: other zstd files and any
-        // differently named file in the tree.
+        // Current DSH versions the on-disk format in the file name
+        // (`session.v<N>.jsonl[.zstd]`).
+        let versioned_dir = path
+            .join("sessions")
+            .join("--E-Code-proj--")
+            .join("session-ghi-789");
+        fs::create_dir_all(&versioned_dir).unwrap();
+        File::create(versioned_dir.join("session.v3.jsonl.zstd")).unwrap();
+
+        let versioned_plain_dir = path
+            .join("sessions")
+            .join("--E-Code-proj--")
+            .join("session-jkl-012");
+        fs::create_dir_all(&versioned_plain_dir).unwrap();
+        File::create(versioned_plain_dir.join("session.v3.jsonl")).unwrap();
+
+        // Non-matching siblings must be excluded: other zstd files, a
+        // non-numeric version segment, and any differently named file.
         File::create(path.join("sessions").join("other.jsonl.zstd")).unwrap();
+        File::create(path.join("sessions").join("session.vX.jsonl.zstd")).unwrap();
         File::create(path.join("sessions").join("unrelated.txt")).unwrap();
 
         let files = scan_directory(path.to_str().unwrap(), "dsh-session-log");
@@ -3409,8 +3437,17 @@ mod tests {
             .iter()
             .filter_map(|file| file.file_name().and_then(|name| name.to_str()))
             .collect();
-        // Byte-lexical path order: `session-abc-123` sorts before `session-def-456`.
-        assert_eq!(names, vec!["session.jsonl.zstd", "session.jsonl"]);
+        // Byte-lexical path order: session-abc-123 < session-def-456 <
+        // session-ghi-789 < session-jkl-012.
+        assert_eq!(
+            names,
+            vec![
+                "session.jsonl.zstd",
+                "session.jsonl",
+                "session.v3.jsonl.zstd",
+                "session.v3.jsonl",
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

DSH's current session-persistence backend names each transcript after the on-disk format version:

``
<DSH_HOME>/sessions/<encoded-cwd>/<session-id>/session.v3.jsonl.zstd
``

But `dsh-session-log` in `scan_directory` only accepted the unversioned spellings:

``rust
"dsh-session-log" => {
    file_name == "session.jsonl.zstd" || file_name == "session.jsonl"
}
``

So on a machine running a versioned backend, **every session is skipped** and `tokscale --client dsh` reports 0 tokens while `claude` / `codex` / `opencode` work. The parser already dispatches on the zstd frame magic, so the file name is only used for discovery.

## Change

Accept `session.v<N>.jsonl[.zstd]` for decimal `N`, alongside the existing `session.jsonl[.zstd]` spellings.

## Tests

`test_scan_directory_dsh_session_log` now also covers `session.v3.jsonl.zstd`, `session.v3.jsonl`, and a non-numeric `session.vX.jsonl.zstd` that must stay excluded.

I could not run `cargo test` locally (no Rust toolchain on this machine) — relying on CI. Verified end-to-end on a real DSH 0.1.5-rc.1 home: with the equivalent matcher behaviour, `tokscale --client dsh` went from 0 to ~16.7B tokens.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DSH session log discovery so `tokscale --client dsh` no longer reports 0 tokens when the session backend uses versioned filenames like `session.v3.jsonl.zstd`. The matcher now accepts `session.v<N>.jsonl[.zstd]` for decimal `N` alongside the existing unversioned names; the parser already sniffs the zstd frame magic, so only file-name discovery changed. Tests cover both versioned spellings and a non-numeric version that must stay excluded.

<sup>Written for commit 44a35a7524bc671c86d0d990afd2e985c16a0b2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

